### PR TITLE
chore: regenerate packages in google-cloud-[o-r], copyright changes only

### DIFF
--- a/packages/google-cloud-optimization/.flake8
+++ b/packages/google-cloud-optimization/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-optimization/MANIFEST.in
+++ b/packages/google-cloud-optimization/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-optimization/google/cloud/optimization/__init__.py
+++ b/packages/google-cloud-optimization/google/cloud/optimization/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-optimization/google/cloud/optimization/gapic_version.py
+++ b/packages/google-cloud-optimization/google/cloud/optimization/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-optimization/google/cloud/optimization_v1/gapic_version.py
+++ b/packages/google-cloud-optimization/google/cloud/optimization_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-optimization/google/cloud/optimization_v1/services/__init__.py
+++ b/packages/google-cloud-optimization/google/cloud/optimization_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-optimization/google/cloud/optimization_v1/services/fleet_routing/__init__.py
+++ b/packages/google-cloud-optimization/google/cloud/optimization_v1/services/fleet_routing/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-optimization/google/cloud/optimization_v1/services/fleet_routing/client.py
+++ b/packages/google-cloud-optimization/google/cloud/optimization_v1/services/fleet_routing/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-optimization/google/cloud/optimization_v1/services/fleet_routing/transports/__init__.py
+++ b/packages/google-cloud-optimization/google/cloud/optimization_v1/services/fleet_routing/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-optimization/google/cloud/optimization_v1/services/fleet_routing/transports/base.py
+++ b/packages/google-cloud-optimization/google/cloud/optimization_v1/services/fleet_routing/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-optimization/google/cloud/optimization_v1/services/fleet_routing/transports/grpc.py
+++ b/packages/google-cloud-optimization/google/cloud/optimization_v1/services/fleet_routing/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-optimization/google/cloud/optimization_v1/services/fleet_routing/transports/grpc_asyncio.py
+++ b/packages/google-cloud-optimization/google/cloud/optimization_v1/services/fleet_routing/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-optimization/google/cloud/optimization_v1/services/fleet_routing/transports/rest.py
+++ b/packages/google-cloud-optimization/google/cloud/optimization_v1/services/fleet_routing/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-optimization/google/cloud/optimization_v1/services/fleet_routing/transports/rest_base.py
+++ b/packages/google-cloud-optimization/google/cloud/optimization_v1/services/fleet_routing/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-optimization/google/cloud/optimization_v1/types/__init__.py
+++ b/packages/google-cloud-optimization/google/cloud/optimization_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-optimization/google/cloud/optimization_v1/types/async_model.py
+++ b/packages/google-cloud-optimization/google/cloud/optimization_v1/types/async_model.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-optimization/google/cloud/optimization_v1/types/fleet_routing.py
+++ b/packages/google-cloud-optimization/google/cloud/optimization_v1/types/fleet_routing.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-optimization/samples/generated_samples/cloudoptimization_v1_generated_fleet_routing_batch_optimize_tours_sync.py
+++ b/packages/google-cloud-optimization/samples/generated_samples/cloudoptimization_v1_generated_fleet_routing_batch_optimize_tours_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-optimization/samples/generated_samples/cloudoptimization_v1_generated_fleet_routing_optimize_tours_async.py
+++ b/packages/google-cloud-optimization/samples/generated_samples/cloudoptimization_v1_generated_fleet_routing_optimize_tours_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-optimization/samples/generated_samples/cloudoptimization_v1_generated_fleet_routing_optimize_tours_sync.py
+++ b/packages/google-cloud-optimization/samples/generated_samples/cloudoptimization_v1_generated_fleet_routing_optimize_tours_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-optimization/tests/__init__.py
+++ b/packages/google-cloud-optimization/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-optimization/tests/unit/__init__.py
+++ b/packages/google-cloud-optimization/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-optimization/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-optimization/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-optimization/tests/unit/gapic/optimization_v1/__init__.py
+++ b/packages/google-cloud-optimization/tests/unit/gapic/optimization_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/.flake8
+++ b/packages/google-cloud-oracledatabase/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/MANIFEST.in
+++ b/packages/google-cloud-oracledatabase/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/google/cloud/oracledatabase/__init__.py
+++ b/packages/google-cloud-oracledatabase/google/cloud/oracledatabase/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/google/cloud/oracledatabase/gapic_version.py
+++ b/packages/google-cloud-oracledatabase/google/cloud/oracledatabase/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/google/cloud/oracledatabase_v1/gapic_version.py
+++ b/packages/google-cloud-oracledatabase/google/cloud/oracledatabase_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/google/cloud/oracledatabase_v1/services/__init__.py
+++ b/packages/google-cloud-oracledatabase/google/cloud/oracledatabase_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/google/cloud/oracledatabase_v1/services/oracle_database/__init__.py
+++ b/packages/google-cloud-oracledatabase/google/cloud/oracledatabase_v1/services/oracle_database/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/google/cloud/oracledatabase_v1/services/oracle_database/client.py
+++ b/packages/google-cloud-oracledatabase/google/cloud/oracledatabase_v1/services/oracle_database/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/google/cloud/oracledatabase_v1/services/oracle_database/pagers.py
+++ b/packages/google-cloud-oracledatabase/google/cloud/oracledatabase_v1/services/oracle_database/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/google/cloud/oracledatabase_v1/services/oracle_database/transports/__init__.py
+++ b/packages/google-cloud-oracledatabase/google/cloud/oracledatabase_v1/services/oracle_database/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/google/cloud/oracledatabase_v1/services/oracle_database/transports/base.py
+++ b/packages/google-cloud-oracledatabase/google/cloud/oracledatabase_v1/services/oracle_database/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/google/cloud/oracledatabase_v1/services/oracle_database/transports/grpc.py
+++ b/packages/google-cloud-oracledatabase/google/cloud/oracledatabase_v1/services/oracle_database/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/google/cloud/oracledatabase_v1/services/oracle_database/transports/grpc_asyncio.py
+++ b/packages/google-cloud-oracledatabase/google/cloud/oracledatabase_v1/services/oracle_database/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/google/cloud/oracledatabase_v1/services/oracle_database/transports/rest.py
+++ b/packages/google-cloud-oracledatabase/google/cloud/oracledatabase_v1/services/oracle_database/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/google/cloud/oracledatabase_v1/services/oracle_database/transports/rest_base.py
+++ b/packages/google-cloud-oracledatabase/google/cloud/oracledatabase_v1/services/oracle_database/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/google/cloud/oracledatabase_v1/types/__init__.py
+++ b/packages/google-cloud-oracledatabase/google/cloud/oracledatabase_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/google/cloud/oracledatabase_v1/types/autonomous_database.py
+++ b/packages/google-cloud-oracledatabase/google/cloud/oracledatabase_v1/types/autonomous_database.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/google/cloud/oracledatabase_v1/types/autonomous_database_character_set.py
+++ b/packages/google-cloud-oracledatabase/google/cloud/oracledatabase_v1/types/autonomous_database_character_set.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/google/cloud/oracledatabase_v1/types/autonomous_db_backup.py
+++ b/packages/google-cloud-oracledatabase/google/cloud/oracledatabase_v1/types/autonomous_db_backup.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/google/cloud/oracledatabase_v1/types/autonomous_db_version.py
+++ b/packages/google-cloud-oracledatabase/google/cloud/oracledatabase_v1/types/autonomous_db_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/google/cloud/oracledatabase_v1/types/common.py
+++ b/packages/google-cloud-oracledatabase/google/cloud/oracledatabase_v1/types/common.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/google/cloud/oracledatabase_v1/types/database.py
+++ b/packages/google-cloud-oracledatabase/google/cloud/oracledatabase_v1/types/database.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/google/cloud/oracledatabase_v1/types/database_character_set.py
+++ b/packages/google-cloud-oracledatabase/google/cloud/oracledatabase_v1/types/database_character_set.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/google/cloud/oracledatabase_v1/types/db_node.py
+++ b/packages/google-cloud-oracledatabase/google/cloud/oracledatabase_v1/types/db_node.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/google/cloud/oracledatabase_v1/types/db_server.py
+++ b/packages/google-cloud-oracledatabase/google/cloud/oracledatabase_v1/types/db_server.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/google/cloud/oracledatabase_v1/types/db_system.py
+++ b/packages/google-cloud-oracledatabase/google/cloud/oracledatabase_v1/types/db_system.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/google/cloud/oracledatabase_v1/types/db_system_initial_storage_size.py
+++ b/packages/google-cloud-oracledatabase/google/cloud/oracledatabase_v1/types/db_system_initial_storage_size.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/google/cloud/oracledatabase_v1/types/db_system_shape.py
+++ b/packages/google-cloud-oracledatabase/google/cloud/oracledatabase_v1/types/db_system_shape.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/google/cloud/oracledatabase_v1/types/db_version.py
+++ b/packages/google-cloud-oracledatabase/google/cloud/oracledatabase_v1/types/db_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/google/cloud/oracledatabase_v1/types/entitlement.py
+++ b/packages/google-cloud-oracledatabase/google/cloud/oracledatabase_v1/types/entitlement.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/google/cloud/oracledatabase_v1/types/exadb_vm_cluster.py
+++ b/packages/google-cloud-oracledatabase/google/cloud/oracledatabase_v1/types/exadb_vm_cluster.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/google/cloud/oracledatabase_v1/types/exascale_db_storage_vault.py
+++ b/packages/google-cloud-oracledatabase/google/cloud/oracledatabase_v1/types/exascale_db_storage_vault.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/google/cloud/oracledatabase_v1/types/gi_version.py
+++ b/packages/google-cloud-oracledatabase/google/cloud/oracledatabase_v1/types/gi_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/google/cloud/oracledatabase_v1/types/location_metadata.py
+++ b/packages/google-cloud-oracledatabase/google/cloud/oracledatabase_v1/types/location_metadata.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/google/cloud/oracledatabase_v1/types/minor_version.py
+++ b/packages/google-cloud-oracledatabase/google/cloud/oracledatabase_v1/types/minor_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/google/cloud/oracledatabase_v1/types/odb_network.py
+++ b/packages/google-cloud-oracledatabase/google/cloud/oracledatabase_v1/types/odb_network.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/google/cloud/oracledatabase_v1/types/odb_subnet.py
+++ b/packages/google-cloud-oracledatabase/google/cloud/oracledatabase_v1/types/odb_subnet.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/google/cloud/oracledatabase_v1/types/oracledatabase.py
+++ b/packages/google-cloud-oracledatabase/google/cloud/oracledatabase_v1/types/oracledatabase.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/google/cloud/oracledatabase_v1/types/pluggable_database.py
+++ b/packages/google-cloud-oracledatabase/google/cloud/oracledatabase_v1/types/pluggable_database.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/google/cloud/oracledatabase_v1/types/vm_cluster.py
+++ b/packages/google-cloud-oracledatabase/google/cloud/oracledatabase_v1/types/vm_cluster.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_create_autonomous_database_sync.py
+++ b/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_create_autonomous_database_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_create_cloud_exadata_infrastructure_sync.py
+++ b/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_create_cloud_exadata_infrastructure_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_create_cloud_vm_cluster_sync.py
+++ b/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_create_cloud_vm_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_create_db_system_sync.py
+++ b/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_create_db_system_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_create_exadb_vm_cluster_sync.py
+++ b/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_create_exadb_vm_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_create_exascale_db_storage_vault_sync.py
+++ b/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_create_exascale_db_storage_vault_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_create_odb_network_sync.py
+++ b/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_create_odb_network_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_create_odb_subnet_sync.py
+++ b/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_create_odb_subnet_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_delete_autonomous_database_sync.py
+++ b/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_delete_autonomous_database_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_delete_cloud_exadata_infrastructure_sync.py
+++ b/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_delete_cloud_exadata_infrastructure_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_delete_cloud_vm_cluster_sync.py
+++ b/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_delete_cloud_vm_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_delete_db_system_sync.py
+++ b/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_delete_db_system_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_delete_exadb_vm_cluster_sync.py
+++ b/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_delete_exadb_vm_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_delete_exascale_db_storage_vault_sync.py
+++ b/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_delete_exascale_db_storage_vault_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_delete_odb_network_sync.py
+++ b/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_delete_odb_network_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_delete_odb_subnet_sync.py
+++ b/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_delete_odb_subnet_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_failover_autonomous_database_sync.py
+++ b/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_failover_autonomous_database_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_generate_autonomous_database_wallet_async.py
+++ b/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_generate_autonomous_database_wallet_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_generate_autonomous_database_wallet_sync.py
+++ b/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_generate_autonomous_database_wallet_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_get_autonomous_database_async.py
+++ b/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_get_autonomous_database_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_get_autonomous_database_sync.py
+++ b/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_get_autonomous_database_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_get_cloud_exadata_infrastructure_async.py
+++ b/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_get_cloud_exadata_infrastructure_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_get_cloud_exadata_infrastructure_sync.py
+++ b/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_get_cloud_exadata_infrastructure_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_get_cloud_vm_cluster_async.py
+++ b/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_get_cloud_vm_cluster_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_get_cloud_vm_cluster_sync.py
+++ b/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_get_cloud_vm_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_get_database_async.py
+++ b/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_get_database_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_get_database_sync.py
+++ b/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_get_database_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_get_db_system_async.py
+++ b/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_get_db_system_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_get_db_system_sync.py
+++ b/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_get_db_system_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_get_exadb_vm_cluster_async.py
+++ b/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_get_exadb_vm_cluster_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_get_exadb_vm_cluster_sync.py
+++ b/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_get_exadb_vm_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_get_exascale_db_storage_vault_async.py
+++ b/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_get_exascale_db_storage_vault_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_get_exascale_db_storage_vault_sync.py
+++ b/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_get_exascale_db_storage_vault_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_get_odb_network_async.py
+++ b/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_get_odb_network_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_get_odb_network_sync.py
+++ b/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_get_odb_network_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_get_odb_subnet_async.py
+++ b/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_get_odb_subnet_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_get_odb_subnet_sync.py
+++ b/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_get_odb_subnet_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_get_pluggable_database_async.py
+++ b/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_get_pluggable_database_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_get_pluggable_database_sync.py
+++ b/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_get_pluggable_database_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_list_autonomous_database_backups_async.py
+++ b/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_list_autonomous_database_backups_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_list_autonomous_database_backups_sync.py
+++ b/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_list_autonomous_database_backups_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_list_autonomous_database_character_sets_async.py
+++ b/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_list_autonomous_database_character_sets_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_list_autonomous_database_character_sets_sync.py
+++ b/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_list_autonomous_database_character_sets_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_list_autonomous_databases_async.py
+++ b/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_list_autonomous_databases_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_list_autonomous_databases_sync.py
+++ b/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_list_autonomous_databases_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_list_autonomous_db_versions_async.py
+++ b/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_list_autonomous_db_versions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_list_autonomous_db_versions_sync.py
+++ b/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_list_autonomous_db_versions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_list_cloud_exadata_infrastructures_async.py
+++ b/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_list_cloud_exadata_infrastructures_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_list_cloud_exadata_infrastructures_sync.py
+++ b/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_list_cloud_exadata_infrastructures_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_list_cloud_vm_clusters_async.py
+++ b/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_list_cloud_vm_clusters_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_list_cloud_vm_clusters_sync.py
+++ b/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_list_cloud_vm_clusters_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_list_database_character_sets_async.py
+++ b/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_list_database_character_sets_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_list_database_character_sets_sync.py
+++ b/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_list_database_character_sets_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_list_databases_async.py
+++ b/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_list_databases_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_list_databases_sync.py
+++ b/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_list_databases_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_list_db_nodes_async.py
+++ b/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_list_db_nodes_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_list_db_nodes_sync.py
+++ b/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_list_db_nodes_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_list_db_servers_async.py
+++ b/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_list_db_servers_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_list_db_servers_sync.py
+++ b/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_list_db_servers_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_list_db_system_initial_storage_sizes_async.py
+++ b/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_list_db_system_initial_storage_sizes_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_list_db_system_initial_storage_sizes_sync.py
+++ b/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_list_db_system_initial_storage_sizes_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_list_db_system_shapes_async.py
+++ b/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_list_db_system_shapes_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_list_db_system_shapes_sync.py
+++ b/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_list_db_system_shapes_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_list_db_systems_async.py
+++ b/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_list_db_systems_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_list_db_systems_sync.py
+++ b/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_list_db_systems_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_list_db_versions_async.py
+++ b/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_list_db_versions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_list_db_versions_sync.py
+++ b/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_list_db_versions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_list_entitlements_async.py
+++ b/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_list_entitlements_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_list_entitlements_sync.py
+++ b/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_list_entitlements_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_list_exadb_vm_clusters_async.py
+++ b/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_list_exadb_vm_clusters_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_list_exadb_vm_clusters_sync.py
+++ b/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_list_exadb_vm_clusters_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_list_exascale_db_storage_vaults_async.py
+++ b/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_list_exascale_db_storage_vaults_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_list_exascale_db_storage_vaults_sync.py
+++ b/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_list_exascale_db_storage_vaults_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_list_gi_versions_async.py
+++ b/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_list_gi_versions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_list_gi_versions_sync.py
+++ b/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_list_gi_versions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_list_minor_versions_async.py
+++ b/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_list_minor_versions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_list_minor_versions_sync.py
+++ b/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_list_minor_versions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_list_odb_networks_async.py
+++ b/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_list_odb_networks_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_list_odb_networks_sync.py
+++ b/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_list_odb_networks_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_list_odb_subnets_async.py
+++ b/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_list_odb_subnets_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_list_odb_subnets_sync.py
+++ b/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_list_odb_subnets_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_list_pluggable_databases_async.py
+++ b/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_list_pluggable_databases_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_list_pluggable_databases_sync.py
+++ b/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_list_pluggable_databases_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_remove_virtual_machine_exadb_vm_cluster_sync.py
+++ b/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_remove_virtual_machine_exadb_vm_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_restart_autonomous_database_sync.py
+++ b/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_restart_autonomous_database_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_restore_autonomous_database_sync.py
+++ b/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_restore_autonomous_database_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_start_autonomous_database_sync.py
+++ b/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_start_autonomous_database_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_stop_autonomous_database_sync.py
+++ b/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_stop_autonomous_database_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_switchover_autonomous_database_sync.py
+++ b/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_switchover_autonomous_database_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_update_autonomous_database_sync.py
+++ b/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_update_autonomous_database_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_update_exadb_vm_cluster_sync.py
+++ b/packages/google-cloud-oracledatabase/samples/generated_samples/oracledatabase_v1_generated_oracle_database_update_exadb_vm_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/tests/__init__.py
+++ b/packages/google-cloud-oracledatabase/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/tests/unit/__init__.py
+++ b/packages/google-cloud-oracledatabase/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-oracledatabase/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-oracledatabase/tests/unit/gapic/oracledatabase_v1/__init__.py
+++ b/packages/google-cloud-oracledatabase/tests/unit/gapic/oracledatabase_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/.flake8
+++ b/packages/google-cloud-orchestration-airflow/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/MANIFEST.in
+++ b/packages/google-cloud-orchestration-airflow/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/google/cloud/orchestration/airflow/service/__init__.py
+++ b/packages/google-cloud-orchestration-airflow/google/cloud/orchestration/airflow/service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/google/cloud/orchestration/airflow/service/gapic_version.py
+++ b/packages/google-cloud-orchestration-airflow/google/cloud/orchestration/airflow/service/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/google/cloud/orchestration/airflow/service_v1/gapic_version.py
+++ b/packages/google-cloud-orchestration-airflow/google/cloud/orchestration/airflow/service_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/google/cloud/orchestration/airflow/service_v1/services/__init__.py
+++ b/packages/google-cloud-orchestration-airflow/google/cloud/orchestration/airflow/service_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/google/cloud/orchestration/airflow/service_v1/services/environments/__init__.py
+++ b/packages/google-cloud-orchestration-airflow/google/cloud/orchestration/airflow/service_v1/services/environments/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/google/cloud/orchestration/airflow/service_v1/services/environments/client.py
+++ b/packages/google-cloud-orchestration-airflow/google/cloud/orchestration/airflow/service_v1/services/environments/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/google/cloud/orchestration/airflow/service_v1/services/environments/pagers.py
+++ b/packages/google-cloud-orchestration-airflow/google/cloud/orchestration/airflow/service_v1/services/environments/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/google/cloud/orchestration/airflow/service_v1/services/environments/transports/__init__.py
+++ b/packages/google-cloud-orchestration-airflow/google/cloud/orchestration/airflow/service_v1/services/environments/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/google/cloud/orchestration/airflow/service_v1/services/environments/transports/base.py
+++ b/packages/google-cloud-orchestration-airflow/google/cloud/orchestration/airflow/service_v1/services/environments/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/google/cloud/orchestration/airflow/service_v1/services/environments/transports/grpc.py
+++ b/packages/google-cloud-orchestration-airflow/google/cloud/orchestration/airflow/service_v1/services/environments/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/google/cloud/orchestration/airflow/service_v1/services/environments/transports/grpc_asyncio.py
+++ b/packages/google-cloud-orchestration-airflow/google/cloud/orchestration/airflow/service_v1/services/environments/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/google/cloud/orchestration/airflow/service_v1/services/environments/transports/rest.py
+++ b/packages/google-cloud-orchestration-airflow/google/cloud/orchestration/airflow/service_v1/services/environments/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/google/cloud/orchestration/airflow/service_v1/services/environments/transports/rest_base.py
+++ b/packages/google-cloud-orchestration-airflow/google/cloud/orchestration/airflow/service_v1/services/environments/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/google/cloud/orchestration/airflow/service_v1/services/image_versions/__init__.py
+++ b/packages/google-cloud-orchestration-airflow/google/cloud/orchestration/airflow/service_v1/services/image_versions/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/google/cloud/orchestration/airflow/service_v1/services/image_versions/async_client.py
+++ b/packages/google-cloud-orchestration-airflow/google/cloud/orchestration/airflow/service_v1/services/image_versions/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/google/cloud/orchestration/airflow/service_v1/services/image_versions/client.py
+++ b/packages/google-cloud-orchestration-airflow/google/cloud/orchestration/airflow/service_v1/services/image_versions/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/google/cloud/orchestration/airflow/service_v1/services/image_versions/pagers.py
+++ b/packages/google-cloud-orchestration-airflow/google/cloud/orchestration/airflow/service_v1/services/image_versions/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/google/cloud/orchestration/airflow/service_v1/services/image_versions/transports/__init__.py
+++ b/packages/google-cloud-orchestration-airflow/google/cloud/orchestration/airflow/service_v1/services/image_versions/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/google/cloud/orchestration/airflow/service_v1/services/image_versions/transports/base.py
+++ b/packages/google-cloud-orchestration-airflow/google/cloud/orchestration/airflow/service_v1/services/image_versions/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/google/cloud/orchestration/airflow/service_v1/services/image_versions/transports/grpc.py
+++ b/packages/google-cloud-orchestration-airflow/google/cloud/orchestration/airflow/service_v1/services/image_versions/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/google/cloud/orchestration/airflow/service_v1/services/image_versions/transports/grpc_asyncio.py
+++ b/packages/google-cloud-orchestration-airflow/google/cloud/orchestration/airflow/service_v1/services/image_versions/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/google/cloud/orchestration/airflow/service_v1/services/image_versions/transports/rest.py
+++ b/packages/google-cloud-orchestration-airflow/google/cloud/orchestration/airflow/service_v1/services/image_versions/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/google/cloud/orchestration/airflow/service_v1/services/image_versions/transports/rest_base.py
+++ b/packages/google-cloud-orchestration-airflow/google/cloud/orchestration/airflow/service_v1/services/image_versions/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/google/cloud/orchestration/airflow/service_v1/types/__init__.py
+++ b/packages/google-cloud-orchestration-airflow/google/cloud/orchestration/airflow/service_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/google/cloud/orchestration/airflow/service_v1/types/image_versions.py
+++ b/packages/google-cloud-orchestration-airflow/google/cloud/orchestration/airflow/service_v1/types/image_versions.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/google/cloud/orchestration/airflow/service_v1/types/operations.py
+++ b/packages/google-cloud-orchestration-airflow/google/cloud/orchestration/airflow/service_v1/types/operations.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/google/cloud/orchestration/airflow/service_v1beta1/gapic_version.py
+++ b/packages/google-cloud-orchestration-airflow/google/cloud/orchestration/airflow/service_v1beta1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/google/cloud/orchestration/airflow/service_v1beta1/services/__init__.py
+++ b/packages/google-cloud-orchestration-airflow/google/cloud/orchestration/airflow/service_v1beta1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/google/cloud/orchestration/airflow/service_v1beta1/services/environments/__init__.py
+++ b/packages/google-cloud-orchestration-airflow/google/cloud/orchestration/airflow/service_v1beta1/services/environments/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/google/cloud/orchestration/airflow/service_v1beta1/services/environments/client.py
+++ b/packages/google-cloud-orchestration-airflow/google/cloud/orchestration/airflow/service_v1beta1/services/environments/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/google/cloud/orchestration/airflow/service_v1beta1/services/environments/pagers.py
+++ b/packages/google-cloud-orchestration-airflow/google/cloud/orchestration/airflow/service_v1beta1/services/environments/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/google/cloud/orchestration/airflow/service_v1beta1/services/environments/transports/__init__.py
+++ b/packages/google-cloud-orchestration-airflow/google/cloud/orchestration/airflow/service_v1beta1/services/environments/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/google/cloud/orchestration/airflow/service_v1beta1/services/environments/transports/base.py
+++ b/packages/google-cloud-orchestration-airflow/google/cloud/orchestration/airflow/service_v1beta1/services/environments/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/google/cloud/orchestration/airflow/service_v1beta1/services/environments/transports/grpc.py
+++ b/packages/google-cloud-orchestration-airflow/google/cloud/orchestration/airflow/service_v1beta1/services/environments/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/google/cloud/orchestration/airflow/service_v1beta1/services/environments/transports/grpc_asyncio.py
+++ b/packages/google-cloud-orchestration-airflow/google/cloud/orchestration/airflow/service_v1beta1/services/environments/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/google/cloud/orchestration/airflow/service_v1beta1/services/environments/transports/rest.py
+++ b/packages/google-cloud-orchestration-airflow/google/cloud/orchestration/airflow/service_v1beta1/services/environments/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/google/cloud/orchestration/airflow/service_v1beta1/services/environments/transports/rest_base.py
+++ b/packages/google-cloud-orchestration-airflow/google/cloud/orchestration/airflow/service_v1beta1/services/environments/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/google/cloud/orchestration/airflow/service_v1beta1/services/image_versions/__init__.py
+++ b/packages/google-cloud-orchestration-airflow/google/cloud/orchestration/airflow/service_v1beta1/services/image_versions/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/google/cloud/orchestration/airflow/service_v1beta1/services/image_versions/async_client.py
+++ b/packages/google-cloud-orchestration-airflow/google/cloud/orchestration/airflow/service_v1beta1/services/image_versions/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/google/cloud/orchestration/airflow/service_v1beta1/services/image_versions/client.py
+++ b/packages/google-cloud-orchestration-airflow/google/cloud/orchestration/airflow/service_v1beta1/services/image_versions/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/google/cloud/orchestration/airflow/service_v1beta1/services/image_versions/pagers.py
+++ b/packages/google-cloud-orchestration-airflow/google/cloud/orchestration/airflow/service_v1beta1/services/image_versions/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/google/cloud/orchestration/airflow/service_v1beta1/services/image_versions/transports/__init__.py
+++ b/packages/google-cloud-orchestration-airflow/google/cloud/orchestration/airflow/service_v1beta1/services/image_versions/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/google/cloud/orchestration/airflow/service_v1beta1/services/image_versions/transports/base.py
+++ b/packages/google-cloud-orchestration-airflow/google/cloud/orchestration/airflow/service_v1beta1/services/image_versions/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/google/cloud/orchestration/airflow/service_v1beta1/services/image_versions/transports/grpc.py
+++ b/packages/google-cloud-orchestration-airflow/google/cloud/orchestration/airflow/service_v1beta1/services/image_versions/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/google/cloud/orchestration/airflow/service_v1beta1/services/image_versions/transports/grpc_asyncio.py
+++ b/packages/google-cloud-orchestration-airflow/google/cloud/orchestration/airflow/service_v1beta1/services/image_versions/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/google/cloud/orchestration/airflow/service_v1beta1/services/image_versions/transports/rest.py
+++ b/packages/google-cloud-orchestration-airflow/google/cloud/orchestration/airflow/service_v1beta1/services/image_versions/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/google/cloud/orchestration/airflow/service_v1beta1/services/image_versions/transports/rest_base.py
+++ b/packages/google-cloud-orchestration-airflow/google/cloud/orchestration/airflow/service_v1beta1/services/image_versions/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/google/cloud/orchestration/airflow/service_v1beta1/types/__init__.py
+++ b/packages/google-cloud-orchestration-airflow/google/cloud/orchestration/airflow/service_v1beta1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/google/cloud/orchestration/airflow/service_v1beta1/types/image_versions.py
+++ b/packages/google-cloud-orchestration-airflow/google/cloud/orchestration/airflow/service_v1beta1/types/image_versions.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/google/cloud/orchestration/airflow/service_v1beta1/types/operations.py
+++ b/packages/google-cloud-orchestration-airflow/google/cloud/orchestration/airflow/service_v1beta1/types/operations.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1_generated_environments_check_upgrade_sync.py
+++ b/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1_generated_environments_check_upgrade_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1_generated_environments_create_environment_sync.py
+++ b/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1_generated_environments_create_environment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1_generated_environments_create_user_workloads_config_map_async.py
+++ b/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1_generated_environments_create_user_workloads_config_map_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1_generated_environments_create_user_workloads_config_map_sync.py
+++ b/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1_generated_environments_create_user_workloads_config_map_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1_generated_environments_create_user_workloads_secret_async.py
+++ b/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1_generated_environments_create_user_workloads_secret_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1_generated_environments_create_user_workloads_secret_sync.py
+++ b/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1_generated_environments_create_user_workloads_secret_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1_generated_environments_database_failover_sync.py
+++ b/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1_generated_environments_database_failover_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1_generated_environments_delete_environment_sync.py
+++ b/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1_generated_environments_delete_environment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1_generated_environments_delete_user_workloads_config_map_async.py
+++ b/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1_generated_environments_delete_user_workloads_config_map_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1_generated_environments_delete_user_workloads_config_map_sync.py
+++ b/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1_generated_environments_delete_user_workloads_config_map_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1_generated_environments_delete_user_workloads_secret_async.py
+++ b/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1_generated_environments_delete_user_workloads_secret_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1_generated_environments_delete_user_workloads_secret_sync.py
+++ b/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1_generated_environments_delete_user_workloads_secret_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1_generated_environments_execute_airflow_command_async.py
+++ b/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1_generated_environments_execute_airflow_command_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1_generated_environments_execute_airflow_command_sync.py
+++ b/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1_generated_environments_execute_airflow_command_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1_generated_environments_fetch_database_properties_async.py
+++ b/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1_generated_environments_fetch_database_properties_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1_generated_environments_fetch_database_properties_sync.py
+++ b/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1_generated_environments_fetch_database_properties_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1_generated_environments_get_environment_async.py
+++ b/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1_generated_environments_get_environment_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1_generated_environments_get_environment_sync.py
+++ b/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1_generated_environments_get_environment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1_generated_environments_get_user_workloads_config_map_async.py
+++ b/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1_generated_environments_get_user_workloads_config_map_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1_generated_environments_get_user_workloads_config_map_sync.py
+++ b/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1_generated_environments_get_user_workloads_config_map_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1_generated_environments_get_user_workloads_secret_async.py
+++ b/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1_generated_environments_get_user_workloads_secret_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1_generated_environments_get_user_workloads_secret_sync.py
+++ b/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1_generated_environments_get_user_workloads_secret_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1_generated_environments_list_environments_async.py
+++ b/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1_generated_environments_list_environments_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1_generated_environments_list_environments_sync.py
+++ b/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1_generated_environments_list_environments_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1_generated_environments_list_user_workloads_config_maps_async.py
+++ b/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1_generated_environments_list_user_workloads_config_maps_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1_generated_environments_list_user_workloads_config_maps_sync.py
+++ b/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1_generated_environments_list_user_workloads_config_maps_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1_generated_environments_list_user_workloads_secrets_async.py
+++ b/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1_generated_environments_list_user_workloads_secrets_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1_generated_environments_list_user_workloads_secrets_sync.py
+++ b/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1_generated_environments_list_user_workloads_secrets_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1_generated_environments_list_workloads_async.py
+++ b/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1_generated_environments_list_workloads_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1_generated_environments_list_workloads_sync.py
+++ b/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1_generated_environments_list_workloads_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1_generated_environments_load_snapshot_sync.py
+++ b/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1_generated_environments_load_snapshot_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1_generated_environments_poll_airflow_command_async.py
+++ b/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1_generated_environments_poll_airflow_command_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1_generated_environments_poll_airflow_command_sync.py
+++ b/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1_generated_environments_poll_airflow_command_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1_generated_environments_save_snapshot_sync.py
+++ b/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1_generated_environments_save_snapshot_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1_generated_environments_stop_airflow_command_async.py
+++ b/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1_generated_environments_stop_airflow_command_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1_generated_environments_stop_airflow_command_sync.py
+++ b/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1_generated_environments_stop_airflow_command_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1_generated_environments_update_environment_sync.py
+++ b/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1_generated_environments_update_environment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1_generated_environments_update_user_workloads_config_map_async.py
+++ b/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1_generated_environments_update_user_workloads_config_map_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1_generated_environments_update_user_workloads_config_map_sync.py
+++ b/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1_generated_environments_update_user_workloads_config_map_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1_generated_environments_update_user_workloads_secret_async.py
+++ b/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1_generated_environments_update_user_workloads_secret_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1_generated_environments_update_user_workloads_secret_sync.py
+++ b/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1_generated_environments_update_user_workloads_secret_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1_generated_image_versions_list_image_versions_async.py
+++ b/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1_generated_image_versions_list_image_versions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1_generated_image_versions_list_image_versions_sync.py
+++ b/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1_generated_image_versions_list_image_versions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_check_upgrade_sync.py
+++ b/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_check_upgrade_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_create_environment_sync.py
+++ b/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_create_environment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_create_user_workloads_config_map_async.py
+++ b/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_create_user_workloads_config_map_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_create_user_workloads_config_map_sync.py
+++ b/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_create_user_workloads_config_map_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_create_user_workloads_secret_async.py
+++ b/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_create_user_workloads_secret_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_create_user_workloads_secret_sync.py
+++ b/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_create_user_workloads_secret_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_database_failover_sync.py
+++ b/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_database_failover_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_delete_environment_sync.py
+++ b/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_delete_environment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_delete_user_workloads_config_map_async.py
+++ b/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_delete_user_workloads_config_map_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_delete_user_workloads_config_map_sync.py
+++ b/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_delete_user_workloads_config_map_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_delete_user_workloads_secret_async.py
+++ b/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_delete_user_workloads_secret_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_delete_user_workloads_secret_sync.py
+++ b/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_delete_user_workloads_secret_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_execute_airflow_command_async.py
+++ b/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_execute_airflow_command_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_execute_airflow_command_sync.py
+++ b/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_execute_airflow_command_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_fetch_database_properties_async.py
+++ b/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_fetch_database_properties_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_fetch_database_properties_sync.py
+++ b/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_fetch_database_properties_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_get_environment_async.py
+++ b/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_get_environment_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_get_environment_sync.py
+++ b/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_get_environment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_get_user_workloads_config_map_async.py
+++ b/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_get_user_workloads_config_map_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_get_user_workloads_config_map_sync.py
+++ b/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_get_user_workloads_config_map_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_get_user_workloads_secret_async.py
+++ b/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_get_user_workloads_secret_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_get_user_workloads_secret_sync.py
+++ b/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_get_user_workloads_secret_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_list_environments_async.py
+++ b/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_list_environments_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_list_environments_sync.py
+++ b/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_list_environments_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_list_user_workloads_config_maps_async.py
+++ b/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_list_user_workloads_config_maps_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_list_user_workloads_config_maps_sync.py
+++ b/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_list_user_workloads_config_maps_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_list_user_workloads_secrets_async.py
+++ b/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_list_user_workloads_secrets_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_list_user_workloads_secrets_sync.py
+++ b/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_list_user_workloads_secrets_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_list_workloads_async.py
+++ b/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_list_workloads_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_list_workloads_sync.py
+++ b/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_list_workloads_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_load_snapshot_sync.py
+++ b/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_load_snapshot_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_poll_airflow_command_async.py
+++ b/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_poll_airflow_command_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_poll_airflow_command_sync.py
+++ b/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_poll_airflow_command_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_restart_web_server_sync.py
+++ b/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_restart_web_server_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_save_snapshot_sync.py
+++ b/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_save_snapshot_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_stop_airflow_command_async.py
+++ b/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_stop_airflow_command_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_stop_airflow_command_sync.py
+++ b/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_stop_airflow_command_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_update_environment_sync.py
+++ b/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_update_environment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_update_user_workloads_config_map_async.py
+++ b/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_update_user_workloads_config_map_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_update_user_workloads_config_map_sync.py
+++ b/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_update_user_workloads_config_map_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_update_user_workloads_secret_async.py
+++ b/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_update_user_workloads_secret_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_update_user_workloads_secret_sync.py
+++ b/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_environments_update_user_workloads_secret_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_image_versions_list_image_versions_async.py
+++ b/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_image_versions_list_image_versions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_image_versions_list_image_versions_sync.py
+++ b/packages/google-cloud-orchestration-airflow/samples/generated_samples/composer_v1beta1_generated_image_versions_list_image_versions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/tests/__init__.py
+++ b/packages/google-cloud-orchestration-airflow/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/tests/unit/__init__.py
+++ b/packages/google-cloud-orchestration-airflow/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-orchestration-airflow/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/tests/unit/gapic/service_v1/__init__.py
+++ b/packages/google-cloud-orchestration-airflow/tests/unit/gapic/service_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-orchestration-airflow/tests/unit/gapic/service_v1beta1/__init__.py
+++ b/packages/google-cloud-orchestration-airflow/tests/unit/gapic/service_v1beta1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-org-policy/.flake8
+++ b/packages/google-cloud-org-policy/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-org-policy/MANIFEST.in
+++ b/packages/google-cloud-org-policy/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-org-policy/google/cloud/orgpolicy/__init__.py
+++ b/packages/google-cloud-org-policy/google/cloud/orgpolicy/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-org-policy/google/cloud/orgpolicy/gapic_version.py
+++ b/packages/google-cloud-org-policy/google/cloud/orgpolicy/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-org-policy/google/cloud/orgpolicy_v2/gapic_version.py
+++ b/packages/google-cloud-org-policy/google/cloud/orgpolicy_v2/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-org-policy/google/cloud/orgpolicy_v2/services/__init__.py
+++ b/packages/google-cloud-org-policy/google/cloud/orgpolicy_v2/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-org-policy/google/cloud/orgpolicy_v2/services/org_policy/__init__.py
+++ b/packages/google-cloud-org-policy/google/cloud/orgpolicy_v2/services/org_policy/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-org-policy/google/cloud/orgpolicy_v2/services/org_policy/async_client.py
+++ b/packages/google-cloud-org-policy/google/cloud/orgpolicy_v2/services/org_policy/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-org-policy/google/cloud/orgpolicy_v2/services/org_policy/client.py
+++ b/packages/google-cloud-org-policy/google/cloud/orgpolicy_v2/services/org_policy/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-org-policy/google/cloud/orgpolicy_v2/services/org_policy/pagers.py
+++ b/packages/google-cloud-org-policy/google/cloud/orgpolicy_v2/services/org_policy/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-org-policy/google/cloud/orgpolicy_v2/services/org_policy/transports/__init__.py
+++ b/packages/google-cloud-org-policy/google/cloud/orgpolicy_v2/services/org_policy/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-org-policy/google/cloud/orgpolicy_v2/services/org_policy/transports/base.py
+++ b/packages/google-cloud-org-policy/google/cloud/orgpolicy_v2/services/org_policy/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-org-policy/google/cloud/orgpolicy_v2/services/org_policy/transports/grpc.py
+++ b/packages/google-cloud-org-policy/google/cloud/orgpolicy_v2/services/org_policy/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-org-policy/google/cloud/orgpolicy_v2/services/org_policy/transports/grpc_asyncio.py
+++ b/packages/google-cloud-org-policy/google/cloud/orgpolicy_v2/services/org_policy/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-org-policy/google/cloud/orgpolicy_v2/services/org_policy/transports/rest.py
+++ b/packages/google-cloud-org-policy/google/cloud/orgpolicy_v2/services/org_policy/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-org-policy/google/cloud/orgpolicy_v2/services/org_policy/transports/rest_base.py
+++ b/packages/google-cloud-org-policy/google/cloud/orgpolicy_v2/services/org_policy/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-org-policy/google/cloud/orgpolicy_v2/types/__init__.py
+++ b/packages/google-cloud-org-policy/google/cloud/orgpolicy_v2/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-org-policy/google/cloud/orgpolicy_v2/types/constraint.py
+++ b/packages/google-cloud-org-policy/google/cloud/orgpolicy_v2/types/constraint.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-org-policy/google/cloud/orgpolicy_v2/types/orgpolicy.py
+++ b/packages/google-cloud-org-policy/google/cloud/orgpolicy_v2/types/orgpolicy.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-org-policy/samples/generated_samples/orgpolicy_v2_generated_org_policy_create_custom_constraint_async.py
+++ b/packages/google-cloud-org-policy/samples/generated_samples/orgpolicy_v2_generated_org_policy_create_custom_constraint_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-org-policy/samples/generated_samples/orgpolicy_v2_generated_org_policy_create_custom_constraint_sync.py
+++ b/packages/google-cloud-org-policy/samples/generated_samples/orgpolicy_v2_generated_org_policy_create_custom_constraint_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-org-policy/samples/generated_samples/orgpolicy_v2_generated_org_policy_create_policy_async.py
+++ b/packages/google-cloud-org-policy/samples/generated_samples/orgpolicy_v2_generated_org_policy_create_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-org-policy/samples/generated_samples/orgpolicy_v2_generated_org_policy_create_policy_sync.py
+++ b/packages/google-cloud-org-policy/samples/generated_samples/orgpolicy_v2_generated_org_policy_create_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-org-policy/samples/generated_samples/orgpolicy_v2_generated_org_policy_delete_custom_constraint_async.py
+++ b/packages/google-cloud-org-policy/samples/generated_samples/orgpolicy_v2_generated_org_policy_delete_custom_constraint_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-org-policy/samples/generated_samples/orgpolicy_v2_generated_org_policy_delete_custom_constraint_sync.py
+++ b/packages/google-cloud-org-policy/samples/generated_samples/orgpolicy_v2_generated_org_policy_delete_custom_constraint_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-org-policy/samples/generated_samples/orgpolicy_v2_generated_org_policy_delete_policy_async.py
+++ b/packages/google-cloud-org-policy/samples/generated_samples/orgpolicy_v2_generated_org_policy_delete_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-org-policy/samples/generated_samples/orgpolicy_v2_generated_org_policy_delete_policy_sync.py
+++ b/packages/google-cloud-org-policy/samples/generated_samples/orgpolicy_v2_generated_org_policy_delete_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-org-policy/samples/generated_samples/orgpolicy_v2_generated_org_policy_get_custom_constraint_async.py
+++ b/packages/google-cloud-org-policy/samples/generated_samples/orgpolicy_v2_generated_org_policy_get_custom_constraint_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-org-policy/samples/generated_samples/orgpolicy_v2_generated_org_policy_get_custom_constraint_sync.py
+++ b/packages/google-cloud-org-policy/samples/generated_samples/orgpolicy_v2_generated_org_policy_get_custom_constraint_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-org-policy/samples/generated_samples/orgpolicy_v2_generated_org_policy_get_effective_policy_async.py
+++ b/packages/google-cloud-org-policy/samples/generated_samples/orgpolicy_v2_generated_org_policy_get_effective_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-org-policy/samples/generated_samples/orgpolicy_v2_generated_org_policy_get_effective_policy_sync.py
+++ b/packages/google-cloud-org-policy/samples/generated_samples/orgpolicy_v2_generated_org_policy_get_effective_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-org-policy/samples/generated_samples/orgpolicy_v2_generated_org_policy_get_policy_async.py
+++ b/packages/google-cloud-org-policy/samples/generated_samples/orgpolicy_v2_generated_org_policy_get_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-org-policy/samples/generated_samples/orgpolicy_v2_generated_org_policy_get_policy_sync.py
+++ b/packages/google-cloud-org-policy/samples/generated_samples/orgpolicy_v2_generated_org_policy_get_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-org-policy/samples/generated_samples/orgpolicy_v2_generated_org_policy_list_constraints_async.py
+++ b/packages/google-cloud-org-policy/samples/generated_samples/orgpolicy_v2_generated_org_policy_list_constraints_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-org-policy/samples/generated_samples/orgpolicy_v2_generated_org_policy_list_constraints_sync.py
+++ b/packages/google-cloud-org-policy/samples/generated_samples/orgpolicy_v2_generated_org_policy_list_constraints_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-org-policy/samples/generated_samples/orgpolicy_v2_generated_org_policy_list_custom_constraints_async.py
+++ b/packages/google-cloud-org-policy/samples/generated_samples/orgpolicy_v2_generated_org_policy_list_custom_constraints_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-org-policy/samples/generated_samples/orgpolicy_v2_generated_org_policy_list_custom_constraints_sync.py
+++ b/packages/google-cloud-org-policy/samples/generated_samples/orgpolicy_v2_generated_org_policy_list_custom_constraints_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-org-policy/samples/generated_samples/orgpolicy_v2_generated_org_policy_list_policies_async.py
+++ b/packages/google-cloud-org-policy/samples/generated_samples/orgpolicy_v2_generated_org_policy_list_policies_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-org-policy/samples/generated_samples/orgpolicy_v2_generated_org_policy_list_policies_sync.py
+++ b/packages/google-cloud-org-policy/samples/generated_samples/orgpolicy_v2_generated_org_policy_list_policies_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-org-policy/samples/generated_samples/orgpolicy_v2_generated_org_policy_update_custom_constraint_async.py
+++ b/packages/google-cloud-org-policy/samples/generated_samples/orgpolicy_v2_generated_org_policy_update_custom_constraint_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-org-policy/samples/generated_samples/orgpolicy_v2_generated_org_policy_update_custom_constraint_sync.py
+++ b/packages/google-cloud-org-policy/samples/generated_samples/orgpolicy_v2_generated_org_policy_update_custom_constraint_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-org-policy/samples/generated_samples/orgpolicy_v2_generated_org_policy_update_policy_async.py
+++ b/packages/google-cloud-org-policy/samples/generated_samples/orgpolicy_v2_generated_org_policy_update_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-org-policy/samples/generated_samples/orgpolicy_v2_generated_org_policy_update_policy_sync.py
+++ b/packages/google-cloud-org-policy/samples/generated_samples/orgpolicy_v2_generated_org_policy_update_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-org-policy/tests/__init__.py
+++ b/packages/google-cloud-org-policy/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-org-policy/tests/unit/__init__.py
+++ b/packages/google-cloud-org-policy/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-org-policy/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-org-policy/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-org-policy/tests/unit/gapic/orgpolicy_v2/__init__.py
+++ b/packages/google-cloud-org-policy/tests/unit/gapic/orgpolicy_v2/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/.flake8
+++ b/packages/google-cloud-os-config/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/MANIFEST.in
+++ b/packages/google-cloud-os-config/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/google/cloud/osconfig/__init__.py
+++ b/packages/google-cloud-os-config/google/cloud/osconfig/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/google/cloud/osconfig/gapic_version.py
+++ b/packages/google-cloud-os-config/google/cloud/osconfig/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/google/cloud/osconfig_v1/gapic_version.py
+++ b/packages/google-cloud-os-config/google/cloud/osconfig_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/google/cloud/osconfig_v1/services/__init__.py
+++ b/packages/google-cloud-os-config/google/cloud/osconfig_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/google/cloud/osconfig_v1/services/os_config_service/__init__.py
+++ b/packages/google-cloud-os-config/google/cloud/osconfig_v1/services/os_config_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/google/cloud/osconfig_v1/services/os_config_service/async_client.py
+++ b/packages/google-cloud-os-config/google/cloud/osconfig_v1/services/os_config_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/google/cloud/osconfig_v1/services/os_config_service/client.py
+++ b/packages/google-cloud-os-config/google/cloud/osconfig_v1/services/os_config_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/google/cloud/osconfig_v1/services/os_config_service/pagers.py
+++ b/packages/google-cloud-os-config/google/cloud/osconfig_v1/services/os_config_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/google/cloud/osconfig_v1/services/os_config_service/transports/__init__.py
+++ b/packages/google-cloud-os-config/google/cloud/osconfig_v1/services/os_config_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/google/cloud/osconfig_v1/services/os_config_service/transports/base.py
+++ b/packages/google-cloud-os-config/google/cloud/osconfig_v1/services/os_config_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/google/cloud/osconfig_v1/services/os_config_service/transports/grpc.py
+++ b/packages/google-cloud-os-config/google/cloud/osconfig_v1/services/os_config_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/google/cloud/osconfig_v1/services/os_config_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-os-config/google/cloud/osconfig_v1/services/os_config_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/google/cloud/osconfig_v1/services/os_config_service/transports/rest.py
+++ b/packages/google-cloud-os-config/google/cloud/osconfig_v1/services/os_config_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/google/cloud/osconfig_v1/services/os_config_service/transports/rest_base.py
+++ b/packages/google-cloud-os-config/google/cloud/osconfig_v1/services/os_config_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/google/cloud/osconfig_v1/services/os_config_zonal_service/__init__.py
+++ b/packages/google-cloud-os-config/google/cloud/osconfig_v1/services/os_config_zonal_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/google/cloud/osconfig_v1/services/os_config_zonal_service/client.py
+++ b/packages/google-cloud-os-config/google/cloud/osconfig_v1/services/os_config_zonal_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/google/cloud/osconfig_v1/services/os_config_zonal_service/pagers.py
+++ b/packages/google-cloud-os-config/google/cloud/osconfig_v1/services/os_config_zonal_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/google/cloud/osconfig_v1/services/os_config_zonal_service/transports/__init__.py
+++ b/packages/google-cloud-os-config/google/cloud/osconfig_v1/services/os_config_zonal_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/google/cloud/osconfig_v1/services/os_config_zonal_service/transports/base.py
+++ b/packages/google-cloud-os-config/google/cloud/osconfig_v1/services/os_config_zonal_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/google/cloud/osconfig_v1/services/os_config_zonal_service/transports/grpc.py
+++ b/packages/google-cloud-os-config/google/cloud/osconfig_v1/services/os_config_zonal_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/google/cloud/osconfig_v1/services/os_config_zonal_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-os-config/google/cloud/osconfig_v1/services/os_config_zonal_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/google/cloud/osconfig_v1/services/os_config_zonal_service/transports/rest.py
+++ b/packages/google-cloud-os-config/google/cloud/osconfig_v1/services/os_config_zonal_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/google/cloud/osconfig_v1/services/os_config_zonal_service/transports/rest_base.py
+++ b/packages/google-cloud-os-config/google/cloud/osconfig_v1/services/os_config_zonal_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/google/cloud/osconfig_v1/types/__init__.py
+++ b/packages/google-cloud-os-config/google/cloud/osconfig_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/google/cloud/osconfig_v1/types/inventory.py
+++ b/packages/google-cloud-os-config/google/cloud/osconfig_v1/types/inventory.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/google/cloud/osconfig_v1/types/os_policy.py
+++ b/packages/google-cloud-os-config/google/cloud/osconfig_v1/types/os_policy.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/google/cloud/osconfig_v1/types/os_policy_assignment_reports.py
+++ b/packages/google-cloud-os-config/google/cloud/osconfig_v1/types/os_policy_assignment_reports.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/google/cloud/osconfig_v1/types/os_policy_assignments.py
+++ b/packages/google-cloud-os-config/google/cloud/osconfig_v1/types/os_policy_assignments.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/google/cloud/osconfig_v1/types/osconfig_common.py
+++ b/packages/google-cloud-os-config/google/cloud/osconfig_v1/types/osconfig_common.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/google/cloud/osconfig_v1/types/osconfig_service.py
+++ b/packages/google-cloud-os-config/google/cloud/osconfig_v1/types/osconfig_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/google/cloud/osconfig_v1/types/osconfig_zonal_service.py
+++ b/packages/google-cloud-os-config/google/cloud/osconfig_v1/types/osconfig_zonal_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/google/cloud/osconfig_v1/types/patch_deployments.py
+++ b/packages/google-cloud-os-config/google/cloud/osconfig_v1/types/patch_deployments.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/google/cloud/osconfig_v1/types/patch_jobs.py
+++ b/packages/google-cloud-os-config/google/cloud/osconfig_v1/types/patch_jobs.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/google/cloud/osconfig_v1/types/vulnerability.py
+++ b/packages/google-cloud-os-config/google/cloud/osconfig_v1/types/vulnerability.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/google/cloud/osconfig_v1alpha/gapic_version.py
+++ b/packages/google-cloud-os-config/google/cloud/osconfig_v1alpha/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/google/cloud/osconfig_v1alpha/services/__init__.py
+++ b/packages/google-cloud-os-config/google/cloud/osconfig_v1alpha/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/google/cloud/osconfig_v1alpha/services/os_config_zonal_service/__init__.py
+++ b/packages/google-cloud-os-config/google/cloud/osconfig_v1alpha/services/os_config_zonal_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/google/cloud/osconfig_v1alpha/services/os_config_zonal_service/client.py
+++ b/packages/google-cloud-os-config/google/cloud/osconfig_v1alpha/services/os_config_zonal_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/google/cloud/osconfig_v1alpha/services/os_config_zonal_service/pagers.py
+++ b/packages/google-cloud-os-config/google/cloud/osconfig_v1alpha/services/os_config_zonal_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/google/cloud/osconfig_v1alpha/services/os_config_zonal_service/transports/__init__.py
+++ b/packages/google-cloud-os-config/google/cloud/osconfig_v1alpha/services/os_config_zonal_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/google/cloud/osconfig_v1alpha/services/os_config_zonal_service/transports/base.py
+++ b/packages/google-cloud-os-config/google/cloud/osconfig_v1alpha/services/os_config_zonal_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/google/cloud/osconfig_v1alpha/services/os_config_zonal_service/transports/grpc.py
+++ b/packages/google-cloud-os-config/google/cloud/osconfig_v1alpha/services/os_config_zonal_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/google/cloud/osconfig_v1alpha/services/os_config_zonal_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-os-config/google/cloud/osconfig_v1alpha/services/os_config_zonal_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/google/cloud/osconfig_v1alpha/services/os_config_zonal_service/transports/rest.py
+++ b/packages/google-cloud-os-config/google/cloud/osconfig_v1alpha/services/os_config_zonal_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/google/cloud/osconfig_v1alpha/services/os_config_zonal_service/transports/rest_base.py
+++ b/packages/google-cloud-os-config/google/cloud/osconfig_v1alpha/services/os_config_zonal_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/google/cloud/osconfig_v1alpha/types/__init__.py
+++ b/packages/google-cloud-os-config/google/cloud/osconfig_v1alpha/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/google/cloud/osconfig_v1alpha/types/config_common.py
+++ b/packages/google-cloud-os-config/google/cloud/osconfig_v1alpha/types/config_common.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/google/cloud/osconfig_v1alpha/types/instance_os_policies_compliance.py
+++ b/packages/google-cloud-os-config/google/cloud/osconfig_v1alpha/types/instance_os_policies_compliance.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/google/cloud/osconfig_v1alpha/types/inventory.py
+++ b/packages/google-cloud-os-config/google/cloud/osconfig_v1alpha/types/inventory.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/google/cloud/osconfig_v1alpha/types/os_policy.py
+++ b/packages/google-cloud-os-config/google/cloud/osconfig_v1alpha/types/os_policy.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/google/cloud/osconfig_v1alpha/types/os_policy_assignment_reports.py
+++ b/packages/google-cloud-os-config/google/cloud/osconfig_v1alpha/types/os_policy_assignment_reports.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/google/cloud/osconfig_v1alpha/types/os_policy_assignments.py
+++ b/packages/google-cloud-os-config/google/cloud/osconfig_v1alpha/types/os_policy_assignments.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/google/cloud/osconfig_v1alpha/types/osconfig_common.py
+++ b/packages/google-cloud-os-config/google/cloud/osconfig_v1alpha/types/osconfig_common.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/google/cloud/osconfig_v1alpha/types/osconfig_zonal_service.py
+++ b/packages/google-cloud-os-config/google/cloud/osconfig_v1alpha/types/osconfig_zonal_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/google/cloud/osconfig_v1alpha/types/vulnerability.py
+++ b/packages/google-cloud-os-config/google/cloud/osconfig_v1alpha/types/vulnerability.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1_generated_os_config_service_cancel_patch_job_async.py
+++ b/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1_generated_os_config_service_cancel_patch_job_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1_generated_os_config_service_cancel_patch_job_sync.py
+++ b/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1_generated_os_config_service_cancel_patch_job_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1_generated_os_config_service_create_patch_deployment_async.py
+++ b/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1_generated_os_config_service_create_patch_deployment_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1_generated_os_config_service_create_patch_deployment_sync.py
+++ b/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1_generated_os_config_service_create_patch_deployment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1_generated_os_config_service_delete_patch_deployment_async.py
+++ b/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1_generated_os_config_service_delete_patch_deployment_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1_generated_os_config_service_delete_patch_deployment_sync.py
+++ b/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1_generated_os_config_service_delete_patch_deployment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1_generated_os_config_service_execute_patch_job_async.py
+++ b/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1_generated_os_config_service_execute_patch_job_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1_generated_os_config_service_execute_patch_job_sync.py
+++ b/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1_generated_os_config_service_execute_patch_job_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1_generated_os_config_service_get_patch_deployment_async.py
+++ b/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1_generated_os_config_service_get_patch_deployment_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1_generated_os_config_service_get_patch_deployment_sync.py
+++ b/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1_generated_os_config_service_get_patch_deployment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1_generated_os_config_service_get_patch_job_async.py
+++ b/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1_generated_os_config_service_get_patch_job_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1_generated_os_config_service_get_patch_job_sync.py
+++ b/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1_generated_os_config_service_get_patch_job_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1_generated_os_config_service_list_patch_deployments_async.py
+++ b/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1_generated_os_config_service_list_patch_deployments_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1_generated_os_config_service_list_patch_deployments_sync.py
+++ b/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1_generated_os_config_service_list_patch_deployments_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1_generated_os_config_service_list_patch_job_instance_details_async.py
+++ b/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1_generated_os_config_service_list_patch_job_instance_details_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1_generated_os_config_service_list_patch_job_instance_details_sync.py
+++ b/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1_generated_os_config_service_list_patch_job_instance_details_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1_generated_os_config_service_list_patch_jobs_async.py
+++ b/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1_generated_os_config_service_list_patch_jobs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1_generated_os_config_service_list_patch_jobs_sync.py
+++ b/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1_generated_os_config_service_list_patch_jobs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1_generated_os_config_service_pause_patch_deployment_async.py
+++ b/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1_generated_os_config_service_pause_patch_deployment_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1_generated_os_config_service_pause_patch_deployment_sync.py
+++ b/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1_generated_os_config_service_pause_patch_deployment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1_generated_os_config_service_resume_patch_deployment_async.py
+++ b/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1_generated_os_config_service_resume_patch_deployment_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1_generated_os_config_service_resume_patch_deployment_sync.py
+++ b/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1_generated_os_config_service_resume_patch_deployment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1_generated_os_config_service_update_patch_deployment_async.py
+++ b/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1_generated_os_config_service_update_patch_deployment_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1_generated_os_config_service_update_patch_deployment_sync.py
+++ b/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1_generated_os_config_service_update_patch_deployment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1_generated_os_config_zonal_service_create_os_policy_assignment_sync.py
+++ b/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1_generated_os_config_zonal_service_create_os_policy_assignment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1_generated_os_config_zonal_service_delete_os_policy_assignment_sync.py
+++ b/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1_generated_os_config_zonal_service_delete_os_policy_assignment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1_generated_os_config_zonal_service_get_inventory_async.py
+++ b/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1_generated_os_config_zonal_service_get_inventory_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1_generated_os_config_zonal_service_get_inventory_sync.py
+++ b/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1_generated_os_config_zonal_service_get_inventory_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1_generated_os_config_zonal_service_get_os_policy_assignment_async.py
+++ b/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1_generated_os_config_zonal_service_get_os_policy_assignment_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1_generated_os_config_zonal_service_get_os_policy_assignment_report_async.py
+++ b/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1_generated_os_config_zonal_service_get_os_policy_assignment_report_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1_generated_os_config_zonal_service_get_os_policy_assignment_report_sync.py
+++ b/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1_generated_os_config_zonal_service_get_os_policy_assignment_report_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1_generated_os_config_zonal_service_get_os_policy_assignment_sync.py
+++ b/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1_generated_os_config_zonal_service_get_os_policy_assignment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1_generated_os_config_zonal_service_get_vulnerability_report_async.py
+++ b/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1_generated_os_config_zonal_service_get_vulnerability_report_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1_generated_os_config_zonal_service_get_vulnerability_report_sync.py
+++ b/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1_generated_os_config_zonal_service_get_vulnerability_report_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1_generated_os_config_zonal_service_list_inventories_async.py
+++ b/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1_generated_os_config_zonal_service_list_inventories_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1_generated_os_config_zonal_service_list_inventories_sync.py
+++ b/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1_generated_os_config_zonal_service_list_inventories_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1_generated_os_config_zonal_service_list_os_policy_assignment_reports_async.py
+++ b/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1_generated_os_config_zonal_service_list_os_policy_assignment_reports_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1_generated_os_config_zonal_service_list_os_policy_assignment_reports_sync.py
+++ b/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1_generated_os_config_zonal_service_list_os_policy_assignment_reports_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1_generated_os_config_zonal_service_list_os_policy_assignment_revisions_async.py
+++ b/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1_generated_os_config_zonal_service_list_os_policy_assignment_revisions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1_generated_os_config_zonal_service_list_os_policy_assignment_revisions_sync.py
+++ b/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1_generated_os_config_zonal_service_list_os_policy_assignment_revisions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1_generated_os_config_zonal_service_list_os_policy_assignments_async.py
+++ b/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1_generated_os_config_zonal_service_list_os_policy_assignments_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1_generated_os_config_zonal_service_list_os_policy_assignments_sync.py
+++ b/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1_generated_os_config_zonal_service_list_os_policy_assignments_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1_generated_os_config_zonal_service_list_vulnerability_reports_async.py
+++ b/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1_generated_os_config_zonal_service_list_vulnerability_reports_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1_generated_os_config_zonal_service_list_vulnerability_reports_sync.py
+++ b/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1_generated_os_config_zonal_service_list_vulnerability_reports_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1_generated_os_config_zonal_service_update_os_policy_assignment_sync.py
+++ b/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1_generated_os_config_zonal_service_update_os_policy_assignment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1alpha_generated_os_config_zonal_service_create_os_policy_assignment_sync.py
+++ b/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1alpha_generated_os_config_zonal_service_create_os_policy_assignment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1alpha_generated_os_config_zonal_service_delete_os_policy_assignment_sync.py
+++ b/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1alpha_generated_os_config_zonal_service_delete_os_policy_assignment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1alpha_generated_os_config_zonal_service_get_instance_os_policies_compliance_async.py
+++ b/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1alpha_generated_os_config_zonal_service_get_instance_os_policies_compliance_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1alpha_generated_os_config_zonal_service_get_instance_os_policies_compliance_sync.py
+++ b/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1alpha_generated_os_config_zonal_service_get_instance_os_policies_compliance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1alpha_generated_os_config_zonal_service_get_inventory_async.py
+++ b/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1alpha_generated_os_config_zonal_service_get_inventory_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1alpha_generated_os_config_zonal_service_get_inventory_sync.py
+++ b/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1alpha_generated_os_config_zonal_service_get_inventory_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1alpha_generated_os_config_zonal_service_get_os_policy_assignment_async.py
+++ b/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1alpha_generated_os_config_zonal_service_get_os_policy_assignment_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1alpha_generated_os_config_zonal_service_get_os_policy_assignment_report_async.py
+++ b/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1alpha_generated_os_config_zonal_service_get_os_policy_assignment_report_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1alpha_generated_os_config_zonal_service_get_os_policy_assignment_report_sync.py
+++ b/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1alpha_generated_os_config_zonal_service_get_os_policy_assignment_report_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1alpha_generated_os_config_zonal_service_get_os_policy_assignment_sync.py
+++ b/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1alpha_generated_os_config_zonal_service_get_os_policy_assignment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1alpha_generated_os_config_zonal_service_get_vulnerability_report_async.py
+++ b/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1alpha_generated_os_config_zonal_service_get_vulnerability_report_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1alpha_generated_os_config_zonal_service_get_vulnerability_report_sync.py
+++ b/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1alpha_generated_os_config_zonal_service_get_vulnerability_report_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1alpha_generated_os_config_zonal_service_list_instance_os_policies_compliances_async.py
+++ b/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1alpha_generated_os_config_zonal_service_list_instance_os_policies_compliances_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1alpha_generated_os_config_zonal_service_list_instance_os_policies_compliances_sync.py
+++ b/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1alpha_generated_os_config_zonal_service_list_instance_os_policies_compliances_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1alpha_generated_os_config_zonal_service_list_inventories_async.py
+++ b/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1alpha_generated_os_config_zonal_service_list_inventories_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1alpha_generated_os_config_zonal_service_list_inventories_sync.py
+++ b/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1alpha_generated_os_config_zonal_service_list_inventories_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1alpha_generated_os_config_zonal_service_list_os_policy_assignment_reports_async.py
+++ b/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1alpha_generated_os_config_zonal_service_list_os_policy_assignment_reports_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1alpha_generated_os_config_zonal_service_list_os_policy_assignment_reports_sync.py
+++ b/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1alpha_generated_os_config_zonal_service_list_os_policy_assignment_reports_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1alpha_generated_os_config_zonal_service_list_os_policy_assignment_revisions_async.py
+++ b/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1alpha_generated_os_config_zonal_service_list_os_policy_assignment_revisions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1alpha_generated_os_config_zonal_service_list_os_policy_assignment_revisions_sync.py
+++ b/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1alpha_generated_os_config_zonal_service_list_os_policy_assignment_revisions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1alpha_generated_os_config_zonal_service_list_os_policy_assignments_async.py
+++ b/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1alpha_generated_os_config_zonal_service_list_os_policy_assignments_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1alpha_generated_os_config_zonal_service_list_os_policy_assignments_sync.py
+++ b/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1alpha_generated_os_config_zonal_service_list_os_policy_assignments_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1alpha_generated_os_config_zonal_service_list_vulnerability_reports_async.py
+++ b/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1alpha_generated_os_config_zonal_service_list_vulnerability_reports_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1alpha_generated_os_config_zonal_service_list_vulnerability_reports_sync.py
+++ b/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1alpha_generated_os_config_zonal_service_list_vulnerability_reports_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1alpha_generated_os_config_zonal_service_update_os_policy_assignment_sync.py
+++ b/packages/google-cloud-os-config/samples/generated_samples/osconfig_v1alpha_generated_os_config_zonal_service_update_os_policy_assignment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/tests/__init__.py
+++ b/packages/google-cloud-os-config/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/tests/unit/__init__.py
+++ b/packages/google-cloud-os-config/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-os-config/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/tests/unit/gapic/osconfig_v1/__init__.py
+++ b/packages/google-cloud-os-config/tests/unit/gapic/osconfig_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-config/tests/unit/gapic/osconfig_v1alpha/__init__.py
+++ b/packages/google-cloud-os-config/tests/unit/gapic/osconfig_v1alpha/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-login/.flake8
+++ b/packages/google-cloud-os-login/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-login/MANIFEST.in
+++ b/packages/google-cloud-os-login/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-login/google/cloud/oslogin/__init__.py
+++ b/packages/google-cloud-os-login/google/cloud/oslogin/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-login/google/cloud/oslogin/gapic_version.py
+++ b/packages/google-cloud-os-login/google/cloud/oslogin/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-login/google/cloud/oslogin_v1/gapic_version.py
+++ b/packages/google-cloud-os-login/google/cloud/oslogin_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-login/google/cloud/oslogin_v1/services/__init__.py
+++ b/packages/google-cloud-os-login/google/cloud/oslogin_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-login/google/cloud/oslogin_v1/services/os_login_service/__init__.py
+++ b/packages/google-cloud-os-login/google/cloud/oslogin_v1/services/os_login_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-login/google/cloud/oslogin_v1/services/os_login_service/async_client.py
+++ b/packages/google-cloud-os-login/google/cloud/oslogin_v1/services/os_login_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-login/google/cloud/oslogin_v1/services/os_login_service/client.py
+++ b/packages/google-cloud-os-login/google/cloud/oslogin_v1/services/os_login_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-login/google/cloud/oslogin_v1/services/os_login_service/transports/__init__.py
+++ b/packages/google-cloud-os-login/google/cloud/oslogin_v1/services/os_login_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-login/google/cloud/oslogin_v1/services/os_login_service/transports/base.py
+++ b/packages/google-cloud-os-login/google/cloud/oslogin_v1/services/os_login_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-login/google/cloud/oslogin_v1/services/os_login_service/transports/grpc.py
+++ b/packages/google-cloud-os-login/google/cloud/oslogin_v1/services/os_login_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-login/google/cloud/oslogin_v1/services/os_login_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-os-login/google/cloud/oslogin_v1/services/os_login_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-login/google/cloud/oslogin_v1/services/os_login_service/transports/rest.py
+++ b/packages/google-cloud-os-login/google/cloud/oslogin_v1/services/os_login_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-login/google/cloud/oslogin_v1/services/os_login_service/transports/rest_base.py
+++ b/packages/google-cloud-os-login/google/cloud/oslogin_v1/services/os_login_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-login/google/cloud/oslogin_v1/types/__init__.py
+++ b/packages/google-cloud-os-login/google/cloud/oslogin_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-login/google/cloud/oslogin_v1/types/oslogin.py
+++ b/packages/google-cloud-os-login/google/cloud/oslogin_v1/types/oslogin.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-login/samples/generated_samples/oslogin_v1_generated_os_login_service_create_ssh_public_key_async.py
+++ b/packages/google-cloud-os-login/samples/generated_samples/oslogin_v1_generated_os_login_service_create_ssh_public_key_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-login/samples/generated_samples/oslogin_v1_generated_os_login_service_create_ssh_public_key_sync.py
+++ b/packages/google-cloud-os-login/samples/generated_samples/oslogin_v1_generated_os_login_service_create_ssh_public_key_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-login/samples/generated_samples/oslogin_v1_generated_os_login_service_delete_posix_account_async.py
+++ b/packages/google-cloud-os-login/samples/generated_samples/oslogin_v1_generated_os_login_service_delete_posix_account_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-login/samples/generated_samples/oslogin_v1_generated_os_login_service_delete_posix_account_sync.py
+++ b/packages/google-cloud-os-login/samples/generated_samples/oslogin_v1_generated_os_login_service_delete_posix_account_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-login/samples/generated_samples/oslogin_v1_generated_os_login_service_delete_ssh_public_key_async.py
+++ b/packages/google-cloud-os-login/samples/generated_samples/oslogin_v1_generated_os_login_service_delete_ssh_public_key_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-login/samples/generated_samples/oslogin_v1_generated_os_login_service_delete_ssh_public_key_sync.py
+++ b/packages/google-cloud-os-login/samples/generated_samples/oslogin_v1_generated_os_login_service_delete_ssh_public_key_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-login/samples/generated_samples/oslogin_v1_generated_os_login_service_get_login_profile_async.py
+++ b/packages/google-cloud-os-login/samples/generated_samples/oslogin_v1_generated_os_login_service_get_login_profile_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-login/samples/generated_samples/oslogin_v1_generated_os_login_service_get_login_profile_sync.py
+++ b/packages/google-cloud-os-login/samples/generated_samples/oslogin_v1_generated_os_login_service_get_login_profile_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-login/samples/generated_samples/oslogin_v1_generated_os_login_service_get_ssh_public_key_async.py
+++ b/packages/google-cloud-os-login/samples/generated_samples/oslogin_v1_generated_os_login_service_get_ssh_public_key_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-login/samples/generated_samples/oslogin_v1_generated_os_login_service_get_ssh_public_key_sync.py
+++ b/packages/google-cloud-os-login/samples/generated_samples/oslogin_v1_generated_os_login_service_get_ssh_public_key_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-login/samples/generated_samples/oslogin_v1_generated_os_login_service_import_ssh_public_key_async.py
+++ b/packages/google-cloud-os-login/samples/generated_samples/oslogin_v1_generated_os_login_service_import_ssh_public_key_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-login/samples/generated_samples/oslogin_v1_generated_os_login_service_import_ssh_public_key_sync.py
+++ b/packages/google-cloud-os-login/samples/generated_samples/oslogin_v1_generated_os_login_service_import_ssh_public_key_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-login/samples/generated_samples/oslogin_v1_generated_os_login_service_update_ssh_public_key_async.py
+++ b/packages/google-cloud-os-login/samples/generated_samples/oslogin_v1_generated_os_login_service_update_ssh_public_key_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-login/samples/generated_samples/oslogin_v1_generated_os_login_service_update_ssh_public_key_sync.py
+++ b/packages/google-cloud-os-login/samples/generated_samples/oslogin_v1_generated_os_login_service_update_ssh_public_key_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-login/tests/__init__.py
+++ b/packages/google-cloud-os-login/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-login/tests/unit/__init__.py
+++ b/packages/google-cloud-os-login/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-login/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-os-login/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-os-login/tests/unit/gapic/oslogin_v1/__init__.py
+++ b/packages/google-cloud-os-login/tests/unit/gapic/oslogin_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-parallelstore/.flake8
+++ b/packages/google-cloud-parallelstore/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-parallelstore/MANIFEST.in
+++ b/packages/google-cloud-parallelstore/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-parallelstore/google/cloud/parallelstore/__init__.py
+++ b/packages/google-cloud-parallelstore/google/cloud/parallelstore/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-parallelstore/google/cloud/parallelstore/gapic_version.py
+++ b/packages/google-cloud-parallelstore/google/cloud/parallelstore/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-parallelstore/google/cloud/parallelstore_v1/gapic_version.py
+++ b/packages/google-cloud-parallelstore/google/cloud/parallelstore_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-parallelstore/google/cloud/parallelstore_v1/services/__init__.py
+++ b/packages/google-cloud-parallelstore/google/cloud/parallelstore_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-parallelstore/google/cloud/parallelstore_v1/services/parallelstore/__init__.py
+++ b/packages/google-cloud-parallelstore/google/cloud/parallelstore_v1/services/parallelstore/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-parallelstore/google/cloud/parallelstore_v1/services/parallelstore/client.py
+++ b/packages/google-cloud-parallelstore/google/cloud/parallelstore_v1/services/parallelstore/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-parallelstore/google/cloud/parallelstore_v1/services/parallelstore/pagers.py
+++ b/packages/google-cloud-parallelstore/google/cloud/parallelstore_v1/services/parallelstore/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-parallelstore/google/cloud/parallelstore_v1/services/parallelstore/transports/__init__.py
+++ b/packages/google-cloud-parallelstore/google/cloud/parallelstore_v1/services/parallelstore/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-parallelstore/google/cloud/parallelstore_v1/services/parallelstore/transports/base.py
+++ b/packages/google-cloud-parallelstore/google/cloud/parallelstore_v1/services/parallelstore/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-parallelstore/google/cloud/parallelstore_v1/services/parallelstore/transports/grpc.py
+++ b/packages/google-cloud-parallelstore/google/cloud/parallelstore_v1/services/parallelstore/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-parallelstore/google/cloud/parallelstore_v1/services/parallelstore/transports/grpc_asyncio.py
+++ b/packages/google-cloud-parallelstore/google/cloud/parallelstore_v1/services/parallelstore/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-parallelstore/google/cloud/parallelstore_v1/services/parallelstore/transports/rest.py
+++ b/packages/google-cloud-parallelstore/google/cloud/parallelstore_v1/services/parallelstore/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-parallelstore/google/cloud/parallelstore_v1/services/parallelstore/transports/rest_base.py
+++ b/packages/google-cloud-parallelstore/google/cloud/parallelstore_v1/services/parallelstore/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-parallelstore/google/cloud/parallelstore_v1/types/__init__.py
+++ b/packages/google-cloud-parallelstore/google/cloud/parallelstore_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-parallelstore/google/cloud/parallelstore_v1/types/parallelstore.py
+++ b/packages/google-cloud-parallelstore/google/cloud/parallelstore_v1/types/parallelstore.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-parallelstore/google/cloud/parallelstore_v1beta/gapic_version.py
+++ b/packages/google-cloud-parallelstore/google/cloud/parallelstore_v1beta/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-parallelstore/google/cloud/parallelstore_v1beta/services/__init__.py
+++ b/packages/google-cloud-parallelstore/google/cloud/parallelstore_v1beta/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-parallelstore/google/cloud/parallelstore_v1beta/services/parallelstore/__init__.py
+++ b/packages/google-cloud-parallelstore/google/cloud/parallelstore_v1beta/services/parallelstore/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-parallelstore/google/cloud/parallelstore_v1beta/services/parallelstore/client.py
+++ b/packages/google-cloud-parallelstore/google/cloud/parallelstore_v1beta/services/parallelstore/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-parallelstore/google/cloud/parallelstore_v1beta/services/parallelstore/pagers.py
+++ b/packages/google-cloud-parallelstore/google/cloud/parallelstore_v1beta/services/parallelstore/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-parallelstore/google/cloud/parallelstore_v1beta/services/parallelstore/transports/__init__.py
+++ b/packages/google-cloud-parallelstore/google/cloud/parallelstore_v1beta/services/parallelstore/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-parallelstore/google/cloud/parallelstore_v1beta/services/parallelstore/transports/base.py
+++ b/packages/google-cloud-parallelstore/google/cloud/parallelstore_v1beta/services/parallelstore/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-parallelstore/google/cloud/parallelstore_v1beta/services/parallelstore/transports/grpc.py
+++ b/packages/google-cloud-parallelstore/google/cloud/parallelstore_v1beta/services/parallelstore/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-parallelstore/google/cloud/parallelstore_v1beta/services/parallelstore/transports/grpc_asyncio.py
+++ b/packages/google-cloud-parallelstore/google/cloud/parallelstore_v1beta/services/parallelstore/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-parallelstore/google/cloud/parallelstore_v1beta/services/parallelstore/transports/rest.py
+++ b/packages/google-cloud-parallelstore/google/cloud/parallelstore_v1beta/services/parallelstore/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-parallelstore/google/cloud/parallelstore_v1beta/services/parallelstore/transports/rest_base.py
+++ b/packages/google-cloud-parallelstore/google/cloud/parallelstore_v1beta/services/parallelstore/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-parallelstore/google/cloud/parallelstore_v1beta/types/__init__.py
+++ b/packages/google-cloud-parallelstore/google/cloud/parallelstore_v1beta/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-parallelstore/google/cloud/parallelstore_v1beta/types/parallelstore.py
+++ b/packages/google-cloud-parallelstore/google/cloud/parallelstore_v1beta/types/parallelstore.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-parallelstore/samples/generated_samples/parallelstore_v1_generated_parallelstore_create_instance_sync.py
+++ b/packages/google-cloud-parallelstore/samples/generated_samples/parallelstore_v1_generated_parallelstore_create_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-parallelstore/samples/generated_samples/parallelstore_v1_generated_parallelstore_delete_instance_sync.py
+++ b/packages/google-cloud-parallelstore/samples/generated_samples/parallelstore_v1_generated_parallelstore_delete_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-parallelstore/samples/generated_samples/parallelstore_v1_generated_parallelstore_export_data_sync.py
+++ b/packages/google-cloud-parallelstore/samples/generated_samples/parallelstore_v1_generated_parallelstore_export_data_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-parallelstore/samples/generated_samples/parallelstore_v1_generated_parallelstore_get_instance_async.py
+++ b/packages/google-cloud-parallelstore/samples/generated_samples/parallelstore_v1_generated_parallelstore_get_instance_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-parallelstore/samples/generated_samples/parallelstore_v1_generated_parallelstore_get_instance_sync.py
+++ b/packages/google-cloud-parallelstore/samples/generated_samples/parallelstore_v1_generated_parallelstore_get_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-parallelstore/samples/generated_samples/parallelstore_v1_generated_parallelstore_import_data_sync.py
+++ b/packages/google-cloud-parallelstore/samples/generated_samples/parallelstore_v1_generated_parallelstore_import_data_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-parallelstore/samples/generated_samples/parallelstore_v1_generated_parallelstore_list_instances_async.py
+++ b/packages/google-cloud-parallelstore/samples/generated_samples/parallelstore_v1_generated_parallelstore_list_instances_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-parallelstore/samples/generated_samples/parallelstore_v1_generated_parallelstore_list_instances_sync.py
+++ b/packages/google-cloud-parallelstore/samples/generated_samples/parallelstore_v1_generated_parallelstore_list_instances_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-parallelstore/samples/generated_samples/parallelstore_v1_generated_parallelstore_update_instance_sync.py
+++ b/packages/google-cloud-parallelstore/samples/generated_samples/parallelstore_v1_generated_parallelstore_update_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-parallelstore/samples/generated_samples/parallelstore_v1beta_generated_parallelstore_create_instance_sync.py
+++ b/packages/google-cloud-parallelstore/samples/generated_samples/parallelstore_v1beta_generated_parallelstore_create_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-parallelstore/samples/generated_samples/parallelstore_v1beta_generated_parallelstore_delete_instance_sync.py
+++ b/packages/google-cloud-parallelstore/samples/generated_samples/parallelstore_v1beta_generated_parallelstore_delete_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-parallelstore/samples/generated_samples/parallelstore_v1beta_generated_parallelstore_export_data_sync.py
+++ b/packages/google-cloud-parallelstore/samples/generated_samples/parallelstore_v1beta_generated_parallelstore_export_data_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-parallelstore/samples/generated_samples/parallelstore_v1beta_generated_parallelstore_get_instance_async.py
+++ b/packages/google-cloud-parallelstore/samples/generated_samples/parallelstore_v1beta_generated_parallelstore_get_instance_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-parallelstore/samples/generated_samples/parallelstore_v1beta_generated_parallelstore_get_instance_sync.py
+++ b/packages/google-cloud-parallelstore/samples/generated_samples/parallelstore_v1beta_generated_parallelstore_get_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-parallelstore/samples/generated_samples/parallelstore_v1beta_generated_parallelstore_import_data_sync.py
+++ b/packages/google-cloud-parallelstore/samples/generated_samples/parallelstore_v1beta_generated_parallelstore_import_data_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-parallelstore/samples/generated_samples/parallelstore_v1beta_generated_parallelstore_list_instances_async.py
+++ b/packages/google-cloud-parallelstore/samples/generated_samples/parallelstore_v1beta_generated_parallelstore_list_instances_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-parallelstore/samples/generated_samples/parallelstore_v1beta_generated_parallelstore_list_instances_sync.py
+++ b/packages/google-cloud-parallelstore/samples/generated_samples/parallelstore_v1beta_generated_parallelstore_list_instances_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-parallelstore/samples/generated_samples/parallelstore_v1beta_generated_parallelstore_update_instance_sync.py
+++ b/packages/google-cloud-parallelstore/samples/generated_samples/parallelstore_v1beta_generated_parallelstore_update_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-parallelstore/tests/__init__.py
+++ b/packages/google-cloud-parallelstore/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-parallelstore/tests/unit/__init__.py
+++ b/packages/google-cloud-parallelstore/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-parallelstore/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-parallelstore/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-parallelstore/tests/unit/gapic/parallelstore_v1/__init__.py
+++ b/packages/google-cloud-parallelstore/tests/unit/gapic/parallelstore_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-parallelstore/tests/unit/gapic/parallelstore_v1beta/__init__.py
+++ b/packages/google-cloud-parallelstore/tests/unit/gapic/parallelstore_v1beta/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-parametermanager/.flake8
+++ b/packages/google-cloud-parametermanager/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-parametermanager/MANIFEST.in
+++ b/packages/google-cloud-parametermanager/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-parametermanager/google/cloud/parametermanager/__init__.py
+++ b/packages/google-cloud-parametermanager/google/cloud/parametermanager/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-parametermanager/google/cloud/parametermanager/gapic_version.py
+++ b/packages/google-cloud-parametermanager/google/cloud/parametermanager/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-parametermanager/google/cloud/parametermanager_v1/gapic_version.py
+++ b/packages/google-cloud-parametermanager/google/cloud/parametermanager_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-parametermanager/google/cloud/parametermanager_v1/services/__init__.py
+++ b/packages/google-cloud-parametermanager/google/cloud/parametermanager_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-parametermanager/google/cloud/parametermanager_v1/services/parameter_manager/__init__.py
+++ b/packages/google-cloud-parametermanager/google/cloud/parametermanager_v1/services/parameter_manager/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-parametermanager/google/cloud/parametermanager_v1/services/parameter_manager/async_client.py
+++ b/packages/google-cloud-parametermanager/google/cloud/parametermanager_v1/services/parameter_manager/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-parametermanager/google/cloud/parametermanager_v1/services/parameter_manager/client.py
+++ b/packages/google-cloud-parametermanager/google/cloud/parametermanager_v1/services/parameter_manager/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-parametermanager/google/cloud/parametermanager_v1/services/parameter_manager/pagers.py
+++ b/packages/google-cloud-parametermanager/google/cloud/parametermanager_v1/services/parameter_manager/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-parametermanager/google/cloud/parametermanager_v1/services/parameter_manager/transports/__init__.py
+++ b/packages/google-cloud-parametermanager/google/cloud/parametermanager_v1/services/parameter_manager/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-parametermanager/google/cloud/parametermanager_v1/services/parameter_manager/transports/base.py
+++ b/packages/google-cloud-parametermanager/google/cloud/parametermanager_v1/services/parameter_manager/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-parametermanager/google/cloud/parametermanager_v1/services/parameter_manager/transports/grpc.py
+++ b/packages/google-cloud-parametermanager/google/cloud/parametermanager_v1/services/parameter_manager/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-parametermanager/google/cloud/parametermanager_v1/services/parameter_manager/transports/grpc_asyncio.py
+++ b/packages/google-cloud-parametermanager/google/cloud/parametermanager_v1/services/parameter_manager/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-parametermanager/google/cloud/parametermanager_v1/services/parameter_manager/transports/rest.py
+++ b/packages/google-cloud-parametermanager/google/cloud/parametermanager_v1/services/parameter_manager/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-parametermanager/google/cloud/parametermanager_v1/services/parameter_manager/transports/rest_base.py
+++ b/packages/google-cloud-parametermanager/google/cloud/parametermanager_v1/services/parameter_manager/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-parametermanager/google/cloud/parametermanager_v1/types/__init__.py
+++ b/packages/google-cloud-parametermanager/google/cloud/parametermanager_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-parametermanager/google/cloud/parametermanager_v1/types/service.py
+++ b/packages/google-cloud-parametermanager/google/cloud/parametermanager_v1/types/service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-parametermanager/samples/generated_samples/parametermanager_v1_generated_parameter_manager_create_parameter_async.py
+++ b/packages/google-cloud-parametermanager/samples/generated_samples/parametermanager_v1_generated_parameter_manager_create_parameter_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-parametermanager/samples/generated_samples/parametermanager_v1_generated_parameter_manager_create_parameter_sync.py
+++ b/packages/google-cloud-parametermanager/samples/generated_samples/parametermanager_v1_generated_parameter_manager_create_parameter_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-parametermanager/samples/generated_samples/parametermanager_v1_generated_parameter_manager_create_parameter_version_async.py
+++ b/packages/google-cloud-parametermanager/samples/generated_samples/parametermanager_v1_generated_parameter_manager_create_parameter_version_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-parametermanager/samples/generated_samples/parametermanager_v1_generated_parameter_manager_create_parameter_version_sync.py
+++ b/packages/google-cloud-parametermanager/samples/generated_samples/parametermanager_v1_generated_parameter_manager_create_parameter_version_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-parametermanager/samples/generated_samples/parametermanager_v1_generated_parameter_manager_delete_parameter_async.py
+++ b/packages/google-cloud-parametermanager/samples/generated_samples/parametermanager_v1_generated_parameter_manager_delete_parameter_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-parametermanager/samples/generated_samples/parametermanager_v1_generated_parameter_manager_delete_parameter_sync.py
+++ b/packages/google-cloud-parametermanager/samples/generated_samples/parametermanager_v1_generated_parameter_manager_delete_parameter_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-parametermanager/samples/generated_samples/parametermanager_v1_generated_parameter_manager_delete_parameter_version_async.py
+++ b/packages/google-cloud-parametermanager/samples/generated_samples/parametermanager_v1_generated_parameter_manager_delete_parameter_version_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-parametermanager/samples/generated_samples/parametermanager_v1_generated_parameter_manager_delete_parameter_version_sync.py
+++ b/packages/google-cloud-parametermanager/samples/generated_samples/parametermanager_v1_generated_parameter_manager_delete_parameter_version_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-parametermanager/samples/generated_samples/parametermanager_v1_generated_parameter_manager_get_parameter_async.py
+++ b/packages/google-cloud-parametermanager/samples/generated_samples/parametermanager_v1_generated_parameter_manager_get_parameter_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-parametermanager/samples/generated_samples/parametermanager_v1_generated_parameter_manager_get_parameter_sync.py
+++ b/packages/google-cloud-parametermanager/samples/generated_samples/parametermanager_v1_generated_parameter_manager_get_parameter_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-parametermanager/samples/generated_samples/parametermanager_v1_generated_parameter_manager_get_parameter_version_async.py
+++ b/packages/google-cloud-parametermanager/samples/generated_samples/parametermanager_v1_generated_parameter_manager_get_parameter_version_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-parametermanager/samples/generated_samples/parametermanager_v1_generated_parameter_manager_get_parameter_version_sync.py
+++ b/packages/google-cloud-parametermanager/samples/generated_samples/parametermanager_v1_generated_parameter_manager_get_parameter_version_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-parametermanager/samples/generated_samples/parametermanager_v1_generated_parameter_manager_list_parameter_versions_async.py
+++ b/packages/google-cloud-parametermanager/samples/generated_samples/parametermanager_v1_generated_parameter_manager_list_parameter_versions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-parametermanager/samples/generated_samples/parametermanager_v1_generated_parameter_manager_list_parameter_versions_sync.py
+++ b/packages/google-cloud-parametermanager/samples/generated_samples/parametermanager_v1_generated_parameter_manager_list_parameter_versions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-parametermanager/samples/generated_samples/parametermanager_v1_generated_parameter_manager_list_parameters_async.py
+++ b/packages/google-cloud-parametermanager/samples/generated_samples/parametermanager_v1_generated_parameter_manager_list_parameters_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-parametermanager/samples/generated_samples/parametermanager_v1_generated_parameter_manager_list_parameters_sync.py
+++ b/packages/google-cloud-parametermanager/samples/generated_samples/parametermanager_v1_generated_parameter_manager_list_parameters_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-parametermanager/samples/generated_samples/parametermanager_v1_generated_parameter_manager_render_parameter_version_async.py
+++ b/packages/google-cloud-parametermanager/samples/generated_samples/parametermanager_v1_generated_parameter_manager_render_parameter_version_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-parametermanager/samples/generated_samples/parametermanager_v1_generated_parameter_manager_render_parameter_version_sync.py
+++ b/packages/google-cloud-parametermanager/samples/generated_samples/parametermanager_v1_generated_parameter_manager_render_parameter_version_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-parametermanager/samples/generated_samples/parametermanager_v1_generated_parameter_manager_update_parameter_async.py
+++ b/packages/google-cloud-parametermanager/samples/generated_samples/parametermanager_v1_generated_parameter_manager_update_parameter_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-parametermanager/samples/generated_samples/parametermanager_v1_generated_parameter_manager_update_parameter_sync.py
+++ b/packages/google-cloud-parametermanager/samples/generated_samples/parametermanager_v1_generated_parameter_manager_update_parameter_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-parametermanager/samples/generated_samples/parametermanager_v1_generated_parameter_manager_update_parameter_version_async.py
+++ b/packages/google-cloud-parametermanager/samples/generated_samples/parametermanager_v1_generated_parameter_manager_update_parameter_version_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-parametermanager/samples/generated_samples/parametermanager_v1_generated_parameter_manager_update_parameter_version_sync.py
+++ b/packages/google-cloud-parametermanager/samples/generated_samples/parametermanager_v1_generated_parameter_manager_update_parameter_version_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-parametermanager/tests/__init__.py
+++ b/packages/google-cloud-parametermanager/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-parametermanager/tests/unit/__init__.py
+++ b/packages/google-cloud-parametermanager/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-parametermanager/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-parametermanager/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-parametermanager/tests/unit/gapic/parametermanager_v1/__init__.py
+++ b/packages/google-cloud-parametermanager/tests/unit/gapic/parametermanager_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-phishing-protection/.flake8
+++ b/packages/google-cloud-phishing-protection/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-phishing-protection/MANIFEST.in
+++ b/packages/google-cloud-phishing-protection/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-phishing-protection/google/cloud/phishingprotection/__init__.py
+++ b/packages/google-cloud-phishing-protection/google/cloud/phishingprotection/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-phishing-protection/google/cloud/phishingprotection/gapic_version.py
+++ b/packages/google-cloud-phishing-protection/google/cloud/phishingprotection/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-phishing-protection/google/cloud/phishingprotection_v1beta1/gapic_version.py
+++ b/packages/google-cloud-phishing-protection/google/cloud/phishingprotection_v1beta1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-phishing-protection/google/cloud/phishingprotection_v1beta1/services/__init__.py
+++ b/packages/google-cloud-phishing-protection/google/cloud/phishingprotection_v1beta1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-phishing-protection/google/cloud/phishingprotection_v1beta1/services/phishing_protection_service_v1_beta1/__init__.py
+++ b/packages/google-cloud-phishing-protection/google/cloud/phishingprotection_v1beta1/services/phishing_protection_service_v1_beta1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-phishing-protection/google/cloud/phishingprotection_v1beta1/services/phishing_protection_service_v1_beta1/async_client.py
+++ b/packages/google-cloud-phishing-protection/google/cloud/phishingprotection_v1beta1/services/phishing_protection_service_v1_beta1/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-phishing-protection/google/cloud/phishingprotection_v1beta1/services/phishing_protection_service_v1_beta1/client.py
+++ b/packages/google-cloud-phishing-protection/google/cloud/phishingprotection_v1beta1/services/phishing_protection_service_v1_beta1/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-phishing-protection/google/cloud/phishingprotection_v1beta1/services/phishing_protection_service_v1_beta1/transports/__init__.py
+++ b/packages/google-cloud-phishing-protection/google/cloud/phishingprotection_v1beta1/services/phishing_protection_service_v1_beta1/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-phishing-protection/google/cloud/phishingprotection_v1beta1/services/phishing_protection_service_v1_beta1/transports/base.py
+++ b/packages/google-cloud-phishing-protection/google/cloud/phishingprotection_v1beta1/services/phishing_protection_service_v1_beta1/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-phishing-protection/google/cloud/phishingprotection_v1beta1/services/phishing_protection_service_v1_beta1/transports/grpc.py
+++ b/packages/google-cloud-phishing-protection/google/cloud/phishingprotection_v1beta1/services/phishing_protection_service_v1_beta1/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-phishing-protection/google/cloud/phishingprotection_v1beta1/services/phishing_protection_service_v1_beta1/transports/grpc_asyncio.py
+++ b/packages/google-cloud-phishing-protection/google/cloud/phishingprotection_v1beta1/services/phishing_protection_service_v1_beta1/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-phishing-protection/google/cloud/phishingprotection_v1beta1/services/phishing_protection_service_v1_beta1/transports/rest.py
+++ b/packages/google-cloud-phishing-protection/google/cloud/phishingprotection_v1beta1/services/phishing_protection_service_v1_beta1/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-phishing-protection/google/cloud/phishingprotection_v1beta1/services/phishing_protection_service_v1_beta1/transports/rest_base.py
+++ b/packages/google-cloud-phishing-protection/google/cloud/phishingprotection_v1beta1/services/phishing_protection_service_v1_beta1/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-phishing-protection/google/cloud/phishingprotection_v1beta1/types/__init__.py
+++ b/packages/google-cloud-phishing-protection/google/cloud/phishingprotection_v1beta1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-phishing-protection/google/cloud/phishingprotection_v1beta1/types/phishingprotection.py
+++ b/packages/google-cloud-phishing-protection/google/cloud/phishingprotection_v1beta1/types/phishingprotection.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-phishing-protection/samples/generated_samples/phishingprotection_v1beta1_generated_phishing_protection_service_v1_beta1_report_phishing_async.py
+++ b/packages/google-cloud-phishing-protection/samples/generated_samples/phishingprotection_v1beta1_generated_phishing_protection_service_v1_beta1_report_phishing_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-phishing-protection/samples/generated_samples/phishingprotection_v1beta1_generated_phishing_protection_service_v1_beta1_report_phishing_sync.py
+++ b/packages/google-cloud-phishing-protection/samples/generated_samples/phishingprotection_v1beta1_generated_phishing_protection_service_v1_beta1_report_phishing_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-phishing-protection/tests/__init__.py
+++ b/packages/google-cloud-phishing-protection/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-phishing-protection/tests/unit/__init__.py
+++ b/packages/google-cloud-phishing-protection/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-phishing-protection/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-phishing-protection/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-phishing-protection/tests/unit/gapic/phishingprotection_v1beta1/__init__.py
+++ b/packages/google-cloud-phishing-protection/tests/unit/gapic/phishingprotection_v1beta1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-policy-troubleshooter/.flake8
+++ b/packages/google-cloud-policy-troubleshooter/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-policy-troubleshooter/MANIFEST.in
+++ b/packages/google-cloud-policy-troubleshooter/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-policy-troubleshooter/google/cloud/policytroubleshooter/__init__.py
+++ b/packages/google-cloud-policy-troubleshooter/google/cloud/policytroubleshooter/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-policy-troubleshooter/google/cloud/policytroubleshooter/gapic_version.py
+++ b/packages/google-cloud-policy-troubleshooter/google/cloud/policytroubleshooter/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-policy-troubleshooter/google/cloud/policytroubleshooter_v1/gapic_version.py
+++ b/packages/google-cloud-policy-troubleshooter/google/cloud/policytroubleshooter_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-policy-troubleshooter/google/cloud/policytroubleshooter_v1/services/__init__.py
+++ b/packages/google-cloud-policy-troubleshooter/google/cloud/policytroubleshooter_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-policy-troubleshooter/google/cloud/policytroubleshooter_v1/services/iam_checker/__init__.py
+++ b/packages/google-cloud-policy-troubleshooter/google/cloud/policytroubleshooter_v1/services/iam_checker/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-policy-troubleshooter/google/cloud/policytroubleshooter_v1/services/iam_checker/async_client.py
+++ b/packages/google-cloud-policy-troubleshooter/google/cloud/policytroubleshooter_v1/services/iam_checker/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-policy-troubleshooter/google/cloud/policytroubleshooter_v1/services/iam_checker/client.py
+++ b/packages/google-cloud-policy-troubleshooter/google/cloud/policytroubleshooter_v1/services/iam_checker/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-policy-troubleshooter/google/cloud/policytroubleshooter_v1/services/iam_checker/transports/__init__.py
+++ b/packages/google-cloud-policy-troubleshooter/google/cloud/policytroubleshooter_v1/services/iam_checker/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-policy-troubleshooter/google/cloud/policytroubleshooter_v1/services/iam_checker/transports/base.py
+++ b/packages/google-cloud-policy-troubleshooter/google/cloud/policytroubleshooter_v1/services/iam_checker/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-policy-troubleshooter/google/cloud/policytroubleshooter_v1/services/iam_checker/transports/grpc.py
+++ b/packages/google-cloud-policy-troubleshooter/google/cloud/policytroubleshooter_v1/services/iam_checker/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-policy-troubleshooter/google/cloud/policytroubleshooter_v1/services/iam_checker/transports/grpc_asyncio.py
+++ b/packages/google-cloud-policy-troubleshooter/google/cloud/policytroubleshooter_v1/services/iam_checker/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-policy-troubleshooter/google/cloud/policytroubleshooter_v1/services/iam_checker/transports/rest.py
+++ b/packages/google-cloud-policy-troubleshooter/google/cloud/policytroubleshooter_v1/services/iam_checker/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-policy-troubleshooter/google/cloud/policytroubleshooter_v1/services/iam_checker/transports/rest_base.py
+++ b/packages/google-cloud-policy-troubleshooter/google/cloud/policytroubleshooter_v1/services/iam_checker/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-policy-troubleshooter/google/cloud/policytroubleshooter_v1/types/__init__.py
+++ b/packages/google-cloud-policy-troubleshooter/google/cloud/policytroubleshooter_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-policy-troubleshooter/google/cloud/policytroubleshooter_v1/types/checker.py
+++ b/packages/google-cloud-policy-troubleshooter/google/cloud/policytroubleshooter_v1/types/checker.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-policy-troubleshooter/google/cloud/policytroubleshooter_v1/types/explanations.py
+++ b/packages/google-cloud-policy-troubleshooter/google/cloud/policytroubleshooter_v1/types/explanations.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-policy-troubleshooter/samples/generated_samples/policytroubleshooter_v1_generated_iam_checker_troubleshoot_iam_policy_async.py
+++ b/packages/google-cloud-policy-troubleshooter/samples/generated_samples/policytroubleshooter_v1_generated_iam_checker_troubleshoot_iam_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-policy-troubleshooter/samples/generated_samples/policytroubleshooter_v1_generated_iam_checker_troubleshoot_iam_policy_sync.py
+++ b/packages/google-cloud-policy-troubleshooter/samples/generated_samples/policytroubleshooter_v1_generated_iam_checker_troubleshoot_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-policy-troubleshooter/tests/__init__.py
+++ b/packages/google-cloud-policy-troubleshooter/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-policy-troubleshooter/tests/unit/__init__.py
+++ b/packages/google-cloud-policy-troubleshooter/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-policy-troubleshooter/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-policy-troubleshooter/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-policy-troubleshooter/tests/unit/gapic/policytroubleshooter_v1/__init__.py
+++ b/packages/google-cloud-policy-troubleshooter/tests/unit/gapic/policytroubleshooter_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-policysimulator/.flake8
+++ b/packages/google-cloud-policysimulator/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-policysimulator/MANIFEST.in
+++ b/packages/google-cloud-policysimulator/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-policysimulator/google/cloud/policysimulator/__init__.py
+++ b/packages/google-cloud-policysimulator/google/cloud/policysimulator/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-policysimulator/google/cloud/policysimulator/gapic_version.py
+++ b/packages/google-cloud-policysimulator/google/cloud/policysimulator/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-policysimulator/google/cloud/policysimulator_v1/gapic_version.py
+++ b/packages/google-cloud-policysimulator/google/cloud/policysimulator_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-policysimulator/google/cloud/policysimulator_v1/services/__init__.py
+++ b/packages/google-cloud-policysimulator/google/cloud/policysimulator_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-policysimulator/google/cloud/policysimulator_v1/services/org_policy_violations_preview_service/__init__.py
+++ b/packages/google-cloud-policysimulator/google/cloud/policysimulator_v1/services/org_policy_violations_preview_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-policysimulator/google/cloud/policysimulator_v1/services/org_policy_violations_preview_service/client.py
+++ b/packages/google-cloud-policysimulator/google/cloud/policysimulator_v1/services/org_policy_violations_preview_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-policysimulator/google/cloud/policysimulator_v1/services/org_policy_violations_preview_service/pagers.py
+++ b/packages/google-cloud-policysimulator/google/cloud/policysimulator_v1/services/org_policy_violations_preview_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-policysimulator/google/cloud/policysimulator_v1/services/org_policy_violations_preview_service/transports/__init__.py
+++ b/packages/google-cloud-policysimulator/google/cloud/policysimulator_v1/services/org_policy_violations_preview_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-policysimulator/google/cloud/policysimulator_v1/services/org_policy_violations_preview_service/transports/base.py
+++ b/packages/google-cloud-policysimulator/google/cloud/policysimulator_v1/services/org_policy_violations_preview_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-policysimulator/google/cloud/policysimulator_v1/services/org_policy_violations_preview_service/transports/grpc.py
+++ b/packages/google-cloud-policysimulator/google/cloud/policysimulator_v1/services/org_policy_violations_preview_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-policysimulator/google/cloud/policysimulator_v1/services/org_policy_violations_preview_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-policysimulator/google/cloud/policysimulator_v1/services/org_policy_violations_preview_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-policysimulator/google/cloud/policysimulator_v1/services/org_policy_violations_preview_service/transports/rest.py
+++ b/packages/google-cloud-policysimulator/google/cloud/policysimulator_v1/services/org_policy_violations_preview_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-policysimulator/google/cloud/policysimulator_v1/services/org_policy_violations_preview_service/transports/rest_base.py
+++ b/packages/google-cloud-policysimulator/google/cloud/policysimulator_v1/services/org_policy_violations_preview_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-policysimulator/google/cloud/policysimulator_v1/services/simulator/__init__.py
+++ b/packages/google-cloud-policysimulator/google/cloud/policysimulator_v1/services/simulator/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-policysimulator/google/cloud/policysimulator_v1/services/simulator/client.py
+++ b/packages/google-cloud-policysimulator/google/cloud/policysimulator_v1/services/simulator/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-policysimulator/google/cloud/policysimulator_v1/services/simulator/pagers.py
+++ b/packages/google-cloud-policysimulator/google/cloud/policysimulator_v1/services/simulator/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-policysimulator/google/cloud/policysimulator_v1/services/simulator/transports/__init__.py
+++ b/packages/google-cloud-policysimulator/google/cloud/policysimulator_v1/services/simulator/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-policysimulator/google/cloud/policysimulator_v1/services/simulator/transports/base.py
+++ b/packages/google-cloud-policysimulator/google/cloud/policysimulator_v1/services/simulator/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-policysimulator/google/cloud/policysimulator_v1/services/simulator/transports/grpc.py
+++ b/packages/google-cloud-policysimulator/google/cloud/policysimulator_v1/services/simulator/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-policysimulator/google/cloud/policysimulator_v1/services/simulator/transports/grpc_asyncio.py
+++ b/packages/google-cloud-policysimulator/google/cloud/policysimulator_v1/services/simulator/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-policysimulator/google/cloud/policysimulator_v1/services/simulator/transports/rest.py
+++ b/packages/google-cloud-policysimulator/google/cloud/policysimulator_v1/services/simulator/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-policysimulator/google/cloud/policysimulator_v1/services/simulator/transports/rest_base.py
+++ b/packages/google-cloud-policysimulator/google/cloud/policysimulator_v1/services/simulator/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-policysimulator/google/cloud/policysimulator_v1/types/__init__.py
+++ b/packages/google-cloud-policysimulator/google/cloud/policysimulator_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-policysimulator/google/cloud/policysimulator_v1/types/explanations.py
+++ b/packages/google-cloud-policysimulator/google/cloud/policysimulator_v1/types/explanations.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-policysimulator/google/cloud/policysimulator_v1/types/orgpolicy.py
+++ b/packages/google-cloud-policysimulator/google/cloud/policysimulator_v1/types/orgpolicy.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-policysimulator/google/cloud/policysimulator_v1/types/simulator.py
+++ b/packages/google-cloud-policysimulator/google/cloud/policysimulator_v1/types/simulator.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-policysimulator/samples/generated_samples/policysimulator_v1_generated_org_policy_violations_preview_service_create_org_policy_violations_preview_sync.py
+++ b/packages/google-cloud-policysimulator/samples/generated_samples/policysimulator_v1_generated_org_policy_violations_preview_service_create_org_policy_violations_preview_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-policysimulator/samples/generated_samples/policysimulator_v1_generated_org_policy_violations_preview_service_get_org_policy_violations_preview_async.py
+++ b/packages/google-cloud-policysimulator/samples/generated_samples/policysimulator_v1_generated_org_policy_violations_preview_service_get_org_policy_violations_preview_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-policysimulator/samples/generated_samples/policysimulator_v1_generated_org_policy_violations_preview_service_get_org_policy_violations_preview_sync.py
+++ b/packages/google-cloud-policysimulator/samples/generated_samples/policysimulator_v1_generated_org_policy_violations_preview_service_get_org_policy_violations_preview_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-policysimulator/samples/generated_samples/policysimulator_v1_generated_org_policy_violations_preview_service_list_org_policy_violations_async.py
+++ b/packages/google-cloud-policysimulator/samples/generated_samples/policysimulator_v1_generated_org_policy_violations_preview_service_list_org_policy_violations_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-policysimulator/samples/generated_samples/policysimulator_v1_generated_org_policy_violations_preview_service_list_org_policy_violations_previews_async.py
+++ b/packages/google-cloud-policysimulator/samples/generated_samples/policysimulator_v1_generated_org_policy_violations_preview_service_list_org_policy_violations_previews_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-policysimulator/samples/generated_samples/policysimulator_v1_generated_org_policy_violations_preview_service_list_org_policy_violations_previews_sync.py
+++ b/packages/google-cloud-policysimulator/samples/generated_samples/policysimulator_v1_generated_org_policy_violations_preview_service_list_org_policy_violations_previews_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-policysimulator/samples/generated_samples/policysimulator_v1_generated_org_policy_violations_preview_service_list_org_policy_violations_sync.py
+++ b/packages/google-cloud-policysimulator/samples/generated_samples/policysimulator_v1_generated_org_policy_violations_preview_service_list_org_policy_violations_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-policysimulator/samples/generated_samples/policysimulator_v1_generated_simulator_create_replay_sync.py
+++ b/packages/google-cloud-policysimulator/samples/generated_samples/policysimulator_v1_generated_simulator_create_replay_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-policysimulator/samples/generated_samples/policysimulator_v1_generated_simulator_get_replay_async.py
+++ b/packages/google-cloud-policysimulator/samples/generated_samples/policysimulator_v1_generated_simulator_get_replay_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-policysimulator/samples/generated_samples/policysimulator_v1_generated_simulator_get_replay_sync.py
+++ b/packages/google-cloud-policysimulator/samples/generated_samples/policysimulator_v1_generated_simulator_get_replay_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-policysimulator/samples/generated_samples/policysimulator_v1_generated_simulator_list_replay_results_async.py
+++ b/packages/google-cloud-policysimulator/samples/generated_samples/policysimulator_v1_generated_simulator_list_replay_results_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-policysimulator/samples/generated_samples/policysimulator_v1_generated_simulator_list_replay_results_sync.py
+++ b/packages/google-cloud-policysimulator/samples/generated_samples/policysimulator_v1_generated_simulator_list_replay_results_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-policysimulator/tests/__init__.py
+++ b/packages/google-cloud-policysimulator/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-policysimulator/tests/unit/__init__.py
+++ b/packages/google-cloud-policysimulator/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-policysimulator/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-policysimulator/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-policysimulator/tests/unit/gapic/policysimulator_v1/__init__.py
+++ b/packages/google-cloud-policysimulator/tests/unit/gapic/policysimulator_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-policytroubleshooter-iam/.flake8
+++ b/packages/google-cloud-policytroubleshooter-iam/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-policytroubleshooter-iam/MANIFEST.in
+++ b/packages/google-cloud-policytroubleshooter-iam/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-policytroubleshooter-iam/google/cloud/policytroubleshooter_iam/__init__.py
+++ b/packages/google-cloud-policytroubleshooter-iam/google/cloud/policytroubleshooter_iam/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-policytroubleshooter-iam/google/cloud/policytroubleshooter_iam/gapic_version.py
+++ b/packages/google-cloud-policytroubleshooter-iam/google/cloud/policytroubleshooter_iam/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-policytroubleshooter-iam/google/cloud/policytroubleshooter_iam_v3/gapic_version.py
+++ b/packages/google-cloud-policytroubleshooter-iam/google/cloud/policytroubleshooter_iam_v3/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-policytroubleshooter-iam/google/cloud/policytroubleshooter_iam_v3/services/__init__.py
+++ b/packages/google-cloud-policytroubleshooter-iam/google/cloud/policytroubleshooter_iam_v3/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-policytroubleshooter-iam/google/cloud/policytroubleshooter_iam_v3/services/policy_troubleshooter/__init__.py
+++ b/packages/google-cloud-policytroubleshooter-iam/google/cloud/policytroubleshooter_iam_v3/services/policy_troubleshooter/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-policytroubleshooter-iam/google/cloud/policytroubleshooter_iam_v3/services/policy_troubleshooter/async_client.py
+++ b/packages/google-cloud-policytroubleshooter-iam/google/cloud/policytroubleshooter_iam_v3/services/policy_troubleshooter/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-policytroubleshooter-iam/google/cloud/policytroubleshooter_iam_v3/services/policy_troubleshooter/client.py
+++ b/packages/google-cloud-policytroubleshooter-iam/google/cloud/policytroubleshooter_iam_v3/services/policy_troubleshooter/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-policytroubleshooter-iam/google/cloud/policytroubleshooter_iam_v3/services/policy_troubleshooter/transports/__init__.py
+++ b/packages/google-cloud-policytroubleshooter-iam/google/cloud/policytroubleshooter_iam_v3/services/policy_troubleshooter/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-policytroubleshooter-iam/google/cloud/policytroubleshooter_iam_v3/services/policy_troubleshooter/transports/base.py
+++ b/packages/google-cloud-policytroubleshooter-iam/google/cloud/policytroubleshooter_iam_v3/services/policy_troubleshooter/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-policytroubleshooter-iam/google/cloud/policytroubleshooter_iam_v3/services/policy_troubleshooter/transports/grpc.py
+++ b/packages/google-cloud-policytroubleshooter-iam/google/cloud/policytroubleshooter_iam_v3/services/policy_troubleshooter/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-policytroubleshooter-iam/google/cloud/policytroubleshooter_iam_v3/services/policy_troubleshooter/transports/grpc_asyncio.py
+++ b/packages/google-cloud-policytroubleshooter-iam/google/cloud/policytroubleshooter_iam_v3/services/policy_troubleshooter/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-policytroubleshooter-iam/google/cloud/policytroubleshooter_iam_v3/services/policy_troubleshooter/transports/rest.py
+++ b/packages/google-cloud-policytroubleshooter-iam/google/cloud/policytroubleshooter_iam_v3/services/policy_troubleshooter/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-policytroubleshooter-iam/google/cloud/policytroubleshooter_iam_v3/services/policy_troubleshooter/transports/rest_base.py
+++ b/packages/google-cloud-policytroubleshooter-iam/google/cloud/policytroubleshooter_iam_v3/services/policy_troubleshooter/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-policytroubleshooter-iam/google/cloud/policytroubleshooter_iam_v3/types/__init__.py
+++ b/packages/google-cloud-policytroubleshooter-iam/google/cloud/policytroubleshooter_iam_v3/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-policytroubleshooter-iam/google/cloud/policytroubleshooter_iam_v3/types/troubleshooter.py
+++ b/packages/google-cloud-policytroubleshooter-iam/google/cloud/policytroubleshooter_iam_v3/types/troubleshooter.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-policytroubleshooter-iam/samples/generated_samples/policytroubleshooter_v3_generated_policy_troubleshooter_troubleshoot_iam_policy_async.py
+++ b/packages/google-cloud-policytroubleshooter-iam/samples/generated_samples/policytroubleshooter_v3_generated_policy_troubleshooter_troubleshoot_iam_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-policytroubleshooter-iam/samples/generated_samples/policytroubleshooter_v3_generated_policy_troubleshooter_troubleshoot_iam_policy_sync.py
+++ b/packages/google-cloud-policytroubleshooter-iam/samples/generated_samples/policytroubleshooter_v3_generated_policy_troubleshooter_troubleshoot_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-policytroubleshooter-iam/tests/__init__.py
+++ b/packages/google-cloud-policytroubleshooter-iam/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-policytroubleshooter-iam/tests/unit/__init__.py
+++ b/packages/google-cloud-policytroubleshooter-iam/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-policytroubleshooter-iam/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-policytroubleshooter-iam/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-policytroubleshooter-iam/tests/unit/gapic/policytroubleshooter_iam_v3/__init__.py
+++ b/packages/google-cloud-policytroubleshooter-iam/tests/unit/gapic/policytroubleshooter_iam_v3/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-ca/.flake8
+++ b/packages/google-cloud-private-ca/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-ca/MANIFEST.in
+++ b/packages/google-cloud-private-ca/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-ca/google/cloud/security/privateca/__init__.py
+++ b/packages/google-cloud-private-ca/google/cloud/security/privateca/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-ca/google/cloud/security/privateca/gapic_version.py
+++ b/packages/google-cloud-private-ca/google/cloud/security/privateca/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-ca/google/cloud/security/privateca_v1/gapic_version.py
+++ b/packages/google-cloud-private-ca/google/cloud/security/privateca_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-ca/google/cloud/security/privateca_v1/services/__init__.py
+++ b/packages/google-cloud-private-ca/google/cloud/security/privateca_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-ca/google/cloud/security/privateca_v1/services/certificate_authority_service/__init__.py
+++ b/packages/google-cloud-private-ca/google/cloud/security/privateca_v1/services/certificate_authority_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-ca/google/cloud/security/privateca_v1/services/certificate_authority_service/client.py
+++ b/packages/google-cloud-private-ca/google/cloud/security/privateca_v1/services/certificate_authority_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-ca/google/cloud/security/privateca_v1/services/certificate_authority_service/pagers.py
+++ b/packages/google-cloud-private-ca/google/cloud/security/privateca_v1/services/certificate_authority_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-ca/google/cloud/security/privateca_v1/services/certificate_authority_service/transports/__init__.py
+++ b/packages/google-cloud-private-ca/google/cloud/security/privateca_v1/services/certificate_authority_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-ca/google/cloud/security/privateca_v1/services/certificate_authority_service/transports/base.py
+++ b/packages/google-cloud-private-ca/google/cloud/security/privateca_v1/services/certificate_authority_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-ca/google/cloud/security/privateca_v1/services/certificate_authority_service/transports/grpc.py
+++ b/packages/google-cloud-private-ca/google/cloud/security/privateca_v1/services/certificate_authority_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-ca/google/cloud/security/privateca_v1/services/certificate_authority_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-private-ca/google/cloud/security/privateca_v1/services/certificate_authority_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-ca/google/cloud/security/privateca_v1/services/certificate_authority_service/transports/rest.py
+++ b/packages/google-cloud-private-ca/google/cloud/security/privateca_v1/services/certificate_authority_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-ca/google/cloud/security/privateca_v1/services/certificate_authority_service/transports/rest_base.py
+++ b/packages/google-cloud-private-ca/google/cloud/security/privateca_v1/services/certificate_authority_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-ca/google/cloud/security/privateca_v1/types/__init__.py
+++ b/packages/google-cloud-private-ca/google/cloud/security/privateca_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-ca/google/cloud/security/privateca_v1/types/resources.py
+++ b/packages/google-cloud-private-ca/google/cloud/security/privateca_v1/types/resources.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-ca/google/cloud/security/privateca_v1/types/service.py
+++ b/packages/google-cloud-private-ca/google/cloud/security/privateca_v1/types/service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-ca/google/cloud/security/privateca_v1beta1/gapic_version.py
+++ b/packages/google-cloud-private-ca/google/cloud/security/privateca_v1beta1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-ca/google/cloud/security/privateca_v1beta1/services/__init__.py
+++ b/packages/google-cloud-private-ca/google/cloud/security/privateca_v1beta1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-ca/google/cloud/security/privateca_v1beta1/services/certificate_authority_service/__init__.py
+++ b/packages/google-cloud-private-ca/google/cloud/security/privateca_v1beta1/services/certificate_authority_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-ca/google/cloud/security/privateca_v1beta1/services/certificate_authority_service/client.py
+++ b/packages/google-cloud-private-ca/google/cloud/security/privateca_v1beta1/services/certificate_authority_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-ca/google/cloud/security/privateca_v1beta1/services/certificate_authority_service/pagers.py
+++ b/packages/google-cloud-private-ca/google/cloud/security/privateca_v1beta1/services/certificate_authority_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-ca/google/cloud/security/privateca_v1beta1/services/certificate_authority_service/transports/__init__.py
+++ b/packages/google-cloud-private-ca/google/cloud/security/privateca_v1beta1/services/certificate_authority_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-ca/google/cloud/security/privateca_v1beta1/services/certificate_authority_service/transports/base.py
+++ b/packages/google-cloud-private-ca/google/cloud/security/privateca_v1beta1/services/certificate_authority_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-ca/google/cloud/security/privateca_v1beta1/services/certificate_authority_service/transports/grpc.py
+++ b/packages/google-cloud-private-ca/google/cloud/security/privateca_v1beta1/services/certificate_authority_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-ca/google/cloud/security/privateca_v1beta1/services/certificate_authority_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-private-ca/google/cloud/security/privateca_v1beta1/services/certificate_authority_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-ca/google/cloud/security/privateca_v1beta1/services/certificate_authority_service/transports/rest.py
+++ b/packages/google-cloud-private-ca/google/cloud/security/privateca_v1beta1/services/certificate_authority_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-ca/google/cloud/security/privateca_v1beta1/services/certificate_authority_service/transports/rest_base.py
+++ b/packages/google-cloud-private-ca/google/cloud/security/privateca_v1beta1/services/certificate_authority_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-ca/google/cloud/security/privateca_v1beta1/types/__init__.py
+++ b/packages/google-cloud-private-ca/google/cloud/security/privateca_v1beta1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-ca/google/cloud/security/privateca_v1beta1/types/resources.py
+++ b/packages/google-cloud-private-ca/google/cloud/security/privateca_v1beta1/types/resources.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-ca/google/cloud/security/privateca_v1beta1/types/service.py
+++ b/packages/google-cloud-private-ca/google/cloud/security/privateca_v1beta1/types/service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1_generated_certificate_authority_service_activate_certificate_authority_sync.py
+++ b/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1_generated_certificate_authority_service_activate_certificate_authority_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1_generated_certificate_authority_service_create_ca_pool_sync.py
+++ b/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1_generated_certificate_authority_service_create_ca_pool_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1_generated_certificate_authority_service_create_certificate_async.py
+++ b/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1_generated_certificate_authority_service_create_certificate_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1_generated_certificate_authority_service_create_certificate_authority_sync.py
+++ b/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1_generated_certificate_authority_service_create_certificate_authority_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1_generated_certificate_authority_service_create_certificate_sync.py
+++ b/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1_generated_certificate_authority_service_create_certificate_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1_generated_certificate_authority_service_create_certificate_template_sync.py
+++ b/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1_generated_certificate_authority_service_create_certificate_template_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1_generated_certificate_authority_service_delete_ca_pool_sync.py
+++ b/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1_generated_certificate_authority_service_delete_ca_pool_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1_generated_certificate_authority_service_delete_certificate_authority_sync.py
+++ b/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1_generated_certificate_authority_service_delete_certificate_authority_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1_generated_certificate_authority_service_delete_certificate_template_sync.py
+++ b/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1_generated_certificate_authority_service_delete_certificate_template_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1_generated_certificate_authority_service_disable_certificate_authority_sync.py
+++ b/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1_generated_certificate_authority_service_disable_certificate_authority_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1_generated_certificate_authority_service_enable_certificate_authority_sync.py
+++ b/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1_generated_certificate_authority_service_enable_certificate_authority_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1_generated_certificate_authority_service_fetch_ca_certs_async.py
+++ b/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1_generated_certificate_authority_service_fetch_ca_certs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1_generated_certificate_authority_service_fetch_ca_certs_sync.py
+++ b/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1_generated_certificate_authority_service_fetch_ca_certs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1_generated_certificate_authority_service_fetch_certificate_authority_csr_async.py
+++ b/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1_generated_certificate_authority_service_fetch_certificate_authority_csr_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1_generated_certificate_authority_service_fetch_certificate_authority_csr_sync.py
+++ b/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1_generated_certificate_authority_service_fetch_certificate_authority_csr_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1_generated_certificate_authority_service_get_ca_pool_async.py
+++ b/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1_generated_certificate_authority_service_get_ca_pool_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1_generated_certificate_authority_service_get_ca_pool_sync.py
+++ b/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1_generated_certificate_authority_service_get_ca_pool_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1_generated_certificate_authority_service_get_certificate_async.py
+++ b/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1_generated_certificate_authority_service_get_certificate_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1_generated_certificate_authority_service_get_certificate_authority_async.py
+++ b/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1_generated_certificate_authority_service_get_certificate_authority_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1_generated_certificate_authority_service_get_certificate_authority_sync.py
+++ b/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1_generated_certificate_authority_service_get_certificate_authority_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1_generated_certificate_authority_service_get_certificate_revocation_list_async.py
+++ b/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1_generated_certificate_authority_service_get_certificate_revocation_list_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1_generated_certificate_authority_service_get_certificate_revocation_list_sync.py
+++ b/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1_generated_certificate_authority_service_get_certificate_revocation_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1_generated_certificate_authority_service_get_certificate_sync.py
+++ b/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1_generated_certificate_authority_service_get_certificate_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1_generated_certificate_authority_service_get_certificate_template_async.py
+++ b/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1_generated_certificate_authority_service_get_certificate_template_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1_generated_certificate_authority_service_get_certificate_template_sync.py
+++ b/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1_generated_certificate_authority_service_get_certificate_template_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1_generated_certificate_authority_service_list_ca_pools_async.py
+++ b/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1_generated_certificate_authority_service_list_ca_pools_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1_generated_certificate_authority_service_list_ca_pools_sync.py
+++ b/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1_generated_certificate_authority_service_list_ca_pools_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1_generated_certificate_authority_service_list_certificate_authorities_async.py
+++ b/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1_generated_certificate_authority_service_list_certificate_authorities_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1_generated_certificate_authority_service_list_certificate_authorities_sync.py
+++ b/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1_generated_certificate_authority_service_list_certificate_authorities_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1_generated_certificate_authority_service_list_certificate_revocation_lists_async.py
+++ b/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1_generated_certificate_authority_service_list_certificate_revocation_lists_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1_generated_certificate_authority_service_list_certificate_revocation_lists_sync.py
+++ b/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1_generated_certificate_authority_service_list_certificate_revocation_lists_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1_generated_certificate_authority_service_list_certificate_templates_async.py
+++ b/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1_generated_certificate_authority_service_list_certificate_templates_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1_generated_certificate_authority_service_list_certificate_templates_sync.py
+++ b/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1_generated_certificate_authority_service_list_certificate_templates_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1_generated_certificate_authority_service_list_certificates_async.py
+++ b/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1_generated_certificate_authority_service_list_certificates_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1_generated_certificate_authority_service_list_certificates_sync.py
+++ b/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1_generated_certificate_authority_service_list_certificates_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1_generated_certificate_authority_service_revoke_certificate_async.py
+++ b/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1_generated_certificate_authority_service_revoke_certificate_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1_generated_certificate_authority_service_revoke_certificate_sync.py
+++ b/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1_generated_certificate_authority_service_revoke_certificate_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1_generated_certificate_authority_service_undelete_certificate_authority_sync.py
+++ b/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1_generated_certificate_authority_service_undelete_certificate_authority_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1_generated_certificate_authority_service_update_ca_pool_sync.py
+++ b/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1_generated_certificate_authority_service_update_ca_pool_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1_generated_certificate_authority_service_update_certificate_async.py
+++ b/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1_generated_certificate_authority_service_update_certificate_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1_generated_certificate_authority_service_update_certificate_authority_sync.py
+++ b/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1_generated_certificate_authority_service_update_certificate_authority_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1_generated_certificate_authority_service_update_certificate_revocation_list_sync.py
+++ b/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1_generated_certificate_authority_service_update_certificate_revocation_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1_generated_certificate_authority_service_update_certificate_sync.py
+++ b/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1_generated_certificate_authority_service_update_certificate_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1_generated_certificate_authority_service_update_certificate_template_sync.py
+++ b/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1_generated_certificate_authority_service_update_certificate_template_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1beta1_generated_certificate_authority_service_activate_certificate_authority_sync.py
+++ b/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1beta1_generated_certificate_authority_service_activate_certificate_authority_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1beta1_generated_certificate_authority_service_create_certificate_async.py
+++ b/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1beta1_generated_certificate_authority_service_create_certificate_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1beta1_generated_certificate_authority_service_create_certificate_authority_sync.py
+++ b/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1beta1_generated_certificate_authority_service_create_certificate_authority_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1beta1_generated_certificate_authority_service_create_certificate_sync.py
+++ b/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1beta1_generated_certificate_authority_service_create_certificate_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1beta1_generated_certificate_authority_service_disable_certificate_authority_sync.py
+++ b/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1beta1_generated_certificate_authority_service_disable_certificate_authority_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1beta1_generated_certificate_authority_service_enable_certificate_authority_sync.py
+++ b/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1beta1_generated_certificate_authority_service_enable_certificate_authority_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1beta1_generated_certificate_authority_service_fetch_certificate_authority_csr_async.py
+++ b/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1beta1_generated_certificate_authority_service_fetch_certificate_authority_csr_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1beta1_generated_certificate_authority_service_fetch_certificate_authority_csr_sync.py
+++ b/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1beta1_generated_certificate_authority_service_fetch_certificate_authority_csr_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1beta1_generated_certificate_authority_service_get_certificate_async.py
+++ b/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1beta1_generated_certificate_authority_service_get_certificate_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1beta1_generated_certificate_authority_service_get_certificate_authority_async.py
+++ b/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1beta1_generated_certificate_authority_service_get_certificate_authority_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1beta1_generated_certificate_authority_service_get_certificate_authority_sync.py
+++ b/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1beta1_generated_certificate_authority_service_get_certificate_authority_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1beta1_generated_certificate_authority_service_get_certificate_revocation_list_async.py
+++ b/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1beta1_generated_certificate_authority_service_get_certificate_revocation_list_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1beta1_generated_certificate_authority_service_get_certificate_revocation_list_sync.py
+++ b/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1beta1_generated_certificate_authority_service_get_certificate_revocation_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1beta1_generated_certificate_authority_service_get_certificate_sync.py
+++ b/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1beta1_generated_certificate_authority_service_get_certificate_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1beta1_generated_certificate_authority_service_get_reusable_config_async.py
+++ b/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1beta1_generated_certificate_authority_service_get_reusable_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1beta1_generated_certificate_authority_service_get_reusable_config_sync.py
+++ b/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1beta1_generated_certificate_authority_service_get_reusable_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1beta1_generated_certificate_authority_service_list_certificate_authorities_async.py
+++ b/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1beta1_generated_certificate_authority_service_list_certificate_authorities_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1beta1_generated_certificate_authority_service_list_certificate_authorities_sync.py
+++ b/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1beta1_generated_certificate_authority_service_list_certificate_authorities_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1beta1_generated_certificate_authority_service_list_certificate_revocation_lists_async.py
+++ b/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1beta1_generated_certificate_authority_service_list_certificate_revocation_lists_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1beta1_generated_certificate_authority_service_list_certificate_revocation_lists_sync.py
+++ b/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1beta1_generated_certificate_authority_service_list_certificate_revocation_lists_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1beta1_generated_certificate_authority_service_list_certificates_async.py
+++ b/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1beta1_generated_certificate_authority_service_list_certificates_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1beta1_generated_certificate_authority_service_list_certificates_sync.py
+++ b/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1beta1_generated_certificate_authority_service_list_certificates_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1beta1_generated_certificate_authority_service_list_reusable_configs_async.py
+++ b/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1beta1_generated_certificate_authority_service_list_reusable_configs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1beta1_generated_certificate_authority_service_list_reusable_configs_sync.py
+++ b/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1beta1_generated_certificate_authority_service_list_reusable_configs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1beta1_generated_certificate_authority_service_restore_certificate_authority_sync.py
+++ b/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1beta1_generated_certificate_authority_service_restore_certificate_authority_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1beta1_generated_certificate_authority_service_revoke_certificate_async.py
+++ b/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1beta1_generated_certificate_authority_service_revoke_certificate_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1beta1_generated_certificate_authority_service_revoke_certificate_sync.py
+++ b/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1beta1_generated_certificate_authority_service_revoke_certificate_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1beta1_generated_certificate_authority_service_schedule_delete_certificate_authority_sync.py
+++ b/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1beta1_generated_certificate_authority_service_schedule_delete_certificate_authority_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1beta1_generated_certificate_authority_service_update_certificate_async.py
+++ b/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1beta1_generated_certificate_authority_service_update_certificate_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1beta1_generated_certificate_authority_service_update_certificate_authority_sync.py
+++ b/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1beta1_generated_certificate_authority_service_update_certificate_authority_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1beta1_generated_certificate_authority_service_update_certificate_revocation_list_sync.py
+++ b/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1beta1_generated_certificate_authority_service_update_certificate_revocation_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1beta1_generated_certificate_authority_service_update_certificate_sync.py
+++ b/packages/google-cloud-private-ca/samples/generated_samples/privateca_v1beta1_generated_certificate_authority_service_update_certificate_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-ca/tests/__init__.py
+++ b/packages/google-cloud-private-ca/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-ca/tests/unit/__init__.py
+++ b/packages/google-cloud-private-ca/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-ca/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-private-ca/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-ca/tests/unit/gapic/privateca_v1/__init__.py
+++ b/packages/google-cloud-private-ca/tests/unit/gapic/privateca_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-ca/tests/unit/gapic/privateca_v1beta1/__init__.py
+++ b/packages/google-cloud-private-ca/tests/unit/gapic/privateca_v1beta1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-catalog/.flake8
+++ b/packages/google-cloud-private-catalog/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-catalog/MANIFEST.in
+++ b/packages/google-cloud-private-catalog/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-catalog/google/cloud/privatecatalog/__init__.py
+++ b/packages/google-cloud-private-catalog/google/cloud/privatecatalog/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-catalog/google/cloud/privatecatalog/gapic_version.py
+++ b/packages/google-cloud-private-catalog/google/cloud/privatecatalog/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-catalog/google/cloud/privatecatalog_v1beta1/gapic_version.py
+++ b/packages/google-cloud-private-catalog/google/cloud/privatecatalog_v1beta1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-catalog/google/cloud/privatecatalog_v1beta1/services/__init__.py
+++ b/packages/google-cloud-private-catalog/google/cloud/privatecatalog_v1beta1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-catalog/google/cloud/privatecatalog_v1beta1/services/private_catalog/__init__.py
+++ b/packages/google-cloud-private-catalog/google/cloud/privatecatalog_v1beta1/services/private_catalog/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-catalog/google/cloud/privatecatalog_v1beta1/services/private_catalog/async_client.py
+++ b/packages/google-cloud-private-catalog/google/cloud/privatecatalog_v1beta1/services/private_catalog/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-catalog/google/cloud/privatecatalog_v1beta1/services/private_catalog/client.py
+++ b/packages/google-cloud-private-catalog/google/cloud/privatecatalog_v1beta1/services/private_catalog/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-catalog/google/cloud/privatecatalog_v1beta1/services/private_catalog/pagers.py
+++ b/packages/google-cloud-private-catalog/google/cloud/privatecatalog_v1beta1/services/private_catalog/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-catalog/google/cloud/privatecatalog_v1beta1/services/private_catalog/transports/__init__.py
+++ b/packages/google-cloud-private-catalog/google/cloud/privatecatalog_v1beta1/services/private_catalog/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-catalog/google/cloud/privatecatalog_v1beta1/services/private_catalog/transports/base.py
+++ b/packages/google-cloud-private-catalog/google/cloud/privatecatalog_v1beta1/services/private_catalog/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-catalog/google/cloud/privatecatalog_v1beta1/services/private_catalog/transports/grpc.py
+++ b/packages/google-cloud-private-catalog/google/cloud/privatecatalog_v1beta1/services/private_catalog/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-catalog/google/cloud/privatecatalog_v1beta1/services/private_catalog/transports/grpc_asyncio.py
+++ b/packages/google-cloud-private-catalog/google/cloud/privatecatalog_v1beta1/services/private_catalog/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-catalog/google/cloud/privatecatalog_v1beta1/services/private_catalog/transports/rest.py
+++ b/packages/google-cloud-private-catalog/google/cloud/privatecatalog_v1beta1/services/private_catalog/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-catalog/google/cloud/privatecatalog_v1beta1/services/private_catalog/transports/rest_base.py
+++ b/packages/google-cloud-private-catalog/google/cloud/privatecatalog_v1beta1/services/private_catalog/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-catalog/google/cloud/privatecatalog_v1beta1/types/__init__.py
+++ b/packages/google-cloud-private-catalog/google/cloud/privatecatalog_v1beta1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-catalog/google/cloud/privatecatalog_v1beta1/types/private_catalog.py
+++ b/packages/google-cloud-private-catalog/google/cloud/privatecatalog_v1beta1/types/private_catalog.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-catalog/samples/generated_samples/cloudprivatecatalog_v1beta1_generated_private_catalog_search_catalogs_async.py
+++ b/packages/google-cloud-private-catalog/samples/generated_samples/cloudprivatecatalog_v1beta1_generated_private_catalog_search_catalogs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-catalog/samples/generated_samples/cloudprivatecatalog_v1beta1_generated_private_catalog_search_catalogs_sync.py
+++ b/packages/google-cloud-private-catalog/samples/generated_samples/cloudprivatecatalog_v1beta1_generated_private_catalog_search_catalogs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-catalog/samples/generated_samples/cloudprivatecatalog_v1beta1_generated_private_catalog_search_products_async.py
+++ b/packages/google-cloud-private-catalog/samples/generated_samples/cloudprivatecatalog_v1beta1_generated_private_catalog_search_products_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-catalog/samples/generated_samples/cloudprivatecatalog_v1beta1_generated_private_catalog_search_products_sync.py
+++ b/packages/google-cloud-private-catalog/samples/generated_samples/cloudprivatecatalog_v1beta1_generated_private_catalog_search_products_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-catalog/samples/generated_samples/cloudprivatecatalog_v1beta1_generated_private_catalog_search_versions_async.py
+++ b/packages/google-cloud-private-catalog/samples/generated_samples/cloudprivatecatalog_v1beta1_generated_private_catalog_search_versions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-catalog/samples/generated_samples/cloudprivatecatalog_v1beta1_generated_private_catalog_search_versions_sync.py
+++ b/packages/google-cloud-private-catalog/samples/generated_samples/cloudprivatecatalog_v1beta1_generated_private_catalog_search_versions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-catalog/tests/__init__.py
+++ b/packages/google-cloud-private-catalog/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-catalog/tests/unit/__init__.py
+++ b/packages/google-cloud-private-catalog/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-catalog/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-private-catalog/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-private-catalog/tests/unit/gapic/privatecatalog_v1beta1/__init__.py
+++ b/packages/google-cloud-private-catalog/tests/unit/gapic/privatecatalog_v1beta1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-privilegedaccessmanager/.flake8
+++ b/packages/google-cloud-privilegedaccessmanager/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-privilegedaccessmanager/MANIFEST.in
+++ b/packages/google-cloud-privilegedaccessmanager/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-privilegedaccessmanager/google/cloud/privilegedaccessmanager/__init__.py
+++ b/packages/google-cloud-privilegedaccessmanager/google/cloud/privilegedaccessmanager/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-privilegedaccessmanager/google/cloud/privilegedaccessmanager/gapic_version.py
+++ b/packages/google-cloud-privilegedaccessmanager/google/cloud/privilegedaccessmanager/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-privilegedaccessmanager/google/cloud/privilegedaccessmanager_v1/gapic_version.py
+++ b/packages/google-cloud-privilegedaccessmanager/google/cloud/privilegedaccessmanager_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-privilegedaccessmanager/google/cloud/privilegedaccessmanager_v1/services/__init__.py
+++ b/packages/google-cloud-privilegedaccessmanager/google/cloud/privilegedaccessmanager_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-privilegedaccessmanager/google/cloud/privilegedaccessmanager_v1/services/privileged_access_manager/__init__.py
+++ b/packages/google-cloud-privilegedaccessmanager/google/cloud/privilegedaccessmanager_v1/services/privileged_access_manager/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-privilegedaccessmanager/google/cloud/privilegedaccessmanager_v1/services/privileged_access_manager/client.py
+++ b/packages/google-cloud-privilegedaccessmanager/google/cloud/privilegedaccessmanager_v1/services/privileged_access_manager/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-privilegedaccessmanager/google/cloud/privilegedaccessmanager_v1/services/privileged_access_manager/pagers.py
+++ b/packages/google-cloud-privilegedaccessmanager/google/cloud/privilegedaccessmanager_v1/services/privileged_access_manager/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-privilegedaccessmanager/google/cloud/privilegedaccessmanager_v1/services/privileged_access_manager/transports/__init__.py
+++ b/packages/google-cloud-privilegedaccessmanager/google/cloud/privilegedaccessmanager_v1/services/privileged_access_manager/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-privilegedaccessmanager/google/cloud/privilegedaccessmanager_v1/services/privileged_access_manager/transports/base.py
+++ b/packages/google-cloud-privilegedaccessmanager/google/cloud/privilegedaccessmanager_v1/services/privileged_access_manager/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-privilegedaccessmanager/google/cloud/privilegedaccessmanager_v1/services/privileged_access_manager/transports/grpc.py
+++ b/packages/google-cloud-privilegedaccessmanager/google/cloud/privilegedaccessmanager_v1/services/privileged_access_manager/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-privilegedaccessmanager/google/cloud/privilegedaccessmanager_v1/services/privileged_access_manager/transports/grpc_asyncio.py
+++ b/packages/google-cloud-privilegedaccessmanager/google/cloud/privilegedaccessmanager_v1/services/privileged_access_manager/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-privilegedaccessmanager/google/cloud/privilegedaccessmanager_v1/services/privileged_access_manager/transports/rest.py
+++ b/packages/google-cloud-privilegedaccessmanager/google/cloud/privilegedaccessmanager_v1/services/privileged_access_manager/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-privilegedaccessmanager/google/cloud/privilegedaccessmanager_v1/services/privileged_access_manager/transports/rest_base.py
+++ b/packages/google-cloud-privilegedaccessmanager/google/cloud/privilegedaccessmanager_v1/services/privileged_access_manager/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-privilegedaccessmanager/google/cloud/privilegedaccessmanager_v1/types/__init__.py
+++ b/packages/google-cloud-privilegedaccessmanager/google/cloud/privilegedaccessmanager_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-privilegedaccessmanager/google/cloud/privilegedaccessmanager_v1/types/privilegedaccessmanager.py
+++ b/packages/google-cloud-privilegedaccessmanager/google/cloud/privilegedaccessmanager_v1/types/privilegedaccessmanager.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-privilegedaccessmanager/samples/generated_samples/privilegedaccessmanager_v1_generated_privileged_access_manager_approve_grant_async.py
+++ b/packages/google-cloud-privilegedaccessmanager/samples/generated_samples/privilegedaccessmanager_v1_generated_privileged_access_manager_approve_grant_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-privilegedaccessmanager/samples/generated_samples/privilegedaccessmanager_v1_generated_privileged_access_manager_approve_grant_sync.py
+++ b/packages/google-cloud-privilegedaccessmanager/samples/generated_samples/privilegedaccessmanager_v1_generated_privileged_access_manager_approve_grant_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-privilegedaccessmanager/samples/generated_samples/privilegedaccessmanager_v1_generated_privileged_access_manager_check_onboarding_status_async.py
+++ b/packages/google-cloud-privilegedaccessmanager/samples/generated_samples/privilegedaccessmanager_v1_generated_privileged_access_manager_check_onboarding_status_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-privilegedaccessmanager/samples/generated_samples/privilegedaccessmanager_v1_generated_privileged_access_manager_check_onboarding_status_sync.py
+++ b/packages/google-cloud-privilegedaccessmanager/samples/generated_samples/privilegedaccessmanager_v1_generated_privileged_access_manager_check_onboarding_status_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-privilegedaccessmanager/samples/generated_samples/privilegedaccessmanager_v1_generated_privileged_access_manager_create_entitlement_sync.py
+++ b/packages/google-cloud-privilegedaccessmanager/samples/generated_samples/privilegedaccessmanager_v1_generated_privileged_access_manager_create_entitlement_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-privilegedaccessmanager/samples/generated_samples/privilegedaccessmanager_v1_generated_privileged_access_manager_create_grant_async.py
+++ b/packages/google-cloud-privilegedaccessmanager/samples/generated_samples/privilegedaccessmanager_v1_generated_privileged_access_manager_create_grant_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-privilegedaccessmanager/samples/generated_samples/privilegedaccessmanager_v1_generated_privileged_access_manager_create_grant_sync.py
+++ b/packages/google-cloud-privilegedaccessmanager/samples/generated_samples/privilegedaccessmanager_v1_generated_privileged_access_manager_create_grant_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-privilegedaccessmanager/samples/generated_samples/privilegedaccessmanager_v1_generated_privileged_access_manager_delete_entitlement_sync.py
+++ b/packages/google-cloud-privilegedaccessmanager/samples/generated_samples/privilegedaccessmanager_v1_generated_privileged_access_manager_delete_entitlement_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-privilegedaccessmanager/samples/generated_samples/privilegedaccessmanager_v1_generated_privileged_access_manager_deny_grant_async.py
+++ b/packages/google-cloud-privilegedaccessmanager/samples/generated_samples/privilegedaccessmanager_v1_generated_privileged_access_manager_deny_grant_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-privilegedaccessmanager/samples/generated_samples/privilegedaccessmanager_v1_generated_privileged_access_manager_deny_grant_sync.py
+++ b/packages/google-cloud-privilegedaccessmanager/samples/generated_samples/privilegedaccessmanager_v1_generated_privileged_access_manager_deny_grant_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-privilegedaccessmanager/samples/generated_samples/privilegedaccessmanager_v1_generated_privileged_access_manager_get_entitlement_async.py
+++ b/packages/google-cloud-privilegedaccessmanager/samples/generated_samples/privilegedaccessmanager_v1_generated_privileged_access_manager_get_entitlement_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-privilegedaccessmanager/samples/generated_samples/privilegedaccessmanager_v1_generated_privileged_access_manager_get_entitlement_sync.py
+++ b/packages/google-cloud-privilegedaccessmanager/samples/generated_samples/privilegedaccessmanager_v1_generated_privileged_access_manager_get_entitlement_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-privilegedaccessmanager/samples/generated_samples/privilegedaccessmanager_v1_generated_privileged_access_manager_get_grant_async.py
+++ b/packages/google-cloud-privilegedaccessmanager/samples/generated_samples/privilegedaccessmanager_v1_generated_privileged_access_manager_get_grant_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-privilegedaccessmanager/samples/generated_samples/privilegedaccessmanager_v1_generated_privileged_access_manager_get_grant_sync.py
+++ b/packages/google-cloud-privilegedaccessmanager/samples/generated_samples/privilegedaccessmanager_v1_generated_privileged_access_manager_get_grant_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-privilegedaccessmanager/samples/generated_samples/privilegedaccessmanager_v1_generated_privileged_access_manager_list_entitlements_async.py
+++ b/packages/google-cloud-privilegedaccessmanager/samples/generated_samples/privilegedaccessmanager_v1_generated_privileged_access_manager_list_entitlements_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-privilegedaccessmanager/samples/generated_samples/privilegedaccessmanager_v1_generated_privileged_access_manager_list_entitlements_sync.py
+++ b/packages/google-cloud-privilegedaccessmanager/samples/generated_samples/privilegedaccessmanager_v1_generated_privileged_access_manager_list_entitlements_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-privilegedaccessmanager/samples/generated_samples/privilegedaccessmanager_v1_generated_privileged_access_manager_list_grants_async.py
+++ b/packages/google-cloud-privilegedaccessmanager/samples/generated_samples/privilegedaccessmanager_v1_generated_privileged_access_manager_list_grants_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-privilegedaccessmanager/samples/generated_samples/privilegedaccessmanager_v1_generated_privileged_access_manager_list_grants_sync.py
+++ b/packages/google-cloud-privilegedaccessmanager/samples/generated_samples/privilegedaccessmanager_v1_generated_privileged_access_manager_list_grants_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-privilegedaccessmanager/samples/generated_samples/privilegedaccessmanager_v1_generated_privileged_access_manager_revoke_grant_sync.py
+++ b/packages/google-cloud-privilegedaccessmanager/samples/generated_samples/privilegedaccessmanager_v1_generated_privileged_access_manager_revoke_grant_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-privilegedaccessmanager/samples/generated_samples/privilegedaccessmanager_v1_generated_privileged_access_manager_search_entitlements_async.py
+++ b/packages/google-cloud-privilegedaccessmanager/samples/generated_samples/privilegedaccessmanager_v1_generated_privileged_access_manager_search_entitlements_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-privilegedaccessmanager/samples/generated_samples/privilegedaccessmanager_v1_generated_privileged_access_manager_search_entitlements_sync.py
+++ b/packages/google-cloud-privilegedaccessmanager/samples/generated_samples/privilegedaccessmanager_v1_generated_privileged_access_manager_search_entitlements_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-privilegedaccessmanager/samples/generated_samples/privilegedaccessmanager_v1_generated_privileged_access_manager_search_grants_async.py
+++ b/packages/google-cloud-privilegedaccessmanager/samples/generated_samples/privilegedaccessmanager_v1_generated_privileged_access_manager_search_grants_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-privilegedaccessmanager/samples/generated_samples/privilegedaccessmanager_v1_generated_privileged_access_manager_search_grants_sync.py
+++ b/packages/google-cloud-privilegedaccessmanager/samples/generated_samples/privilegedaccessmanager_v1_generated_privileged_access_manager_search_grants_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-privilegedaccessmanager/samples/generated_samples/privilegedaccessmanager_v1_generated_privileged_access_manager_update_entitlement_sync.py
+++ b/packages/google-cloud-privilegedaccessmanager/samples/generated_samples/privilegedaccessmanager_v1_generated_privileged_access_manager_update_entitlement_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-privilegedaccessmanager/tests/__init__.py
+++ b/packages/google-cloud-privilegedaccessmanager/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-privilegedaccessmanager/tests/unit/__init__.py
+++ b/packages/google-cloud-privilegedaccessmanager/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-privilegedaccessmanager/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-privilegedaccessmanager/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-privilegedaccessmanager/tests/unit/gapic/privilegedaccessmanager_v1/__init__.py
+++ b/packages/google-cloud-privilegedaccessmanager/tests/unit/gapic/privilegedaccessmanager_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-pubsub/.flake8
+++ b/packages/google-cloud-pubsub/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-pubsub/MANIFEST.in
+++ b/packages/google-cloud-pubsub/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-pubsub/google/pubsub/__init__.py
+++ b/packages/google-cloud-pubsub/google/pubsub/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-pubsub/google/pubsub/gapic_version.py
+++ b/packages/google-cloud-pubsub/google/pubsub/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-pubsub/google/pubsub_v1/gapic_version.py
+++ b/packages/google-cloud-pubsub/google/pubsub_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-pubsub/google/pubsub_v1/services/__init__.py
+++ b/packages/google-cloud-pubsub/google/pubsub_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-pubsub/google/pubsub_v1/services/publisher/__init__.py
+++ b/packages/google-cloud-pubsub/google/pubsub_v1/services/publisher/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-pubsub/google/pubsub_v1/services/publisher/async_client.py
+++ b/packages/google-cloud-pubsub/google/pubsub_v1/services/publisher/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-pubsub/google/pubsub_v1/services/publisher/client.py
+++ b/packages/google-cloud-pubsub/google/pubsub_v1/services/publisher/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-pubsub/google/pubsub_v1/services/publisher/pagers.py
+++ b/packages/google-cloud-pubsub/google/pubsub_v1/services/publisher/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-pubsub/google/pubsub_v1/services/publisher/transports/__init__.py
+++ b/packages/google-cloud-pubsub/google/pubsub_v1/services/publisher/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-pubsub/google/pubsub_v1/services/publisher/transports/base.py
+++ b/packages/google-cloud-pubsub/google/pubsub_v1/services/publisher/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-pubsub/google/pubsub_v1/services/publisher/transports/grpc.py
+++ b/packages/google-cloud-pubsub/google/pubsub_v1/services/publisher/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-pubsub/google/pubsub_v1/services/publisher/transports/grpc_asyncio.py
+++ b/packages/google-cloud-pubsub/google/pubsub_v1/services/publisher/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-pubsub/google/pubsub_v1/services/publisher/transports/rest.py
+++ b/packages/google-cloud-pubsub/google/pubsub_v1/services/publisher/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-pubsub/google/pubsub_v1/services/publisher/transports/rest_base.py
+++ b/packages/google-cloud-pubsub/google/pubsub_v1/services/publisher/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-pubsub/google/pubsub_v1/services/schema_service/__init__.py
+++ b/packages/google-cloud-pubsub/google/pubsub_v1/services/schema_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-pubsub/google/pubsub_v1/services/schema_service/async_client.py
+++ b/packages/google-cloud-pubsub/google/pubsub_v1/services/schema_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-pubsub/google/pubsub_v1/services/schema_service/client.py
+++ b/packages/google-cloud-pubsub/google/pubsub_v1/services/schema_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-pubsub/google/pubsub_v1/services/schema_service/pagers.py
+++ b/packages/google-cloud-pubsub/google/pubsub_v1/services/schema_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-pubsub/google/pubsub_v1/services/schema_service/transports/__init__.py
+++ b/packages/google-cloud-pubsub/google/pubsub_v1/services/schema_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-pubsub/google/pubsub_v1/services/schema_service/transports/base.py
+++ b/packages/google-cloud-pubsub/google/pubsub_v1/services/schema_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-pubsub/google/pubsub_v1/services/schema_service/transports/grpc.py
+++ b/packages/google-cloud-pubsub/google/pubsub_v1/services/schema_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-pubsub/google/pubsub_v1/services/schema_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-pubsub/google/pubsub_v1/services/schema_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-pubsub/google/pubsub_v1/services/schema_service/transports/rest.py
+++ b/packages/google-cloud-pubsub/google/pubsub_v1/services/schema_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-pubsub/google/pubsub_v1/services/schema_service/transports/rest_base.py
+++ b/packages/google-cloud-pubsub/google/pubsub_v1/services/schema_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-pubsub/google/pubsub_v1/services/subscriber/__init__.py
+++ b/packages/google-cloud-pubsub/google/pubsub_v1/services/subscriber/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-pubsub/google/pubsub_v1/services/subscriber/async_client.py
+++ b/packages/google-cloud-pubsub/google/pubsub_v1/services/subscriber/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-pubsub/google/pubsub_v1/services/subscriber/client.py
+++ b/packages/google-cloud-pubsub/google/pubsub_v1/services/subscriber/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-pubsub/google/pubsub_v1/services/subscriber/pagers.py
+++ b/packages/google-cloud-pubsub/google/pubsub_v1/services/subscriber/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-pubsub/google/pubsub_v1/services/subscriber/transports/__init__.py
+++ b/packages/google-cloud-pubsub/google/pubsub_v1/services/subscriber/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-pubsub/google/pubsub_v1/services/subscriber/transports/base.py
+++ b/packages/google-cloud-pubsub/google/pubsub_v1/services/subscriber/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-pubsub/google/pubsub_v1/services/subscriber/transports/grpc.py
+++ b/packages/google-cloud-pubsub/google/pubsub_v1/services/subscriber/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-pubsub/google/pubsub_v1/services/subscriber/transports/grpc_asyncio.py
+++ b/packages/google-cloud-pubsub/google/pubsub_v1/services/subscriber/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-pubsub/google/pubsub_v1/services/subscriber/transports/rest.py
+++ b/packages/google-cloud-pubsub/google/pubsub_v1/services/subscriber/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-pubsub/google/pubsub_v1/services/subscriber/transports/rest_base.py
+++ b/packages/google-cloud-pubsub/google/pubsub_v1/services/subscriber/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-pubsub/google/pubsub_v1/types/__init__.py
+++ b/packages/google-cloud-pubsub/google/pubsub_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-pubsub/google/pubsub_v1/types/pubsub.py
+++ b/packages/google-cloud-pubsub/google/pubsub_v1/types/pubsub.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-pubsub/google/pubsub_v1/types/schema.py
+++ b/packages/google-cloud-pubsub/google/pubsub_v1/types/schema.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_publisher_create_topic_async.py
+++ b/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_publisher_create_topic_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_publisher_create_topic_sync.py
+++ b/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_publisher_create_topic_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_publisher_delete_topic_async.py
+++ b/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_publisher_delete_topic_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_publisher_delete_topic_sync.py
+++ b/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_publisher_delete_topic_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_publisher_detach_subscription_async.py
+++ b/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_publisher_detach_subscription_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_publisher_detach_subscription_sync.py
+++ b/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_publisher_detach_subscription_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_publisher_get_topic_async.py
+++ b/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_publisher_get_topic_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_publisher_get_topic_sync.py
+++ b/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_publisher_get_topic_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_publisher_list_topic_snapshots_async.py
+++ b/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_publisher_list_topic_snapshots_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_publisher_list_topic_snapshots_sync.py
+++ b/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_publisher_list_topic_snapshots_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_publisher_list_topic_subscriptions_async.py
+++ b/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_publisher_list_topic_subscriptions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_publisher_list_topic_subscriptions_sync.py
+++ b/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_publisher_list_topic_subscriptions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_publisher_list_topics_async.py
+++ b/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_publisher_list_topics_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_publisher_list_topics_sync.py
+++ b/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_publisher_list_topics_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_publisher_publish_async.py
+++ b/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_publisher_publish_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_publisher_publish_sync.py
+++ b/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_publisher_publish_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_publisher_update_topic_async.py
+++ b/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_publisher_update_topic_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_publisher_update_topic_sync.py
+++ b/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_publisher_update_topic_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_schema_service_commit_schema_async.py
+++ b/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_schema_service_commit_schema_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_schema_service_commit_schema_sync.py
+++ b/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_schema_service_commit_schema_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_schema_service_create_schema_async.py
+++ b/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_schema_service_create_schema_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_schema_service_create_schema_sync.py
+++ b/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_schema_service_create_schema_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_schema_service_delete_schema_async.py
+++ b/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_schema_service_delete_schema_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_schema_service_delete_schema_revision_async.py
+++ b/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_schema_service_delete_schema_revision_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_schema_service_delete_schema_revision_sync.py
+++ b/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_schema_service_delete_schema_revision_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_schema_service_delete_schema_sync.py
+++ b/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_schema_service_delete_schema_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_schema_service_get_schema_async.py
+++ b/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_schema_service_get_schema_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_schema_service_get_schema_sync.py
+++ b/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_schema_service_get_schema_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_schema_service_list_schema_revisions_async.py
+++ b/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_schema_service_list_schema_revisions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_schema_service_list_schema_revisions_sync.py
+++ b/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_schema_service_list_schema_revisions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_schema_service_list_schemas_async.py
+++ b/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_schema_service_list_schemas_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_schema_service_list_schemas_sync.py
+++ b/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_schema_service_list_schemas_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_schema_service_rollback_schema_async.py
+++ b/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_schema_service_rollback_schema_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_schema_service_rollback_schema_sync.py
+++ b/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_schema_service_rollback_schema_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_schema_service_validate_message_async.py
+++ b/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_schema_service_validate_message_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_schema_service_validate_message_sync.py
+++ b/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_schema_service_validate_message_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_schema_service_validate_schema_async.py
+++ b/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_schema_service_validate_schema_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_schema_service_validate_schema_sync.py
+++ b/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_schema_service_validate_schema_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_subscriber_acknowledge_async.py
+++ b/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_subscriber_acknowledge_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_subscriber_acknowledge_sync.py
+++ b/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_subscriber_acknowledge_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_subscriber_create_snapshot_async.py
+++ b/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_subscriber_create_snapshot_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_subscriber_create_snapshot_sync.py
+++ b/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_subscriber_create_snapshot_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_subscriber_create_subscription_async.py
+++ b/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_subscriber_create_subscription_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_subscriber_create_subscription_sync.py
+++ b/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_subscriber_create_subscription_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_subscriber_delete_snapshot_async.py
+++ b/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_subscriber_delete_snapshot_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_subscriber_delete_snapshot_sync.py
+++ b/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_subscriber_delete_snapshot_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_subscriber_delete_subscription_async.py
+++ b/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_subscriber_delete_subscription_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_subscriber_delete_subscription_sync.py
+++ b/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_subscriber_delete_subscription_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_subscriber_get_snapshot_async.py
+++ b/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_subscriber_get_snapshot_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_subscriber_get_snapshot_sync.py
+++ b/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_subscriber_get_snapshot_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_subscriber_get_subscription_async.py
+++ b/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_subscriber_get_subscription_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_subscriber_get_subscription_sync.py
+++ b/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_subscriber_get_subscription_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_subscriber_list_snapshots_async.py
+++ b/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_subscriber_list_snapshots_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_subscriber_list_snapshots_sync.py
+++ b/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_subscriber_list_snapshots_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_subscriber_list_subscriptions_async.py
+++ b/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_subscriber_list_subscriptions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_subscriber_list_subscriptions_sync.py
+++ b/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_subscriber_list_subscriptions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_subscriber_modify_ack_deadline_async.py
+++ b/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_subscriber_modify_ack_deadline_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_subscriber_modify_ack_deadline_sync.py
+++ b/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_subscriber_modify_ack_deadline_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_subscriber_modify_push_config_async.py
+++ b/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_subscriber_modify_push_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_subscriber_modify_push_config_sync.py
+++ b/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_subscriber_modify_push_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_subscriber_pull_async.py
+++ b/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_subscriber_pull_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_subscriber_pull_sync.py
+++ b/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_subscriber_pull_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_subscriber_seek_async.py
+++ b/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_subscriber_seek_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_subscriber_seek_sync.py
+++ b/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_subscriber_seek_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_subscriber_streaming_pull_async.py
+++ b/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_subscriber_streaming_pull_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_subscriber_streaming_pull_sync.py
+++ b/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_subscriber_streaming_pull_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_subscriber_update_snapshot_async.py
+++ b/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_subscriber_update_snapshot_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_subscriber_update_snapshot_sync.py
+++ b/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_subscriber_update_snapshot_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_subscriber_update_subscription_async.py
+++ b/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_subscriber_update_subscription_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_subscriber_update_subscription_sync.py
+++ b/packages/google-cloud-pubsub/samples/generated_samples/pubsub_v1_generated_subscriber_update_subscription_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-pubsub/tests/__init__.py
+++ b/packages/google-cloud-pubsub/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-pubsub/tests/unit/__init__.py
+++ b/packages/google-cloud-pubsub/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-pubsub/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-pubsub/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-pubsub/tests/unit/gapic/pubsub_v1/__init__.py
+++ b/packages/google-cloud-pubsub/tests/unit/gapic/pubsub_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-quotas/.flake8
+++ b/packages/google-cloud-quotas/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-quotas/MANIFEST.in
+++ b/packages/google-cloud-quotas/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-quotas/google/cloud/cloudquotas/__init__.py
+++ b/packages/google-cloud-quotas/google/cloud/cloudquotas/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-quotas/google/cloud/cloudquotas/gapic_version.py
+++ b/packages/google-cloud-quotas/google/cloud/cloudquotas/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-quotas/google/cloud/cloudquotas_v1/gapic_version.py
+++ b/packages/google-cloud-quotas/google/cloud/cloudquotas_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-quotas/google/cloud/cloudquotas_v1/services/__init__.py
+++ b/packages/google-cloud-quotas/google/cloud/cloudquotas_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-quotas/google/cloud/cloudquotas_v1/services/cloud_quotas/__init__.py
+++ b/packages/google-cloud-quotas/google/cloud/cloudquotas_v1/services/cloud_quotas/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-quotas/google/cloud/cloudquotas_v1/services/cloud_quotas/async_client.py
+++ b/packages/google-cloud-quotas/google/cloud/cloudquotas_v1/services/cloud_quotas/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-quotas/google/cloud/cloudquotas_v1/services/cloud_quotas/client.py
+++ b/packages/google-cloud-quotas/google/cloud/cloudquotas_v1/services/cloud_quotas/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-quotas/google/cloud/cloudquotas_v1/services/cloud_quotas/pagers.py
+++ b/packages/google-cloud-quotas/google/cloud/cloudquotas_v1/services/cloud_quotas/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-quotas/google/cloud/cloudquotas_v1/services/cloud_quotas/transports/__init__.py
+++ b/packages/google-cloud-quotas/google/cloud/cloudquotas_v1/services/cloud_quotas/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-quotas/google/cloud/cloudquotas_v1/services/cloud_quotas/transports/base.py
+++ b/packages/google-cloud-quotas/google/cloud/cloudquotas_v1/services/cloud_quotas/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-quotas/google/cloud/cloudquotas_v1/services/cloud_quotas/transports/grpc.py
+++ b/packages/google-cloud-quotas/google/cloud/cloudquotas_v1/services/cloud_quotas/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-quotas/google/cloud/cloudquotas_v1/services/cloud_quotas/transports/grpc_asyncio.py
+++ b/packages/google-cloud-quotas/google/cloud/cloudquotas_v1/services/cloud_quotas/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-quotas/google/cloud/cloudquotas_v1/services/cloud_quotas/transports/rest.py
+++ b/packages/google-cloud-quotas/google/cloud/cloudquotas_v1/services/cloud_quotas/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-quotas/google/cloud/cloudquotas_v1/services/cloud_quotas/transports/rest_base.py
+++ b/packages/google-cloud-quotas/google/cloud/cloudquotas_v1/services/cloud_quotas/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-quotas/google/cloud/cloudquotas_v1/types/__init__.py
+++ b/packages/google-cloud-quotas/google/cloud/cloudquotas_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-quotas/google/cloud/cloudquotas_v1/types/cloudquotas.py
+++ b/packages/google-cloud-quotas/google/cloud/cloudquotas_v1/types/cloudquotas.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-quotas/google/cloud/cloudquotas_v1/types/resources.py
+++ b/packages/google-cloud-quotas/google/cloud/cloudquotas_v1/types/resources.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-quotas/google/cloud/cloudquotas_v1beta/gapic_version.py
+++ b/packages/google-cloud-quotas/google/cloud/cloudquotas_v1beta/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-quotas/google/cloud/cloudquotas_v1beta/services/__init__.py
+++ b/packages/google-cloud-quotas/google/cloud/cloudquotas_v1beta/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-quotas/google/cloud/cloudquotas_v1beta/services/cloud_quotas/__init__.py
+++ b/packages/google-cloud-quotas/google/cloud/cloudquotas_v1beta/services/cloud_quotas/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-quotas/google/cloud/cloudquotas_v1beta/services/cloud_quotas/async_client.py
+++ b/packages/google-cloud-quotas/google/cloud/cloudquotas_v1beta/services/cloud_quotas/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-quotas/google/cloud/cloudquotas_v1beta/services/cloud_quotas/client.py
+++ b/packages/google-cloud-quotas/google/cloud/cloudquotas_v1beta/services/cloud_quotas/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-quotas/google/cloud/cloudquotas_v1beta/services/cloud_quotas/pagers.py
+++ b/packages/google-cloud-quotas/google/cloud/cloudquotas_v1beta/services/cloud_quotas/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-quotas/google/cloud/cloudquotas_v1beta/services/cloud_quotas/transports/__init__.py
+++ b/packages/google-cloud-quotas/google/cloud/cloudquotas_v1beta/services/cloud_quotas/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-quotas/google/cloud/cloudquotas_v1beta/services/cloud_quotas/transports/base.py
+++ b/packages/google-cloud-quotas/google/cloud/cloudquotas_v1beta/services/cloud_quotas/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-quotas/google/cloud/cloudquotas_v1beta/services/cloud_quotas/transports/grpc.py
+++ b/packages/google-cloud-quotas/google/cloud/cloudquotas_v1beta/services/cloud_quotas/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-quotas/google/cloud/cloudquotas_v1beta/services/cloud_quotas/transports/grpc_asyncio.py
+++ b/packages/google-cloud-quotas/google/cloud/cloudquotas_v1beta/services/cloud_quotas/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-quotas/google/cloud/cloudquotas_v1beta/services/cloud_quotas/transports/rest.py
+++ b/packages/google-cloud-quotas/google/cloud/cloudquotas_v1beta/services/cloud_quotas/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-quotas/google/cloud/cloudquotas_v1beta/services/cloud_quotas/transports/rest_base.py
+++ b/packages/google-cloud-quotas/google/cloud/cloudquotas_v1beta/services/cloud_quotas/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-quotas/google/cloud/cloudquotas_v1beta/services/quota_adjuster_settings_manager/__init__.py
+++ b/packages/google-cloud-quotas/google/cloud/cloudquotas_v1beta/services/quota_adjuster_settings_manager/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-quotas/google/cloud/cloudquotas_v1beta/services/quota_adjuster_settings_manager/async_client.py
+++ b/packages/google-cloud-quotas/google/cloud/cloudquotas_v1beta/services/quota_adjuster_settings_manager/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-quotas/google/cloud/cloudquotas_v1beta/services/quota_adjuster_settings_manager/client.py
+++ b/packages/google-cloud-quotas/google/cloud/cloudquotas_v1beta/services/quota_adjuster_settings_manager/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-quotas/google/cloud/cloudquotas_v1beta/services/quota_adjuster_settings_manager/transports/__init__.py
+++ b/packages/google-cloud-quotas/google/cloud/cloudquotas_v1beta/services/quota_adjuster_settings_manager/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-quotas/google/cloud/cloudquotas_v1beta/services/quota_adjuster_settings_manager/transports/base.py
+++ b/packages/google-cloud-quotas/google/cloud/cloudquotas_v1beta/services/quota_adjuster_settings_manager/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-quotas/google/cloud/cloudquotas_v1beta/services/quota_adjuster_settings_manager/transports/grpc.py
+++ b/packages/google-cloud-quotas/google/cloud/cloudquotas_v1beta/services/quota_adjuster_settings_manager/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-quotas/google/cloud/cloudquotas_v1beta/services/quota_adjuster_settings_manager/transports/grpc_asyncio.py
+++ b/packages/google-cloud-quotas/google/cloud/cloudquotas_v1beta/services/quota_adjuster_settings_manager/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-quotas/google/cloud/cloudquotas_v1beta/services/quota_adjuster_settings_manager/transports/rest.py
+++ b/packages/google-cloud-quotas/google/cloud/cloudquotas_v1beta/services/quota_adjuster_settings_manager/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-quotas/google/cloud/cloudquotas_v1beta/services/quota_adjuster_settings_manager/transports/rest_base.py
+++ b/packages/google-cloud-quotas/google/cloud/cloudquotas_v1beta/services/quota_adjuster_settings_manager/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-quotas/google/cloud/cloudquotas_v1beta/types/__init__.py
+++ b/packages/google-cloud-quotas/google/cloud/cloudquotas_v1beta/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-quotas/google/cloud/cloudquotas_v1beta/types/cloudquotas.py
+++ b/packages/google-cloud-quotas/google/cloud/cloudquotas_v1beta/types/cloudquotas.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-quotas/google/cloud/cloudquotas_v1beta/types/quota_adjuster_settings.py
+++ b/packages/google-cloud-quotas/google/cloud/cloudquotas_v1beta/types/quota_adjuster_settings.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-quotas/google/cloud/cloudquotas_v1beta/types/resources.py
+++ b/packages/google-cloud-quotas/google/cloud/cloudquotas_v1beta/types/resources.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-quotas/samples/generated_samples/cloudquotas_v1_generated_cloud_quotas_create_quota_preference_async.py
+++ b/packages/google-cloud-quotas/samples/generated_samples/cloudquotas_v1_generated_cloud_quotas_create_quota_preference_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-quotas/samples/generated_samples/cloudquotas_v1_generated_cloud_quotas_create_quota_preference_sync.py
+++ b/packages/google-cloud-quotas/samples/generated_samples/cloudquotas_v1_generated_cloud_quotas_create_quota_preference_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-quotas/samples/generated_samples/cloudquotas_v1_generated_cloud_quotas_get_quota_info_async.py
+++ b/packages/google-cloud-quotas/samples/generated_samples/cloudquotas_v1_generated_cloud_quotas_get_quota_info_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-quotas/samples/generated_samples/cloudquotas_v1_generated_cloud_quotas_get_quota_info_sync.py
+++ b/packages/google-cloud-quotas/samples/generated_samples/cloudquotas_v1_generated_cloud_quotas_get_quota_info_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-quotas/samples/generated_samples/cloudquotas_v1_generated_cloud_quotas_get_quota_preference_async.py
+++ b/packages/google-cloud-quotas/samples/generated_samples/cloudquotas_v1_generated_cloud_quotas_get_quota_preference_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-quotas/samples/generated_samples/cloudquotas_v1_generated_cloud_quotas_get_quota_preference_sync.py
+++ b/packages/google-cloud-quotas/samples/generated_samples/cloudquotas_v1_generated_cloud_quotas_get_quota_preference_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-quotas/samples/generated_samples/cloudquotas_v1_generated_cloud_quotas_list_quota_infos_async.py
+++ b/packages/google-cloud-quotas/samples/generated_samples/cloudquotas_v1_generated_cloud_quotas_list_quota_infos_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-quotas/samples/generated_samples/cloudquotas_v1_generated_cloud_quotas_list_quota_infos_sync.py
+++ b/packages/google-cloud-quotas/samples/generated_samples/cloudquotas_v1_generated_cloud_quotas_list_quota_infos_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-quotas/samples/generated_samples/cloudquotas_v1_generated_cloud_quotas_list_quota_preferences_async.py
+++ b/packages/google-cloud-quotas/samples/generated_samples/cloudquotas_v1_generated_cloud_quotas_list_quota_preferences_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-quotas/samples/generated_samples/cloudquotas_v1_generated_cloud_quotas_list_quota_preferences_sync.py
+++ b/packages/google-cloud-quotas/samples/generated_samples/cloudquotas_v1_generated_cloud_quotas_list_quota_preferences_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-quotas/samples/generated_samples/cloudquotas_v1_generated_cloud_quotas_update_quota_preference_async.py
+++ b/packages/google-cloud-quotas/samples/generated_samples/cloudquotas_v1_generated_cloud_quotas_update_quota_preference_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-quotas/samples/generated_samples/cloudquotas_v1_generated_cloud_quotas_update_quota_preference_sync.py
+++ b/packages/google-cloud-quotas/samples/generated_samples/cloudquotas_v1_generated_cloud_quotas_update_quota_preference_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-quotas/samples/generated_samples/cloudquotas_v1beta_generated_cloud_quotas_create_quota_preference_async.py
+++ b/packages/google-cloud-quotas/samples/generated_samples/cloudquotas_v1beta_generated_cloud_quotas_create_quota_preference_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-quotas/samples/generated_samples/cloudquotas_v1beta_generated_cloud_quotas_create_quota_preference_sync.py
+++ b/packages/google-cloud-quotas/samples/generated_samples/cloudquotas_v1beta_generated_cloud_quotas_create_quota_preference_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-quotas/samples/generated_samples/cloudquotas_v1beta_generated_cloud_quotas_get_quota_info_async.py
+++ b/packages/google-cloud-quotas/samples/generated_samples/cloudquotas_v1beta_generated_cloud_quotas_get_quota_info_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-quotas/samples/generated_samples/cloudquotas_v1beta_generated_cloud_quotas_get_quota_info_sync.py
+++ b/packages/google-cloud-quotas/samples/generated_samples/cloudquotas_v1beta_generated_cloud_quotas_get_quota_info_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-quotas/samples/generated_samples/cloudquotas_v1beta_generated_cloud_quotas_get_quota_preference_async.py
+++ b/packages/google-cloud-quotas/samples/generated_samples/cloudquotas_v1beta_generated_cloud_quotas_get_quota_preference_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-quotas/samples/generated_samples/cloudquotas_v1beta_generated_cloud_quotas_get_quota_preference_sync.py
+++ b/packages/google-cloud-quotas/samples/generated_samples/cloudquotas_v1beta_generated_cloud_quotas_get_quota_preference_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-quotas/samples/generated_samples/cloudquotas_v1beta_generated_cloud_quotas_list_quota_infos_async.py
+++ b/packages/google-cloud-quotas/samples/generated_samples/cloudquotas_v1beta_generated_cloud_quotas_list_quota_infos_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-quotas/samples/generated_samples/cloudquotas_v1beta_generated_cloud_quotas_list_quota_infos_sync.py
+++ b/packages/google-cloud-quotas/samples/generated_samples/cloudquotas_v1beta_generated_cloud_quotas_list_quota_infos_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-quotas/samples/generated_samples/cloudquotas_v1beta_generated_cloud_quotas_list_quota_preferences_async.py
+++ b/packages/google-cloud-quotas/samples/generated_samples/cloudquotas_v1beta_generated_cloud_quotas_list_quota_preferences_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-quotas/samples/generated_samples/cloudquotas_v1beta_generated_cloud_quotas_list_quota_preferences_sync.py
+++ b/packages/google-cloud-quotas/samples/generated_samples/cloudquotas_v1beta_generated_cloud_quotas_list_quota_preferences_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-quotas/samples/generated_samples/cloudquotas_v1beta_generated_cloud_quotas_update_quota_preference_async.py
+++ b/packages/google-cloud-quotas/samples/generated_samples/cloudquotas_v1beta_generated_cloud_quotas_update_quota_preference_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-quotas/samples/generated_samples/cloudquotas_v1beta_generated_cloud_quotas_update_quota_preference_sync.py
+++ b/packages/google-cloud-quotas/samples/generated_samples/cloudquotas_v1beta_generated_cloud_quotas_update_quota_preference_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-quotas/samples/generated_samples/cloudquotas_v1beta_generated_quota_adjuster_settings_manager_get_quota_adjuster_settings_async.py
+++ b/packages/google-cloud-quotas/samples/generated_samples/cloudquotas_v1beta_generated_quota_adjuster_settings_manager_get_quota_adjuster_settings_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-quotas/samples/generated_samples/cloudquotas_v1beta_generated_quota_adjuster_settings_manager_get_quota_adjuster_settings_sync.py
+++ b/packages/google-cloud-quotas/samples/generated_samples/cloudquotas_v1beta_generated_quota_adjuster_settings_manager_get_quota_adjuster_settings_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-quotas/samples/generated_samples/cloudquotas_v1beta_generated_quota_adjuster_settings_manager_update_quota_adjuster_settings_async.py
+++ b/packages/google-cloud-quotas/samples/generated_samples/cloudquotas_v1beta_generated_quota_adjuster_settings_manager_update_quota_adjuster_settings_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-quotas/samples/generated_samples/cloudquotas_v1beta_generated_quota_adjuster_settings_manager_update_quota_adjuster_settings_sync.py
+++ b/packages/google-cloud-quotas/samples/generated_samples/cloudquotas_v1beta_generated_quota_adjuster_settings_manager_update_quota_adjuster_settings_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-quotas/tests/__init__.py
+++ b/packages/google-cloud-quotas/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-quotas/tests/unit/__init__.py
+++ b/packages/google-cloud-quotas/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-quotas/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-quotas/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-quotas/tests/unit/gapic/cloudquotas_v1/__init__.py
+++ b/packages/google-cloud-quotas/tests/unit/gapic/cloudquotas_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-quotas/tests/unit/gapic/cloudquotas_v1beta/__init__.py
+++ b/packages/google-cloud-quotas/tests/unit/gapic/cloudquotas_v1beta/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-rapidmigrationassessment/.flake8
+++ b/packages/google-cloud-rapidmigrationassessment/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-rapidmigrationassessment/MANIFEST.in
+++ b/packages/google-cloud-rapidmigrationassessment/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-rapidmigrationassessment/google/cloud/rapidmigrationassessment/__init__.py
+++ b/packages/google-cloud-rapidmigrationassessment/google/cloud/rapidmigrationassessment/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-rapidmigrationassessment/google/cloud/rapidmigrationassessment/gapic_version.py
+++ b/packages/google-cloud-rapidmigrationassessment/google/cloud/rapidmigrationassessment/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-rapidmigrationassessment/google/cloud/rapidmigrationassessment_v1/gapic_version.py
+++ b/packages/google-cloud-rapidmigrationassessment/google/cloud/rapidmigrationassessment_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-rapidmigrationassessment/google/cloud/rapidmigrationassessment_v1/services/__init__.py
+++ b/packages/google-cloud-rapidmigrationassessment/google/cloud/rapidmigrationassessment_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-rapidmigrationassessment/google/cloud/rapidmigrationassessment_v1/services/rapid_migration_assessment/__init__.py
+++ b/packages/google-cloud-rapidmigrationassessment/google/cloud/rapidmigrationassessment_v1/services/rapid_migration_assessment/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-rapidmigrationassessment/google/cloud/rapidmigrationassessment_v1/services/rapid_migration_assessment/client.py
+++ b/packages/google-cloud-rapidmigrationassessment/google/cloud/rapidmigrationassessment_v1/services/rapid_migration_assessment/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-rapidmigrationassessment/google/cloud/rapidmigrationassessment_v1/services/rapid_migration_assessment/pagers.py
+++ b/packages/google-cloud-rapidmigrationassessment/google/cloud/rapidmigrationassessment_v1/services/rapid_migration_assessment/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-rapidmigrationassessment/google/cloud/rapidmigrationassessment_v1/services/rapid_migration_assessment/transports/__init__.py
+++ b/packages/google-cloud-rapidmigrationassessment/google/cloud/rapidmigrationassessment_v1/services/rapid_migration_assessment/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-rapidmigrationassessment/google/cloud/rapidmigrationassessment_v1/services/rapid_migration_assessment/transports/base.py
+++ b/packages/google-cloud-rapidmigrationassessment/google/cloud/rapidmigrationassessment_v1/services/rapid_migration_assessment/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-rapidmigrationassessment/google/cloud/rapidmigrationassessment_v1/services/rapid_migration_assessment/transports/grpc.py
+++ b/packages/google-cloud-rapidmigrationassessment/google/cloud/rapidmigrationassessment_v1/services/rapid_migration_assessment/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-rapidmigrationassessment/google/cloud/rapidmigrationassessment_v1/services/rapid_migration_assessment/transports/grpc_asyncio.py
+++ b/packages/google-cloud-rapidmigrationassessment/google/cloud/rapidmigrationassessment_v1/services/rapid_migration_assessment/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-rapidmigrationassessment/google/cloud/rapidmigrationassessment_v1/services/rapid_migration_assessment/transports/rest.py
+++ b/packages/google-cloud-rapidmigrationassessment/google/cloud/rapidmigrationassessment_v1/services/rapid_migration_assessment/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-rapidmigrationassessment/google/cloud/rapidmigrationassessment_v1/services/rapid_migration_assessment/transports/rest_base.py
+++ b/packages/google-cloud-rapidmigrationassessment/google/cloud/rapidmigrationassessment_v1/services/rapid_migration_assessment/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-rapidmigrationassessment/google/cloud/rapidmigrationassessment_v1/types/__init__.py
+++ b/packages/google-cloud-rapidmigrationassessment/google/cloud/rapidmigrationassessment_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-rapidmigrationassessment/google/cloud/rapidmigrationassessment_v1/types/api_entities.py
+++ b/packages/google-cloud-rapidmigrationassessment/google/cloud/rapidmigrationassessment_v1/types/api_entities.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-rapidmigrationassessment/google/cloud/rapidmigrationassessment_v1/types/rapidmigrationassessment.py
+++ b/packages/google-cloud-rapidmigrationassessment/google/cloud/rapidmigrationassessment_v1/types/rapidmigrationassessment.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-rapidmigrationassessment/samples/generated_samples/rapidmigrationassessment_v1_generated_rapid_migration_assessment_create_annotation_sync.py
+++ b/packages/google-cloud-rapidmigrationassessment/samples/generated_samples/rapidmigrationassessment_v1_generated_rapid_migration_assessment_create_annotation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-rapidmigrationassessment/samples/generated_samples/rapidmigrationassessment_v1_generated_rapid_migration_assessment_create_collector_sync.py
+++ b/packages/google-cloud-rapidmigrationassessment/samples/generated_samples/rapidmigrationassessment_v1_generated_rapid_migration_assessment_create_collector_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-rapidmigrationassessment/samples/generated_samples/rapidmigrationassessment_v1_generated_rapid_migration_assessment_delete_collector_sync.py
+++ b/packages/google-cloud-rapidmigrationassessment/samples/generated_samples/rapidmigrationassessment_v1_generated_rapid_migration_assessment_delete_collector_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-rapidmigrationassessment/samples/generated_samples/rapidmigrationassessment_v1_generated_rapid_migration_assessment_get_annotation_async.py
+++ b/packages/google-cloud-rapidmigrationassessment/samples/generated_samples/rapidmigrationassessment_v1_generated_rapid_migration_assessment_get_annotation_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-rapidmigrationassessment/samples/generated_samples/rapidmigrationassessment_v1_generated_rapid_migration_assessment_get_annotation_sync.py
+++ b/packages/google-cloud-rapidmigrationassessment/samples/generated_samples/rapidmigrationassessment_v1_generated_rapid_migration_assessment_get_annotation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-rapidmigrationassessment/samples/generated_samples/rapidmigrationassessment_v1_generated_rapid_migration_assessment_get_collector_async.py
+++ b/packages/google-cloud-rapidmigrationassessment/samples/generated_samples/rapidmigrationassessment_v1_generated_rapid_migration_assessment_get_collector_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-rapidmigrationassessment/samples/generated_samples/rapidmigrationassessment_v1_generated_rapid_migration_assessment_get_collector_sync.py
+++ b/packages/google-cloud-rapidmigrationassessment/samples/generated_samples/rapidmigrationassessment_v1_generated_rapid_migration_assessment_get_collector_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-rapidmigrationassessment/samples/generated_samples/rapidmigrationassessment_v1_generated_rapid_migration_assessment_list_collectors_async.py
+++ b/packages/google-cloud-rapidmigrationassessment/samples/generated_samples/rapidmigrationassessment_v1_generated_rapid_migration_assessment_list_collectors_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-rapidmigrationassessment/samples/generated_samples/rapidmigrationassessment_v1_generated_rapid_migration_assessment_list_collectors_sync.py
+++ b/packages/google-cloud-rapidmigrationassessment/samples/generated_samples/rapidmigrationassessment_v1_generated_rapid_migration_assessment_list_collectors_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-rapidmigrationassessment/samples/generated_samples/rapidmigrationassessment_v1_generated_rapid_migration_assessment_pause_collector_sync.py
+++ b/packages/google-cloud-rapidmigrationassessment/samples/generated_samples/rapidmigrationassessment_v1_generated_rapid_migration_assessment_pause_collector_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-rapidmigrationassessment/samples/generated_samples/rapidmigrationassessment_v1_generated_rapid_migration_assessment_register_collector_sync.py
+++ b/packages/google-cloud-rapidmigrationassessment/samples/generated_samples/rapidmigrationassessment_v1_generated_rapid_migration_assessment_register_collector_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-rapidmigrationassessment/samples/generated_samples/rapidmigrationassessment_v1_generated_rapid_migration_assessment_resume_collector_sync.py
+++ b/packages/google-cloud-rapidmigrationassessment/samples/generated_samples/rapidmigrationassessment_v1_generated_rapid_migration_assessment_resume_collector_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-rapidmigrationassessment/samples/generated_samples/rapidmigrationassessment_v1_generated_rapid_migration_assessment_update_collector_sync.py
+++ b/packages/google-cloud-rapidmigrationassessment/samples/generated_samples/rapidmigrationassessment_v1_generated_rapid_migration_assessment_update_collector_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-rapidmigrationassessment/tests/__init__.py
+++ b/packages/google-cloud-rapidmigrationassessment/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-rapidmigrationassessment/tests/unit/__init__.py
+++ b/packages/google-cloud-rapidmigrationassessment/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-rapidmigrationassessment/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-rapidmigrationassessment/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-rapidmigrationassessment/tests/unit/gapic/rapidmigrationassessment_v1/__init__.py
+++ b/packages/google-cloud-rapidmigrationassessment/tests/unit/gapic/rapidmigrationassessment_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recaptcha-enterprise/.flake8
+++ b/packages/google-cloud-recaptcha-enterprise/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recaptcha-enterprise/MANIFEST.in
+++ b/packages/google-cloud-recaptcha-enterprise/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recaptcha-enterprise/google/cloud/recaptchaenterprise/__init__.py
+++ b/packages/google-cloud-recaptcha-enterprise/google/cloud/recaptchaenterprise/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recaptcha-enterprise/google/cloud/recaptchaenterprise/gapic_version.py
+++ b/packages/google-cloud-recaptcha-enterprise/google/cloud/recaptchaenterprise/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recaptcha-enterprise/google/cloud/recaptchaenterprise_v1/gapic_version.py
+++ b/packages/google-cloud-recaptcha-enterprise/google/cloud/recaptchaenterprise_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recaptcha-enterprise/google/cloud/recaptchaenterprise_v1/services/__init__.py
+++ b/packages/google-cloud-recaptcha-enterprise/google/cloud/recaptchaenterprise_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recaptcha-enterprise/google/cloud/recaptchaenterprise_v1/services/recaptcha_enterprise_service/__init__.py
+++ b/packages/google-cloud-recaptcha-enterprise/google/cloud/recaptchaenterprise_v1/services/recaptcha_enterprise_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recaptcha-enterprise/google/cloud/recaptchaenterprise_v1/services/recaptcha_enterprise_service/async_client.py
+++ b/packages/google-cloud-recaptcha-enterprise/google/cloud/recaptchaenterprise_v1/services/recaptcha_enterprise_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recaptcha-enterprise/google/cloud/recaptchaenterprise_v1/services/recaptcha_enterprise_service/client.py
+++ b/packages/google-cloud-recaptcha-enterprise/google/cloud/recaptchaenterprise_v1/services/recaptcha_enterprise_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recaptcha-enterprise/google/cloud/recaptchaenterprise_v1/services/recaptcha_enterprise_service/pagers.py
+++ b/packages/google-cloud-recaptcha-enterprise/google/cloud/recaptchaenterprise_v1/services/recaptcha_enterprise_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recaptcha-enterprise/google/cloud/recaptchaenterprise_v1/services/recaptcha_enterprise_service/transports/__init__.py
+++ b/packages/google-cloud-recaptcha-enterprise/google/cloud/recaptchaenterprise_v1/services/recaptcha_enterprise_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recaptcha-enterprise/google/cloud/recaptchaenterprise_v1/services/recaptcha_enterprise_service/transports/base.py
+++ b/packages/google-cloud-recaptcha-enterprise/google/cloud/recaptchaenterprise_v1/services/recaptcha_enterprise_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recaptcha-enterprise/google/cloud/recaptchaenterprise_v1/services/recaptcha_enterprise_service/transports/grpc.py
+++ b/packages/google-cloud-recaptcha-enterprise/google/cloud/recaptchaenterprise_v1/services/recaptcha_enterprise_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recaptcha-enterprise/google/cloud/recaptchaenterprise_v1/services/recaptcha_enterprise_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-recaptcha-enterprise/google/cloud/recaptchaenterprise_v1/services/recaptcha_enterprise_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recaptcha-enterprise/google/cloud/recaptchaenterprise_v1/types/__init__.py
+++ b/packages/google-cloud-recaptcha-enterprise/google/cloud/recaptchaenterprise_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recaptcha-enterprise/google/cloud/recaptchaenterprise_v1/types/recaptchaenterprise.py
+++ b/packages/google-cloud-recaptcha-enterprise/google/cloud/recaptchaenterprise_v1/types/recaptchaenterprise.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recaptcha-enterprise/samples/generated_samples/recaptchaenterprise_v1_generated_recaptcha_enterprise_service_add_ip_override_async.py
+++ b/packages/google-cloud-recaptcha-enterprise/samples/generated_samples/recaptchaenterprise_v1_generated_recaptcha_enterprise_service_add_ip_override_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recaptcha-enterprise/samples/generated_samples/recaptchaenterprise_v1_generated_recaptcha_enterprise_service_add_ip_override_sync.py
+++ b/packages/google-cloud-recaptcha-enterprise/samples/generated_samples/recaptchaenterprise_v1_generated_recaptcha_enterprise_service_add_ip_override_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recaptcha-enterprise/samples/generated_samples/recaptchaenterprise_v1_generated_recaptcha_enterprise_service_annotate_assessment_async.py
+++ b/packages/google-cloud-recaptcha-enterprise/samples/generated_samples/recaptchaenterprise_v1_generated_recaptcha_enterprise_service_annotate_assessment_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recaptcha-enterprise/samples/generated_samples/recaptchaenterprise_v1_generated_recaptcha_enterprise_service_annotate_assessment_sync.py
+++ b/packages/google-cloud-recaptcha-enterprise/samples/generated_samples/recaptchaenterprise_v1_generated_recaptcha_enterprise_service_annotate_assessment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recaptcha-enterprise/samples/generated_samples/recaptchaenterprise_v1_generated_recaptcha_enterprise_service_create_assessment_async.py
+++ b/packages/google-cloud-recaptcha-enterprise/samples/generated_samples/recaptchaenterprise_v1_generated_recaptcha_enterprise_service_create_assessment_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recaptcha-enterprise/samples/generated_samples/recaptchaenterprise_v1_generated_recaptcha_enterprise_service_create_assessment_sync.py
+++ b/packages/google-cloud-recaptcha-enterprise/samples/generated_samples/recaptchaenterprise_v1_generated_recaptcha_enterprise_service_create_assessment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recaptcha-enterprise/samples/generated_samples/recaptchaenterprise_v1_generated_recaptcha_enterprise_service_create_firewall_policy_async.py
+++ b/packages/google-cloud-recaptcha-enterprise/samples/generated_samples/recaptchaenterprise_v1_generated_recaptcha_enterprise_service_create_firewall_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recaptcha-enterprise/samples/generated_samples/recaptchaenterprise_v1_generated_recaptcha_enterprise_service_create_firewall_policy_sync.py
+++ b/packages/google-cloud-recaptcha-enterprise/samples/generated_samples/recaptchaenterprise_v1_generated_recaptcha_enterprise_service_create_firewall_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recaptcha-enterprise/samples/generated_samples/recaptchaenterprise_v1_generated_recaptcha_enterprise_service_create_key_async.py
+++ b/packages/google-cloud-recaptcha-enterprise/samples/generated_samples/recaptchaenterprise_v1_generated_recaptcha_enterprise_service_create_key_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recaptcha-enterprise/samples/generated_samples/recaptchaenterprise_v1_generated_recaptcha_enterprise_service_create_key_sync.py
+++ b/packages/google-cloud-recaptcha-enterprise/samples/generated_samples/recaptchaenterprise_v1_generated_recaptcha_enterprise_service_create_key_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recaptcha-enterprise/samples/generated_samples/recaptchaenterprise_v1_generated_recaptcha_enterprise_service_delete_firewall_policy_async.py
+++ b/packages/google-cloud-recaptcha-enterprise/samples/generated_samples/recaptchaenterprise_v1_generated_recaptcha_enterprise_service_delete_firewall_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recaptcha-enterprise/samples/generated_samples/recaptchaenterprise_v1_generated_recaptcha_enterprise_service_delete_firewall_policy_sync.py
+++ b/packages/google-cloud-recaptcha-enterprise/samples/generated_samples/recaptchaenterprise_v1_generated_recaptcha_enterprise_service_delete_firewall_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recaptcha-enterprise/samples/generated_samples/recaptchaenterprise_v1_generated_recaptcha_enterprise_service_delete_key_async.py
+++ b/packages/google-cloud-recaptcha-enterprise/samples/generated_samples/recaptchaenterprise_v1_generated_recaptcha_enterprise_service_delete_key_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recaptcha-enterprise/samples/generated_samples/recaptchaenterprise_v1_generated_recaptcha_enterprise_service_delete_key_sync.py
+++ b/packages/google-cloud-recaptcha-enterprise/samples/generated_samples/recaptchaenterprise_v1_generated_recaptcha_enterprise_service_delete_key_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recaptcha-enterprise/samples/generated_samples/recaptchaenterprise_v1_generated_recaptcha_enterprise_service_get_firewall_policy_async.py
+++ b/packages/google-cloud-recaptcha-enterprise/samples/generated_samples/recaptchaenterprise_v1_generated_recaptcha_enterprise_service_get_firewall_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recaptcha-enterprise/samples/generated_samples/recaptchaenterprise_v1_generated_recaptcha_enterprise_service_get_firewall_policy_sync.py
+++ b/packages/google-cloud-recaptcha-enterprise/samples/generated_samples/recaptchaenterprise_v1_generated_recaptcha_enterprise_service_get_firewall_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recaptcha-enterprise/samples/generated_samples/recaptchaenterprise_v1_generated_recaptcha_enterprise_service_get_key_async.py
+++ b/packages/google-cloud-recaptcha-enterprise/samples/generated_samples/recaptchaenterprise_v1_generated_recaptcha_enterprise_service_get_key_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recaptcha-enterprise/samples/generated_samples/recaptchaenterprise_v1_generated_recaptcha_enterprise_service_get_key_sync.py
+++ b/packages/google-cloud-recaptcha-enterprise/samples/generated_samples/recaptchaenterprise_v1_generated_recaptcha_enterprise_service_get_key_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recaptcha-enterprise/samples/generated_samples/recaptchaenterprise_v1_generated_recaptcha_enterprise_service_get_metrics_async.py
+++ b/packages/google-cloud-recaptcha-enterprise/samples/generated_samples/recaptchaenterprise_v1_generated_recaptcha_enterprise_service_get_metrics_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recaptcha-enterprise/samples/generated_samples/recaptchaenterprise_v1_generated_recaptcha_enterprise_service_get_metrics_sync.py
+++ b/packages/google-cloud-recaptcha-enterprise/samples/generated_samples/recaptchaenterprise_v1_generated_recaptcha_enterprise_service_get_metrics_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recaptcha-enterprise/samples/generated_samples/recaptchaenterprise_v1_generated_recaptcha_enterprise_service_list_firewall_policies_async.py
+++ b/packages/google-cloud-recaptcha-enterprise/samples/generated_samples/recaptchaenterprise_v1_generated_recaptcha_enterprise_service_list_firewall_policies_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recaptcha-enterprise/samples/generated_samples/recaptchaenterprise_v1_generated_recaptcha_enterprise_service_list_firewall_policies_sync.py
+++ b/packages/google-cloud-recaptcha-enterprise/samples/generated_samples/recaptchaenterprise_v1_generated_recaptcha_enterprise_service_list_firewall_policies_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recaptcha-enterprise/samples/generated_samples/recaptchaenterprise_v1_generated_recaptcha_enterprise_service_list_ip_overrides_async.py
+++ b/packages/google-cloud-recaptcha-enterprise/samples/generated_samples/recaptchaenterprise_v1_generated_recaptcha_enterprise_service_list_ip_overrides_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recaptcha-enterprise/samples/generated_samples/recaptchaenterprise_v1_generated_recaptcha_enterprise_service_list_ip_overrides_sync.py
+++ b/packages/google-cloud-recaptcha-enterprise/samples/generated_samples/recaptchaenterprise_v1_generated_recaptcha_enterprise_service_list_ip_overrides_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recaptcha-enterprise/samples/generated_samples/recaptchaenterprise_v1_generated_recaptcha_enterprise_service_list_keys_async.py
+++ b/packages/google-cloud-recaptcha-enterprise/samples/generated_samples/recaptchaenterprise_v1_generated_recaptcha_enterprise_service_list_keys_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recaptcha-enterprise/samples/generated_samples/recaptchaenterprise_v1_generated_recaptcha_enterprise_service_list_keys_sync.py
+++ b/packages/google-cloud-recaptcha-enterprise/samples/generated_samples/recaptchaenterprise_v1_generated_recaptcha_enterprise_service_list_keys_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recaptcha-enterprise/samples/generated_samples/recaptchaenterprise_v1_generated_recaptcha_enterprise_service_list_related_account_group_memberships_async.py
+++ b/packages/google-cloud-recaptcha-enterprise/samples/generated_samples/recaptchaenterprise_v1_generated_recaptcha_enterprise_service_list_related_account_group_memberships_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recaptcha-enterprise/samples/generated_samples/recaptchaenterprise_v1_generated_recaptcha_enterprise_service_list_related_account_group_memberships_sync.py
+++ b/packages/google-cloud-recaptcha-enterprise/samples/generated_samples/recaptchaenterprise_v1_generated_recaptcha_enterprise_service_list_related_account_group_memberships_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recaptcha-enterprise/samples/generated_samples/recaptchaenterprise_v1_generated_recaptcha_enterprise_service_list_related_account_groups_async.py
+++ b/packages/google-cloud-recaptcha-enterprise/samples/generated_samples/recaptchaenterprise_v1_generated_recaptcha_enterprise_service_list_related_account_groups_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recaptcha-enterprise/samples/generated_samples/recaptchaenterprise_v1_generated_recaptcha_enterprise_service_list_related_account_groups_sync.py
+++ b/packages/google-cloud-recaptcha-enterprise/samples/generated_samples/recaptchaenterprise_v1_generated_recaptcha_enterprise_service_list_related_account_groups_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recaptcha-enterprise/samples/generated_samples/recaptchaenterprise_v1_generated_recaptcha_enterprise_service_migrate_key_async.py
+++ b/packages/google-cloud-recaptcha-enterprise/samples/generated_samples/recaptchaenterprise_v1_generated_recaptcha_enterprise_service_migrate_key_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recaptcha-enterprise/samples/generated_samples/recaptchaenterprise_v1_generated_recaptcha_enterprise_service_migrate_key_sync.py
+++ b/packages/google-cloud-recaptcha-enterprise/samples/generated_samples/recaptchaenterprise_v1_generated_recaptcha_enterprise_service_migrate_key_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recaptcha-enterprise/samples/generated_samples/recaptchaenterprise_v1_generated_recaptcha_enterprise_service_remove_ip_override_async.py
+++ b/packages/google-cloud-recaptcha-enterprise/samples/generated_samples/recaptchaenterprise_v1_generated_recaptcha_enterprise_service_remove_ip_override_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recaptcha-enterprise/samples/generated_samples/recaptchaenterprise_v1_generated_recaptcha_enterprise_service_remove_ip_override_sync.py
+++ b/packages/google-cloud-recaptcha-enterprise/samples/generated_samples/recaptchaenterprise_v1_generated_recaptcha_enterprise_service_remove_ip_override_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recaptcha-enterprise/samples/generated_samples/recaptchaenterprise_v1_generated_recaptcha_enterprise_service_reorder_firewall_policies_async.py
+++ b/packages/google-cloud-recaptcha-enterprise/samples/generated_samples/recaptchaenterprise_v1_generated_recaptcha_enterprise_service_reorder_firewall_policies_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recaptcha-enterprise/samples/generated_samples/recaptchaenterprise_v1_generated_recaptcha_enterprise_service_reorder_firewall_policies_sync.py
+++ b/packages/google-cloud-recaptcha-enterprise/samples/generated_samples/recaptchaenterprise_v1_generated_recaptcha_enterprise_service_reorder_firewall_policies_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recaptcha-enterprise/samples/generated_samples/recaptchaenterprise_v1_generated_recaptcha_enterprise_service_retrieve_legacy_secret_key_async.py
+++ b/packages/google-cloud-recaptcha-enterprise/samples/generated_samples/recaptchaenterprise_v1_generated_recaptcha_enterprise_service_retrieve_legacy_secret_key_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recaptcha-enterprise/samples/generated_samples/recaptchaenterprise_v1_generated_recaptcha_enterprise_service_retrieve_legacy_secret_key_sync.py
+++ b/packages/google-cloud-recaptcha-enterprise/samples/generated_samples/recaptchaenterprise_v1_generated_recaptcha_enterprise_service_retrieve_legacy_secret_key_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recaptcha-enterprise/samples/generated_samples/recaptchaenterprise_v1_generated_recaptcha_enterprise_service_search_related_account_group_memberships_async.py
+++ b/packages/google-cloud-recaptcha-enterprise/samples/generated_samples/recaptchaenterprise_v1_generated_recaptcha_enterprise_service_search_related_account_group_memberships_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recaptcha-enterprise/samples/generated_samples/recaptchaenterprise_v1_generated_recaptcha_enterprise_service_search_related_account_group_memberships_sync.py
+++ b/packages/google-cloud-recaptcha-enterprise/samples/generated_samples/recaptchaenterprise_v1_generated_recaptcha_enterprise_service_search_related_account_group_memberships_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recaptcha-enterprise/samples/generated_samples/recaptchaenterprise_v1_generated_recaptcha_enterprise_service_update_firewall_policy_async.py
+++ b/packages/google-cloud-recaptcha-enterprise/samples/generated_samples/recaptchaenterprise_v1_generated_recaptcha_enterprise_service_update_firewall_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recaptcha-enterprise/samples/generated_samples/recaptchaenterprise_v1_generated_recaptcha_enterprise_service_update_firewall_policy_sync.py
+++ b/packages/google-cloud-recaptcha-enterprise/samples/generated_samples/recaptchaenterprise_v1_generated_recaptcha_enterprise_service_update_firewall_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recaptcha-enterprise/samples/generated_samples/recaptchaenterprise_v1_generated_recaptcha_enterprise_service_update_key_async.py
+++ b/packages/google-cloud-recaptcha-enterprise/samples/generated_samples/recaptchaenterprise_v1_generated_recaptcha_enterprise_service_update_key_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recaptcha-enterprise/samples/generated_samples/recaptchaenterprise_v1_generated_recaptcha_enterprise_service_update_key_sync.py
+++ b/packages/google-cloud-recaptcha-enterprise/samples/generated_samples/recaptchaenterprise_v1_generated_recaptcha_enterprise_service_update_key_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recaptcha-enterprise/tests/__init__.py
+++ b/packages/google-cloud-recaptcha-enterprise/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recaptcha-enterprise/tests/unit/__init__.py
+++ b/packages/google-cloud-recaptcha-enterprise/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recaptcha-enterprise/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-recaptcha-enterprise/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recaptcha-enterprise/tests/unit/gapic/recaptchaenterprise_v1/__init__.py
+++ b/packages/google-cloud-recaptcha-enterprise/tests/unit/gapic/recaptchaenterprise_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommendations-ai/.flake8
+++ b/packages/google-cloud-recommendations-ai/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommendations-ai/MANIFEST.in
+++ b/packages/google-cloud-recommendations-ai/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommendations-ai/google/cloud/recommendationengine/__init__.py
+++ b/packages/google-cloud-recommendations-ai/google/cloud/recommendationengine/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommendations-ai/google/cloud/recommendationengine/gapic_version.py
+++ b/packages/google-cloud-recommendations-ai/google/cloud/recommendationengine/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommendations-ai/google/cloud/recommendationengine_v1beta1/gapic_version.py
+++ b/packages/google-cloud-recommendations-ai/google/cloud/recommendationengine_v1beta1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommendations-ai/google/cloud/recommendationengine_v1beta1/services/__init__.py
+++ b/packages/google-cloud-recommendations-ai/google/cloud/recommendationengine_v1beta1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommendations-ai/google/cloud/recommendationengine_v1beta1/services/catalog_service/__init__.py
+++ b/packages/google-cloud-recommendations-ai/google/cloud/recommendationengine_v1beta1/services/catalog_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommendations-ai/google/cloud/recommendationengine_v1beta1/services/catalog_service/client.py
+++ b/packages/google-cloud-recommendations-ai/google/cloud/recommendationengine_v1beta1/services/catalog_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommendations-ai/google/cloud/recommendationengine_v1beta1/services/catalog_service/pagers.py
+++ b/packages/google-cloud-recommendations-ai/google/cloud/recommendationengine_v1beta1/services/catalog_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommendations-ai/google/cloud/recommendationengine_v1beta1/services/catalog_service/transports/__init__.py
+++ b/packages/google-cloud-recommendations-ai/google/cloud/recommendationengine_v1beta1/services/catalog_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommendations-ai/google/cloud/recommendationengine_v1beta1/services/catalog_service/transports/base.py
+++ b/packages/google-cloud-recommendations-ai/google/cloud/recommendationengine_v1beta1/services/catalog_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommendations-ai/google/cloud/recommendationengine_v1beta1/services/catalog_service/transports/grpc.py
+++ b/packages/google-cloud-recommendations-ai/google/cloud/recommendationengine_v1beta1/services/catalog_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommendations-ai/google/cloud/recommendationengine_v1beta1/services/catalog_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-recommendations-ai/google/cloud/recommendationengine_v1beta1/services/catalog_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommendations-ai/google/cloud/recommendationengine_v1beta1/services/catalog_service/transports/rest.py
+++ b/packages/google-cloud-recommendations-ai/google/cloud/recommendationengine_v1beta1/services/catalog_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommendations-ai/google/cloud/recommendationengine_v1beta1/services/catalog_service/transports/rest_base.py
+++ b/packages/google-cloud-recommendations-ai/google/cloud/recommendationengine_v1beta1/services/catalog_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommendations-ai/google/cloud/recommendationengine_v1beta1/services/prediction_api_key_registry/__init__.py
+++ b/packages/google-cloud-recommendations-ai/google/cloud/recommendationengine_v1beta1/services/prediction_api_key_registry/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommendations-ai/google/cloud/recommendationengine_v1beta1/services/prediction_api_key_registry/async_client.py
+++ b/packages/google-cloud-recommendations-ai/google/cloud/recommendationengine_v1beta1/services/prediction_api_key_registry/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommendations-ai/google/cloud/recommendationengine_v1beta1/services/prediction_api_key_registry/client.py
+++ b/packages/google-cloud-recommendations-ai/google/cloud/recommendationengine_v1beta1/services/prediction_api_key_registry/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommendations-ai/google/cloud/recommendationengine_v1beta1/services/prediction_api_key_registry/pagers.py
+++ b/packages/google-cloud-recommendations-ai/google/cloud/recommendationengine_v1beta1/services/prediction_api_key_registry/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommendations-ai/google/cloud/recommendationengine_v1beta1/services/prediction_api_key_registry/transports/__init__.py
+++ b/packages/google-cloud-recommendations-ai/google/cloud/recommendationengine_v1beta1/services/prediction_api_key_registry/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommendations-ai/google/cloud/recommendationengine_v1beta1/services/prediction_api_key_registry/transports/base.py
+++ b/packages/google-cloud-recommendations-ai/google/cloud/recommendationengine_v1beta1/services/prediction_api_key_registry/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommendations-ai/google/cloud/recommendationengine_v1beta1/services/prediction_api_key_registry/transports/grpc.py
+++ b/packages/google-cloud-recommendations-ai/google/cloud/recommendationengine_v1beta1/services/prediction_api_key_registry/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommendations-ai/google/cloud/recommendationengine_v1beta1/services/prediction_api_key_registry/transports/grpc_asyncio.py
+++ b/packages/google-cloud-recommendations-ai/google/cloud/recommendationengine_v1beta1/services/prediction_api_key_registry/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommendations-ai/google/cloud/recommendationengine_v1beta1/services/prediction_api_key_registry/transports/rest.py
+++ b/packages/google-cloud-recommendations-ai/google/cloud/recommendationengine_v1beta1/services/prediction_api_key_registry/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommendations-ai/google/cloud/recommendationengine_v1beta1/services/prediction_api_key_registry/transports/rest_base.py
+++ b/packages/google-cloud-recommendations-ai/google/cloud/recommendationengine_v1beta1/services/prediction_api_key_registry/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommendations-ai/google/cloud/recommendationengine_v1beta1/services/prediction_service/__init__.py
+++ b/packages/google-cloud-recommendations-ai/google/cloud/recommendationengine_v1beta1/services/prediction_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommendations-ai/google/cloud/recommendationengine_v1beta1/services/prediction_service/async_client.py
+++ b/packages/google-cloud-recommendations-ai/google/cloud/recommendationengine_v1beta1/services/prediction_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommendations-ai/google/cloud/recommendationengine_v1beta1/services/prediction_service/client.py
+++ b/packages/google-cloud-recommendations-ai/google/cloud/recommendationengine_v1beta1/services/prediction_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommendations-ai/google/cloud/recommendationengine_v1beta1/services/prediction_service/pagers.py
+++ b/packages/google-cloud-recommendations-ai/google/cloud/recommendationengine_v1beta1/services/prediction_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommendations-ai/google/cloud/recommendationengine_v1beta1/services/prediction_service/transports/__init__.py
+++ b/packages/google-cloud-recommendations-ai/google/cloud/recommendationengine_v1beta1/services/prediction_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommendations-ai/google/cloud/recommendationengine_v1beta1/services/prediction_service/transports/base.py
+++ b/packages/google-cloud-recommendations-ai/google/cloud/recommendationengine_v1beta1/services/prediction_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommendations-ai/google/cloud/recommendationengine_v1beta1/services/prediction_service/transports/grpc.py
+++ b/packages/google-cloud-recommendations-ai/google/cloud/recommendationengine_v1beta1/services/prediction_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommendations-ai/google/cloud/recommendationengine_v1beta1/services/prediction_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-recommendations-ai/google/cloud/recommendationengine_v1beta1/services/prediction_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommendations-ai/google/cloud/recommendationengine_v1beta1/services/prediction_service/transports/rest.py
+++ b/packages/google-cloud-recommendations-ai/google/cloud/recommendationengine_v1beta1/services/prediction_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommendations-ai/google/cloud/recommendationengine_v1beta1/services/prediction_service/transports/rest_base.py
+++ b/packages/google-cloud-recommendations-ai/google/cloud/recommendationengine_v1beta1/services/prediction_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommendations-ai/google/cloud/recommendationengine_v1beta1/services/user_event_service/__init__.py
+++ b/packages/google-cloud-recommendations-ai/google/cloud/recommendationengine_v1beta1/services/user_event_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommendations-ai/google/cloud/recommendationengine_v1beta1/services/user_event_service/client.py
+++ b/packages/google-cloud-recommendations-ai/google/cloud/recommendationengine_v1beta1/services/user_event_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommendations-ai/google/cloud/recommendationengine_v1beta1/services/user_event_service/pagers.py
+++ b/packages/google-cloud-recommendations-ai/google/cloud/recommendationengine_v1beta1/services/user_event_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommendations-ai/google/cloud/recommendationengine_v1beta1/services/user_event_service/transports/__init__.py
+++ b/packages/google-cloud-recommendations-ai/google/cloud/recommendationengine_v1beta1/services/user_event_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommendations-ai/google/cloud/recommendationengine_v1beta1/services/user_event_service/transports/base.py
+++ b/packages/google-cloud-recommendations-ai/google/cloud/recommendationengine_v1beta1/services/user_event_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommendations-ai/google/cloud/recommendationengine_v1beta1/services/user_event_service/transports/grpc.py
+++ b/packages/google-cloud-recommendations-ai/google/cloud/recommendationengine_v1beta1/services/user_event_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommendations-ai/google/cloud/recommendationengine_v1beta1/services/user_event_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-recommendations-ai/google/cloud/recommendationengine_v1beta1/services/user_event_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommendations-ai/google/cloud/recommendationengine_v1beta1/services/user_event_service/transports/rest.py
+++ b/packages/google-cloud-recommendations-ai/google/cloud/recommendationengine_v1beta1/services/user_event_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommendations-ai/google/cloud/recommendationengine_v1beta1/services/user_event_service/transports/rest_base.py
+++ b/packages/google-cloud-recommendations-ai/google/cloud/recommendationengine_v1beta1/services/user_event_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommendations-ai/google/cloud/recommendationengine_v1beta1/types/__init__.py
+++ b/packages/google-cloud-recommendations-ai/google/cloud/recommendationengine_v1beta1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommendations-ai/google/cloud/recommendationengine_v1beta1/types/catalog.py
+++ b/packages/google-cloud-recommendations-ai/google/cloud/recommendationengine_v1beta1/types/catalog.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommendations-ai/google/cloud/recommendationengine_v1beta1/types/catalog_service.py
+++ b/packages/google-cloud-recommendations-ai/google/cloud/recommendationengine_v1beta1/types/catalog_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommendations-ai/google/cloud/recommendationengine_v1beta1/types/common.py
+++ b/packages/google-cloud-recommendations-ai/google/cloud/recommendationengine_v1beta1/types/common.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommendations-ai/google/cloud/recommendationengine_v1beta1/types/import_.py
+++ b/packages/google-cloud-recommendations-ai/google/cloud/recommendationengine_v1beta1/types/import_.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommendations-ai/google/cloud/recommendationengine_v1beta1/types/prediction_apikey_registry_service.py
+++ b/packages/google-cloud-recommendations-ai/google/cloud/recommendationengine_v1beta1/types/prediction_apikey_registry_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommendations-ai/google/cloud/recommendationengine_v1beta1/types/prediction_service.py
+++ b/packages/google-cloud-recommendations-ai/google/cloud/recommendationengine_v1beta1/types/prediction_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommendations-ai/google/cloud/recommendationengine_v1beta1/types/recommendationengine_resources.py
+++ b/packages/google-cloud-recommendations-ai/google/cloud/recommendationengine_v1beta1/types/recommendationengine_resources.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommendations-ai/google/cloud/recommendationengine_v1beta1/types/user_event.py
+++ b/packages/google-cloud-recommendations-ai/google/cloud/recommendationengine_v1beta1/types/user_event.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommendations-ai/google/cloud/recommendationengine_v1beta1/types/user_event_service.py
+++ b/packages/google-cloud-recommendations-ai/google/cloud/recommendationengine_v1beta1/types/user_event_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommendations-ai/samples/generated_samples/recommendationengine_v1beta1_generated_catalog_service_create_catalog_item_async.py
+++ b/packages/google-cloud-recommendations-ai/samples/generated_samples/recommendationengine_v1beta1_generated_catalog_service_create_catalog_item_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommendations-ai/samples/generated_samples/recommendationengine_v1beta1_generated_catalog_service_create_catalog_item_sync.py
+++ b/packages/google-cloud-recommendations-ai/samples/generated_samples/recommendationengine_v1beta1_generated_catalog_service_create_catalog_item_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommendations-ai/samples/generated_samples/recommendationengine_v1beta1_generated_catalog_service_delete_catalog_item_async.py
+++ b/packages/google-cloud-recommendations-ai/samples/generated_samples/recommendationengine_v1beta1_generated_catalog_service_delete_catalog_item_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommendations-ai/samples/generated_samples/recommendationengine_v1beta1_generated_catalog_service_delete_catalog_item_sync.py
+++ b/packages/google-cloud-recommendations-ai/samples/generated_samples/recommendationengine_v1beta1_generated_catalog_service_delete_catalog_item_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommendations-ai/samples/generated_samples/recommendationengine_v1beta1_generated_catalog_service_get_catalog_item_async.py
+++ b/packages/google-cloud-recommendations-ai/samples/generated_samples/recommendationengine_v1beta1_generated_catalog_service_get_catalog_item_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommendations-ai/samples/generated_samples/recommendationengine_v1beta1_generated_catalog_service_get_catalog_item_sync.py
+++ b/packages/google-cloud-recommendations-ai/samples/generated_samples/recommendationengine_v1beta1_generated_catalog_service_get_catalog_item_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommendations-ai/samples/generated_samples/recommendationengine_v1beta1_generated_catalog_service_import_catalog_items_sync.py
+++ b/packages/google-cloud-recommendations-ai/samples/generated_samples/recommendationengine_v1beta1_generated_catalog_service_import_catalog_items_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommendations-ai/samples/generated_samples/recommendationengine_v1beta1_generated_catalog_service_list_catalog_items_async.py
+++ b/packages/google-cloud-recommendations-ai/samples/generated_samples/recommendationengine_v1beta1_generated_catalog_service_list_catalog_items_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommendations-ai/samples/generated_samples/recommendationengine_v1beta1_generated_catalog_service_list_catalog_items_sync.py
+++ b/packages/google-cloud-recommendations-ai/samples/generated_samples/recommendationengine_v1beta1_generated_catalog_service_list_catalog_items_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommendations-ai/samples/generated_samples/recommendationengine_v1beta1_generated_catalog_service_update_catalog_item_async.py
+++ b/packages/google-cloud-recommendations-ai/samples/generated_samples/recommendationengine_v1beta1_generated_catalog_service_update_catalog_item_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommendations-ai/samples/generated_samples/recommendationengine_v1beta1_generated_catalog_service_update_catalog_item_sync.py
+++ b/packages/google-cloud-recommendations-ai/samples/generated_samples/recommendationengine_v1beta1_generated_catalog_service_update_catalog_item_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommendations-ai/samples/generated_samples/recommendationengine_v1beta1_generated_prediction_api_key_registry_create_prediction_api_key_registration_async.py
+++ b/packages/google-cloud-recommendations-ai/samples/generated_samples/recommendationengine_v1beta1_generated_prediction_api_key_registry_create_prediction_api_key_registration_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommendations-ai/samples/generated_samples/recommendationengine_v1beta1_generated_prediction_api_key_registry_create_prediction_api_key_registration_sync.py
+++ b/packages/google-cloud-recommendations-ai/samples/generated_samples/recommendationengine_v1beta1_generated_prediction_api_key_registry_create_prediction_api_key_registration_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommendations-ai/samples/generated_samples/recommendationengine_v1beta1_generated_prediction_api_key_registry_delete_prediction_api_key_registration_async.py
+++ b/packages/google-cloud-recommendations-ai/samples/generated_samples/recommendationengine_v1beta1_generated_prediction_api_key_registry_delete_prediction_api_key_registration_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommendations-ai/samples/generated_samples/recommendationengine_v1beta1_generated_prediction_api_key_registry_delete_prediction_api_key_registration_sync.py
+++ b/packages/google-cloud-recommendations-ai/samples/generated_samples/recommendationengine_v1beta1_generated_prediction_api_key_registry_delete_prediction_api_key_registration_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommendations-ai/samples/generated_samples/recommendationengine_v1beta1_generated_prediction_api_key_registry_list_prediction_api_key_registrations_async.py
+++ b/packages/google-cloud-recommendations-ai/samples/generated_samples/recommendationengine_v1beta1_generated_prediction_api_key_registry_list_prediction_api_key_registrations_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommendations-ai/samples/generated_samples/recommendationengine_v1beta1_generated_prediction_api_key_registry_list_prediction_api_key_registrations_sync.py
+++ b/packages/google-cloud-recommendations-ai/samples/generated_samples/recommendationengine_v1beta1_generated_prediction_api_key_registry_list_prediction_api_key_registrations_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommendations-ai/samples/generated_samples/recommendationengine_v1beta1_generated_prediction_service_predict_async.py
+++ b/packages/google-cloud-recommendations-ai/samples/generated_samples/recommendationengine_v1beta1_generated_prediction_service_predict_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommendations-ai/samples/generated_samples/recommendationengine_v1beta1_generated_prediction_service_predict_sync.py
+++ b/packages/google-cloud-recommendations-ai/samples/generated_samples/recommendationengine_v1beta1_generated_prediction_service_predict_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommendations-ai/samples/generated_samples/recommendationengine_v1beta1_generated_user_event_service_collect_user_event_async.py
+++ b/packages/google-cloud-recommendations-ai/samples/generated_samples/recommendationengine_v1beta1_generated_user_event_service_collect_user_event_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommendations-ai/samples/generated_samples/recommendationengine_v1beta1_generated_user_event_service_collect_user_event_sync.py
+++ b/packages/google-cloud-recommendations-ai/samples/generated_samples/recommendationengine_v1beta1_generated_user_event_service_collect_user_event_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommendations-ai/samples/generated_samples/recommendationengine_v1beta1_generated_user_event_service_import_user_events_sync.py
+++ b/packages/google-cloud-recommendations-ai/samples/generated_samples/recommendationengine_v1beta1_generated_user_event_service_import_user_events_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommendations-ai/samples/generated_samples/recommendationengine_v1beta1_generated_user_event_service_list_user_events_async.py
+++ b/packages/google-cloud-recommendations-ai/samples/generated_samples/recommendationengine_v1beta1_generated_user_event_service_list_user_events_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommendations-ai/samples/generated_samples/recommendationengine_v1beta1_generated_user_event_service_list_user_events_sync.py
+++ b/packages/google-cloud-recommendations-ai/samples/generated_samples/recommendationengine_v1beta1_generated_user_event_service_list_user_events_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommendations-ai/samples/generated_samples/recommendationengine_v1beta1_generated_user_event_service_purge_user_events_sync.py
+++ b/packages/google-cloud-recommendations-ai/samples/generated_samples/recommendationengine_v1beta1_generated_user_event_service_purge_user_events_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommendations-ai/samples/generated_samples/recommendationengine_v1beta1_generated_user_event_service_write_user_event_async.py
+++ b/packages/google-cloud-recommendations-ai/samples/generated_samples/recommendationengine_v1beta1_generated_user_event_service_write_user_event_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommendations-ai/samples/generated_samples/recommendationengine_v1beta1_generated_user_event_service_write_user_event_sync.py
+++ b/packages/google-cloud-recommendations-ai/samples/generated_samples/recommendationengine_v1beta1_generated_user_event_service_write_user_event_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommendations-ai/tests/__init__.py
+++ b/packages/google-cloud-recommendations-ai/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommendations-ai/tests/unit/__init__.py
+++ b/packages/google-cloud-recommendations-ai/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommendations-ai/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-recommendations-ai/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommendations-ai/tests/unit/gapic/recommendationengine_v1beta1/__init__.py
+++ b/packages/google-cloud-recommendations-ai/tests/unit/gapic/recommendationengine_v1beta1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommender/.flake8
+++ b/packages/google-cloud-recommender/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommender/MANIFEST.in
+++ b/packages/google-cloud-recommender/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommender/google/cloud/recommender/__init__.py
+++ b/packages/google-cloud-recommender/google/cloud/recommender/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommender/google/cloud/recommender/gapic_version.py
+++ b/packages/google-cloud-recommender/google/cloud/recommender/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommender/google/cloud/recommender_v1/gapic_version.py
+++ b/packages/google-cloud-recommender/google/cloud/recommender_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommender/google/cloud/recommender_v1/services/__init__.py
+++ b/packages/google-cloud-recommender/google/cloud/recommender_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommender/google/cloud/recommender_v1/services/recommender/__init__.py
+++ b/packages/google-cloud-recommender/google/cloud/recommender_v1/services/recommender/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommender/google/cloud/recommender_v1/services/recommender/async_client.py
+++ b/packages/google-cloud-recommender/google/cloud/recommender_v1/services/recommender/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommender/google/cloud/recommender_v1/services/recommender/client.py
+++ b/packages/google-cloud-recommender/google/cloud/recommender_v1/services/recommender/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommender/google/cloud/recommender_v1/services/recommender/pagers.py
+++ b/packages/google-cloud-recommender/google/cloud/recommender_v1/services/recommender/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommender/google/cloud/recommender_v1/services/recommender/transports/__init__.py
+++ b/packages/google-cloud-recommender/google/cloud/recommender_v1/services/recommender/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommender/google/cloud/recommender_v1/services/recommender/transports/base.py
+++ b/packages/google-cloud-recommender/google/cloud/recommender_v1/services/recommender/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommender/google/cloud/recommender_v1/services/recommender/transports/grpc.py
+++ b/packages/google-cloud-recommender/google/cloud/recommender_v1/services/recommender/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommender/google/cloud/recommender_v1/services/recommender/transports/grpc_asyncio.py
+++ b/packages/google-cloud-recommender/google/cloud/recommender_v1/services/recommender/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommender/google/cloud/recommender_v1/services/recommender/transports/rest.py
+++ b/packages/google-cloud-recommender/google/cloud/recommender_v1/services/recommender/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommender/google/cloud/recommender_v1/services/recommender/transports/rest_base.py
+++ b/packages/google-cloud-recommender/google/cloud/recommender_v1/services/recommender/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommender/google/cloud/recommender_v1/types/__init__.py
+++ b/packages/google-cloud-recommender/google/cloud/recommender_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommender/google/cloud/recommender_v1/types/insight.py
+++ b/packages/google-cloud-recommender/google/cloud/recommender_v1/types/insight.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommender/google/cloud/recommender_v1/types/insight_type_config.py
+++ b/packages/google-cloud-recommender/google/cloud/recommender_v1/types/insight_type_config.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommender/google/cloud/recommender_v1/types/recommendation.py
+++ b/packages/google-cloud-recommender/google/cloud/recommender_v1/types/recommendation.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommender/google/cloud/recommender_v1/types/recommender_config.py
+++ b/packages/google-cloud-recommender/google/cloud/recommender_v1/types/recommender_config.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommender/google/cloud/recommender_v1/types/recommender_service.py
+++ b/packages/google-cloud-recommender/google/cloud/recommender_v1/types/recommender_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommender/google/cloud/recommender_v1beta1/gapic_version.py
+++ b/packages/google-cloud-recommender/google/cloud/recommender_v1beta1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommender/google/cloud/recommender_v1beta1/services/__init__.py
+++ b/packages/google-cloud-recommender/google/cloud/recommender_v1beta1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommender/google/cloud/recommender_v1beta1/services/recommender/__init__.py
+++ b/packages/google-cloud-recommender/google/cloud/recommender_v1beta1/services/recommender/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommender/google/cloud/recommender_v1beta1/services/recommender/async_client.py
+++ b/packages/google-cloud-recommender/google/cloud/recommender_v1beta1/services/recommender/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommender/google/cloud/recommender_v1beta1/services/recommender/client.py
+++ b/packages/google-cloud-recommender/google/cloud/recommender_v1beta1/services/recommender/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommender/google/cloud/recommender_v1beta1/services/recommender/pagers.py
+++ b/packages/google-cloud-recommender/google/cloud/recommender_v1beta1/services/recommender/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommender/google/cloud/recommender_v1beta1/services/recommender/transports/__init__.py
+++ b/packages/google-cloud-recommender/google/cloud/recommender_v1beta1/services/recommender/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommender/google/cloud/recommender_v1beta1/services/recommender/transports/base.py
+++ b/packages/google-cloud-recommender/google/cloud/recommender_v1beta1/services/recommender/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommender/google/cloud/recommender_v1beta1/services/recommender/transports/grpc.py
+++ b/packages/google-cloud-recommender/google/cloud/recommender_v1beta1/services/recommender/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommender/google/cloud/recommender_v1beta1/services/recommender/transports/grpc_asyncio.py
+++ b/packages/google-cloud-recommender/google/cloud/recommender_v1beta1/services/recommender/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommender/google/cloud/recommender_v1beta1/services/recommender/transports/rest.py
+++ b/packages/google-cloud-recommender/google/cloud/recommender_v1beta1/services/recommender/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommender/google/cloud/recommender_v1beta1/services/recommender/transports/rest_base.py
+++ b/packages/google-cloud-recommender/google/cloud/recommender_v1beta1/services/recommender/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommender/google/cloud/recommender_v1beta1/types/__init__.py
+++ b/packages/google-cloud-recommender/google/cloud/recommender_v1beta1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommender/google/cloud/recommender_v1beta1/types/insight.py
+++ b/packages/google-cloud-recommender/google/cloud/recommender_v1beta1/types/insight.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommender/google/cloud/recommender_v1beta1/types/insight_type_config.py
+++ b/packages/google-cloud-recommender/google/cloud/recommender_v1beta1/types/insight_type_config.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommender/google/cloud/recommender_v1beta1/types/recommendation.py
+++ b/packages/google-cloud-recommender/google/cloud/recommender_v1beta1/types/recommendation.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommender/google/cloud/recommender_v1beta1/types/recommender_config.py
+++ b/packages/google-cloud-recommender/google/cloud/recommender_v1beta1/types/recommender_config.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommender/google/cloud/recommender_v1beta1/types/recommender_service.py
+++ b/packages/google-cloud-recommender/google/cloud/recommender_v1beta1/types/recommender_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommender/samples/generated_samples/recommender_v1_generated_recommender_get_insight_async.py
+++ b/packages/google-cloud-recommender/samples/generated_samples/recommender_v1_generated_recommender_get_insight_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommender/samples/generated_samples/recommender_v1_generated_recommender_get_insight_sync.py
+++ b/packages/google-cloud-recommender/samples/generated_samples/recommender_v1_generated_recommender_get_insight_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommender/samples/generated_samples/recommender_v1_generated_recommender_get_insight_type_config_async.py
+++ b/packages/google-cloud-recommender/samples/generated_samples/recommender_v1_generated_recommender_get_insight_type_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommender/samples/generated_samples/recommender_v1_generated_recommender_get_insight_type_config_sync.py
+++ b/packages/google-cloud-recommender/samples/generated_samples/recommender_v1_generated_recommender_get_insight_type_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommender/samples/generated_samples/recommender_v1_generated_recommender_get_recommendation_async.py
+++ b/packages/google-cloud-recommender/samples/generated_samples/recommender_v1_generated_recommender_get_recommendation_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommender/samples/generated_samples/recommender_v1_generated_recommender_get_recommendation_sync.py
+++ b/packages/google-cloud-recommender/samples/generated_samples/recommender_v1_generated_recommender_get_recommendation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommender/samples/generated_samples/recommender_v1_generated_recommender_get_recommender_config_async.py
+++ b/packages/google-cloud-recommender/samples/generated_samples/recommender_v1_generated_recommender_get_recommender_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommender/samples/generated_samples/recommender_v1_generated_recommender_get_recommender_config_sync.py
+++ b/packages/google-cloud-recommender/samples/generated_samples/recommender_v1_generated_recommender_get_recommender_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommender/samples/generated_samples/recommender_v1_generated_recommender_list_insights_async.py
+++ b/packages/google-cloud-recommender/samples/generated_samples/recommender_v1_generated_recommender_list_insights_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommender/samples/generated_samples/recommender_v1_generated_recommender_list_insights_sync.py
+++ b/packages/google-cloud-recommender/samples/generated_samples/recommender_v1_generated_recommender_list_insights_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommender/samples/generated_samples/recommender_v1_generated_recommender_list_recommendations_async.py
+++ b/packages/google-cloud-recommender/samples/generated_samples/recommender_v1_generated_recommender_list_recommendations_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommender/samples/generated_samples/recommender_v1_generated_recommender_list_recommendations_sync.py
+++ b/packages/google-cloud-recommender/samples/generated_samples/recommender_v1_generated_recommender_list_recommendations_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommender/samples/generated_samples/recommender_v1_generated_recommender_mark_insight_accepted_async.py
+++ b/packages/google-cloud-recommender/samples/generated_samples/recommender_v1_generated_recommender_mark_insight_accepted_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommender/samples/generated_samples/recommender_v1_generated_recommender_mark_insight_accepted_sync.py
+++ b/packages/google-cloud-recommender/samples/generated_samples/recommender_v1_generated_recommender_mark_insight_accepted_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommender/samples/generated_samples/recommender_v1_generated_recommender_mark_recommendation_claimed_async.py
+++ b/packages/google-cloud-recommender/samples/generated_samples/recommender_v1_generated_recommender_mark_recommendation_claimed_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommender/samples/generated_samples/recommender_v1_generated_recommender_mark_recommendation_claimed_sync.py
+++ b/packages/google-cloud-recommender/samples/generated_samples/recommender_v1_generated_recommender_mark_recommendation_claimed_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommender/samples/generated_samples/recommender_v1_generated_recommender_mark_recommendation_dismissed_async.py
+++ b/packages/google-cloud-recommender/samples/generated_samples/recommender_v1_generated_recommender_mark_recommendation_dismissed_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommender/samples/generated_samples/recommender_v1_generated_recommender_mark_recommendation_dismissed_sync.py
+++ b/packages/google-cloud-recommender/samples/generated_samples/recommender_v1_generated_recommender_mark_recommendation_dismissed_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommender/samples/generated_samples/recommender_v1_generated_recommender_mark_recommendation_failed_async.py
+++ b/packages/google-cloud-recommender/samples/generated_samples/recommender_v1_generated_recommender_mark_recommendation_failed_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommender/samples/generated_samples/recommender_v1_generated_recommender_mark_recommendation_failed_sync.py
+++ b/packages/google-cloud-recommender/samples/generated_samples/recommender_v1_generated_recommender_mark_recommendation_failed_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommender/samples/generated_samples/recommender_v1_generated_recommender_mark_recommendation_succeeded_async.py
+++ b/packages/google-cloud-recommender/samples/generated_samples/recommender_v1_generated_recommender_mark_recommendation_succeeded_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommender/samples/generated_samples/recommender_v1_generated_recommender_mark_recommendation_succeeded_sync.py
+++ b/packages/google-cloud-recommender/samples/generated_samples/recommender_v1_generated_recommender_mark_recommendation_succeeded_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommender/samples/generated_samples/recommender_v1_generated_recommender_update_insight_type_config_async.py
+++ b/packages/google-cloud-recommender/samples/generated_samples/recommender_v1_generated_recommender_update_insight_type_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommender/samples/generated_samples/recommender_v1_generated_recommender_update_insight_type_config_sync.py
+++ b/packages/google-cloud-recommender/samples/generated_samples/recommender_v1_generated_recommender_update_insight_type_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommender/samples/generated_samples/recommender_v1_generated_recommender_update_recommender_config_async.py
+++ b/packages/google-cloud-recommender/samples/generated_samples/recommender_v1_generated_recommender_update_recommender_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommender/samples/generated_samples/recommender_v1_generated_recommender_update_recommender_config_sync.py
+++ b/packages/google-cloud-recommender/samples/generated_samples/recommender_v1_generated_recommender_update_recommender_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommender/samples/generated_samples/recommender_v1beta1_generated_recommender_get_insight_async.py
+++ b/packages/google-cloud-recommender/samples/generated_samples/recommender_v1beta1_generated_recommender_get_insight_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommender/samples/generated_samples/recommender_v1beta1_generated_recommender_get_insight_sync.py
+++ b/packages/google-cloud-recommender/samples/generated_samples/recommender_v1beta1_generated_recommender_get_insight_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommender/samples/generated_samples/recommender_v1beta1_generated_recommender_get_insight_type_config_async.py
+++ b/packages/google-cloud-recommender/samples/generated_samples/recommender_v1beta1_generated_recommender_get_insight_type_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommender/samples/generated_samples/recommender_v1beta1_generated_recommender_get_insight_type_config_sync.py
+++ b/packages/google-cloud-recommender/samples/generated_samples/recommender_v1beta1_generated_recommender_get_insight_type_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommender/samples/generated_samples/recommender_v1beta1_generated_recommender_get_recommendation_async.py
+++ b/packages/google-cloud-recommender/samples/generated_samples/recommender_v1beta1_generated_recommender_get_recommendation_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommender/samples/generated_samples/recommender_v1beta1_generated_recommender_get_recommendation_sync.py
+++ b/packages/google-cloud-recommender/samples/generated_samples/recommender_v1beta1_generated_recommender_get_recommendation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommender/samples/generated_samples/recommender_v1beta1_generated_recommender_get_recommender_config_async.py
+++ b/packages/google-cloud-recommender/samples/generated_samples/recommender_v1beta1_generated_recommender_get_recommender_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommender/samples/generated_samples/recommender_v1beta1_generated_recommender_get_recommender_config_sync.py
+++ b/packages/google-cloud-recommender/samples/generated_samples/recommender_v1beta1_generated_recommender_get_recommender_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommender/samples/generated_samples/recommender_v1beta1_generated_recommender_list_insight_types_async.py
+++ b/packages/google-cloud-recommender/samples/generated_samples/recommender_v1beta1_generated_recommender_list_insight_types_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommender/samples/generated_samples/recommender_v1beta1_generated_recommender_list_insight_types_sync.py
+++ b/packages/google-cloud-recommender/samples/generated_samples/recommender_v1beta1_generated_recommender_list_insight_types_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommender/samples/generated_samples/recommender_v1beta1_generated_recommender_list_insights_async.py
+++ b/packages/google-cloud-recommender/samples/generated_samples/recommender_v1beta1_generated_recommender_list_insights_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommender/samples/generated_samples/recommender_v1beta1_generated_recommender_list_insights_sync.py
+++ b/packages/google-cloud-recommender/samples/generated_samples/recommender_v1beta1_generated_recommender_list_insights_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommender/samples/generated_samples/recommender_v1beta1_generated_recommender_list_recommendations_async.py
+++ b/packages/google-cloud-recommender/samples/generated_samples/recommender_v1beta1_generated_recommender_list_recommendations_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommender/samples/generated_samples/recommender_v1beta1_generated_recommender_list_recommendations_sync.py
+++ b/packages/google-cloud-recommender/samples/generated_samples/recommender_v1beta1_generated_recommender_list_recommendations_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommender/samples/generated_samples/recommender_v1beta1_generated_recommender_list_recommenders_async.py
+++ b/packages/google-cloud-recommender/samples/generated_samples/recommender_v1beta1_generated_recommender_list_recommenders_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommender/samples/generated_samples/recommender_v1beta1_generated_recommender_list_recommenders_sync.py
+++ b/packages/google-cloud-recommender/samples/generated_samples/recommender_v1beta1_generated_recommender_list_recommenders_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommender/samples/generated_samples/recommender_v1beta1_generated_recommender_mark_insight_accepted_async.py
+++ b/packages/google-cloud-recommender/samples/generated_samples/recommender_v1beta1_generated_recommender_mark_insight_accepted_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommender/samples/generated_samples/recommender_v1beta1_generated_recommender_mark_insight_accepted_sync.py
+++ b/packages/google-cloud-recommender/samples/generated_samples/recommender_v1beta1_generated_recommender_mark_insight_accepted_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommender/samples/generated_samples/recommender_v1beta1_generated_recommender_mark_recommendation_claimed_async.py
+++ b/packages/google-cloud-recommender/samples/generated_samples/recommender_v1beta1_generated_recommender_mark_recommendation_claimed_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommender/samples/generated_samples/recommender_v1beta1_generated_recommender_mark_recommendation_claimed_sync.py
+++ b/packages/google-cloud-recommender/samples/generated_samples/recommender_v1beta1_generated_recommender_mark_recommendation_claimed_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommender/samples/generated_samples/recommender_v1beta1_generated_recommender_mark_recommendation_failed_async.py
+++ b/packages/google-cloud-recommender/samples/generated_samples/recommender_v1beta1_generated_recommender_mark_recommendation_failed_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommender/samples/generated_samples/recommender_v1beta1_generated_recommender_mark_recommendation_failed_sync.py
+++ b/packages/google-cloud-recommender/samples/generated_samples/recommender_v1beta1_generated_recommender_mark_recommendation_failed_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommender/samples/generated_samples/recommender_v1beta1_generated_recommender_mark_recommendation_succeeded_async.py
+++ b/packages/google-cloud-recommender/samples/generated_samples/recommender_v1beta1_generated_recommender_mark_recommendation_succeeded_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommender/samples/generated_samples/recommender_v1beta1_generated_recommender_mark_recommendation_succeeded_sync.py
+++ b/packages/google-cloud-recommender/samples/generated_samples/recommender_v1beta1_generated_recommender_mark_recommendation_succeeded_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommender/samples/generated_samples/recommender_v1beta1_generated_recommender_update_insight_type_config_async.py
+++ b/packages/google-cloud-recommender/samples/generated_samples/recommender_v1beta1_generated_recommender_update_insight_type_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommender/samples/generated_samples/recommender_v1beta1_generated_recommender_update_insight_type_config_sync.py
+++ b/packages/google-cloud-recommender/samples/generated_samples/recommender_v1beta1_generated_recommender_update_insight_type_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommender/samples/generated_samples/recommender_v1beta1_generated_recommender_update_recommender_config_async.py
+++ b/packages/google-cloud-recommender/samples/generated_samples/recommender_v1beta1_generated_recommender_update_recommender_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommender/samples/generated_samples/recommender_v1beta1_generated_recommender_update_recommender_config_sync.py
+++ b/packages/google-cloud-recommender/samples/generated_samples/recommender_v1beta1_generated_recommender_update_recommender_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommender/tests/__init__.py
+++ b/packages/google-cloud-recommender/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommender/tests/unit/__init__.py
+++ b/packages/google-cloud-recommender/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommender/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-recommender/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommender/tests/unit/gapic/recommender_v1/__init__.py
+++ b/packages/google-cloud-recommender/tests/unit/gapic/recommender_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-recommender/tests/unit/gapic/recommender_v1beta1/__init__.py
+++ b/packages/google-cloud-recommender/tests/unit/gapic/recommender_v1beta1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis-cluster/.flake8
+++ b/packages/google-cloud-redis-cluster/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis-cluster/MANIFEST.in
+++ b/packages/google-cloud-redis-cluster/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis-cluster/google/cloud/redis_cluster/__init__.py
+++ b/packages/google-cloud-redis-cluster/google/cloud/redis_cluster/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis-cluster/google/cloud/redis_cluster/gapic_version.py
+++ b/packages/google-cloud-redis-cluster/google/cloud/redis_cluster/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis-cluster/google/cloud/redis_cluster_v1/gapic_version.py
+++ b/packages/google-cloud-redis-cluster/google/cloud/redis_cluster_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis-cluster/google/cloud/redis_cluster_v1/services/__init__.py
+++ b/packages/google-cloud-redis-cluster/google/cloud/redis_cluster_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis-cluster/google/cloud/redis_cluster_v1/services/cloud_redis_cluster/__init__.py
+++ b/packages/google-cloud-redis-cluster/google/cloud/redis_cluster_v1/services/cloud_redis_cluster/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis-cluster/google/cloud/redis_cluster_v1/services/cloud_redis_cluster/client.py
+++ b/packages/google-cloud-redis-cluster/google/cloud/redis_cluster_v1/services/cloud_redis_cluster/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis-cluster/google/cloud/redis_cluster_v1/services/cloud_redis_cluster/pagers.py
+++ b/packages/google-cloud-redis-cluster/google/cloud/redis_cluster_v1/services/cloud_redis_cluster/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis-cluster/google/cloud/redis_cluster_v1/services/cloud_redis_cluster/transports/__init__.py
+++ b/packages/google-cloud-redis-cluster/google/cloud/redis_cluster_v1/services/cloud_redis_cluster/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis-cluster/google/cloud/redis_cluster_v1/services/cloud_redis_cluster/transports/base.py
+++ b/packages/google-cloud-redis-cluster/google/cloud/redis_cluster_v1/services/cloud_redis_cluster/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis-cluster/google/cloud/redis_cluster_v1/services/cloud_redis_cluster/transports/grpc.py
+++ b/packages/google-cloud-redis-cluster/google/cloud/redis_cluster_v1/services/cloud_redis_cluster/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis-cluster/google/cloud/redis_cluster_v1/services/cloud_redis_cluster/transports/grpc_asyncio.py
+++ b/packages/google-cloud-redis-cluster/google/cloud/redis_cluster_v1/services/cloud_redis_cluster/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis-cluster/google/cloud/redis_cluster_v1/services/cloud_redis_cluster/transports/rest.py
+++ b/packages/google-cloud-redis-cluster/google/cloud/redis_cluster_v1/services/cloud_redis_cluster/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis-cluster/google/cloud/redis_cluster_v1/services/cloud_redis_cluster/transports/rest_base.py
+++ b/packages/google-cloud-redis-cluster/google/cloud/redis_cluster_v1/services/cloud_redis_cluster/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis-cluster/google/cloud/redis_cluster_v1/types/__init__.py
+++ b/packages/google-cloud-redis-cluster/google/cloud/redis_cluster_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis-cluster/google/cloud/redis_cluster_v1/types/cloud_redis_cluster.py
+++ b/packages/google-cloud-redis-cluster/google/cloud/redis_cluster_v1/types/cloud_redis_cluster.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis-cluster/google/cloud/redis_cluster_v1beta1/gapic_version.py
+++ b/packages/google-cloud-redis-cluster/google/cloud/redis_cluster_v1beta1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis-cluster/google/cloud/redis_cluster_v1beta1/services/__init__.py
+++ b/packages/google-cloud-redis-cluster/google/cloud/redis_cluster_v1beta1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis-cluster/google/cloud/redis_cluster_v1beta1/services/cloud_redis_cluster/__init__.py
+++ b/packages/google-cloud-redis-cluster/google/cloud/redis_cluster_v1beta1/services/cloud_redis_cluster/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis-cluster/google/cloud/redis_cluster_v1beta1/services/cloud_redis_cluster/client.py
+++ b/packages/google-cloud-redis-cluster/google/cloud/redis_cluster_v1beta1/services/cloud_redis_cluster/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis-cluster/google/cloud/redis_cluster_v1beta1/services/cloud_redis_cluster/pagers.py
+++ b/packages/google-cloud-redis-cluster/google/cloud/redis_cluster_v1beta1/services/cloud_redis_cluster/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis-cluster/google/cloud/redis_cluster_v1beta1/services/cloud_redis_cluster/transports/__init__.py
+++ b/packages/google-cloud-redis-cluster/google/cloud/redis_cluster_v1beta1/services/cloud_redis_cluster/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis-cluster/google/cloud/redis_cluster_v1beta1/services/cloud_redis_cluster/transports/base.py
+++ b/packages/google-cloud-redis-cluster/google/cloud/redis_cluster_v1beta1/services/cloud_redis_cluster/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis-cluster/google/cloud/redis_cluster_v1beta1/services/cloud_redis_cluster/transports/grpc.py
+++ b/packages/google-cloud-redis-cluster/google/cloud/redis_cluster_v1beta1/services/cloud_redis_cluster/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis-cluster/google/cloud/redis_cluster_v1beta1/services/cloud_redis_cluster/transports/grpc_asyncio.py
+++ b/packages/google-cloud-redis-cluster/google/cloud/redis_cluster_v1beta1/services/cloud_redis_cluster/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis-cluster/google/cloud/redis_cluster_v1beta1/services/cloud_redis_cluster/transports/rest.py
+++ b/packages/google-cloud-redis-cluster/google/cloud/redis_cluster_v1beta1/services/cloud_redis_cluster/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis-cluster/google/cloud/redis_cluster_v1beta1/services/cloud_redis_cluster/transports/rest_base.py
+++ b/packages/google-cloud-redis-cluster/google/cloud/redis_cluster_v1beta1/services/cloud_redis_cluster/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis-cluster/google/cloud/redis_cluster_v1beta1/types/__init__.py
+++ b/packages/google-cloud-redis-cluster/google/cloud/redis_cluster_v1beta1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis-cluster/google/cloud/redis_cluster_v1beta1/types/cloud_redis_cluster.py
+++ b/packages/google-cloud-redis-cluster/google/cloud/redis_cluster_v1beta1/types/cloud_redis_cluster.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis-cluster/samples/generated_samples/redis_v1_generated_cloud_redis_cluster_backup_cluster_sync.py
+++ b/packages/google-cloud-redis-cluster/samples/generated_samples/redis_v1_generated_cloud_redis_cluster_backup_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis-cluster/samples/generated_samples/redis_v1_generated_cloud_redis_cluster_create_cluster_sync.py
+++ b/packages/google-cloud-redis-cluster/samples/generated_samples/redis_v1_generated_cloud_redis_cluster_create_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis-cluster/samples/generated_samples/redis_v1_generated_cloud_redis_cluster_delete_backup_sync.py
+++ b/packages/google-cloud-redis-cluster/samples/generated_samples/redis_v1_generated_cloud_redis_cluster_delete_backup_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis-cluster/samples/generated_samples/redis_v1_generated_cloud_redis_cluster_delete_cluster_sync.py
+++ b/packages/google-cloud-redis-cluster/samples/generated_samples/redis_v1_generated_cloud_redis_cluster_delete_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis-cluster/samples/generated_samples/redis_v1_generated_cloud_redis_cluster_export_backup_sync.py
+++ b/packages/google-cloud-redis-cluster/samples/generated_samples/redis_v1_generated_cloud_redis_cluster_export_backup_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis-cluster/samples/generated_samples/redis_v1_generated_cloud_redis_cluster_get_backup_async.py
+++ b/packages/google-cloud-redis-cluster/samples/generated_samples/redis_v1_generated_cloud_redis_cluster_get_backup_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis-cluster/samples/generated_samples/redis_v1_generated_cloud_redis_cluster_get_backup_collection_async.py
+++ b/packages/google-cloud-redis-cluster/samples/generated_samples/redis_v1_generated_cloud_redis_cluster_get_backup_collection_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis-cluster/samples/generated_samples/redis_v1_generated_cloud_redis_cluster_get_backup_collection_sync.py
+++ b/packages/google-cloud-redis-cluster/samples/generated_samples/redis_v1_generated_cloud_redis_cluster_get_backup_collection_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis-cluster/samples/generated_samples/redis_v1_generated_cloud_redis_cluster_get_backup_sync.py
+++ b/packages/google-cloud-redis-cluster/samples/generated_samples/redis_v1_generated_cloud_redis_cluster_get_backup_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis-cluster/samples/generated_samples/redis_v1_generated_cloud_redis_cluster_get_cluster_async.py
+++ b/packages/google-cloud-redis-cluster/samples/generated_samples/redis_v1_generated_cloud_redis_cluster_get_cluster_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis-cluster/samples/generated_samples/redis_v1_generated_cloud_redis_cluster_get_cluster_certificate_authority_async.py
+++ b/packages/google-cloud-redis-cluster/samples/generated_samples/redis_v1_generated_cloud_redis_cluster_get_cluster_certificate_authority_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis-cluster/samples/generated_samples/redis_v1_generated_cloud_redis_cluster_get_cluster_certificate_authority_sync.py
+++ b/packages/google-cloud-redis-cluster/samples/generated_samples/redis_v1_generated_cloud_redis_cluster_get_cluster_certificate_authority_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis-cluster/samples/generated_samples/redis_v1_generated_cloud_redis_cluster_get_cluster_sync.py
+++ b/packages/google-cloud-redis-cluster/samples/generated_samples/redis_v1_generated_cloud_redis_cluster_get_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis-cluster/samples/generated_samples/redis_v1_generated_cloud_redis_cluster_get_shared_regional_certificate_authority_async.py
+++ b/packages/google-cloud-redis-cluster/samples/generated_samples/redis_v1_generated_cloud_redis_cluster_get_shared_regional_certificate_authority_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis-cluster/samples/generated_samples/redis_v1_generated_cloud_redis_cluster_get_shared_regional_certificate_authority_sync.py
+++ b/packages/google-cloud-redis-cluster/samples/generated_samples/redis_v1_generated_cloud_redis_cluster_get_shared_regional_certificate_authority_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis-cluster/samples/generated_samples/redis_v1_generated_cloud_redis_cluster_list_backup_collections_async.py
+++ b/packages/google-cloud-redis-cluster/samples/generated_samples/redis_v1_generated_cloud_redis_cluster_list_backup_collections_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis-cluster/samples/generated_samples/redis_v1_generated_cloud_redis_cluster_list_backup_collections_sync.py
+++ b/packages/google-cloud-redis-cluster/samples/generated_samples/redis_v1_generated_cloud_redis_cluster_list_backup_collections_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis-cluster/samples/generated_samples/redis_v1_generated_cloud_redis_cluster_list_backups_async.py
+++ b/packages/google-cloud-redis-cluster/samples/generated_samples/redis_v1_generated_cloud_redis_cluster_list_backups_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis-cluster/samples/generated_samples/redis_v1_generated_cloud_redis_cluster_list_backups_sync.py
+++ b/packages/google-cloud-redis-cluster/samples/generated_samples/redis_v1_generated_cloud_redis_cluster_list_backups_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis-cluster/samples/generated_samples/redis_v1_generated_cloud_redis_cluster_list_clusters_async.py
+++ b/packages/google-cloud-redis-cluster/samples/generated_samples/redis_v1_generated_cloud_redis_cluster_list_clusters_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis-cluster/samples/generated_samples/redis_v1_generated_cloud_redis_cluster_list_clusters_sync.py
+++ b/packages/google-cloud-redis-cluster/samples/generated_samples/redis_v1_generated_cloud_redis_cluster_list_clusters_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis-cluster/samples/generated_samples/redis_v1_generated_cloud_redis_cluster_reschedule_cluster_maintenance_sync.py
+++ b/packages/google-cloud-redis-cluster/samples/generated_samples/redis_v1_generated_cloud_redis_cluster_reschedule_cluster_maintenance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis-cluster/samples/generated_samples/redis_v1_generated_cloud_redis_cluster_update_cluster_sync.py
+++ b/packages/google-cloud-redis-cluster/samples/generated_samples/redis_v1_generated_cloud_redis_cluster_update_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis-cluster/samples/generated_samples/redis_v1beta1_generated_cloud_redis_cluster_backup_cluster_sync.py
+++ b/packages/google-cloud-redis-cluster/samples/generated_samples/redis_v1beta1_generated_cloud_redis_cluster_backup_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis-cluster/samples/generated_samples/redis_v1beta1_generated_cloud_redis_cluster_create_cluster_sync.py
+++ b/packages/google-cloud-redis-cluster/samples/generated_samples/redis_v1beta1_generated_cloud_redis_cluster_create_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis-cluster/samples/generated_samples/redis_v1beta1_generated_cloud_redis_cluster_delete_backup_sync.py
+++ b/packages/google-cloud-redis-cluster/samples/generated_samples/redis_v1beta1_generated_cloud_redis_cluster_delete_backup_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis-cluster/samples/generated_samples/redis_v1beta1_generated_cloud_redis_cluster_delete_cluster_sync.py
+++ b/packages/google-cloud-redis-cluster/samples/generated_samples/redis_v1beta1_generated_cloud_redis_cluster_delete_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis-cluster/samples/generated_samples/redis_v1beta1_generated_cloud_redis_cluster_export_backup_sync.py
+++ b/packages/google-cloud-redis-cluster/samples/generated_samples/redis_v1beta1_generated_cloud_redis_cluster_export_backup_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis-cluster/samples/generated_samples/redis_v1beta1_generated_cloud_redis_cluster_get_backup_async.py
+++ b/packages/google-cloud-redis-cluster/samples/generated_samples/redis_v1beta1_generated_cloud_redis_cluster_get_backup_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis-cluster/samples/generated_samples/redis_v1beta1_generated_cloud_redis_cluster_get_backup_collection_async.py
+++ b/packages/google-cloud-redis-cluster/samples/generated_samples/redis_v1beta1_generated_cloud_redis_cluster_get_backup_collection_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis-cluster/samples/generated_samples/redis_v1beta1_generated_cloud_redis_cluster_get_backup_collection_sync.py
+++ b/packages/google-cloud-redis-cluster/samples/generated_samples/redis_v1beta1_generated_cloud_redis_cluster_get_backup_collection_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis-cluster/samples/generated_samples/redis_v1beta1_generated_cloud_redis_cluster_get_backup_sync.py
+++ b/packages/google-cloud-redis-cluster/samples/generated_samples/redis_v1beta1_generated_cloud_redis_cluster_get_backup_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis-cluster/samples/generated_samples/redis_v1beta1_generated_cloud_redis_cluster_get_cluster_async.py
+++ b/packages/google-cloud-redis-cluster/samples/generated_samples/redis_v1beta1_generated_cloud_redis_cluster_get_cluster_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis-cluster/samples/generated_samples/redis_v1beta1_generated_cloud_redis_cluster_get_cluster_certificate_authority_async.py
+++ b/packages/google-cloud-redis-cluster/samples/generated_samples/redis_v1beta1_generated_cloud_redis_cluster_get_cluster_certificate_authority_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis-cluster/samples/generated_samples/redis_v1beta1_generated_cloud_redis_cluster_get_cluster_certificate_authority_sync.py
+++ b/packages/google-cloud-redis-cluster/samples/generated_samples/redis_v1beta1_generated_cloud_redis_cluster_get_cluster_certificate_authority_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis-cluster/samples/generated_samples/redis_v1beta1_generated_cloud_redis_cluster_get_cluster_sync.py
+++ b/packages/google-cloud-redis-cluster/samples/generated_samples/redis_v1beta1_generated_cloud_redis_cluster_get_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis-cluster/samples/generated_samples/redis_v1beta1_generated_cloud_redis_cluster_get_shared_regional_certificate_authority_async.py
+++ b/packages/google-cloud-redis-cluster/samples/generated_samples/redis_v1beta1_generated_cloud_redis_cluster_get_shared_regional_certificate_authority_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis-cluster/samples/generated_samples/redis_v1beta1_generated_cloud_redis_cluster_get_shared_regional_certificate_authority_sync.py
+++ b/packages/google-cloud-redis-cluster/samples/generated_samples/redis_v1beta1_generated_cloud_redis_cluster_get_shared_regional_certificate_authority_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis-cluster/samples/generated_samples/redis_v1beta1_generated_cloud_redis_cluster_list_backup_collections_async.py
+++ b/packages/google-cloud-redis-cluster/samples/generated_samples/redis_v1beta1_generated_cloud_redis_cluster_list_backup_collections_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis-cluster/samples/generated_samples/redis_v1beta1_generated_cloud_redis_cluster_list_backup_collections_sync.py
+++ b/packages/google-cloud-redis-cluster/samples/generated_samples/redis_v1beta1_generated_cloud_redis_cluster_list_backup_collections_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis-cluster/samples/generated_samples/redis_v1beta1_generated_cloud_redis_cluster_list_backups_async.py
+++ b/packages/google-cloud-redis-cluster/samples/generated_samples/redis_v1beta1_generated_cloud_redis_cluster_list_backups_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis-cluster/samples/generated_samples/redis_v1beta1_generated_cloud_redis_cluster_list_backups_sync.py
+++ b/packages/google-cloud-redis-cluster/samples/generated_samples/redis_v1beta1_generated_cloud_redis_cluster_list_backups_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis-cluster/samples/generated_samples/redis_v1beta1_generated_cloud_redis_cluster_list_clusters_async.py
+++ b/packages/google-cloud-redis-cluster/samples/generated_samples/redis_v1beta1_generated_cloud_redis_cluster_list_clusters_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis-cluster/samples/generated_samples/redis_v1beta1_generated_cloud_redis_cluster_list_clusters_sync.py
+++ b/packages/google-cloud-redis-cluster/samples/generated_samples/redis_v1beta1_generated_cloud_redis_cluster_list_clusters_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis-cluster/samples/generated_samples/redis_v1beta1_generated_cloud_redis_cluster_reschedule_cluster_maintenance_sync.py
+++ b/packages/google-cloud-redis-cluster/samples/generated_samples/redis_v1beta1_generated_cloud_redis_cluster_reschedule_cluster_maintenance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis-cluster/samples/generated_samples/redis_v1beta1_generated_cloud_redis_cluster_update_cluster_sync.py
+++ b/packages/google-cloud-redis-cluster/samples/generated_samples/redis_v1beta1_generated_cloud_redis_cluster_update_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis-cluster/tests/__init__.py
+++ b/packages/google-cloud-redis-cluster/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis-cluster/tests/unit/__init__.py
+++ b/packages/google-cloud-redis-cluster/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis-cluster/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-redis-cluster/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis-cluster/tests/unit/gapic/redis_cluster_v1/__init__.py
+++ b/packages/google-cloud-redis-cluster/tests/unit/gapic/redis_cluster_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis-cluster/tests/unit/gapic/redis_cluster_v1beta1/__init__.py
+++ b/packages/google-cloud-redis-cluster/tests/unit/gapic/redis_cluster_v1beta1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis/.flake8
+++ b/packages/google-cloud-redis/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis/MANIFEST.in
+++ b/packages/google-cloud-redis/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis/google/cloud/redis/__init__.py
+++ b/packages/google-cloud-redis/google/cloud/redis/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis/google/cloud/redis/gapic_version.py
+++ b/packages/google-cloud-redis/google/cloud/redis/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis/google/cloud/redis_v1/gapic_version.py
+++ b/packages/google-cloud-redis/google/cloud/redis_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis/google/cloud/redis_v1/services/__init__.py
+++ b/packages/google-cloud-redis/google/cloud/redis_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis/google/cloud/redis_v1/services/cloud_redis/__init__.py
+++ b/packages/google-cloud-redis/google/cloud/redis_v1/services/cloud_redis/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis/google/cloud/redis_v1/services/cloud_redis/client.py
+++ b/packages/google-cloud-redis/google/cloud/redis_v1/services/cloud_redis/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis/google/cloud/redis_v1/services/cloud_redis/pagers.py
+++ b/packages/google-cloud-redis/google/cloud/redis_v1/services/cloud_redis/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis/google/cloud/redis_v1/services/cloud_redis/transports/__init__.py
+++ b/packages/google-cloud-redis/google/cloud/redis_v1/services/cloud_redis/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis/google/cloud/redis_v1/services/cloud_redis/transports/base.py
+++ b/packages/google-cloud-redis/google/cloud/redis_v1/services/cloud_redis/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis/google/cloud/redis_v1/services/cloud_redis/transports/grpc.py
+++ b/packages/google-cloud-redis/google/cloud/redis_v1/services/cloud_redis/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis/google/cloud/redis_v1/services/cloud_redis/transports/grpc_asyncio.py
+++ b/packages/google-cloud-redis/google/cloud/redis_v1/services/cloud_redis/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis/google/cloud/redis_v1/services/cloud_redis/transports/rest.py
+++ b/packages/google-cloud-redis/google/cloud/redis_v1/services/cloud_redis/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis/google/cloud/redis_v1/services/cloud_redis/transports/rest_base.py
+++ b/packages/google-cloud-redis/google/cloud/redis_v1/services/cloud_redis/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis/google/cloud/redis_v1/types/__init__.py
+++ b/packages/google-cloud-redis/google/cloud/redis_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis/google/cloud/redis_v1/types/cloud_redis.py
+++ b/packages/google-cloud-redis/google/cloud/redis_v1/types/cloud_redis.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis/google/cloud/redis_v1beta1/gapic_version.py
+++ b/packages/google-cloud-redis/google/cloud/redis_v1beta1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis/google/cloud/redis_v1beta1/services/__init__.py
+++ b/packages/google-cloud-redis/google/cloud/redis_v1beta1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis/google/cloud/redis_v1beta1/services/cloud_redis/__init__.py
+++ b/packages/google-cloud-redis/google/cloud/redis_v1beta1/services/cloud_redis/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis/google/cloud/redis_v1beta1/services/cloud_redis/client.py
+++ b/packages/google-cloud-redis/google/cloud/redis_v1beta1/services/cloud_redis/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis/google/cloud/redis_v1beta1/services/cloud_redis/pagers.py
+++ b/packages/google-cloud-redis/google/cloud/redis_v1beta1/services/cloud_redis/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis/google/cloud/redis_v1beta1/services/cloud_redis/transports/__init__.py
+++ b/packages/google-cloud-redis/google/cloud/redis_v1beta1/services/cloud_redis/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis/google/cloud/redis_v1beta1/services/cloud_redis/transports/base.py
+++ b/packages/google-cloud-redis/google/cloud/redis_v1beta1/services/cloud_redis/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis/google/cloud/redis_v1beta1/services/cloud_redis/transports/grpc.py
+++ b/packages/google-cloud-redis/google/cloud/redis_v1beta1/services/cloud_redis/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis/google/cloud/redis_v1beta1/services/cloud_redis/transports/grpc_asyncio.py
+++ b/packages/google-cloud-redis/google/cloud/redis_v1beta1/services/cloud_redis/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis/google/cloud/redis_v1beta1/services/cloud_redis/transports/rest.py
+++ b/packages/google-cloud-redis/google/cloud/redis_v1beta1/services/cloud_redis/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis/google/cloud/redis_v1beta1/services/cloud_redis/transports/rest_base.py
+++ b/packages/google-cloud-redis/google/cloud/redis_v1beta1/services/cloud_redis/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis/google/cloud/redis_v1beta1/types/__init__.py
+++ b/packages/google-cloud-redis/google/cloud/redis_v1beta1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis/google/cloud/redis_v1beta1/types/cloud_redis.py
+++ b/packages/google-cloud-redis/google/cloud/redis_v1beta1/types/cloud_redis.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis/samples/generated_samples/redis_v1_generated_cloud_redis_create_instance_sync.py
+++ b/packages/google-cloud-redis/samples/generated_samples/redis_v1_generated_cloud_redis_create_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis/samples/generated_samples/redis_v1_generated_cloud_redis_delete_instance_sync.py
+++ b/packages/google-cloud-redis/samples/generated_samples/redis_v1_generated_cloud_redis_delete_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis/samples/generated_samples/redis_v1_generated_cloud_redis_export_instance_sync.py
+++ b/packages/google-cloud-redis/samples/generated_samples/redis_v1_generated_cloud_redis_export_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis/samples/generated_samples/redis_v1_generated_cloud_redis_failover_instance_sync.py
+++ b/packages/google-cloud-redis/samples/generated_samples/redis_v1_generated_cloud_redis_failover_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis/samples/generated_samples/redis_v1_generated_cloud_redis_get_instance_async.py
+++ b/packages/google-cloud-redis/samples/generated_samples/redis_v1_generated_cloud_redis_get_instance_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis/samples/generated_samples/redis_v1_generated_cloud_redis_get_instance_auth_string_async.py
+++ b/packages/google-cloud-redis/samples/generated_samples/redis_v1_generated_cloud_redis_get_instance_auth_string_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis/samples/generated_samples/redis_v1_generated_cloud_redis_get_instance_auth_string_sync.py
+++ b/packages/google-cloud-redis/samples/generated_samples/redis_v1_generated_cloud_redis_get_instance_auth_string_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis/samples/generated_samples/redis_v1_generated_cloud_redis_get_instance_sync.py
+++ b/packages/google-cloud-redis/samples/generated_samples/redis_v1_generated_cloud_redis_get_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis/samples/generated_samples/redis_v1_generated_cloud_redis_import_instance_sync.py
+++ b/packages/google-cloud-redis/samples/generated_samples/redis_v1_generated_cloud_redis_import_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis/samples/generated_samples/redis_v1_generated_cloud_redis_list_instances_async.py
+++ b/packages/google-cloud-redis/samples/generated_samples/redis_v1_generated_cloud_redis_list_instances_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis/samples/generated_samples/redis_v1_generated_cloud_redis_list_instances_sync.py
+++ b/packages/google-cloud-redis/samples/generated_samples/redis_v1_generated_cloud_redis_list_instances_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis/samples/generated_samples/redis_v1_generated_cloud_redis_reschedule_maintenance_sync.py
+++ b/packages/google-cloud-redis/samples/generated_samples/redis_v1_generated_cloud_redis_reschedule_maintenance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis/samples/generated_samples/redis_v1_generated_cloud_redis_update_instance_sync.py
+++ b/packages/google-cloud-redis/samples/generated_samples/redis_v1_generated_cloud_redis_update_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis/samples/generated_samples/redis_v1_generated_cloud_redis_upgrade_instance_sync.py
+++ b/packages/google-cloud-redis/samples/generated_samples/redis_v1_generated_cloud_redis_upgrade_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis/samples/generated_samples/redis_v1beta1_generated_cloud_redis_create_instance_sync.py
+++ b/packages/google-cloud-redis/samples/generated_samples/redis_v1beta1_generated_cloud_redis_create_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis/samples/generated_samples/redis_v1beta1_generated_cloud_redis_delete_instance_sync.py
+++ b/packages/google-cloud-redis/samples/generated_samples/redis_v1beta1_generated_cloud_redis_delete_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis/samples/generated_samples/redis_v1beta1_generated_cloud_redis_export_instance_sync.py
+++ b/packages/google-cloud-redis/samples/generated_samples/redis_v1beta1_generated_cloud_redis_export_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis/samples/generated_samples/redis_v1beta1_generated_cloud_redis_failover_instance_sync.py
+++ b/packages/google-cloud-redis/samples/generated_samples/redis_v1beta1_generated_cloud_redis_failover_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis/samples/generated_samples/redis_v1beta1_generated_cloud_redis_get_instance_async.py
+++ b/packages/google-cloud-redis/samples/generated_samples/redis_v1beta1_generated_cloud_redis_get_instance_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis/samples/generated_samples/redis_v1beta1_generated_cloud_redis_get_instance_auth_string_async.py
+++ b/packages/google-cloud-redis/samples/generated_samples/redis_v1beta1_generated_cloud_redis_get_instance_auth_string_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis/samples/generated_samples/redis_v1beta1_generated_cloud_redis_get_instance_auth_string_sync.py
+++ b/packages/google-cloud-redis/samples/generated_samples/redis_v1beta1_generated_cloud_redis_get_instance_auth_string_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis/samples/generated_samples/redis_v1beta1_generated_cloud_redis_get_instance_sync.py
+++ b/packages/google-cloud-redis/samples/generated_samples/redis_v1beta1_generated_cloud_redis_get_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis/samples/generated_samples/redis_v1beta1_generated_cloud_redis_import_instance_sync.py
+++ b/packages/google-cloud-redis/samples/generated_samples/redis_v1beta1_generated_cloud_redis_import_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis/samples/generated_samples/redis_v1beta1_generated_cloud_redis_list_instances_async.py
+++ b/packages/google-cloud-redis/samples/generated_samples/redis_v1beta1_generated_cloud_redis_list_instances_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis/samples/generated_samples/redis_v1beta1_generated_cloud_redis_list_instances_sync.py
+++ b/packages/google-cloud-redis/samples/generated_samples/redis_v1beta1_generated_cloud_redis_list_instances_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis/samples/generated_samples/redis_v1beta1_generated_cloud_redis_reschedule_maintenance_sync.py
+++ b/packages/google-cloud-redis/samples/generated_samples/redis_v1beta1_generated_cloud_redis_reschedule_maintenance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis/samples/generated_samples/redis_v1beta1_generated_cloud_redis_update_instance_sync.py
+++ b/packages/google-cloud-redis/samples/generated_samples/redis_v1beta1_generated_cloud_redis_update_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis/samples/generated_samples/redis_v1beta1_generated_cloud_redis_upgrade_instance_sync.py
+++ b/packages/google-cloud-redis/samples/generated_samples/redis_v1beta1_generated_cloud_redis_upgrade_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis/tests/__init__.py
+++ b/packages/google-cloud-redis/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis/tests/unit/__init__.py
+++ b/packages/google-cloud-redis/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-redis/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis/tests/unit/gapic/redis_v1/__init__.py
+++ b/packages/google-cloud-redis/tests/unit/gapic/redis_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-redis/tests/unit/gapic/redis_v1beta1/__init__.py
+++ b/packages/google-cloud-redis/tests/unit/gapic/redis_v1beta1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/.flake8
+++ b/packages/google-cloud-resource-manager/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/MANIFEST.in
+++ b/packages/google-cloud-resource-manager/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/google/cloud/resourcemanager/__init__.py
+++ b/packages/google-cloud-resource-manager/google/cloud/resourcemanager/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/google/cloud/resourcemanager/gapic_version.py
+++ b/packages/google-cloud-resource-manager/google/cloud/resourcemanager/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/gapic_version.py
+++ b/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/__init__.py
+++ b/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/folders/__init__.py
+++ b/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/folders/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/folders/client.py
+++ b/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/folders/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/folders/pagers.py
+++ b/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/folders/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/folders/transports/__init__.py
+++ b/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/folders/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/folders/transports/base.py
+++ b/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/folders/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/folders/transports/grpc.py
+++ b/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/folders/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/folders/transports/grpc_asyncio.py
+++ b/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/folders/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/folders/transports/rest.py
+++ b/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/folders/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/folders/transports/rest_base.py
+++ b/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/folders/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/organizations/__init__.py
+++ b/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/organizations/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/organizations/async_client.py
+++ b/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/organizations/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/organizations/client.py
+++ b/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/organizations/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/organizations/pagers.py
+++ b/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/organizations/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/organizations/transports/__init__.py
+++ b/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/organizations/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/organizations/transports/base.py
+++ b/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/organizations/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/organizations/transports/grpc.py
+++ b/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/organizations/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/organizations/transports/grpc_asyncio.py
+++ b/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/organizations/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/organizations/transports/rest.py
+++ b/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/organizations/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/organizations/transports/rest_base.py
+++ b/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/organizations/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/projects/__init__.py
+++ b/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/projects/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/projects/client.py
+++ b/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/projects/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/projects/pagers.py
+++ b/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/projects/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/projects/transports/__init__.py
+++ b/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/projects/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/projects/transports/base.py
+++ b/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/projects/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/projects/transports/grpc.py
+++ b/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/projects/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/projects/transports/grpc_asyncio.py
+++ b/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/projects/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/projects/transports/rest.py
+++ b/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/projects/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/projects/transports/rest_base.py
+++ b/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/projects/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/tag_bindings/__init__.py
+++ b/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/tag_bindings/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/tag_bindings/client.py
+++ b/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/tag_bindings/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/tag_bindings/pagers.py
+++ b/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/tag_bindings/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/tag_bindings/transports/__init__.py
+++ b/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/tag_bindings/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/tag_bindings/transports/base.py
+++ b/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/tag_bindings/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/tag_bindings/transports/grpc.py
+++ b/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/tag_bindings/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/tag_bindings/transports/grpc_asyncio.py
+++ b/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/tag_bindings/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/tag_bindings/transports/rest.py
+++ b/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/tag_bindings/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/tag_bindings/transports/rest_base.py
+++ b/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/tag_bindings/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/tag_holds/__init__.py
+++ b/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/tag_holds/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/tag_holds/client.py
+++ b/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/tag_holds/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/tag_holds/pagers.py
+++ b/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/tag_holds/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/tag_holds/transports/__init__.py
+++ b/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/tag_holds/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/tag_holds/transports/base.py
+++ b/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/tag_holds/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/tag_holds/transports/grpc.py
+++ b/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/tag_holds/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/tag_holds/transports/grpc_asyncio.py
+++ b/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/tag_holds/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/tag_holds/transports/rest.py
+++ b/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/tag_holds/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/tag_holds/transports/rest_base.py
+++ b/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/tag_holds/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/tag_keys/__init__.py
+++ b/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/tag_keys/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/tag_keys/client.py
+++ b/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/tag_keys/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/tag_keys/pagers.py
+++ b/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/tag_keys/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/tag_keys/transports/__init__.py
+++ b/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/tag_keys/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/tag_keys/transports/base.py
+++ b/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/tag_keys/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/tag_keys/transports/grpc.py
+++ b/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/tag_keys/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/tag_keys/transports/grpc_asyncio.py
+++ b/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/tag_keys/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/tag_keys/transports/rest.py
+++ b/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/tag_keys/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/tag_keys/transports/rest_base.py
+++ b/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/tag_keys/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/tag_values/__init__.py
+++ b/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/tag_values/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/tag_values/client.py
+++ b/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/tag_values/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/tag_values/pagers.py
+++ b/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/tag_values/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/tag_values/transports/__init__.py
+++ b/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/tag_values/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/tag_values/transports/base.py
+++ b/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/tag_values/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/tag_values/transports/grpc.py
+++ b/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/tag_values/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/tag_values/transports/grpc_asyncio.py
+++ b/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/tag_values/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/tag_values/transports/rest.py
+++ b/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/tag_values/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/tag_values/transports/rest_base.py
+++ b/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/services/tag_values/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/types/__init__.py
+++ b/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/types/folders.py
+++ b/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/types/folders.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/types/organizations.py
+++ b/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/types/organizations.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/types/projects.py
+++ b/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/types/projects.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/types/tag_bindings.py
+++ b/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/types/tag_bindings.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/types/tag_holds.py
+++ b/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/types/tag_holds.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/types/tag_keys.py
+++ b/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/types/tag_keys.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/types/tag_values.py
+++ b/packages/google-cloud-resource-manager/google/cloud/resourcemanager_v3/types/tag_values.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_folders_create_folder_sync.py
+++ b/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_folders_create_folder_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_folders_delete_folder_sync.py
+++ b/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_folders_delete_folder_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_folders_get_folder_async.py
+++ b/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_folders_get_folder_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_folders_get_folder_sync.py
+++ b/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_folders_get_folder_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_folders_get_iam_policy_async.py
+++ b/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_folders_get_iam_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_folders_get_iam_policy_sync.py
+++ b/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_folders_get_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_folders_list_folders_async.py
+++ b/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_folders_list_folders_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_folders_list_folders_sync.py
+++ b/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_folders_list_folders_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_folders_move_folder_sync.py
+++ b/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_folders_move_folder_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_folders_search_folders_async.py
+++ b/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_folders_search_folders_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_folders_search_folders_sync.py
+++ b/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_folders_search_folders_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_folders_set_iam_policy_async.py
+++ b/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_folders_set_iam_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_folders_set_iam_policy_sync.py
+++ b/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_folders_set_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_folders_test_iam_permissions_async.py
+++ b/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_folders_test_iam_permissions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_folders_test_iam_permissions_sync.py
+++ b/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_folders_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_folders_undelete_folder_sync.py
+++ b/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_folders_undelete_folder_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_folders_update_folder_sync.py
+++ b/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_folders_update_folder_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_organizations_get_iam_policy_async.py
+++ b/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_organizations_get_iam_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_organizations_get_iam_policy_sync.py
+++ b/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_organizations_get_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_organizations_get_organization_async.py
+++ b/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_organizations_get_organization_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_organizations_get_organization_sync.py
+++ b/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_organizations_get_organization_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_organizations_search_organizations_async.py
+++ b/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_organizations_search_organizations_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_organizations_search_organizations_sync.py
+++ b/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_organizations_search_organizations_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_organizations_set_iam_policy_async.py
+++ b/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_organizations_set_iam_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_organizations_set_iam_policy_sync.py
+++ b/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_organizations_set_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_organizations_test_iam_permissions_async.py
+++ b/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_organizations_test_iam_permissions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_organizations_test_iam_permissions_sync.py
+++ b/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_organizations_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_projects_create_project_sync.py
+++ b/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_projects_create_project_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_projects_delete_project_sync.py
+++ b/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_projects_delete_project_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_projects_get_iam_policy_async.py
+++ b/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_projects_get_iam_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_projects_get_iam_policy_sync.py
+++ b/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_projects_get_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_projects_get_project_async.py
+++ b/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_projects_get_project_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_projects_get_project_sync.py
+++ b/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_projects_get_project_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_projects_list_projects_async.py
+++ b/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_projects_list_projects_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_projects_list_projects_sync.py
+++ b/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_projects_list_projects_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_projects_move_project_sync.py
+++ b/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_projects_move_project_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_projects_search_projects_async.py
+++ b/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_projects_search_projects_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_projects_search_projects_sync.py
+++ b/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_projects_search_projects_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_projects_set_iam_policy_async.py
+++ b/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_projects_set_iam_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_projects_set_iam_policy_sync.py
+++ b/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_projects_set_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_projects_test_iam_permissions_async.py
+++ b/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_projects_test_iam_permissions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_projects_test_iam_permissions_sync.py
+++ b/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_projects_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_projects_undelete_project_sync.py
+++ b/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_projects_undelete_project_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_projects_update_project_sync.py
+++ b/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_projects_update_project_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_tag_bindings_create_tag_binding_sync.py
+++ b/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_tag_bindings_create_tag_binding_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_tag_bindings_delete_tag_binding_sync.py
+++ b/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_tag_bindings_delete_tag_binding_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_tag_bindings_list_effective_tags_async.py
+++ b/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_tag_bindings_list_effective_tags_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_tag_bindings_list_effective_tags_sync.py
+++ b/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_tag_bindings_list_effective_tags_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_tag_bindings_list_tag_bindings_async.py
+++ b/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_tag_bindings_list_tag_bindings_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_tag_bindings_list_tag_bindings_sync.py
+++ b/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_tag_bindings_list_tag_bindings_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_tag_holds_create_tag_hold_sync.py
+++ b/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_tag_holds_create_tag_hold_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_tag_holds_delete_tag_hold_sync.py
+++ b/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_tag_holds_delete_tag_hold_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_tag_holds_list_tag_holds_async.py
+++ b/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_tag_holds_list_tag_holds_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_tag_holds_list_tag_holds_sync.py
+++ b/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_tag_holds_list_tag_holds_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_tag_keys_create_tag_key_sync.py
+++ b/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_tag_keys_create_tag_key_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_tag_keys_delete_tag_key_sync.py
+++ b/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_tag_keys_delete_tag_key_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_tag_keys_get_iam_policy_async.py
+++ b/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_tag_keys_get_iam_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_tag_keys_get_iam_policy_sync.py
+++ b/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_tag_keys_get_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_tag_keys_get_namespaced_tag_key_async.py
+++ b/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_tag_keys_get_namespaced_tag_key_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_tag_keys_get_namespaced_tag_key_sync.py
+++ b/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_tag_keys_get_namespaced_tag_key_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_tag_keys_get_tag_key_async.py
+++ b/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_tag_keys_get_tag_key_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_tag_keys_get_tag_key_sync.py
+++ b/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_tag_keys_get_tag_key_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_tag_keys_list_tag_keys_async.py
+++ b/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_tag_keys_list_tag_keys_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_tag_keys_list_tag_keys_sync.py
+++ b/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_tag_keys_list_tag_keys_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_tag_keys_set_iam_policy_async.py
+++ b/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_tag_keys_set_iam_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_tag_keys_set_iam_policy_sync.py
+++ b/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_tag_keys_set_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_tag_keys_test_iam_permissions_async.py
+++ b/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_tag_keys_test_iam_permissions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_tag_keys_test_iam_permissions_sync.py
+++ b/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_tag_keys_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_tag_keys_update_tag_key_sync.py
+++ b/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_tag_keys_update_tag_key_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_tag_values_create_tag_value_sync.py
+++ b/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_tag_values_create_tag_value_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_tag_values_delete_tag_value_sync.py
+++ b/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_tag_values_delete_tag_value_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_tag_values_get_iam_policy_async.py
+++ b/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_tag_values_get_iam_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_tag_values_get_iam_policy_sync.py
+++ b/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_tag_values_get_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_tag_values_get_namespaced_tag_value_async.py
+++ b/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_tag_values_get_namespaced_tag_value_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_tag_values_get_namespaced_tag_value_sync.py
+++ b/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_tag_values_get_namespaced_tag_value_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_tag_values_get_tag_value_async.py
+++ b/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_tag_values_get_tag_value_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_tag_values_get_tag_value_sync.py
+++ b/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_tag_values_get_tag_value_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_tag_values_list_tag_values_async.py
+++ b/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_tag_values_list_tag_values_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_tag_values_list_tag_values_sync.py
+++ b/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_tag_values_list_tag_values_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_tag_values_set_iam_policy_async.py
+++ b/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_tag_values_set_iam_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_tag_values_set_iam_policy_sync.py
+++ b/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_tag_values_set_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_tag_values_test_iam_permissions_async.py
+++ b/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_tag_values_test_iam_permissions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_tag_values_test_iam_permissions_sync.py
+++ b/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_tag_values_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_tag_values_update_tag_value_sync.py
+++ b/packages/google-cloud-resource-manager/samples/generated_samples/cloudresourcemanager_v3_generated_tag_values_update_tag_value_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/tests/__init__.py
+++ b/packages/google-cloud-resource-manager/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/tests/unit/__init__.py
+++ b/packages/google-cloud-resource-manager/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-resource-manager/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-resource-manager/tests/unit/gapic/resourcemanager_v3/__init__.py
+++ b/packages/google-cloud-resource-manager/tests/unit/gapic/resourcemanager_v3/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/.flake8
+++ b/packages/google-cloud-retail/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/MANIFEST.in
+++ b/packages/google-cloud-retail/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail/__init__.py
+++ b/packages/google-cloud-retail/google/cloud/retail/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail/gapic_version.py
+++ b/packages/google-cloud-retail/google/cloud/retail/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/gapic_version.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/services/__init__.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/services/analytics_service/__init__.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/services/analytics_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/services/analytics_service/client.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/services/analytics_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/services/analytics_service/transports/__init__.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/services/analytics_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/services/analytics_service/transports/base.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/services/analytics_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/services/analytics_service/transports/grpc.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/services/analytics_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/services/analytics_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/services/analytics_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/services/analytics_service/transports/rest.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/services/analytics_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/services/analytics_service/transports/rest_base.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/services/analytics_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/services/catalog_service/__init__.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/services/catalog_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/services/catalog_service/async_client.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/services/catalog_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/services/catalog_service/client.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/services/catalog_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/services/catalog_service/pagers.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/services/catalog_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/services/catalog_service/transports/__init__.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/services/catalog_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/services/catalog_service/transports/base.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/services/catalog_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/services/catalog_service/transports/grpc.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/services/catalog_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/services/catalog_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/services/catalog_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/services/catalog_service/transports/rest.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/services/catalog_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/services/catalog_service/transports/rest_base.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/services/catalog_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/services/completion_service/__init__.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/services/completion_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/services/completion_service/client.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/services/completion_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/services/completion_service/transports/__init__.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/services/completion_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/services/completion_service/transports/base.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/services/completion_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/services/completion_service/transports/grpc.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/services/completion_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/services/completion_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/services/completion_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/services/completion_service/transports/rest.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/services/completion_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/services/completion_service/transports/rest_base.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/services/completion_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/services/control_service/__init__.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/services/control_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/services/control_service/async_client.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/services/control_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/services/control_service/client.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/services/control_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/services/control_service/pagers.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/services/control_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/services/control_service/transports/__init__.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/services/control_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/services/control_service/transports/base.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/services/control_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/services/control_service/transports/grpc.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/services/control_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/services/control_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/services/control_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/services/control_service/transports/rest.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/services/control_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/services/control_service/transports/rest_base.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/services/control_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/services/conversational_search_service/__init__.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/services/conversational_search_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/services/conversational_search_service/async_client.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/services/conversational_search_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/services/conversational_search_service/client.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/services/conversational_search_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/services/conversational_search_service/transports/__init__.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/services/conversational_search_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/services/conversational_search_service/transports/base.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/services/conversational_search_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/services/conversational_search_service/transports/grpc.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/services/conversational_search_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/services/conversational_search_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/services/conversational_search_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/services/conversational_search_service/transports/rest.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/services/conversational_search_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/services/conversational_search_service/transports/rest_base.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/services/conversational_search_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/services/generative_question_service/__init__.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/services/generative_question_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/services/generative_question_service/async_client.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/services/generative_question_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/services/generative_question_service/client.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/services/generative_question_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/services/generative_question_service/transports/__init__.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/services/generative_question_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/services/generative_question_service/transports/base.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/services/generative_question_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/services/generative_question_service/transports/grpc.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/services/generative_question_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/services/generative_question_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/services/generative_question_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/services/generative_question_service/transports/rest.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/services/generative_question_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/services/generative_question_service/transports/rest_base.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/services/generative_question_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/services/model_service/__init__.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/services/model_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/services/model_service/client.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/services/model_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/services/model_service/pagers.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/services/model_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/services/model_service/transports/__init__.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/services/model_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/services/model_service/transports/base.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/services/model_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/services/model_service/transports/grpc.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/services/model_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/services/model_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/services/model_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/services/model_service/transports/rest.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/services/model_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/services/model_service/transports/rest_base.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/services/model_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/services/prediction_service/__init__.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/services/prediction_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/services/prediction_service/async_client.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/services/prediction_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/services/prediction_service/client.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/services/prediction_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/services/prediction_service/transports/__init__.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/services/prediction_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/services/prediction_service/transports/base.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/services/prediction_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/services/prediction_service/transports/grpc.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/services/prediction_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/services/prediction_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/services/prediction_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/services/prediction_service/transports/rest.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/services/prediction_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/services/prediction_service/transports/rest_base.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/services/prediction_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/services/product_service/__init__.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/services/product_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/services/product_service/client.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/services/product_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/services/product_service/pagers.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/services/product_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/services/product_service/transports/__init__.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/services/product_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/services/product_service/transports/base.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/services/product_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/services/product_service/transports/grpc.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/services/product_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/services/product_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/services/product_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/services/product_service/transports/rest.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/services/product_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/services/product_service/transports/rest_base.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/services/product_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/services/search_service/__init__.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/services/search_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/services/search_service/async_client.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/services/search_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/services/search_service/client.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/services/search_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/services/search_service/pagers.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/services/search_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/services/search_service/transports/__init__.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/services/search_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/services/search_service/transports/base.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/services/search_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/services/search_service/transports/grpc.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/services/search_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/services/search_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/services/search_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/services/search_service/transports/rest.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/services/search_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/services/search_service/transports/rest_base.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/services/search_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/services/serving_config_service/__init__.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/services/serving_config_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/services/serving_config_service/async_client.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/services/serving_config_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/services/serving_config_service/client.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/services/serving_config_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/services/serving_config_service/pagers.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/services/serving_config_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/services/serving_config_service/transports/__init__.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/services/serving_config_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/services/serving_config_service/transports/base.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/services/serving_config_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/services/serving_config_service/transports/grpc.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/services/serving_config_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/services/serving_config_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/services/serving_config_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/services/serving_config_service/transports/rest.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/services/serving_config_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/services/serving_config_service/transports/rest_base.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/services/serving_config_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/services/user_event_service/__init__.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/services/user_event_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/services/user_event_service/client.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/services/user_event_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/services/user_event_service/transports/__init__.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/services/user_event_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/services/user_event_service/transports/base.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/services/user_event_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/services/user_event_service/transports/grpc.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/services/user_event_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/services/user_event_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/services/user_event_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/services/user_event_service/transports/rest.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/services/user_event_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/services/user_event_service/transports/rest_base.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/services/user_event_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/types/__init__.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/types/analytics_service.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/types/analytics_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/types/catalog.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/types/catalog.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/types/catalog_service.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/types/catalog_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/types/common.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/types/common.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/types/completion_service.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/types/completion_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/types/control.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/types/control.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/types/control_service.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/types/control_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/types/conversational_search_service.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/types/conversational_search_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/types/export_config.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/types/export_config.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/types/generative_question.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/types/generative_question.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/types/generative_question_service.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/types/generative_question_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/types/import_config.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/types/import_config.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/types/model.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/types/model.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/types/model_service.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/types/model_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/types/prediction_service.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/types/prediction_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/types/product.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/types/product.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/types/product_service.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/types/product_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/types/promotion.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/types/promotion.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/types/purge_config.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/types/purge_config.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/types/safety.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/types/safety.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/types/search_service.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/types/search_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/types/serving_config.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/types/serving_config.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/types/serving_config_service.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/types/serving_config_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/types/user_event.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/types/user_event.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2/types/user_event_service.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2/types/user_event_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/gapic_version.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/__init__.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/analytics_service/__init__.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/analytics_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/analytics_service/client.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/analytics_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/analytics_service/transports/__init__.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/analytics_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/analytics_service/transports/base.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/analytics_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/analytics_service/transports/grpc.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/analytics_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/analytics_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/analytics_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/analytics_service/transports/rest.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/analytics_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/analytics_service/transports/rest_base.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/analytics_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/branch_service/__init__.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/branch_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/branch_service/async_client.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/branch_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/branch_service/client.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/branch_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/branch_service/transports/__init__.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/branch_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/branch_service/transports/base.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/branch_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/branch_service/transports/grpc.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/branch_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/branch_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/branch_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/branch_service/transports/rest.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/branch_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/branch_service/transports/rest_base.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/branch_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/catalog_service/__init__.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/catalog_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/catalog_service/async_client.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/catalog_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/catalog_service/client.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/catalog_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/catalog_service/pagers.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/catalog_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/catalog_service/transports/__init__.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/catalog_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/catalog_service/transports/base.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/catalog_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/catalog_service/transports/grpc.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/catalog_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/catalog_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/catalog_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/catalog_service/transports/rest.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/catalog_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/catalog_service/transports/rest_base.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/catalog_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/completion_service/__init__.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/completion_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/completion_service/client.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/completion_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/completion_service/transports/__init__.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/completion_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/completion_service/transports/base.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/completion_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/completion_service/transports/grpc.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/completion_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/completion_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/completion_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/completion_service/transports/rest.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/completion_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/completion_service/transports/rest_base.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/completion_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/control_service/__init__.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/control_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/control_service/async_client.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/control_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/control_service/client.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/control_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/control_service/pagers.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/control_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/control_service/transports/__init__.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/control_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/control_service/transports/base.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/control_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/control_service/transports/grpc.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/control_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/control_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/control_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/control_service/transports/rest.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/control_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/control_service/transports/rest_base.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/control_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/conversational_search_service/__init__.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/conversational_search_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/conversational_search_service/async_client.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/conversational_search_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/conversational_search_service/client.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/conversational_search_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/conversational_search_service/transports/__init__.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/conversational_search_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/conversational_search_service/transports/base.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/conversational_search_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/conversational_search_service/transports/grpc.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/conversational_search_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/conversational_search_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/conversational_search_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/conversational_search_service/transports/rest.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/conversational_search_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/conversational_search_service/transports/rest_base.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/conversational_search_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/generative_question_service/__init__.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/generative_question_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/generative_question_service/async_client.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/generative_question_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/generative_question_service/client.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/generative_question_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/generative_question_service/transports/__init__.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/generative_question_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/generative_question_service/transports/base.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/generative_question_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/generative_question_service/transports/grpc.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/generative_question_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/generative_question_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/generative_question_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/generative_question_service/transports/rest.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/generative_question_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/generative_question_service/transports/rest_base.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/generative_question_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/merchant_center_account_link_service/__init__.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/merchant_center_account_link_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/merchant_center_account_link_service/client.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/merchant_center_account_link_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/merchant_center_account_link_service/transports/__init__.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/merchant_center_account_link_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/merchant_center_account_link_service/transports/base.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/merchant_center_account_link_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/merchant_center_account_link_service/transports/grpc.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/merchant_center_account_link_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/merchant_center_account_link_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/merchant_center_account_link_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/merchant_center_account_link_service/transports/rest.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/merchant_center_account_link_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/merchant_center_account_link_service/transports/rest_base.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/merchant_center_account_link_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/model_service/__init__.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/model_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/model_service/client.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/model_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/model_service/pagers.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/model_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/model_service/transports/__init__.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/model_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/model_service/transports/base.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/model_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/model_service/transports/grpc.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/model_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/model_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/model_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/model_service/transports/rest.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/model_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/model_service/transports/rest_base.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/model_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/prediction_service/__init__.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/prediction_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/prediction_service/async_client.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/prediction_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/prediction_service/client.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/prediction_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/prediction_service/transports/__init__.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/prediction_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/prediction_service/transports/base.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/prediction_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/prediction_service/transports/grpc.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/prediction_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/prediction_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/prediction_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/prediction_service/transports/rest.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/prediction_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/prediction_service/transports/rest_base.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/prediction_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/product_service/__init__.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/product_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/product_service/client.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/product_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/product_service/pagers.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/product_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/product_service/transports/__init__.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/product_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/product_service/transports/base.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/product_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/product_service/transports/grpc.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/product_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/product_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/product_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/product_service/transports/rest.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/product_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/product_service/transports/rest_base.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/product_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/project_service/__init__.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/project_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/project_service/client.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/project_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/project_service/transports/__init__.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/project_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/project_service/transports/base.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/project_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/project_service/transports/grpc.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/project_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/project_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/project_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/project_service/transports/rest.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/project_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/project_service/transports/rest_base.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/project_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/search_service/__init__.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/search_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/search_service/async_client.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/search_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/search_service/client.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/search_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/search_service/pagers.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/search_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/search_service/transports/__init__.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/search_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/search_service/transports/base.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/search_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/search_service/transports/grpc.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/search_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/search_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/search_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/search_service/transports/rest.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/search_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/search_service/transports/rest_base.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/search_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/serving_config_service/__init__.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/serving_config_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/serving_config_service/async_client.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/serving_config_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/serving_config_service/client.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/serving_config_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/serving_config_service/pagers.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/serving_config_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/serving_config_service/transports/__init__.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/serving_config_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/serving_config_service/transports/base.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/serving_config_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/serving_config_service/transports/grpc.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/serving_config_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/serving_config_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/serving_config_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/serving_config_service/transports/rest.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/serving_config_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/serving_config_service/transports/rest_base.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/serving_config_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/user_event_service/__init__.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/user_event_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/user_event_service/client.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/user_event_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/user_event_service/transports/__init__.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/user_event_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/user_event_service/transports/base.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/user_event_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/user_event_service/transports/grpc.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/user_event_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/user_event_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/user_event_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/user_event_service/transports/rest.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/user_event_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/user_event_service/transports/rest_base.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/services/user_event_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/types/__init__.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/types/analytics_service.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/types/analytics_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/types/branch.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/types/branch.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/types/branch_service.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/types/branch_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/types/catalog.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/types/catalog.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/types/catalog_service.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/types/catalog_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/types/common.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/types/common.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/types/completion_service.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/types/completion_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/types/control.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/types/control.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/types/control_service.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/types/control_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/types/conversational_search_service.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/types/conversational_search_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/types/export_config.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/types/export_config.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/types/generative_question.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/types/generative_question.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/types/generative_question_service.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/types/generative_question_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/types/import_config.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/types/import_config.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/types/merchant_center_account_link.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/types/merchant_center_account_link.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/types/merchant_center_account_link_service.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/types/merchant_center_account_link_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/types/model.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/types/model.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/types/model_service.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/types/model_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/types/prediction_service.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/types/prediction_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/types/product.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/types/product.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/types/product_service.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/types/product_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/types/project.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/types/project.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/types/project_service.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/types/project_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/types/promotion.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/types/promotion.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/types/purge_config.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/types/purge_config.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/types/safety.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/types/safety.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/types/search_service.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/types/search_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/types/serving_config.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/types/serving_config.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/types/serving_config_service.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/types/serving_config_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/types/user_event.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/types/user_event.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2alpha/types/user_event_service.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2alpha/types/user_event_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/gapic_version.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/services/__init__.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/services/analytics_service/__init__.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/services/analytics_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/services/analytics_service/client.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/services/analytics_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/services/analytics_service/transports/__init__.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/services/analytics_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/services/analytics_service/transports/base.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/services/analytics_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/services/analytics_service/transports/grpc.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/services/analytics_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/services/analytics_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/services/analytics_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/services/analytics_service/transports/rest.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/services/analytics_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/services/analytics_service/transports/rest_base.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/services/analytics_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/services/catalog_service/__init__.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/services/catalog_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/services/catalog_service/async_client.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/services/catalog_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/services/catalog_service/client.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/services/catalog_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/services/catalog_service/pagers.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/services/catalog_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/services/catalog_service/transports/__init__.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/services/catalog_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/services/catalog_service/transports/base.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/services/catalog_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/services/catalog_service/transports/grpc.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/services/catalog_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/services/catalog_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/services/catalog_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/services/catalog_service/transports/rest.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/services/catalog_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/services/catalog_service/transports/rest_base.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/services/catalog_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/services/completion_service/__init__.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/services/completion_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/services/completion_service/client.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/services/completion_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/services/completion_service/transports/__init__.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/services/completion_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/services/completion_service/transports/base.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/services/completion_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/services/completion_service/transports/grpc.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/services/completion_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/services/completion_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/services/completion_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/services/completion_service/transports/rest.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/services/completion_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/services/completion_service/transports/rest_base.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/services/completion_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/services/control_service/__init__.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/services/control_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/services/control_service/async_client.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/services/control_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/services/control_service/client.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/services/control_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/services/control_service/pagers.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/services/control_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/services/control_service/transports/__init__.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/services/control_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/services/control_service/transports/base.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/services/control_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/services/control_service/transports/grpc.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/services/control_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/services/control_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/services/control_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/services/control_service/transports/rest.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/services/control_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/services/control_service/transports/rest_base.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/services/control_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/services/conversational_search_service/__init__.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/services/conversational_search_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/services/conversational_search_service/async_client.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/services/conversational_search_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/services/conversational_search_service/client.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/services/conversational_search_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/services/conversational_search_service/transports/__init__.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/services/conversational_search_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/services/conversational_search_service/transports/base.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/services/conversational_search_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/services/conversational_search_service/transports/grpc.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/services/conversational_search_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/services/conversational_search_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/services/conversational_search_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/services/conversational_search_service/transports/rest.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/services/conversational_search_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/services/conversational_search_service/transports/rest_base.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/services/conversational_search_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/services/generative_question_service/__init__.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/services/generative_question_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/services/generative_question_service/async_client.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/services/generative_question_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/services/generative_question_service/client.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/services/generative_question_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/services/generative_question_service/transports/__init__.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/services/generative_question_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/services/generative_question_service/transports/base.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/services/generative_question_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/services/generative_question_service/transports/grpc.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/services/generative_question_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/services/generative_question_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/services/generative_question_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/services/generative_question_service/transports/rest.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/services/generative_question_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/services/generative_question_service/transports/rest_base.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/services/generative_question_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/services/model_service/__init__.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/services/model_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/services/model_service/client.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/services/model_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/services/model_service/pagers.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/services/model_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/services/model_service/transports/__init__.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/services/model_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/services/model_service/transports/base.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/services/model_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/services/model_service/transports/grpc.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/services/model_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/services/model_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/services/model_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/services/model_service/transports/rest.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/services/model_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/services/model_service/transports/rest_base.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/services/model_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/services/prediction_service/__init__.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/services/prediction_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/services/prediction_service/async_client.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/services/prediction_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/services/prediction_service/client.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/services/prediction_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/services/prediction_service/transports/__init__.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/services/prediction_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/services/prediction_service/transports/base.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/services/prediction_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/services/prediction_service/transports/grpc.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/services/prediction_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/services/prediction_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/services/prediction_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/services/prediction_service/transports/rest.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/services/prediction_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/services/prediction_service/transports/rest_base.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/services/prediction_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/services/product_service/__init__.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/services/product_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/services/product_service/client.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/services/product_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/services/product_service/pagers.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/services/product_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/services/product_service/transports/__init__.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/services/product_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/services/product_service/transports/base.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/services/product_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/services/product_service/transports/grpc.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/services/product_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/services/product_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/services/product_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/services/product_service/transports/rest.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/services/product_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/services/product_service/transports/rest_base.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/services/product_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/services/project_service/__init__.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/services/project_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/services/project_service/async_client.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/services/project_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/services/project_service/client.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/services/project_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/services/project_service/transports/__init__.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/services/project_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/services/project_service/transports/base.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/services/project_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/services/project_service/transports/grpc.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/services/project_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/services/project_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/services/project_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/services/project_service/transports/rest.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/services/project_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/services/project_service/transports/rest_base.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/services/project_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/services/search_service/__init__.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/services/search_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/services/search_service/async_client.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/services/search_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/services/search_service/client.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/services/search_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/services/search_service/pagers.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/services/search_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/services/search_service/transports/__init__.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/services/search_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/services/search_service/transports/base.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/services/search_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/services/search_service/transports/grpc.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/services/search_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/services/search_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/services/search_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/services/search_service/transports/rest.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/services/search_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/services/search_service/transports/rest_base.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/services/search_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/services/serving_config_service/__init__.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/services/serving_config_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/services/serving_config_service/async_client.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/services/serving_config_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/services/serving_config_service/client.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/services/serving_config_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/services/serving_config_service/pagers.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/services/serving_config_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/services/serving_config_service/transports/__init__.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/services/serving_config_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/services/serving_config_service/transports/base.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/services/serving_config_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/services/serving_config_service/transports/grpc.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/services/serving_config_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/services/serving_config_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/services/serving_config_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/services/serving_config_service/transports/rest.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/services/serving_config_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/services/serving_config_service/transports/rest_base.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/services/serving_config_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/services/user_event_service/__init__.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/services/user_event_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/services/user_event_service/client.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/services/user_event_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/services/user_event_service/transports/__init__.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/services/user_event_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/services/user_event_service/transports/base.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/services/user_event_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/services/user_event_service/transports/grpc.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/services/user_event_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/services/user_event_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/services/user_event_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/services/user_event_service/transports/rest.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/services/user_event_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/services/user_event_service/transports/rest_base.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/services/user_event_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/types/__init__.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/types/analytics_service.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/types/analytics_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/types/catalog.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/types/catalog.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/types/catalog_service.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/types/catalog_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/types/common.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/types/common.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/types/completion_service.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/types/completion_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/types/control.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/types/control.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/types/control_service.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/types/control_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/types/conversational_search_service.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/types/conversational_search_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/types/export_config.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/types/export_config.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/types/generative_question.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/types/generative_question.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/types/generative_question_service.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/types/generative_question_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/types/import_config.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/types/import_config.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/types/model.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/types/model.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/types/model_service.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/types/model_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/types/prediction_service.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/types/prediction_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/types/product.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/types/product.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/types/product_service.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/types/product_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/types/project.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/types/project.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/types/project_service.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/types/project_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/types/promotion.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/types/promotion.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/types/purge_config.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/types/purge_config.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/types/safety.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/types/safety.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/types/search_service.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/types/search_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/types/serving_config.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/types/serving_config.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/types/serving_config_service.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/types/serving_config_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/types/user_event.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/types/user_event.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/google/cloud/retail_v2beta/types/user_event_service.py
+++ b/packages/google-cloud-retail/google/cloud/retail_v2beta/types/user_event_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_analytics_service_export_analytics_metrics_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_analytics_service_export_analytics_metrics_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_catalog_service_add_catalog_attribute_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_catalog_service_add_catalog_attribute_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_catalog_service_add_catalog_attribute_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_catalog_service_add_catalog_attribute_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_catalog_service_get_attributes_config_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_catalog_service_get_attributes_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_catalog_service_get_attributes_config_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_catalog_service_get_attributes_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_catalog_service_get_completion_config_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_catalog_service_get_completion_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_catalog_service_get_completion_config_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_catalog_service_get_completion_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_catalog_service_get_default_branch_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_catalog_service_get_default_branch_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_catalog_service_get_default_branch_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_catalog_service_get_default_branch_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_catalog_service_list_catalogs_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_catalog_service_list_catalogs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_catalog_service_list_catalogs_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_catalog_service_list_catalogs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_catalog_service_remove_catalog_attribute_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_catalog_service_remove_catalog_attribute_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_catalog_service_remove_catalog_attribute_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_catalog_service_remove_catalog_attribute_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_catalog_service_replace_catalog_attribute_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_catalog_service_replace_catalog_attribute_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_catalog_service_replace_catalog_attribute_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_catalog_service_replace_catalog_attribute_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_catalog_service_set_default_branch_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_catalog_service_set_default_branch_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_catalog_service_set_default_branch_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_catalog_service_set_default_branch_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_catalog_service_update_attributes_config_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_catalog_service_update_attributes_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_catalog_service_update_attributes_config_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_catalog_service_update_attributes_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_catalog_service_update_catalog_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_catalog_service_update_catalog_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_catalog_service_update_catalog_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_catalog_service_update_catalog_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_catalog_service_update_completion_config_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_catalog_service_update_completion_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_catalog_service_update_completion_config_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_catalog_service_update_completion_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_completion_service_complete_query_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_completion_service_complete_query_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_completion_service_complete_query_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_completion_service_complete_query_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_completion_service_import_completion_data_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_completion_service_import_completion_data_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_control_service_create_control_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_control_service_create_control_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_control_service_create_control_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_control_service_create_control_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_control_service_delete_control_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_control_service_delete_control_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_control_service_delete_control_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_control_service_delete_control_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_control_service_get_control_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_control_service_get_control_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_control_service_get_control_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_control_service_get_control_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_control_service_list_controls_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_control_service_list_controls_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_control_service_list_controls_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_control_service_list_controls_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_control_service_update_control_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_control_service_update_control_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_control_service_update_control_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_control_service_update_control_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_conversational_search_service_conversational_search_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_conversational_search_service_conversational_search_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_conversational_search_service_conversational_search_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_conversational_search_service_conversational_search_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_generative_question_service_batch_update_generative_question_configs_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_generative_question_service_batch_update_generative_question_configs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_generative_question_service_batch_update_generative_question_configs_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_generative_question_service_batch_update_generative_question_configs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_generative_question_service_get_generative_questions_feature_config_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_generative_question_service_get_generative_questions_feature_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_generative_question_service_get_generative_questions_feature_config_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_generative_question_service_get_generative_questions_feature_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_generative_question_service_list_generative_question_configs_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_generative_question_service_list_generative_question_configs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_generative_question_service_list_generative_question_configs_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_generative_question_service_list_generative_question_configs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_generative_question_service_update_generative_question_config_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_generative_question_service_update_generative_question_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_generative_question_service_update_generative_question_config_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_generative_question_service_update_generative_question_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_generative_question_service_update_generative_questions_feature_config_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_generative_question_service_update_generative_questions_feature_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_generative_question_service_update_generative_questions_feature_config_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_generative_question_service_update_generative_questions_feature_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_model_service_create_model_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_model_service_create_model_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_model_service_delete_model_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_model_service_delete_model_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_model_service_delete_model_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_model_service_delete_model_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_model_service_get_model_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_model_service_get_model_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_model_service_get_model_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_model_service_get_model_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_model_service_list_models_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_model_service_list_models_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_model_service_list_models_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_model_service_list_models_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_model_service_pause_model_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_model_service_pause_model_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_model_service_pause_model_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_model_service_pause_model_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_model_service_resume_model_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_model_service_resume_model_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_model_service_resume_model_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_model_service_resume_model_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_model_service_tune_model_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_model_service_tune_model_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_model_service_update_model_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_model_service_update_model_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_model_service_update_model_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_model_service_update_model_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_prediction_service_predict_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_prediction_service_predict_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_prediction_service_predict_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_prediction_service_predict_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_product_service_add_fulfillment_places_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_product_service_add_fulfillment_places_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_product_service_add_local_inventories_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_product_service_add_local_inventories_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_product_service_create_product_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_product_service_create_product_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_product_service_create_product_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_product_service_create_product_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_product_service_delete_product_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_product_service_delete_product_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_product_service_delete_product_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_product_service_delete_product_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_product_service_get_product_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_product_service_get_product_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_product_service_get_product_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_product_service_get_product_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_product_service_import_products_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_product_service_import_products_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_product_service_list_products_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_product_service_list_products_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_product_service_list_products_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_product_service_list_products_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_product_service_purge_products_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_product_service_purge_products_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_product_service_remove_fulfillment_places_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_product_service_remove_fulfillment_places_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_product_service_remove_local_inventories_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_product_service_remove_local_inventories_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_product_service_set_inventory_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_product_service_set_inventory_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_product_service_update_product_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_product_service_update_product_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_product_service_update_product_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_product_service_update_product_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_search_service_search_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_search_service_search_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_search_service_search_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_search_service_search_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_serving_config_service_add_control_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_serving_config_service_add_control_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_serving_config_service_add_control_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_serving_config_service_add_control_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_serving_config_service_create_serving_config_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_serving_config_service_create_serving_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_serving_config_service_create_serving_config_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_serving_config_service_create_serving_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_serving_config_service_delete_serving_config_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_serving_config_service_delete_serving_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_serving_config_service_delete_serving_config_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_serving_config_service_delete_serving_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_serving_config_service_get_serving_config_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_serving_config_service_get_serving_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_serving_config_service_get_serving_config_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_serving_config_service_get_serving_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_serving_config_service_list_serving_configs_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_serving_config_service_list_serving_configs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_serving_config_service_list_serving_configs_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_serving_config_service_list_serving_configs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_serving_config_service_remove_control_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_serving_config_service_remove_control_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_serving_config_service_remove_control_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_serving_config_service_remove_control_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_serving_config_service_update_serving_config_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_serving_config_service_update_serving_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_serving_config_service_update_serving_config_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_serving_config_service_update_serving_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_user_event_service_collect_user_event_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_user_event_service_collect_user_event_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_user_event_service_collect_user_event_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_user_event_service_collect_user_event_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_user_event_service_import_user_events_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_user_event_service_import_user_events_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_user_event_service_purge_user_events_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_user_event_service_purge_user_events_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_user_event_service_rejoin_user_events_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_user_event_service_rejoin_user_events_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_user_event_service_write_user_event_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_user_event_service_write_user_event_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_user_event_service_write_user_event_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2_generated_user_event_service_write_user_event_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_analytics_service_export_analytics_metrics_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_analytics_service_export_analytics_metrics_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_branch_service_get_branch_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_branch_service_get_branch_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_branch_service_get_branch_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_branch_service_get_branch_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_branch_service_list_branches_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_branch_service_list_branches_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_branch_service_list_branches_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_branch_service_list_branches_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_catalog_service_add_catalog_attribute_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_catalog_service_add_catalog_attribute_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_catalog_service_add_catalog_attribute_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_catalog_service_add_catalog_attribute_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_catalog_service_batch_remove_catalog_attributes_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_catalog_service_batch_remove_catalog_attributes_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_catalog_service_batch_remove_catalog_attributes_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_catalog_service_batch_remove_catalog_attributes_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_catalog_service_get_attributes_config_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_catalog_service_get_attributes_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_catalog_service_get_attributes_config_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_catalog_service_get_attributes_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_catalog_service_get_completion_config_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_catalog_service_get_completion_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_catalog_service_get_completion_config_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_catalog_service_get_completion_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_catalog_service_get_default_branch_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_catalog_service_get_default_branch_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_catalog_service_get_default_branch_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_catalog_service_get_default_branch_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_catalog_service_list_catalogs_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_catalog_service_list_catalogs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_catalog_service_list_catalogs_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_catalog_service_list_catalogs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_catalog_service_remove_catalog_attribute_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_catalog_service_remove_catalog_attribute_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_catalog_service_remove_catalog_attribute_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_catalog_service_remove_catalog_attribute_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_catalog_service_replace_catalog_attribute_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_catalog_service_replace_catalog_attribute_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_catalog_service_replace_catalog_attribute_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_catalog_service_replace_catalog_attribute_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_catalog_service_set_default_branch_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_catalog_service_set_default_branch_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_catalog_service_set_default_branch_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_catalog_service_set_default_branch_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_catalog_service_update_attributes_config_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_catalog_service_update_attributes_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_catalog_service_update_attributes_config_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_catalog_service_update_attributes_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_catalog_service_update_catalog_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_catalog_service_update_catalog_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_catalog_service_update_catalog_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_catalog_service_update_catalog_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_catalog_service_update_completion_config_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_catalog_service_update_completion_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_catalog_service_update_completion_config_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_catalog_service_update_completion_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_completion_service_complete_query_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_completion_service_complete_query_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_completion_service_complete_query_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_completion_service_complete_query_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_completion_service_import_completion_data_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_completion_service_import_completion_data_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_control_service_create_control_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_control_service_create_control_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_control_service_create_control_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_control_service_create_control_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_control_service_delete_control_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_control_service_delete_control_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_control_service_delete_control_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_control_service_delete_control_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_control_service_get_control_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_control_service_get_control_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_control_service_get_control_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_control_service_get_control_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_control_service_list_controls_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_control_service_list_controls_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_control_service_list_controls_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_control_service_list_controls_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_control_service_update_control_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_control_service_update_control_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_control_service_update_control_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_control_service_update_control_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_conversational_search_service_conversational_search_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_conversational_search_service_conversational_search_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_conversational_search_service_conversational_search_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_conversational_search_service_conversational_search_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_generative_question_service_batch_update_generative_question_configs_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_generative_question_service_batch_update_generative_question_configs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_generative_question_service_batch_update_generative_question_configs_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_generative_question_service_batch_update_generative_question_configs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_generative_question_service_get_generative_questions_feature_config_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_generative_question_service_get_generative_questions_feature_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_generative_question_service_get_generative_questions_feature_config_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_generative_question_service_get_generative_questions_feature_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_generative_question_service_list_generative_question_configs_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_generative_question_service_list_generative_question_configs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_generative_question_service_list_generative_question_configs_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_generative_question_service_list_generative_question_configs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_generative_question_service_update_generative_question_config_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_generative_question_service_update_generative_question_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_generative_question_service_update_generative_question_config_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_generative_question_service_update_generative_question_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_generative_question_service_update_generative_questions_feature_config_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_generative_question_service_update_generative_questions_feature_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_generative_question_service_update_generative_questions_feature_config_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_generative_question_service_update_generative_questions_feature_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_merchant_center_account_link_service_create_merchant_center_account_link_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_merchant_center_account_link_service_create_merchant_center_account_link_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_merchant_center_account_link_service_delete_merchant_center_account_link_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_merchant_center_account_link_service_delete_merchant_center_account_link_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_merchant_center_account_link_service_delete_merchant_center_account_link_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_merchant_center_account_link_service_delete_merchant_center_account_link_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_merchant_center_account_link_service_list_merchant_center_account_links_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_merchant_center_account_link_service_list_merchant_center_account_links_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_merchant_center_account_link_service_list_merchant_center_account_links_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_merchant_center_account_link_service_list_merchant_center_account_links_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_model_service_create_model_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_model_service_create_model_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_model_service_delete_model_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_model_service_delete_model_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_model_service_delete_model_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_model_service_delete_model_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_model_service_get_model_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_model_service_get_model_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_model_service_get_model_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_model_service_get_model_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_model_service_list_models_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_model_service_list_models_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_model_service_list_models_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_model_service_list_models_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_model_service_pause_model_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_model_service_pause_model_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_model_service_pause_model_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_model_service_pause_model_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_model_service_resume_model_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_model_service_resume_model_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_model_service_resume_model_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_model_service_resume_model_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_model_service_tune_model_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_model_service_tune_model_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_model_service_update_model_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_model_service_update_model_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_model_service_update_model_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_model_service_update_model_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_prediction_service_predict_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_prediction_service_predict_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_prediction_service_predict_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_prediction_service_predict_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_product_service_add_fulfillment_places_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_product_service_add_fulfillment_places_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_product_service_add_local_inventories_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_product_service_add_local_inventories_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_product_service_create_product_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_product_service_create_product_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_product_service_create_product_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_product_service_create_product_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_product_service_delete_product_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_product_service_delete_product_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_product_service_delete_product_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_product_service_delete_product_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_product_service_export_products_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_product_service_export_products_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_product_service_get_product_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_product_service_get_product_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_product_service_get_product_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_product_service_get_product_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_product_service_import_products_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_product_service_import_products_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_product_service_list_products_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_product_service_list_products_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_product_service_list_products_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_product_service_list_products_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_product_service_purge_products_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_product_service_purge_products_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_product_service_remove_fulfillment_places_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_product_service_remove_fulfillment_places_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_product_service_remove_local_inventories_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_product_service_remove_local_inventories_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_product_service_set_inventory_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_product_service_set_inventory_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_product_service_update_product_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_product_service_update_product_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_product_service_update_product_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_product_service_update_product_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_project_service_accept_terms_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_project_service_accept_terms_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_project_service_accept_terms_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_project_service_accept_terms_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_project_service_enroll_solution_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_project_service_enroll_solution_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_project_service_get_alert_config_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_project_service_get_alert_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_project_service_get_alert_config_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_project_service_get_alert_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_project_service_get_logging_config_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_project_service_get_logging_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_project_service_get_logging_config_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_project_service_get_logging_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_project_service_get_project_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_project_service_get_project_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_project_service_get_project_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_project_service_get_project_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_project_service_list_enrolled_solutions_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_project_service_list_enrolled_solutions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_project_service_list_enrolled_solutions_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_project_service_list_enrolled_solutions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_project_service_update_alert_config_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_project_service_update_alert_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_project_service_update_alert_config_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_project_service_update_alert_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_project_service_update_logging_config_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_project_service_update_logging_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_project_service_update_logging_config_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_project_service_update_logging_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_search_service_search_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_search_service_search_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_search_service_search_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_search_service_search_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_serving_config_service_add_control_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_serving_config_service_add_control_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_serving_config_service_add_control_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_serving_config_service_add_control_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_serving_config_service_create_serving_config_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_serving_config_service_create_serving_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_serving_config_service_create_serving_config_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_serving_config_service_create_serving_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_serving_config_service_delete_serving_config_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_serving_config_service_delete_serving_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_serving_config_service_delete_serving_config_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_serving_config_service_delete_serving_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_serving_config_service_get_serving_config_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_serving_config_service_get_serving_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_serving_config_service_get_serving_config_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_serving_config_service_get_serving_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_serving_config_service_list_serving_configs_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_serving_config_service_list_serving_configs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_serving_config_service_list_serving_configs_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_serving_config_service_list_serving_configs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_serving_config_service_remove_control_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_serving_config_service_remove_control_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_serving_config_service_remove_control_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_serving_config_service_remove_control_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_serving_config_service_update_serving_config_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_serving_config_service_update_serving_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_serving_config_service_update_serving_config_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_serving_config_service_update_serving_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_user_event_service_collect_user_event_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_user_event_service_collect_user_event_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_user_event_service_collect_user_event_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_user_event_service_collect_user_event_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_user_event_service_export_user_events_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_user_event_service_export_user_events_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_user_event_service_import_user_events_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_user_event_service_import_user_events_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_user_event_service_purge_user_events_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_user_event_service_purge_user_events_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_user_event_service_rejoin_user_events_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_user_event_service_rejoin_user_events_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_user_event_service_write_user_event_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_user_event_service_write_user_event_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_user_event_service_write_user_event_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2alpha_generated_user_event_service_write_user_event_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_analytics_service_export_analytics_metrics_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_analytics_service_export_analytics_metrics_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_catalog_service_add_catalog_attribute_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_catalog_service_add_catalog_attribute_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_catalog_service_add_catalog_attribute_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_catalog_service_add_catalog_attribute_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_catalog_service_batch_remove_catalog_attributes_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_catalog_service_batch_remove_catalog_attributes_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_catalog_service_batch_remove_catalog_attributes_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_catalog_service_batch_remove_catalog_attributes_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_catalog_service_get_attributes_config_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_catalog_service_get_attributes_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_catalog_service_get_attributes_config_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_catalog_service_get_attributes_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_catalog_service_get_completion_config_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_catalog_service_get_completion_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_catalog_service_get_completion_config_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_catalog_service_get_completion_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_catalog_service_get_default_branch_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_catalog_service_get_default_branch_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_catalog_service_get_default_branch_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_catalog_service_get_default_branch_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_catalog_service_list_catalogs_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_catalog_service_list_catalogs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_catalog_service_list_catalogs_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_catalog_service_list_catalogs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_catalog_service_remove_catalog_attribute_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_catalog_service_remove_catalog_attribute_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_catalog_service_remove_catalog_attribute_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_catalog_service_remove_catalog_attribute_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_catalog_service_replace_catalog_attribute_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_catalog_service_replace_catalog_attribute_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_catalog_service_replace_catalog_attribute_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_catalog_service_replace_catalog_attribute_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_catalog_service_set_default_branch_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_catalog_service_set_default_branch_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_catalog_service_set_default_branch_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_catalog_service_set_default_branch_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_catalog_service_update_attributes_config_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_catalog_service_update_attributes_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_catalog_service_update_attributes_config_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_catalog_service_update_attributes_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_catalog_service_update_catalog_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_catalog_service_update_catalog_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_catalog_service_update_catalog_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_catalog_service_update_catalog_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_catalog_service_update_completion_config_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_catalog_service_update_completion_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_catalog_service_update_completion_config_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_catalog_service_update_completion_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_completion_service_complete_query_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_completion_service_complete_query_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_completion_service_complete_query_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_completion_service_complete_query_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_completion_service_import_completion_data_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_completion_service_import_completion_data_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_control_service_create_control_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_control_service_create_control_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_control_service_create_control_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_control_service_create_control_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_control_service_delete_control_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_control_service_delete_control_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_control_service_delete_control_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_control_service_delete_control_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_control_service_get_control_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_control_service_get_control_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_control_service_get_control_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_control_service_get_control_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_control_service_list_controls_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_control_service_list_controls_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_control_service_list_controls_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_control_service_list_controls_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_control_service_update_control_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_control_service_update_control_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_control_service_update_control_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_control_service_update_control_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_conversational_search_service_conversational_search_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_conversational_search_service_conversational_search_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_conversational_search_service_conversational_search_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_conversational_search_service_conversational_search_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_generative_question_service_batch_update_generative_question_configs_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_generative_question_service_batch_update_generative_question_configs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_generative_question_service_batch_update_generative_question_configs_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_generative_question_service_batch_update_generative_question_configs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_generative_question_service_get_generative_questions_feature_config_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_generative_question_service_get_generative_questions_feature_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_generative_question_service_get_generative_questions_feature_config_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_generative_question_service_get_generative_questions_feature_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_generative_question_service_list_generative_question_configs_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_generative_question_service_list_generative_question_configs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_generative_question_service_list_generative_question_configs_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_generative_question_service_list_generative_question_configs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_generative_question_service_update_generative_question_config_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_generative_question_service_update_generative_question_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_generative_question_service_update_generative_question_config_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_generative_question_service_update_generative_question_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_generative_question_service_update_generative_questions_feature_config_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_generative_question_service_update_generative_questions_feature_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_generative_question_service_update_generative_questions_feature_config_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_generative_question_service_update_generative_questions_feature_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_model_service_create_model_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_model_service_create_model_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_model_service_delete_model_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_model_service_delete_model_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_model_service_delete_model_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_model_service_delete_model_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_model_service_get_model_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_model_service_get_model_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_model_service_get_model_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_model_service_get_model_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_model_service_list_models_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_model_service_list_models_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_model_service_list_models_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_model_service_list_models_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_model_service_pause_model_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_model_service_pause_model_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_model_service_pause_model_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_model_service_pause_model_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_model_service_resume_model_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_model_service_resume_model_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_model_service_resume_model_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_model_service_resume_model_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_model_service_tune_model_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_model_service_tune_model_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_model_service_update_model_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_model_service_update_model_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_model_service_update_model_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_model_service_update_model_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_prediction_service_predict_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_prediction_service_predict_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_prediction_service_predict_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_prediction_service_predict_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_product_service_add_fulfillment_places_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_product_service_add_fulfillment_places_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_product_service_add_local_inventories_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_product_service_add_local_inventories_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_product_service_create_product_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_product_service_create_product_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_product_service_create_product_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_product_service_create_product_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_product_service_delete_product_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_product_service_delete_product_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_product_service_delete_product_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_product_service_delete_product_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_product_service_export_products_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_product_service_export_products_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_product_service_get_product_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_product_service_get_product_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_product_service_get_product_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_product_service_get_product_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_product_service_import_products_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_product_service_import_products_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_product_service_list_products_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_product_service_list_products_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_product_service_list_products_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_product_service_list_products_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_product_service_purge_products_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_product_service_purge_products_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_product_service_remove_fulfillment_places_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_product_service_remove_fulfillment_places_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_product_service_remove_local_inventories_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_product_service_remove_local_inventories_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_product_service_set_inventory_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_product_service_set_inventory_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_product_service_update_product_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_product_service_update_product_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_product_service_update_product_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_product_service_update_product_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_project_service_get_alert_config_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_project_service_get_alert_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_project_service_get_alert_config_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_project_service_get_alert_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_project_service_update_alert_config_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_project_service_update_alert_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_project_service_update_alert_config_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_project_service_update_alert_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_search_service_search_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_search_service_search_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_search_service_search_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_search_service_search_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_serving_config_service_add_control_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_serving_config_service_add_control_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_serving_config_service_add_control_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_serving_config_service_add_control_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_serving_config_service_create_serving_config_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_serving_config_service_create_serving_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_serving_config_service_create_serving_config_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_serving_config_service_create_serving_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_serving_config_service_delete_serving_config_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_serving_config_service_delete_serving_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_serving_config_service_delete_serving_config_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_serving_config_service_delete_serving_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_serving_config_service_get_serving_config_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_serving_config_service_get_serving_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_serving_config_service_get_serving_config_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_serving_config_service_get_serving_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_serving_config_service_list_serving_configs_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_serving_config_service_list_serving_configs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_serving_config_service_list_serving_configs_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_serving_config_service_list_serving_configs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_serving_config_service_remove_control_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_serving_config_service_remove_control_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_serving_config_service_remove_control_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_serving_config_service_remove_control_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_serving_config_service_update_serving_config_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_serving_config_service_update_serving_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_serving_config_service_update_serving_config_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_serving_config_service_update_serving_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_user_event_service_collect_user_event_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_user_event_service_collect_user_event_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_user_event_service_collect_user_event_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_user_event_service_collect_user_event_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_user_event_service_export_user_events_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_user_event_service_export_user_events_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_user_event_service_import_user_events_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_user_event_service_import_user_events_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_user_event_service_purge_user_events_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_user_event_service_purge_user_events_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_user_event_service_rejoin_user_events_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_user_event_service_rejoin_user_events_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_user_event_service_write_user_event_async.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_user_event_service_write_user_event_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_user_event_service_write_user_event_sync.py
+++ b/packages/google-cloud-retail/samples/generated_samples/retail_v2beta_generated_user_event_service_write_user_event_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/tests/__init__.py
+++ b/packages/google-cloud-retail/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/tests/unit/__init__.py
+++ b/packages/google-cloud-retail/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-retail/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/tests/unit/gapic/retail_v2/__init__.py
+++ b/packages/google-cloud-retail/tests/unit/gapic/retail_v2/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/tests/unit/gapic/retail_v2alpha/__init__.py
+++ b/packages/google-cloud-retail/tests/unit/gapic/retail_v2alpha/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-retail/tests/unit/gapic/retail_v2beta/__init__.py
+++ b/packages/google-cloud-retail/tests/unit/gapic/retail_v2beta/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/.flake8
+++ b/packages/google-cloud-run/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/MANIFEST.in
+++ b/packages/google-cloud-run/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/google/cloud/run/__init__.py
+++ b/packages/google-cloud-run/google/cloud/run/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/google/cloud/run/gapic_version.py
+++ b/packages/google-cloud-run/google/cloud/run/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/google/cloud/run_v2/gapic_version.py
+++ b/packages/google-cloud-run/google/cloud/run_v2/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/google/cloud/run_v2/services/__init__.py
+++ b/packages/google-cloud-run/google/cloud/run_v2/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/google/cloud/run_v2/services/builds/__init__.py
+++ b/packages/google-cloud-run/google/cloud/run_v2/services/builds/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/google/cloud/run_v2/services/builds/async_client.py
+++ b/packages/google-cloud-run/google/cloud/run_v2/services/builds/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/google/cloud/run_v2/services/builds/client.py
+++ b/packages/google-cloud-run/google/cloud/run_v2/services/builds/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/google/cloud/run_v2/services/builds/transports/__init__.py
+++ b/packages/google-cloud-run/google/cloud/run_v2/services/builds/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/google/cloud/run_v2/services/builds/transports/base.py
+++ b/packages/google-cloud-run/google/cloud/run_v2/services/builds/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/google/cloud/run_v2/services/builds/transports/grpc.py
+++ b/packages/google-cloud-run/google/cloud/run_v2/services/builds/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/google/cloud/run_v2/services/builds/transports/grpc_asyncio.py
+++ b/packages/google-cloud-run/google/cloud/run_v2/services/builds/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/google/cloud/run_v2/services/builds/transports/rest.py
+++ b/packages/google-cloud-run/google/cloud/run_v2/services/builds/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/google/cloud/run_v2/services/builds/transports/rest_base.py
+++ b/packages/google-cloud-run/google/cloud/run_v2/services/builds/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/google/cloud/run_v2/services/executions/__init__.py
+++ b/packages/google-cloud-run/google/cloud/run_v2/services/executions/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/google/cloud/run_v2/services/executions/client.py
+++ b/packages/google-cloud-run/google/cloud/run_v2/services/executions/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/google/cloud/run_v2/services/executions/pagers.py
+++ b/packages/google-cloud-run/google/cloud/run_v2/services/executions/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/google/cloud/run_v2/services/executions/transports/__init__.py
+++ b/packages/google-cloud-run/google/cloud/run_v2/services/executions/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/google/cloud/run_v2/services/executions/transports/base.py
+++ b/packages/google-cloud-run/google/cloud/run_v2/services/executions/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/google/cloud/run_v2/services/executions/transports/grpc.py
+++ b/packages/google-cloud-run/google/cloud/run_v2/services/executions/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/google/cloud/run_v2/services/executions/transports/grpc_asyncio.py
+++ b/packages/google-cloud-run/google/cloud/run_v2/services/executions/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/google/cloud/run_v2/services/executions/transports/rest.py
+++ b/packages/google-cloud-run/google/cloud/run_v2/services/executions/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/google/cloud/run_v2/services/executions/transports/rest_base.py
+++ b/packages/google-cloud-run/google/cloud/run_v2/services/executions/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/google/cloud/run_v2/services/instances/__init__.py
+++ b/packages/google-cloud-run/google/cloud/run_v2/services/instances/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/google/cloud/run_v2/services/instances/client.py
+++ b/packages/google-cloud-run/google/cloud/run_v2/services/instances/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/google/cloud/run_v2/services/instances/pagers.py
+++ b/packages/google-cloud-run/google/cloud/run_v2/services/instances/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/google/cloud/run_v2/services/instances/transports/__init__.py
+++ b/packages/google-cloud-run/google/cloud/run_v2/services/instances/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/google/cloud/run_v2/services/instances/transports/base.py
+++ b/packages/google-cloud-run/google/cloud/run_v2/services/instances/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/google/cloud/run_v2/services/instances/transports/grpc.py
+++ b/packages/google-cloud-run/google/cloud/run_v2/services/instances/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/google/cloud/run_v2/services/instances/transports/grpc_asyncio.py
+++ b/packages/google-cloud-run/google/cloud/run_v2/services/instances/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/google/cloud/run_v2/services/instances/transports/rest.py
+++ b/packages/google-cloud-run/google/cloud/run_v2/services/instances/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/google/cloud/run_v2/services/instances/transports/rest_base.py
+++ b/packages/google-cloud-run/google/cloud/run_v2/services/instances/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/google/cloud/run_v2/services/jobs/__init__.py
+++ b/packages/google-cloud-run/google/cloud/run_v2/services/jobs/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/google/cloud/run_v2/services/jobs/client.py
+++ b/packages/google-cloud-run/google/cloud/run_v2/services/jobs/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/google/cloud/run_v2/services/jobs/pagers.py
+++ b/packages/google-cloud-run/google/cloud/run_v2/services/jobs/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/google/cloud/run_v2/services/jobs/transports/__init__.py
+++ b/packages/google-cloud-run/google/cloud/run_v2/services/jobs/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/google/cloud/run_v2/services/jobs/transports/base.py
+++ b/packages/google-cloud-run/google/cloud/run_v2/services/jobs/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/google/cloud/run_v2/services/jobs/transports/grpc.py
+++ b/packages/google-cloud-run/google/cloud/run_v2/services/jobs/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/google/cloud/run_v2/services/jobs/transports/grpc_asyncio.py
+++ b/packages/google-cloud-run/google/cloud/run_v2/services/jobs/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/google/cloud/run_v2/services/jobs/transports/rest.py
+++ b/packages/google-cloud-run/google/cloud/run_v2/services/jobs/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/google/cloud/run_v2/services/jobs/transports/rest_base.py
+++ b/packages/google-cloud-run/google/cloud/run_v2/services/jobs/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/google/cloud/run_v2/services/revisions/__init__.py
+++ b/packages/google-cloud-run/google/cloud/run_v2/services/revisions/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/google/cloud/run_v2/services/revisions/client.py
+++ b/packages/google-cloud-run/google/cloud/run_v2/services/revisions/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/google/cloud/run_v2/services/revisions/pagers.py
+++ b/packages/google-cloud-run/google/cloud/run_v2/services/revisions/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/google/cloud/run_v2/services/revisions/transports/__init__.py
+++ b/packages/google-cloud-run/google/cloud/run_v2/services/revisions/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/google/cloud/run_v2/services/revisions/transports/base.py
+++ b/packages/google-cloud-run/google/cloud/run_v2/services/revisions/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/google/cloud/run_v2/services/revisions/transports/grpc.py
+++ b/packages/google-cloud-run/google/cloud/run_v2/services/revisions/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/google/cloud/run_v2/services/revisions/transports/grpc_asyncio.py
+++ b/packages/google-cloud-run/google/cloud/run_v2/services/revisions/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/google/cloud/run_v2/services/revisions/transports/rest.py
+++ b/packages/google-cloud-run/google/cloud/run_v2/services/revisions/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/google/cloud/run_v2/services/revisions/transports/rest_base.py
+++ b/packages/google-cloud-run/google/cloud/run_v2/services/revisions/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/google/cloud/run_v2/services/services/__init__.py
+++ b/packages/google-cloud-run/google/cloud/run_v2/services/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/google/cloud/run_v2/services/services/client.py
+++ b/packages/google-cloud-run/google/cloud/run_v2/services/services/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/google/cloud/run_v2/services/services/pagers.py
+++ b/packages/google-cloud-run/google/cloud/run_v2/services/services/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/google/cloud/run_v2/services/services/transports/__init__.py
+++ b/packages/google-cloud-run/google/cloud/run_v2/services/services/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/google/cloud/run_v2/services/services/transports/base.py
+++ b/packages/google-cloud-run/google/cloud/run_v2/services/services/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/google/cloud/run_v2/services/services/transports/grpc.py
+++ b/packages/google-cloud-run/google/cloud/run_v2/services/services/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/google/cloud/run_v2/services/services/transports/grpc_asyncio.py
+++ b/packages/google-cloud-run/google/cloud/run_v2/services/services/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/google/cloud/run_v2/services/services/transports/rest.py
+++ b/packages/google-cloud-run/google/cloud/run_v2/services/services/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/google/cloud/run_v2/services/services/transports/rest_base.py
+++ b/packages/google-cloud-run/google/cloud/run_v2/services/services/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/google/cloud/run_v2/services/tasks/__init__.py
+++ b/packages/google-cloud-run/google/cloud/run_v2/services/tasks/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/google/cloud/run_v2/services/tasks/async_client.py
+++ b/packages/google-cloud-run/google/cloud/run_v2/services/tasks/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/google/cloud/run_v2/services/tasks/client.py
+++ b/packages/google-cloud-run/google/cloud/run_v2/services/tasks/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/google/cloud/run_v2/services/tasks/pagers.py
+++ b/packages/google-cloud-run/google/cloud/run_v2/services/tasks/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/google/cloud/run_v2/services/tasks/transports/__init__.py
+++ b/packages/google-cloud-run/google/cloud/run_v2/services/tasks/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/google/cloud/run_v2/services/tasks/transports/base.py
+++ b/packages/google-cloud-run/google/cloud/run_v2/services/tasks/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/google/cloud/run_v2/services/tasks/transports/grpc.py
+++ b/packages/google-cloud-run/google/cloud/run_v2/services/tasks/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/google/cloud/run_v2/services/tasks/transports/grpc_asyncio.py
+++ b/packages/google-cloud-run/google/cloud/run_v2/services/tasks/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/google/cloud/run_v2/services/tasks/transports/rest.py
+++ b/packages/google-cloud-run/google/cloud/run_v2/services/tasks/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/google/cloud/run_v2/services/tasks/transports/rest_base.py
+++ b/packages/google-cloud-run/google/cloud/run_v2/services/tasks/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/google/cloud/run_v2/services/worker_pools/__init__.py
+++ b/packages/google-cloud-run/google/cloud/run_v2/services/worker_pools/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/google/cloud/run_v2/services/worker_pools/client.py
+++ b/packages/google-cloud-run/google/cloud/run_v2/services/worker_pools/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/google/cloud/run_v2/services/worker_pools/pagers.py
+++ b/packages/google-cloud-run/google/cloud/run_v2/services/worker_pools/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/google/cloud/run_v2/services/worker_pools/transports/__init__.py
+++ b/packages/google-cloud-run/google/cloud/run_v2/services/worker_pools/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/google/cloud/run_v2/services/worker_pools/transports/base.py
+++ b/packages/google-cloud-run/google/cloud/run_v2/services/worker_pools/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/google/cloud/run_v2/services/worker_pools/transports/grpc.py
+++ b/packages/google-cloud-run/google/cloud/run_v2/services/worker_pools/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/google/cloud/run_v2/services/worker_pools/transports/grpc_asyncio.py
+++ b/packages/google-cloud-run/google/cloud/run_v2/services/worker_pools/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/google/cloud/run_v2/services/worker_pools/transports/rest.py
+++ b/packages/google-cloud-run/google/cloud/run_v2/services/worker_pools/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/google/cloud/run_v2/services/worker_pools/transports/rest_base.py
+++ b/packages/google-cloud-run/google/cloud/run_v2/services/worker_pools/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/google/cloud/run_v2/types/__init__.py
+++ b/packages/google-cloud-run/google/cloud/run_v2/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/google/cloud/run_v2/types/build.py
+++ b/packages/google-cloud-run/google/cloud/run_v2/types/build.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/google/cloud/run_v2/types/condition.py
+++ b/packages/google-cloud-run/google/cloud/run_v2/types/condition.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/google/cloud/run_v2/types/container_status.py
+++ b/packages/google-cloud-run/google/cloud/run_v2/types/container_status.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/google/cloud/run_v2/types/execution.py
+++ b/packages/google-cloud-run/google/cloud/run_v2/types/execution.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/google/cloud/run_v2/types/execution_template.py
+++ b/packages/google-cloud-run/google/cloud/run_v2/types/execution_template.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/google/cloud/run_v2/types/instance.py
+++ b/packages/google-cloud-run/google/cloud/run_v2/types/instance.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/google/cloud/run_v2/types/instance_split.py
+++ b/packages/google-cloud-run/google/cloud/run_v2/types/instance_split.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/google/cloud/run_v2/types/job.py
+++ b/packages/google-cloud-run/google/cloud/run_v2/types/job.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/google/cloud/run_v2/types/k8s_min.py
+++ b/packages/google-cloud-run/google/cloud/run_v2/types/k8s_min.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/google/cloud/run_v2/types/revision.py
+++ b/packages/google-cloud-run/google/cloud/run_v2/types/revision.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/google/cloud/run_v2/types/revision_template.py
+++ b/packages/google-cloud-run/google/cloud/run_v2/types/revision_template.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/google/cloud/run_v2/types/service.py
+++ b/packages/google-cloud-run/google/cloud/run_v2/types/service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/google/cloud/run_v2/types/status.py
+++ b/packages/google-cloud-run/google/cloud/run_v2/types/status.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/google/cloud/run_v2/types/task.py
+++ b/packages/google-cloud-run/google/cloud/run_v2/types/task.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/google/cloud/run_v2/types/task_template.py
+++ b/packages/google-cloud-run/google/cloud/run_v2/types/task_template.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/google/cloud/run_v2/types/traffic_target.py
+++ b/packages/google-cloud-run/google/cloud/run_v2/types/traffic_target.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/google/cloud/run_v2/types/vendor_settings.py
+++ b/packages/google-cloud-run/google/cloud/run_v2/types/vendor_settings.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/google/cloud/run_v2/types/worker_pool.py
+++ b/packages/google-cloud-run/google/cloud/run_v2/types/worker_pool.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/google/cloud/run_v2/types/worker_pool_revision_template.py
+++ b/packages/google-cloud-run/google/cloud/run_v2/types/worker_pool_revision_template.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/samples/generated_samples/run_v2_generated_builds_submit_build_async.py
+++ b/packages/google-cloud-run/samples/generated_samples/run_v2_generated_builds_submit_build_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/samples/generated_samples/run_v2_generated_builds_submit_build_sync.py
+++ b/packages/google-cloud-run/samples/generated_samples/run_v2_generated_builds_submit_build_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/samples/generated_samples/run_v2_generated_executions_cancel_execution_sync.py
+++ b/packages/google-cloud-run/samples/generated_samples/run_v2_generated_executions_cancel_execution_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/samples/generated_samples/run_v2_generated_executions_delete_execution_sync.py
+++ b/packages/google-cloud-run/samples/generated_samples/run_v2_generated_executions_delete_execution_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/samples/generated_samples/run_v2_generated_executions_get_execution_async.py
+++ b/packages/google-cloud-run/samples/generated_samples/run_v2_generated_executions_get_execution_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/samples/generated_samples/run_v2_generated_executions_get_execution_sync.py
+++ b/packages/google-cloud-run/samples/generated_samples/run_v2_generated_executions_get_execution_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/samples/generated_samples/run_v2_generated_executions_list_executions_async.py
+++ b/packages/google-cloud-run/samples/generated_samples/run_v2_generated_executions_list_executions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/samples/generated_samples/run_v2_generated_executions_list_executions_sync.py
+++ b/packages/google-cloud-run/samples/generated_samples/run_v2_generated_executions_list_executions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/samples/generated_samples/run_v2_generated_instances_create_instance_sync.py
+++ b/packages/google-cloud-run/samples/generated_samples/run_v2_generated_instances_create_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/samples/generated_samples/run_v2_generated_instances_delete_instance_sync.py
+++ b/packages/google-cloud-run/samples/generated_samples/run_v2_generated_instances_delete_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/samples/generated_samples/run_v2_generated_instances_get_instance_async.py
+++ b/packages/google-cloud-run/samples/generated_samples/run_v2_generated_instances_get_instance_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/samples/generated_samples/run_v2_generated_instances_get_instance_sync.py
+++ b/packages/google-cloud-run/samples/generated_samples/run_v2_generated_instances_get_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/samples/generated_samples/run_v2_generated_instances_list_instances_async.py
+++ b/packages/google-cloud-run/samples/generated_samples/run_v2_generated_instances_list_instances_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/samples/generated_samples/run_v2_generated_instances_list_instances_sync.py
+++ b/packages/google-cloud-run/samples/generated_samples/run_v2_generated_instances_list_instances_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/samples/generated_samples/run_v2_generated_instances_start_instance_sync.py
+++ b/packages/google-cloud-run/samples/generated_samples/run_v2_generated_instances_start_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/samples/generated_samples/run_v2_generated_instances_stop_instance_sync.py
+++ b/packages/google-cloud-run/samples/generated_samples/run_v2_generated_instances_stop_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/samples/generated_samples/run_v2_generated_jobs_create_job_sync.py
+++ b/packages/google-cloud-run/samples/generated_samples/run_v2_generated_jobs_create_job_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/samples/generated_samples/run_v2_generated_jobs_delete_job_sync.py
+++ b/packages/google-cloud-run/samples/generated_samples/run_v2_generated_jobs_delete_job_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/samples/generated_samples/run_v2_generated_jobs_get_iam_policy_async.py
+++ b/packages/google-cloud-run/samples/generated_samples/run_v2_generated_jobs_get_iam_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/samples/generated_samples/run_v2_generated_jobs_get_iam_policy_sync.py
+++ b/packages/google-cloud-run/samples/generated_samples/run_v2_generated_jobs_get_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/samples/generated_samples/run_v2_generated_jobs_get_job_async.py
+++ b/packages/google-cloud-run/samples/generated_samples/run_v2_generated_jobs_get_job_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/samples/generated_samples/run_v2_generated_jobs_get_job_sync.py
+++ b/packages/google-cloud-run/samples/generated_samples/run_v2_generated_jobs_get_job_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/samples/generated_samples/run_v2_generated_jobs_list_jobs_async.py
+++ b/packages/google-cloud-run/samples/generated_samples/run_v2_generated_jobs_list_jobs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/samples/generated_samples/run_v2_generated_jobs_list_jobs_sync.py
+++ b/packages/google-cloud-run/samples/generated_samples/run_v2_generated_jobs_list_jobs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/samples/generated_samples/run_v2_generated_jobs_run_job_sync.py
+++ b/packages/google-cloud-run/samples/generated_samples/run_v2_generated_jobs_run_job_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/samples/generated_samples/run_v2_generated_jobs_set_iam_policy_async.py
+++ b/packages/google-cloud-run/samples/generated_samples/run_v2_generated_jobs_set_iam_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/samples/generated_samples/run_v2_generated_jobs_set_iam_policy_sync.py
+++ b/packages/google-cloud-run/samples/generated_samples/run_v2_generated_jobs_set_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/samples/generated_samples/run_v2_generated_jobs_test_iam_permissions_async.py
+++ b/packages/google-cloud-run/samples/generated_samples/run_v2_generated_jobs_test_iam_permissions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/samples/generated_samples/run_v2_generated_jobs_test_iam_permissions_sync.py
+++ b/packages/google-cloud-run/samples/generated_samples/run_v2_generated_jobs_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/samples/generated_samples/run_v2_generated_jobs_update_job_sync.py
+++ b/packages/google-cloud-run/samples/generated_samples/run_v2_generated_jobs_update_job_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/samples/generated_samples/run_v2_generated_revisions_delete_revision_sync.py
+++ b/packages/google-cloud-run/samples/generated_samples/run_v2_generated_revisions_delete_revision_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/samples/generated_samples/run_v2_generated_revisions_get_revision_async.py
+++ b/packages/google-cloud-run/samples/generated_samples/run_v2_generated_revisions_get_revision_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/samples/generated_samples/run_v2_generated_revisions_get_revision_sync.py
+++ b/packages/google-cloud-run/samples/generated_samples/run_v2_generated_revisions_get_revision_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/samples/generated_samples/run_v2_generated_revisions_list_revisions_async.py
+++ b/packages/google-cloud-run/samples/generated_samples/run_v2_generated_revisions_list_revisions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/samples/generated_samples/run_v2_generated_revisions_list_revisions_sync.py
+++ b/packages/google-cloud-run/samples/generated_samples/run_v2_generated_revisions_list_revisions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/samples/generated_samples/run_v2_generated_services_create_service_sync.py
+++ b/packages/google-cloud-run/samples/generated_samples/run_v2_generated_services_create_service_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/samples/generated_samples/run_v2_generated_services_delete_service_sync.py
+++ b/packages/google-cloud-run/samples/generated_samples/run_v2_generated_services_delete_service_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/samples/generated_samples/run_v2_generated_services_get_iam_policy_async.py
+++ b/packages/google-cloud-run/samples/generated_samples/run_v2_generated_services_get_iam_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/samples/generated_samples/run_v2_generated_services_get_iam_policy_sync.py
+++ b/packages/google-cloud-run/samples/generated_samples/run_v2_generated_services_get_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/samples/generated_samples/run_v2_generated_services_get_service_async.py
+++ b/packages/google-cloud-run/samples/generated_samples/run_v2_generated_services_get_service_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/samples/generated_samples/run_v2_generated_services_get_service_sync.py
+++ b/packages/google-cloud-run/samples/generated_samples/run_v2_generated_services_get_service_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/samples/generated_samples/run_v2_generated_services_list_services_async.py
+++ b/packages/google-cloud-run/samples/generated_samples/run_v2_generated_services_list_services_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/samples/generated_samples/run_v2_generated_services_list_services_sync.py
+++ b/packages/google-cloud-run/samples/generated_samples/run_v2_generated_services_list_services_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/samples/generated_samples/run_v2_generated_services_set_iam_policy_async.py
+++ b/packages/google-cloud-run/samples/generated_samples/run_v2_generated_services_set_iam_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/samples/generated_samples/run_v2_generated_services_set_iam_policy_sync.py
+++ b/packages/google-cloud-run/samples/generated_samples/run_v2_generated_services_set_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/samples/generated_samples/run_v2_generated_services_test_iam_permissions_async.py
+++ b/packages/google-cloud-run/samples/generated_samples/run_v2_generated_services_test_iam_permissions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/samples/generated_samples/run_v2_generated_services_test_iam_permissions_sync.py
+++ b/packages/google-cloud-run/samples/generated_samples/run_v2_generated_services_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/samples/generated_samples/run_v2_generated_services_update_service_sync.py
+++ b/packages/google-cloud-run/samples/generated_samples/run_v2_generated_services_update_service_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/samples/generated_samples/run_v2_generated_tasks_get_task_async.py
+++ b/packages/google-cloud-run/samples/generated_samples/run_v2_generated_tasks_get_task_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/samples/generated_samples/run_v2_generated_tasks_get_task_sync.py
+++ b/packages/google-cloud-run/samples/generated_samples/run_v2_generated_tasks_get_task_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/samples/generated_samples/run_v2_generated_tasks_list_tasks_async.py
+++ b/packages/google-cloud-run/samples/generated_samples/run_v2_generated_tasks_list_tasks_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/samples/generated_samples/run_v2_generated_tasks_list_tasks_sync.py
+++ b/packages/google-cloud-run/samples/generated_samples/run_v2_generated_tasks_list_tasks_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/samples/generated_samples/run_v2_generated_worker_pools_create_worker_pool_sync.py
+++ b/packages/google-cloud-run/samples/generated_samples/run_v2_generated_worker_pools_create_worker_pool_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/samples/generated_samples/run_v2_generated_worker_pools_delete_worker_pool_sync.py
+++ b/packages/google-cloud-run/samples/generated_samples/run_v2_generated_worker_pools_delete_worker_pool_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/samples/generated_samples/run_v2_generated_worker_pools_get_iam_policy_async.py
+++ b/packages/google-cloud-run/samples/generated_samples/run_v2_generated_worker_pools_get_iam_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/samples/generated_samples/run_v2_generated_worker_pools_get_iam_policy_sync.py
+++ b/packages/google-cloud-run/samples/generated_samples/run_v2_generated_worker_pools_get_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/samples/generated_samples/run_v2_generated_worker_pools_get_worker_pool_async.py
+++ b/packages/google-cloud-run/samples/generated_samples/run_v2_generated_worker_pools_get_worker_pool_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/samples/generated_samples/run_v2_generated_worker_pools_get_worker_pool_sync.py
+++ b/packages/google-cloud-run/samples/generated_samples/run_v2_generated_worker_pools_get_worker_pool_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/samples/generated_samples/run_v2_generated_worker_pools_list_worker_pools_async.py
+++ b/packages/google-cloud-run/samples/generated_samples/run_v2_generated_worker_pools_list_worker_pools_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/samples/generated_samples/run_v2_generated_worker_pools_list_worker_pools_sync.py
+++ b/packages/google-cloud-run/samples/generated_samples/run_v2_generated_worker_pools_list_worker_pools_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/samples/generated_samples/run_v2_generated_worker_pools_set_iam_policy_async.py
+++ b/packages/google-cloud-run/samples/generated_samples/run_v2_generated_worker_pools_set_iam_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/samples/generated_samples/run_v2_generated_worker_pools_set_iam_policy_sync.py
+++ b/packages/google-cloud-run/samples/generated_samples/run_v2_generated_worker_pools_set_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/samples/generated_samples/run_v2_generated_worker_pools_test_iam_permissions_async.py
+++ b/packages/google-cloud-run/samples/generated_samples/run_v2_generated_worker_pools_test_iam_permissions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/samples/generated_samples/run_v2_generated_worker_pools_test_iam_permissions_sync.py
+++ b/packages/google-cloud-run/samples/generated_samples/run_v2_generated_worker_pools_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/samples/generated_samples/run_v2_generated_worker_pools_update_worker_pool_sync.py
+++ b/packages/google-cloud-run/samples/generated_samples/run_v2_generated_worker_pools_update_worker_pool_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/tests/__init__.py
+++ b/packages/google-cloud-run/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/tests/unit/__init__.py
+++ b/packages/google-cloud-run/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-run/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-run/tests/unit/gapic/run_v2/__init__.py
+++ b/packages/google-cloud-run/tests/unit/gapic/run_v2/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
This is the result of regenerating all packages, but only committing files which have only changed in a single line, and that's a copyright line.
