### PR TITLE
chore: regenerate packages in google-cloud-s, copyright changes only

### DIFF
--- a/packages/google-cloud-saasplatform-saasservicemgmt/.flake8
+++ b/packages/google-cloud-saasplatform-saasservicemgmt/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-saasplatform-saasservicemgmt/MANIFEST.in
+++ b/packages/google-cloud-saasplatform-saasservicemgmt/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-saasplatform-saasservicemgmt/google/cloud/saasplatform_saasservicemgmt/__init__.py
+++ b/packages/google-cloud-saasplatform-saasservicemgmt/google/cloud/saasplatform_saasservicemgmt/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-saasplatform-saasservicemgmt/google/cloud/saasplatform_saasservicemgmt/gapic_version.py
+++ b/packages/google-cloud-saasplatform-saasservicemgmt/google/cloud/saasplatform_saasservicemgmt/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-saasplatform-saasservicemgmt/google/cloud/saasplatform_saasservicemgmt_v1beta1/gapic_version.py
+++ b/packages/google-cloud-saasplatform-saasservicemgmt/google/cloud/saasplatform_saasservicemgmt_v1beta1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-saasplatform-saasservicemgmt/google/cloud/saasplatform_saasservicemgmt_v1beta1/services/__init__.py
+++ b/packages/google-cloud-saasplatform-saasservicemgmt/google/cloud/saasplatform_saasservicemgmt_v1beta1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-saasplatform-saasservicemgmt/google/cloud/saasplatform_saasservicemgmt_v1beta1/services/saas_deployments/__init__.py
+++ b/packages/google-cloud-saasplatform-saasservicemgmt/google/cloud/saasplatform_saasservicemgmt_v1beta1/services/saas_deployments/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-saasplatform-saasservicemgmt/google/cloud/saasplatform_saasservicemgmt_v1beta1/services/saas_deployments/async_client.py
+++ b/packages/google-cloud-saasplatform-saasservicemgmt/google/cloud/saasplatform_saasservicemgmt_v1beta1/services/saas_deployments/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-saasplatform-saasservicemgmt/google/cloud/saasplatform_saasservicemgmt_v1beta1/services/saas_deployments/client.py
+++ b/packages/google-cloud-saasplatform-saasservicemgmt/google/cloud/saasplatform_saasservicemgmt_v1beta1/services/saas_deployments/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-saasplatform-saasservicemgmt/google/cloud/saasplatform_saasservicemgmt_v1beta1/services/saas_deployments/pagers.py
+++ b/packages/google-cloud-saasplatform-saasservicemgmt/google/cloud/saasplatform_saasservicemgmt_v1beta1/services/saas_deployments/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-saasplatform-saasservicemgmt/google/cloud/saasplatform_saasservicemgmt_v1beta1/services/saas_deployments/transports/__init__.py
+++ b/packages/google-cloud-saasplatform-saasservicemgmt/google/cloud/saasplatform_saasservicemgmt_v1beta1/services/saas_deployments/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-saasplatform-saasservicemgmt/google/cloud/saasplatform_saasservicemgmt_v1beta1/services/saas_deployments/transports/base.py
+++ b/packages/google-cloud-saasplatform-saasservicemgmt/google/cloud/saasplatform_saasservicemgmt_v1beta1/services/saas_deployments/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-saasplatform-saasservicemgmt/google/cloud/saasplatform_saasservicemgmt_v1beta1/services/saas_deployments/transports/grpc.py
+++ b/packages/google-cloud-saasplatform-saasservicemgmt/google/cloud/saasplatform_saasservicemgmt_v1beta1/services/saas_deployments/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-saasplatform-saasservicemgmt/google/cloud/saasplatform_saasservicemgmt_v1beta1/services/saas_deployments/transports/grpc_asyncio.py
+++ b/packages/google-cloud-saasplatform-saasservicemgmt/google/cloud/saasplatform_saasservicemgmt_v1beta1/services/saas_deployments/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-saasplatform-saasservicemgmt/google/cloud/saasplatform_saasservicemgmt_v1beta1/services/saas_deployments/transports/rest.py
+++ b/packages/google-cloud-saasplatform-saasservicemgmt/google/cloud/saasplatform_saasservicemgmt_v1beta1/services/saas_deployments/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-saasplatform-saasservicemgmt/google/cloud/saasplatform_saasservicemgmt_v1beta1/services/saas_deployments/transports/rest_base.py
+++ b/packages/google-cloud-saasplatform-saasservicemgmt/google/cloud/saasplatform_saasservicemgmt_v1beta1/services/saas_deployments/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-saasplatform-saasservicemgmt/google/cloud/saasplatform_saasservicemgmt_v1beta1/services/saas_rollouts/__init__.py
+++ b/packages/google-cloud-saasplatform-saasservicemgmt/google/cloud/saasplatform_saasservicemgmt_v1beta1/services/saas_rollouts/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-saasplatform-saasservicemgmt/google/cloud/saasplatform_saasservicemgmt_v1beta1/services/saas_rollouts/async_client.py
+++ b/packages/google-cloud-saasplatform-saasservicemgmt/google/cloud/saasplatform_saasservicemgmt_v1beta1/services/saas_rollouts/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-saasplatform-saasservicemgmt/google/cloud/saasplatform_saasservicemgmt_v1beta1/services/saas_rollouts/client.py
+++ b/packages/google-cloud-saasplatform-saasservicemgmt/google/cloud/saasplatform_saasservicemgmt_v1beta1/services/saas_rollouts/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-saasplatform-saasservicemgmt/google/cloud/saasplatform_saasservicemgmt_v1beta1/services/saas_rollouts/pagers.py
+++ b/packages/google-cloud-saasplatform-saasservicemgmt/google/cloud/saasplatform_saasservicemgmt_v1beta1/services/saas_rollouts/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-saasplatform-saasservicemgmt/google/cloud/saasplatform_saasservicemgmt_v1beta1/services/saas_rollouts/transports/__init__.py
+++ b/packages/google-cloud-saasplatform-saasservicemgmt/google/cloud/saasplatform_saasservicemgmt_v1beta1/services/saas_rollouts/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-saasplatform-saasservicemgmt/google/cloud/saasplatform_saasservicemgmt_v1beta1/services/saas_rollouts/transports/base.py
+++ b/packages/google-cloud-saasplatform-saasservicemgmt/google/cloud/saasplatform_saasservicemgmt_v1beta1/services/saas_rollouts/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-saasplatform-saasservicemgmt/google/cloud/saasplatform_saasservicemgmt_v1beta1/services/saas_rollouts/transports/grpc.py
+++ b/packages/google-cloud-saasplatform-saasservicemgmt/google/cloud/saasplatform_saasservicemgmt_v1beta1/services/saas_rollouts/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-saasplatform-saasservicemgmt/google/cloud/saasplatform_saasservicemgmt_v1beta1/services/saas_rollouts/transports/grpc_asyncio.py
+++ b/packages/google-cloud-saasplatform-saasservicemgmt/google/cloud/saasplatform_saasservicemgmt_v1beta1/services/saas_rollouts/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-saasplatform-saasservicemgmt/google/cloud/saasplatform_saasservicemgmt_v1beta1/services/saas_rollouts/transports/rest.py
+++ b/packages/google-cloud-saasplatform-saasservicemgmt/google/cloud/saasplatform_saasservicemgmt_v1beta1/services/saas_rollouts/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-saasplatform-saasservicemgmt/google/cloud/saasplatform_saasservicemgmt_v1beta1/services/saas_rollouts/transports/rest_base.py
+++ b/packages/google-cloud-saasplatform-saasservicemgmt/google/cloud/saasplatform_saasservicemgmt_v1beta1/services/saas_rollouts/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-saasplatform-saasservicemgmt/google/cloud/saasplatform_saasservicemgmt_v1beta1/types/__init__.py
+++ b/packages/google-cloud-saasplatform-saasservicemgmt/google/cloud/saasplatform_saasservicemgmt_v1beta1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-saasplatform-saasservicemgmt/google/cloud/saasplatform_saasservicemgmt_v1beta1/types/common.py
+++ b/packages/google-cloud-saasplatform-saasservicemgmt/google/cloud/saasplatform_saasservicemgmt_v1beta1/types/common.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-saasplatform-saasservicemgmt/google/cloud/saasplatform_saasservicemgmt_v1beta1/types/deployments_resources.py
+++ b/packages/google-cloud-saasplatform-saasservicemgmt/google/cloud/saasplatform_saasservicemgmt_v1beta1/types/deployments_resources.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-saasplatform-saasservicemgmt/google/cloud/saasplatform_saasservicemgmt_v1beta1/types/deployments_service.py
+++ b/packages/google-cloud-saasplatform-saasservicemgmt/google/cloud/saasplatform_saasservicemgmt_v1beta1/types/deployments_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-saasplatform-saasservicemgmt/google/cloud/saasplatform_saasservicemgmt_v1beta1/types/rollouts_resources.py
+++ b/packages/google-cloud-saasplatform-saasservicemgmt/google/cloud/saasplatform_saasservicemgmt_v1beta1/types/rollouts_resources.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-saasplatform-saasservicemgmt/google/cloud/saasplatform_saasservicemgmt_v1beta1/types/rollouts_service.py
+++ b/packages/google-cloud-saasplatform-saasservicemgmt/google/cloud/saasplatform_saasservicemgmt_v1beta1/types/rollouts_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_deployments_create_release_async.py
+++ b/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_deployments_create_release_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_deployments_create_release_sync.py
+++ b/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_deployments_create_release_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_deployments_create_saas_async.py
+++ b/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_deployments_create_saas_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_deployments_create_saas_sync.py
+++ b/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_deployments_create_saas_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_deployments_create_tenant_async.py
+++ b/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_deployments_create_tenant_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_deployments_create_tenant_sync.py
+++ b/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_deployments_create_tenant_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_deployments_create_unit_async.py
+++ b/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_deployments_create_unit_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_deployments_create_unit_kind_async.py
+++ b/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_deployments_create_unit_kind_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_deployments_create_unit_kind_sync.py
+++ b/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_deployments_create_unit_kind_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_deployments_create_unit_operation_async.py
+++ b/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_deployments_create_unit_operation_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_deployments_create_unit_operation_sync.py
+++ b/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_deployments_create_unit_operation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_deployments_create_unit_sync.py
+++ b/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_deployments_create_unit_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_deployments_delete_release_async.py
+++ b/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_deployments_delete_release_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_deployments_delete_release_sync.py
+++ b/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_deployments_delete_release_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_deployments_delete_saas_async.py
+++ b/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_deployments_delete_saas_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_deployments_delete_saas_sync.py
+++ b/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_deployments_delete_saas_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_deployments_delete_tenant_async.py
+++ b/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_deployments_delete_tenant_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_deployments_delete_tenant_sync.py
+++ b/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_deployments_delete_tenant_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_deployments_delete_unit_async.py
+++ b/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_deployments_delete_unit_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_deployments_delete_unit_kind_async.py
+++ b/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_deployments_delete_unit_kind_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_deployments_delete_unit_kind_sync.py
+++ b/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_deployments_delete_unit_kind_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_deployments_delete_unit_operation_async.py
+++ b/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_deployments_delete_unit_operation_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_deployments_delete_unit_operation_sync.py
+++ b/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_deployments_delete_unit_operation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_deployments_delete_unit_sync.py
+++ b/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_deployments_delete_unit_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_deployments_get_release_async.py
+++ b/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_deployments_get_release_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_deployments_get_release_sync.py
+++ b/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_deployments_get_release_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_deployments_get_saas_async.py
+++ b/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_deployments_get_saas_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_deployments_get_saas_sync.py
+++ b/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_deployments_get_saas_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_deployments_get_tenant_async.py
+++ b/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_deployments_get_tenant_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_deployments_get_tenant_sync.py
+++ b/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_deployments_get_tenant_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_deployments_get_unit_async.py
+++ b/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_deployments_get_unit_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_deployments_get_unit_kind_async.py
+++ b/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_deployments_get_unit_kind_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_deployments_get_unit_kind_sync.py
+++ b/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_deployments_get_unit_kind_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_deployments_get_unit_operation_async.py
+++ b/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_deployments_get_unit_operation_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_deployments_get_unit_operation_sync.py
+++ b/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_deployments_get_unit_operation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_deployments_get_unit_sync.py
+++ b/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_deployments_get_unit_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_deployments_list_releases_async.py
+++ b/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_deployments_list_releases_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_deployments_list_releases_sync.py
+++ b/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_deployments_list_releases_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_deployments_list_saas_async.py
+++ b/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_deployments_list_saas_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_deployments_list_saas_sync.py
+++ b/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_deployments_list_saas_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_deployments_list_tenants_async.py
+++ b/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_deployments_list_tenants_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_deployments_list_tenants_sync.py
+++ b/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_deployments_list_tenants_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_deployments_list_unit_kinds_async.py
+++ b/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_deployments_list_unit_kinds_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_deployments_list_unit_kinds_sync.py
+++ b/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_deployments_list_unit_kinds_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_deployments_list_unit_operations_async.py
+++ b/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_deployments_list_unit_operations_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_deployments_list_unit_operations_sync.py
+++ b/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_deployments_list_unit_operations_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_deployments_list_units_async.py
+++ b/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_deployments_list_units_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_deployments_list_units_sync.py
+++ b/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_deployments_list_units_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_deployments_update_release_async.py
+++ b/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_deployments_update_release_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_deployments_update_release_sync.py
+++ b/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_deployments_update_release_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_deployments_update_saas_async.py
+++ b/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_deployments_update_saas_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_deployments_update_saas_sync.py
+++ b/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_deployments_update_saas_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_deployments_update_tenant_async.py
+++ b/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_deployments_update_tenant_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_deployments_update_tenant_sync.py
+++ b/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_deployments_update_tenant_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_deployments_update_unit_async.py
+++ b/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_deployments_update_unit_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_deployments_update_unit_kind_async.py
+++ b/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_deployments_update_unit_kind_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_deployments_update_unit_kind_sync.py
+++ b/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_deployments_update_unit_kind_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_deployments_update_unit_operation_async.py
+++ b/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_deployments_update_unit_operation_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_deployments_update_unit_operation_sync.py
+++ b/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_deployments_update_unit_operation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_deployments_update_unit_sync.py
+++ b/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_deployments_update_unit_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_rollouts_create_rollout_async.py
+++ b/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_rollouts_create_rollout_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_rollouts_create_rollout_kind_async.py
+++ b/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_rollouts_create_rollout_kind_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_rollouts_create_rollout_kind_sync.py
+++ b/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_rollouts_create_rollout_kind_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_rollouts_create_rollout_sync.py
+++ b/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_rollouts_create_rollout_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_rollouts_delete_rollout_async.py
+++ b/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_rollouts_delete_rollout_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_rollouts_delete_rollout_kind_async.py
+++ b/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_rollouts_delete_rollout_kind_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_rollouts_delete_rollout_kind_sync.py
+++ b/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_rollouts_delete_rollout_kind_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_rollouts_delete_rollout_sync.py
+++ b/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_rollouts_delete_rollout_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_rollouts_get_rollout_async.py
+++ b/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_rollouts_get_rollout_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_rollouts_get_rollout_kind_async.py
+++ b/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_rollouts_get_rollout_kind_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_rollouts_get_rollout_kind_sync.py
+++ b/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_rollouts_get_rollout_kind_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_rollouts_get_rollout_sync.py
+++ b/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_rollouts_get_rollout_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_rollouts_list_rollout_kinds_async.py
+++ b/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_rollouts_list_rollout_kinds_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_rollouts_list_rollout_kinds_sync.py
+++ b/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_rollouts_list_rollout_kinds_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_rollouts_list_rollouts_async.py
+++ b/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_rollouts_list_rollouts_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_rollouts_list_rollouts_sync.py
+++ b/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_rollouts_list_rollouts_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_rollouts_update_rollout_async.py
+++ b/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_rollouts_update_rollout_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_rollouts_update_rollout_kind_async.py
+++ b/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_rollouts_update_rollout_kind_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_rollouts_update_rollout_kind_sync.py
+++ b/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_rollouts_update_rollout_kind_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_rollouts_update_rollout_sync.py
+++ b/packages/google-cloud-saasplatform-saasservicemgmt/samples/generated_samples/saasservicemgmt_v1beta1_generated_saas_rollouts_update_rollout_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-saasplatform-saasservicemgmt/tests/__init__.py
+++ b/packages/google-cloud-saasplatform-saasservicemgmt/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-saasplatform-saasservicemgmt/tests/unit/__init__.py
+++ b/packages/google-cloud-saasplatform-saasservicemgmt/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-saasplatform-saasservicemgmt/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-saasplatform-saasservicemgmt/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-saasplatform-saasservicemgmt/tests/unit/gapic/saasplatform_saasservicemgmt_v1beta1/__init__.py
+++ b/packages/google-cloud-saasplatform-saasservicemgmt/tests/unit/gapic/saasplatform_saasservicemgmt_v1beta1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-scheduler/.flake8
+++ b/packages/google-cloud-scheduler/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-scheduler/MANIFEST.in
+++ b/packages/google-cloud-scheduler/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-scheduler/google/cloud/scheduler/__init__.py
+++ b/packages/google-cloud-scheduler/google/cloud/scheduler/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-scheduler/google/cloud/scheduler/gapic_version.py
+++ b/packages/google-cloud-scheduler/google/cloud/scheduler/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-scheduler/google/cloud/scheduler_v1/gapic_version.py
+++ b/packages/google-cloud-scheduler/google/cloud/scheduler_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-scheduler/google/cloud/scheduler_v1/services/__init__.py
+++ b/packages/google-cloud-scheduler/google/cloud/scheduler_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-scheduler/google/cloud/scheduler_v1/services/cloud_scheduler/__init__.py
+++ b/packages/google-cloud-scheduler/google/cloud/scheduler_v1/services/cloud_scheduler/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-scheduler/google/cloud/scheduler_v1/services/cloud_scheduler/async_client.py
+++ b/packages/google-cloud-scheduler/google/cloud/scheduler_v1/services/cloud_scheduler/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-scheduler/google/cloud/scheduler_v1/services/cloud_scheduler/client.py
+++ b/packages/google-cloud-scheduler/google/cloud/scheduler_v1/services/cloud_scheduler/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-scheduler/google/cloud/scheduler_v1/services/cloud_scheduler/pagers.py
+++ b/packages/google-cloud-scheduler/google/cloud/scheduler_v1/services/cloud_scheduler/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-scheduler/google/cloud/scheduler_v1/services/cloud_scheduler/transports/__init__.py
+++ b/packages/google-cloud-scheduler/google/cloud/scheduler_v1/services/cloud_scheduler/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-scheduler/google/cloud/scheduler_v1/services/cloud_scheduler/transports/base.py
+++ b/packages/google-cloud-scheduler/google/cloud/scheduler_v1/services/cloud_scheduler/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-scheduler/google/cloud/scheduler_v1/services/cloud_scheduler/transports/grpc.py
+++ b/packages/google-cloud-scheduler/google/cloud/scheduler_v1/services/cloud_scheduler/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-scheduler/google/cloud/scheduler_v1/services/cloud_scheduler/transports/grpc_asyncio.py
+++ b/packages/google-cloud-scheduler/google/cloud/scheduler_v1/services/cloud_scheduler/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-scheduler/google/cloud/scheduler_v1/services/cloud_scheduler/transports/rest.py
+++ b/packages/google-cloud-scheduler/google/cloud/scheduler_v1/services/cloud_scheduler/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-scheduler/google/cloud/scheduler_v1/services/cloud_scheduler/transports/rest_base.py
+++ b/packages/google-cloud-scheduler/google/cloud/scheduler_v1/services/cloud_scheduler/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-scheduler/google/cloud/scheduler_v1/types/__init__.py
+++ b/packages/google-cloud-scheduler/google/cloud/scheduler_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-scheduler/google/cloud/scheduler_v1/types/cloudscheduler.py
+++ b/packages/google-cloud-scheduler/google/cloud/scheduler_v1/types/cloudscheduler.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-scheduler/google/cloud/scheduler_v1/types/job.py
+++ b/packages/google-cloud-scheduler/google/cloud/scheduler_v1/types/job.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-scheduler/google/cloud/scheduler_v1/types/target.py
+++ b/packages/google-cloud-scheduler/google/cloud/scheduler_v1/types/target.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-scheduler/google/cloud/scheduler_v1beta1/gapic_version.py
+++ b/packages/google-cloud-scheduler/google/cloud/scheduler_v1beta1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-scheduler/google/cloud/scheduler_v1beta1/services/__init__.py
+++ b/packages/google-cloud-scheduler/google/cloud/scheduler_v1beta1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-scheduler/google/cloud/scheduler_v1beta1/services/cloud_scheduler/__init__.py
+++ b/packages/google-cloud-scheduler/google/cloud/scheduler_v1beta1/services/cloud_scheduler/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-scheduler/google/cloud/scheduler_v1beta1/services/cloud_scheduler/async_client.py
+++ b/packages/google-cloud-scheduler/google/cloud/scheduler_v1beta1/services/cloud_scheduler/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-scheduler/google/cloud/scheduler_v1beta1/services/cloud_scheduler/client.py
+++ b/packages/google-cloud-scheduler/google/cloud/scheduler_v1beta1/services/cloud_scheduler/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-scheduler/google/cloud/scheduler_v1beta1/services/cloud_scheduler/pagers.py
+++ b/packages/google-cloud-scheduler/google/cloud/scheduler_v1beta1/services/cloud_scheduler/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-scheduler/google/cloud/scheduler_v1beta1/services/cloud_scheduler/transports/__init__.py
+++ b/packages/google-cloud-scheduler/google/cloud/scheduler_v1beta1/services/cloud_scheduler/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-scheduler/google/cloud/scheduler_v1beta1/services/cloud_scheduler/transports/base.py
+++ b/packages/google-cloud-scheduler/google/cloud/scheduler_v1beta1/services/cloud_scheduler/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-scheduler/google/cloud/scheduler_v1beta1/services/cloud_scheduler/transports/grpc.py
+++ b/packages/google-cloud-scheduler/google/cloud/scheduler_v1beta1/services/cloud_scheduler/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-scheduler/google/cloud/scheduler_v1beta1/services/cloud_scheduler/transports/grpc_asyncio.py
+++ b/packages/google-cloud-scheduler/google/cloud/scheduler_v1beta1/services/cloud_scheduler/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-scheduler/google/cloud/scheduler_v1beta1/services/cloud_scheduler/transports/rest.py
+++ b/packages/google-cloud-scheduler/google/cloud/scheduler_v1beta1/services/cloud_scheduler/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-scheduler/google/cloud/scheduler_v1beta1/services/cloud_scheduler/transports/rest_base.py
+++ b/packages/google-cloud-scheduler/google/cloud/scheduler_v1beta1/services/cloud_scheduler/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-scheduler/google/cloud/scheduler_v1beta1/types/__init__.py
+++ b/packages/google-cloud-scheduler/google/cloud/scheduler_v1beta1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-scheduler/google/cloud/scheduler_v1beta1/types/cloudscheduler.py
+++ b/packages/google-cloud-scheduler/google/cloud/scheduler_v1beta1/types/cloudscheduler.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-scheduler/google/cloud/scheduler_v1beta1/types/job.py
+++ b/packages/google-cloud-scheduler/google/cloud/scheduler_v1beta1/types/job.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-scheduler/google/cloud/scheduler_v1beta1/types/target.py
+++ b/packages/google-cloud-scheduler/google/cloud/scheduler_v1beta1/types/target.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-scheduler/samples/generated_samples/cloudscheduler_v1_generated_cloud_scheduler_create_job_async.py
+++ b/packages/google-cloud-scheduler/samples/generated_samples/cloudscheduler_v1_generated_cloud_scheduler_create_job_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-scheduler/samples/generated_samples/cloudscheduler_v1_generated_cloud_scheduler_create_job_sync.py
+++ b/packages/google-cloud-scheduler/samples/generated_samples/cloudscheduler_v1_generated_cloud_scheduler_create_job_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-scheduler/samples/generated_samples/cloudscheduler_v1_generated_cloud_scheduler_delete_job_async.py
+++ b/packages/google-cloud-scheduler/samples/generated_samples/cloudscheduler_v1_generated_cloud_scheduler_delete_job_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-scheduler/samples/generated_samples/cloudscheduler_v1_generated_cloud_scheduler_delete_job_sync.py
+++ b/packages/google-cloud-scheduler/samples/generated_samples/cloudscheduler_v1_generated_cloud_scheduler_delete_job_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-scheduler/samples/generated_samples/cloudscheduler_v1_generated_cloud_scheduler_get_job_async.py
+++ b/packages/google-cloud-scheduler/samples/generated_samples/cloudscheduler_v1_generated_cloud_scheduler_get_job_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-scheduler/samples/generated_samples/cloudscheduler_v1_generated_cloud_scheduler_get_job_sync.py
+++ b/packages/google-cloud-scheduler/samples/generated_samples/cloudscheduler_v1_generated_cloud_scheduler_get_job_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-scheduler/samples/generated_samples/cloudscheduler_v1_generated_cloud_scheduler_list_jobs_async.py
+++ b/packages/google-cloud-scheduler/samples/generated_samples/cloudscheduler_v1_generated_cloud_scheduler_list_jobs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-scheduler/samples/generated_samples/cloudscheduler_v1_generated_cloud_scheduler_list_jobs_sync.py
+++ b/packages/google-cloud-scheduler/samples/generated_samples/cloudscheduler_v1_generated_cloud_scheduler_list_jobs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-scheduler/samples/generated_samples/cloudscheduler_v1_generated_cloud_scheduler_pause_job_async.py
+++ b/packages/google-cloud-scheduler/samples/generated_samples/cloudscheduler_v1_generated_cloud_scheduler_pause_job_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-scheduler/samples/generated_samples/cloudscheduler_v1_generated_cloud_scheduler_pause_job_sync.py
+++ b/packages/google-cloud-scheduler/samples/generated_samples/cloudscheduler_v1_generated_cloud_scheduler_pause_job_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-scheduler/samples/generated_samples/cloudscheduler_v1_generated_cloud_scheduler_resume_job_async.py
+++ b/packages/google-cloud-scheduler/samples/generated_samples/cloudscheduler_v1_generated_cloud_scheduler_resume_job_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-scheduler/samples/generated_samples/cloudscheduler_v1_generated_cloud_scheduler_resume_job_sync.py
+++ b/packages/google-cloud-scheduler/samples/generated_samples/cloudscheduler_v1_generated_cloud_scheduler_resume_job_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-scheduler/samples/generated_samples/cloudscheduler_v1_generated_cloud_scheduler_run_job_async.py
+++ b/packages/google-cloud-scheduler/samples/generated_samples/cloudscheduler_v1_generated_cloud_scheduler_run_job_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-scheduler/samples/generated_samples/cloudscheduler_v1_generated_cloud_scheduler_run_job_sync.py
+++ b/packages/google-cloud-scheduler/samples/generated_samples/cloudscheduler_v1_generated_cloud_scheduler_run_job_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-scheduler/samples/generated_samples/cloudscheduler_v1_generated_cloud_scheduler_update_job_async.py
+++ b/packages/google-cloud-scheduler/samples/generated_samples/cloudscheduler_v1_generated_cloud_scheduler_update_job_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-scheduler/samples/generated_samples/cloudscheduler_v1_generated_cloud_scheduler_update_job_sync.py
+++ b/packages/google-cloud-scheduler/samples/generated_samples/cloudscheduler_v1_generated_cloud_scheduler_update_job_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-scheduler/samples/generated_samples/cloudscheduler_v1beta1_generated_cloud_scheduler_create_job_async.py
+++ b/packages/google-cloud-scheduler/samples/generated_samples/cloudscheduler_v1beta1_generated_cloud_scheduler_create_job_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-scheduler/samples/generated_samples/cloudscheduler_v1beta1_generated_cloud_scheduler_create_job_sync.py
+++ b/packages/google-cloud-scheduler/samples/generated_samples/cloudscheduler_v1beta1_generated_cloud_scheduler_create_job_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-scheduler/samples/generated_samples/cloudscheduler_v1beta1_generated_cloud_scheduler_delete_job_async.py
+++ b/packages/google-cloud-scheduler/samples/generated_samples/cloudscheduler_v1beta1_generated_cloud_scheduler_delete_job_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-scheduler/samples/generated_samples/cloudscheduler_v1beta1_generated_cloud_scheduler_delete_job_sync.py
+++ b/packages/google-cloud-scheduler/samples/generated_samples/cloudscheduler_v1beta1_generated_cloud_scheduler_delete_job_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-scheduler/samples/generated_samples/cloudscheduler_v1beta1_generated_cloud_scheduler_get_job_async.py
+++ b/packages/google-cloud-scheduler/samples/generated_samples/cloudscheduler_v1beta1_generated_cloud_scheduler_get_job_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-scheduler/samples/generated_samples/cloudscheduler_v1beta1_generated_cloud_scheduler_get_job_sync.py
+++ b/packages/google-cloud-scheduler/samples/generated_samples/cloudscheduler_v1beta1_generated_cloud_scheduler_get_job_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-scheduler/samples/generated_samples/cloudscheduler_v1beta1_generated_cloud_scheduler_list_jobs_async.py
+++ b/packages/google-cloud-scheduler/samples/generated_samples/cloudscheduler_v1beta1_generated_cloud_scheduler_list_jobs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-scheduler/samples/generated_samples/cloudscheduler_v1beta1_generated_cloud_scheduler_list_jobs_sync.py
+++ b/packages/google-cloud-scheduler/samples/generated_samples/cloudscheduler_v1beta1_generated_cloud_scheduler_list_jobs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-scheduler/samples/generated_samples/cloudscheduler_v1beta1_generated_cloud_scheduler_pause_job_async.py
+++ b/packages/google-cloud-scheduler/samples/generated_samples/cloudscheduler_v1beta1_generated_cloud_scheduler_pause_job_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-scheduler/samples/generated_samples/cloudscheduler_v1beta1_generated_cloud_scheduler_pause_job_sync.py
+++ b/packages/google-cloud-scheduler/samples/generated_samples/cloudscheduler_v1beta1_generated_cloud_scheduler_pause_job_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-scheduler/samples/generated_samples/cloudscheduler_v1beta1_generated_cloud_scheduler_resume_job_async.py
+++ b/packages/google-cloud-scheduler/samples/generated_samples/cloudscheduler_v1beta1_generated_cloud_scheduler_resume_job_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-scheduler/samples/generated_samples/cloudscheduler_v1beta1_generated_cloud_scheduler_resume_job_sync.py
+++ b/packages/google-cloud-scheduler/samples/generated_samples/cloudscheduler_v1beta1_generated_cloud_scheduler_resume_job_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-scheduler/samples/generated_samples/cloudscheduler_v1beta1_generated_cloud_scheduler_run_job_async.py
+++ b/packages/google-cloud-scheduler/samples/generated_samples/cloudscheduler_v1beta1_generated_cloud_scheduler_run_job_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-scheduler/samples/generated_samples/cloudscheduler_v1beta1_generated_cloud_scheduler_run_job_sync.py
+++ b/packages/google-cloud-scheduler/samples/generated_samples/cloudscheduler_v1beta1_generated_cloud_scheduler_run_job_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-scheduler/samples/generated_samples/cloudscheduler_v1beta1_generated_cloud_scheduler_update_job_async.py
+++ b/packages/google-cloud-scheduler/samples/generated_samples/cloudscheduler_v1beta1_generated_cloud_scheduler_update_job_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-scheduler/samples/generated_samples/cloudscheduler_v1beta1_generated_cloud_scheduler_update_job_sync.py
+++ b/packages/google-cloud-scheduler/samples/generated_samples/cloudscheduler_v1beta1_generated_cloud_scheduler_update_job_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-scheduler/tests/__init__.py
+++ b/packages/google-cloud-scheduler/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-scheduler/tests/unit/__init__.py
+++ b/packages/google-cloud-scheduler/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-scheduler/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-scheduler/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-scheduler/tests/unit/gapic/scheduler_v1/__init__.py
+++ b/packages/google-cloud-scheduler/tests/unit/gapic/scheduler_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-scheduler/tests/unit/gapic/scheduler_v1beta1/__init__.py
+++ b/packages/google-cloud-scheduler/tests/unit/gapic/scheduler_v1beta1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/.flake8
+++ b/packages/google-cloud-secret-manager/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/MANIFEST.in
+++ b/packages/google-cloud-secret-manager/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/google/cloud/secretmanager/__init__.py
+++ b/packages/google-cloud-secret-manager/google/cloud/secretmanager/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/google/cloud/secretmanager/gapic_version.py
+++ b/packages/google-cloud-secret-manager/google/cloud/secretmanager/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/google/cloud/secretmanager_v1/gapic_version.py
+++ b/packages/google-cloud-secret-manager/google/cloud/secretmanager_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/google/cloud/secretmanager_v1/services/__init__.py
+++ b/packages/google-cloud-secret-manager/google/cloud/secretmanager_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/google/cloud/secretmanager_v1/services/secret_manager_service/__init__.py
+++ b/packages/google-cloud-secret-manager/google/cloud/secretmanager_v1/services/secret_manager_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/google/cloud/secretmanager_v1/services/secret_manager_service/async_client.py
+++ b/packages/google-cloud-secret-manager/google/cloud/secretmanager_v1/services/secret_manager_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/google/cloud/secretmanager_v1/services/secret_manager_service/client.py
+++ b/packages/google-cloud-secret-manager/google/cloud/secretmanager_v1/services/secret_manager_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/google/cloud/secretmanager_v1/services/secret_manager_service/pagers.py
+++ b/packages/google-cloud-secret-manager/google/cloud/secretmanager_v1/services/secret_manager_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/google/cloud/secretmanager_v1/services/secret_manager_service/transports/__init__.py
+++ b/packages/google-cloud-secret-manager/google/cloud/secretmanager_v1/services/secret_manager_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/google/cloud/secretmanager_v1/services/secret_manager_service/transports/base.py
+++ b/packages/google-cloud-secret-manager/google/cloud/secretmanager_v1/services/secret_manager_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/google/cloud/secretmanager_v1/services/secret_manager_service/transports/grpc.py
+++ b/packages/google-cloud-secret-manager/google/cloud/secretmanager_v1/services/secret_manager_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/google/cloud/secretmanager_v1/services/secret_manager_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-secret-manager/google/cloud/secretmanager_v1/services/secret_manager_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/google/cloud/secretmanager_v1/services/secret_manager_service/transports/rest.py
+++ b/packages/google-cloud-secret-manager/google/cloud/secretmanager_v1/services/secret_manager_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/google/cloud/secretmanager_v1/services/secret_manager_service/transports/rest_base.py
+++ b/packages/google-cloud-secret-manager/google/cloud/secretmanager_v1/services/secret_manager_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/google/cloud/secretmanager_v1/types/__init__.py
+++ b/packages/google-cloud-secret-manager/google/cloud/secretmanager_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/google/cloud/secretmanager_v1/types/resources.py
+++ b/packages/google-cloud-secret-manager/google/cloud/secretmanager_v1/types/resources.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/google/cloud/secretmanager_v1/types/service.py
+++ b/packages/google-cloud-secret-manager/google/cloud/secretmanager_v1/types/service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/google/cloud/secretmanager_v1beta1/gapic_version.py
+++ b/packages/google-cloud-secret-manager/google/cloud/secretmanager_v1beta1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/google/cloud/secretmanager_v1beta1/services/__init__.py
+++ b/packages/google-cloud-secret-manager/google/cloud/secretmanager_v1beta1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/google/cloud/secretmanager_v1beta1/services/secret_manager_service/__init__.py
+++ b/packages/google-cloud-secret-manager/google/cloud/secretmanager_v1beta1/services/secret_manager_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/google/cloud/secretmanager_v1beta1/services/secret_manager_service/async_client.py
+++ b/packages/google-cloud-secret-manager/google/cloud/secretmanager_v1beta1/services/secret_manager_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/google/cloud/secretmanager_v1beta1/services/secret_manager_service/client.py
+++ b/packages/google-cloud-secret-manager/google/cloud/secretmanager_v1beta1/services/secret_manager_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/google/cloud/secretmanager_v1beta1/services/secret_manager_service/pagers.py
+++ b/packages/google-cloud-secret-manager/google/cloud/secretmanager_v1beta1/services/secret_manager_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/google/cloud/secretmanager_v1beta1/services/secret_manager_service/transports/__init__.py
+++ b/packages/google-cloud-secret-manager/google/cloud/secretmanager_v1beta1/services/secret_manager_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/google/cloud/secretmanager_v1beta1/services/secret_manager_service/transports/base.py
+++ b/packages/google-cloud-secret-manager/google/cloud/secretmanager_v1beta1/services/secret_manager_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/google/cloud/secretmanager_v1beta1/services/secret_manager_service/transports/grpc.py
+++ b/packages/google-cloud-secret-manager/google/cloud/secretmanager_v1beta1/services/secret_manager_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/google/cloud/secretmanager_v1beta1/services/secret_manager_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-secret-manager/google/cloud/secretmanager_v1beta1/services/secret_manager_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/google/cloud/secretmanager_v1beta1/services/secret_manager_service/transports/rest.py
+++ b/packages/google-cloud-secret-manager/google/cloud/secretmanager_v1beta1/services/secret_manager_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/google/cloud/secretmanager_v1beta1/services/secret_manager_service/transports/rest_base.py
+++ b/packages/google-cloud-secret-manager/google/cloud/secretmanager_v1beta1/services/secret_manager_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/google/cloud/secretmanager_v1beta1/types/__init__.py
+++ b/packages/google-cloud-secret-manager/google/cloud/secretmanager_v1beta1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/google/cloud/secretmanager_v1beta1/types/resources.py
+++ b/packages/google-cloud-secret-manager/google/cloud/secretmanager_v1beta1/types/resources.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/google/cloud/secretmanager_v1beta1/types/service.py
+++ b/packages/google-cloud-secret-manager/google/cloud/secretmanager_v1beta1/types/service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/google/cloud/secretmanager_v1beta2/gapic_version.py
+++ b/packages/google-cloud-secret-manager/google/cloud/secretmanager_v1beta2/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/google/cloud/secretmanager_v1beta2/services/__init__.py
+++ b/packages/google-cloud-secret-manager/google/cloud/secretmanager_v1beta2/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/google/cloud/secretmanager_v1beta2/services/secret_manager_service/__init__.py
+++ b/packages/google-cloud-secret-manager/google/cloud/secretmanager_v1beta2/services/secret_manager_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/google/cloud/secretmanager_v1beta2/services/secret_manager_service/async_client.py
+++ b/packages/google-cloud-secret-manager/google/cloud/secretmanager_v1beta2/services/secret_manager_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/google/cloud/secretmanager_v1beta2/services/secret_manager_service/client.py
+++ b/packages/google-cloud-secret-manager/google/cloud/secretmanager_v1beta2/services/secret_manager_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/google/cloud/secretmanager_v1beta2/services/secret_manager_service/pagers.py
+++ b/packages/google-cloud-secret-manager/google/cloud/secretmanager_v1beta2/services/secret_manager_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/google/cloud/secretmanager_v1beta2/services/secret_manager_service/transports/__init__.py
+++ b/packages/google-cloud-secret-manager/google/cloud/secretmanager_v1beta2/services/secret_manager_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/google/cloud/secretmanager_v1beta2/services/secret_manager_service/transports/base.py
+++ b/packages/google-cloud-secret-manager/google/cloud/secretmanager_v1beta2/services/secret_manager_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/google/cloud/secretmanager_v1beta2/services/secret_manager_service/transports/grpc.py
+++ b/packages/google-cloud-secret-manager/google/cloud/secretmanager_v1beta2/services/secret_manager_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/google/cloud/secretmanager_v1beta2/services/secret_manager_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-secret-manager/google/cloud/secretmanager_v1beta2/services/secret_manager_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/google/cloud/secretmanager_v1beta2/services/secret_manager_service/transports/rest.py
+++ b/packages/google-cloud-secret-manager/google/cloud/secretmanager_v1beta2/services/secret_manager_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/google/cloud/secretmanager_v1beta2/services/secret_manager_service/transports/rest_base.py
+++ b/packages/google-cloud-secret-manager/google/cloud/secretmanager_v1beta2/services/secret_manager_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/google/cloud/secretmanager_v1beta2/types/__init__.py
+++ b/packages/google-cloud-secret-manager/google/cloud/secretmanager_v1beta2/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/google/cloud/secretmanager_v1beta2/types/resources.py
+++ b/packages/google-cloud-secret-manager/google/cloud/secretmanager_v1beta2/types/resources.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/google/cloud/secretmanager_v1beta2/types/service.py
+++ b/packages/google-cloud-secret-manager/google/cloud/secretmanager_v1beta2/types/service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1_generated_secret_manager_service_access_secret_version_async.py
+++ b/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1_generated_secret_manager_service_access_secret_version_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1_generated_secret_manager_service_access_secret_version_sync.py
+++ b/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1_generated_secret_manager_service_access_secret_version_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1_generated_secret_manager_service_add_secret_version_async.py
+++ b/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1_generated_secret_manager_service_add_secret_version_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1_generated_secret_manager_service_add_secret_version_sync.py
+++ b/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1_generated_secret_manager_service_add_secret_version_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1_generated_secret_manager_service_create_secret_async.py
+++ b/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1_generated_secret_manager_service_create_secret_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1_generated_secret_manager_service_create_secret_sync.py
+++ b/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1_generated_secret_manager_service_create_secret_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1_generated_secret_manager_service_delete_secret_async.py
+++ b/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1_generated_secret_manager_service_delete_secret_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1_generated_secret_manager_service_delete_secret_sync.py
+++ b/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1_generated_secret_manager_service_delete_secret_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1_generated_secret_manager_service_destroy_secret_version_async.py
+++ b/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1_generated_secret_manager_service_destroy_secret_version_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1_generated_secret_manager_service_destroy_secret_version_sync.py
+++ b/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1_generated_secret_manager_service_destroy_secret_version_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1_generated_secret_manager_service_disable_secret_version_async.py
+++ b/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1_generated_secret_manager_service_disable_secret_version_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1_generated_secret_manager_service_disable_secret_version_sync.py
+++ b/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1_generated_secret_manager_service_disable_secret_version_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1_generated_secret_manager_service_enable_secret_version_async.py
+++ b/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1_generated_secret_manager_service_enable_secret_version_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1_generated_secret_manager_service_enable_secret_version_sync.py
+++ b/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1_generated_secret_manager_service_enable_secret_version_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1_generated_secret_manager_service_get_iam_policy_async.py
+++ b/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1_generated_secret_manager_service_get_iam_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1_generated_secret_manager_service_get_iam_policy_sync.py
+++ b/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1_generated_secret_manager_service_get_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1_generated_secret_manager_service_get_secret_async.py
+++ b/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1_generated_secret_manager_service_get_secret_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1_generated_secret_manager_service_get_secret_sync.py
+++ b/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1_generated_secret_manager_service_get_secret_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1_generated_secret_manager_service_get_secret_version_async.py
+++ b/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1_generated_secret_manager_service_get_secret_version_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1_generated_secret_manager_service_get_secret_version_sync.py
+++ b/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1_generated_secret_manager_service_get_secret_version_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1_generated_secret_manager_service_list_secret_versions_async.py
+++ b/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1_generated_secret_manager_service_list_secret_versions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1_generated_secret_manager_service_list_secret_versions_sync.py
+++ b/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1_generated_secret_manager_service_list_secret_versions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1_generated_secret_manager_service_list_secrets_async.py
+++ b/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1_generated_secret_manager_service_list_secrets_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1_generated_secret_manager_service_list_secrets_sync.py
+++ b/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1_generated_secret_manager_service_list_secrets_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1_generated_secret_manager_service_set_iam_policy_async.py
+++ b/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1_generated_secret_manager_service_set_iam_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1_generated_secret_manager_service_set_iam_policy_sync.py
+++ b/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1_generated_secret_manager_service_set_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1_generated_secret_manager_service_test_iam_permissions_async.py
+++ b/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1_generated_secret_manager_service_test_iam_permissions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1_generated_secret_manager_service_test_iam_permissions_sync.py
+++ b/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1_generated_secret_manager_service_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1_generated_secret_manager_service_update_secret_async.py
+++ b/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1_generated_secret_manager_service_update_secret_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1_generated_secret_manager_service_update_secret_sync.py
+++ b/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1_generated_secret_manager_service_update_secret_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta1_generated_secret_manager_service_access_secret_version_async.py
+++ b/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta1_generated_secret_manager_service_access_secret_version_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta1_generated_secret_manager_service_access_secret_version_sync.py
+++ b/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta1_generated_secret_manager_service_access_secret_version_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta1_generated_secret_manager_service_add_secret_version_async.py
+++ b/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta1_generated_secret_manager_service_add_secret_version_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta1_generated_secret_manager_service_add_secret_version_sync.py
+++ b/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta1_generated_secret_manager_service_add_secret_version_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta1_generated_secret_manager_service_create_secret_async.py
+++ b/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta1_generated_secret_manager_service_create_secret_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta1_generated_secret_manager_service_create_secret_sync.py
+++ b/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta1_generated_secret_manager_service_create_secret_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta1_generated_secret_manager_service_delete_secret_async.py
+++ b/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta1_generated_secret_manager_service_delete_secret_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta1_generated_secret_manager_service_delete_secret_sync.py
+++ b/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta1_generated_secret_manager_service_delete_secret_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta1_generated_secret_manager_service_destroy_secret_version_async.py
+++ b/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta1_generated_secret_manager_service_destroy_secret_version_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta1_generated_secret_manager_service_destroy_secret_version_sync.py
+++ b/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta1_generated_secret_manager_service_destroy_secret_version_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta1_generated_secret_manager_service_disable_secret_version_async.py
+++ b/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta1_generated_secret_manager_service_disable_secret_version_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta1_generated_secret_manager_service_disable_secret_version_sync.py
+++ b/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta1_generated_secret_manager_service_disable_secret_version_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta1_generated_secret_manager_service_enable_secret_version_async.py
+++ b/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta1_generated_secret_manager_service_enable_secret_version_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta1_generated_secret_manager_service_enable_secret_version_sync.py
+++ b/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta1_generated_secret_manager_service_enable_secret_version_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta1_generated_secret_manager_service_get_iam_policy_async.py
+++ b/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta1_generated_secret_manager_service_get_iam_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta1_generated_secret_manager_service_get_iam_policy_sync.py
+++ b/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta1_generated_secret_manager_service_get_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta1_generated_secret_manager_service_get_secret_async.py
+++ b/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta1_generated_secret_manager_service_get_secret_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta1_generated_secret_manager_service_get_secret_sync.py
+++ b/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta1_generated_secret_manager_service_get_secret_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta1_generated_secret_manager_service_get_secret_version_async.py
+++ b/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta1_generated_secret_manager_service_get_secret_version_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta1_generated_secret_manager_service_get_secret_version_sync.py
+++ b/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta1_generated_secret_manager_service_get_secret_version_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta1_generated_secret_manager_service_list_secret_versions_async.py
+++ b/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta1_generated_secret_manager_service_list_secret_versions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta1_generated_secret_manager_service_list_secret_versions_sync.py
+++ b/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta1_generated_secret_manager_service_list_secret_versions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta1_generated_secret_manager_service_list_secrets_async.py
+++ b/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta1_generated_secret_manager_service_list_secrets_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta1_generated_secret_manager_service_list_secrets_sync.py
+++ b/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta1_generated_secret_manager_service_list_secrets_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta1_generated_secret_manager_service_set_iam_policy_async.py
+++ b/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta1_generated_secret_manager_service_set_iam_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta1_generated_secret_manager_service_set_iam_policy_sync.py
+++ b/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta1_generated_secret_manager_service_set_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta1_generated_secret_manager_service_test_iam_permissions_async.py
+++ b/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta1_generated_secret_manager_service_test_iam_permissions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta1_generated_secret_manager_service_test_iam_permissions_sync.py
+++ b/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta1_generated_secret_manager_service_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta1_generated_secret_manager_service_update_secret_async.py
+++ b/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta1_generated_secret_manager_service_update_secret_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta1_generated_secret_manager_service_update_secret_sync.py
+++ b/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta1_generated_secret_manager_service_update_secret_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta2_generated_secret_manager_service_access_secret_version_async.py
+++ b/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta2_generated_secret_manager_service_access_secret_version_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta2_generated_secret_manager_service_access_secret_version_sync.py
+++ b/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta2_generated_secret_manager_service_access_secret_version_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta2_generated_secret_manager_service_add_secret_version_async.py
+++ b/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta2_generated_secret_manager_service_add_secret_version_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta2_generated_secret_manager_service_add_secret_version_sync.py
+++ b/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta2_generated_secret_manager_service_add_secret_version_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta2_generated_secret_manager_service_create_secret_async.py
+++ b/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta2_generated_secret_manager_service_create_secret_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta2_generated_secret_manager_service_create_secret_sync.py
+++ b/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta2_generated_secret_manager_service_create_secret_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta2_generated_secret_manager_service_delete_secret_async.py
+++ b/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta2_generated_secret_manager_service_delete_secret_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta2_generated_secret_manager_service_delete_secret_sync.py
+++ b/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta2_generated_secret_manager_service_delete_secret_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta2_generated_secret_manager_service_destroy_secret_version_async.py
+++ b/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta2_generated_secret_manager_service_destroy_secret_version_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta2_generated_secret_manager_service_destroy_secret_version_sync.py
+++ b/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta2_generated_secret_manager_service_destroy_secret_version_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta2_generated_secret_manager_service_disable_secret_version_async.py
+++ b/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta2_generated_secret_manager_service_disable_secret_version_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta2_generated_secret_manager_service_disable_secret_version_sync.py
+++ b/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta2_generated_secret_manager_service_disable_secret_version_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta2_generated_secret_manager_service_enable_secret_version_async.py
+++ b/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta2_generated_secret_manager_service_enable_secret_version_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta2_generated_secret_manager_service_enable_secret_version_sync.py
+++ b/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta2_generated_secret_manager_service_enable_secret_version_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta2_generated_secret_manager_service_get_iam_policy_async.py
+++ b/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta2_generated_secret_manager_service_get_iam_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta2_generated_secret_manager_service_get_iam_policy_sync.py
+++ b/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta2_generated_secret_manager_service_get_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta2_generated_secret_manager_service_get_secret_async.py
+++ b/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta2_generated_secret_manager_service_get_secret_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta2_generated_secret_manager_service_get_secret_sync.py
+++ b/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta2_generated_secret_manager_service_get_secret_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta2_generated_secret_manager_service_get_secret_version_async.py
+++ b/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta2_generated_secret_manager_service_get_secret_version_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta2_generated_secret_manager_service_get_secret_version_sync.py
+++ b/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta2_generated_secret_manager_service_get_secret_version_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta2_generated_secret_manager_service_list_secret_versions_async.py
+++ b/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta2_generated_secret_manager_service_list_secret_versions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta2_generated_secret_manager_service_list_secret_versions_sync.py
+++ b/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta2_generated_secret_manager_service_list_secret_versions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta2_generated_secret_manager_service_list_secrets_async.py
+++ b/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta2_generated_secret_manager_service_list_secrets_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta2_generated_secret_manager_service_list_secrets_sync.py
+++ b/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta2_generated_secret_manager_service_list_secrets_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta2_generated_secret_manager_service_set_iam_policy_async.py
+++ b/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta2_generated_secret_manager_service_set_iam_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta2_generated_secret_manager_service_set_iam_policy_sync.py
+++ b/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta2_generated_secret_manager_service_set_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta2_generated_secret_manager_service_test_iam_permissions_async.py
+++ b/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta2_generated_secret_manager_service_test_iam_permissions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta2_generated_secret_manager_service_test_iam_permissions_sync.py
+++ b/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta2_generated_secret_manager_service_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta2_generated_secret_manager_service_update_secret_async.py
+++ b/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta2_generated_secret_manager_service_update_secret_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta2_generated_secret_manager_service_update_secret_sync.py
+++ b/packages/google-cloud-secret-manager/samples/generated_samples/secretmanager_v1beta2_generated_secret_manager_service_update_secret_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/tests/__init__.py
+++ b/packages/google-cloud-secret-manager/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/tests/unit/__init__.py
+++ b/packages/google-cloud-secret-manager/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-secret-manager/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/tests/unit/gapic/secretmanager_v1/__init__.py
+++ b/packages/google-cloud-secret-manager/tests/unit/gapic/secretmanager_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/tests/unit/gapic/secretmanager_v1beta1/__init__.py
+++ b/packages/google-cloud-secret-manager/tests/unit/gapic/secretmanager_v1beta1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-secret-manager/tests/unit/gapic/secretmanager_v1beta2/__init__.py
+++ b/packages/google-cloud-secret-manager/tests/unit/gapic/secretmanager_v1beta2/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securesourcemanager/.flake8
+++ b/packages/google-cloud-securesourcemanager/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securesourcemanager/MANIFEST.in
+++ b/packages/google-cloud-securesourcemanager/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securesourcemanager/google/cloud/securesourcemanager/__init__.py
+++ b/packages/google-cloud-securesourcemanager/google/cloud/securesourcemanager/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securesourcemanager/google/cloud/securesourcemanager/gapic_version.py
+++ b/packages/google-cloud-securesourcemanager/google/cloud/securesourcemanager/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securesourcemanager/google/cloud/securesourcemanager_v1/gapic_version.py
+++ b/packages/google-cloud-securesourcemanager/google/cloud/securesourcemanager_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securesourcemanager/google/cloud/securesourcemanager_v1/services/__init__.py
+++ b/packages/google-cloud-securesourcemanager/google/cloud/securesourcemanager_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securesourcemanager/google/cloud/securesourcemanager_v1/services/secure_source_manager/__init__.py
+++ b/packages/google-cloud-securesourcemanager/google/cloud/securesourcemanager_v1/services/secure_source_manager/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securesourcemanager/google/cloud/securesourcemanager_v1/services/secure_source_manager/client.py
+++ b/packages/google-cloud-securesourcemanager/google/cloud/securesourcemanager_v1/services/secure_source_manager/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securesourcemanager/google/cloud/securesourcemanager_v1/services/secure_source_manager/pagers.py
+++ b/packages/google-cloud-securesourcemanager/google/cloud/securesourcemanager_v1/services/secure_source_manager/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securesourcemanager/google/cloud/securesourcemanager_v1/services/secure_source_manager/transports/__init__.py
+++ b/packages/google-cloud-securesourcemanager/google/cloud/securesourcemanager_v1/services/secure_source_manager/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securesourcemanager/google/cloud/securesourcemanager_v1/services/secure_source_manager/transports/base.py
+++ b/packages/google-cloud-securesourcemanager/google/cloud/securesourcemanager_v1/services/secure_source_manager/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securesourcemanager/google/cloud/securesourcemanager_v1/services/secure_source_manager/transports/grpc.py
+++ b/packages/google-cloud-securesourcemanager/google/cloud/securesourcemanager_v1/services/secure_source_manager/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securesourcemanager/google/cloud/securesourcemanager_v1/services/secure_source_manager/transports/grpc_asyncio.py
+++ b/packages/google-cloud-securesourcemanager/google/cloud/securesourcemanager_v1/services/secure_source_manager/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securesourcemanager/google/cloud/securesourcemanager_v1/services/secure_source_manager/transports/rest.py
+++ b/packages/google-cloud-securesourcemanager/google/cloud/securesourcemanager_v1/services/secure_source_manager/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securesourcemanager/google/cloud/securesourcemanager_v1/services/secure_source_manager/transports/rest_base.py
+++ b/packages/google-cloud-securesourcemanager/google/cloud/securesourcemanager_v1/services/secure_source_manager/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securesourcemanager/google/cloud/securesourcemanager_v1/types/__init__.py
+++ b/packages/google-cloud-securesourcemanager/google/cloud/securesourcemanager_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securesourcemanager/google/cloud/securesourcemanager_v1/types/secure_source_manager.py
+++ b/packages/google-cloud-securesourcemanager/google/cloud/securesourcemanager_v1/types/secure_source_manager.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_batch_create_pull_request_comments_sync.py
+++ b/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_batch_create_pull_request_comments_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_close_issue_sync.py
+++ b/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_close_issue_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_close_pull_request_sync.py
+++ b/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_close_pull_request_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_create_branch_rule_sync.py
+++ b/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_create_branch_rule_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_create_hook_sync.py
+++ b/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_create_hook_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_create_instance_sync.py
+++ b/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_create_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_create_issue_comment_sync.py
+++ b/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_create_issue_comment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_create_issue_sync.py
+++ b/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_create_issue_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_create_pull_request_comment_sync.py
+++ b/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_create_pull_request_comment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_create_pull_request_sync.py
+++ b/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_create_pull_request_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_create_repository_sync.py
+++ b/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_create_repository_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_delete_branch_rule_sync.py
+++ b/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_delete_branch_rule_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_delete_hook_sync.py
+++ b/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_delete_hook_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_delete_instance_sync.py
+++ b/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_delete_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_delete_issue_comment_sync.py
+++ b/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_delete_issue_comment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_delete_issue_sync.py
+++ b/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_delete_issue_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_delete_pull_request_comment_sync.py
+++ b/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_delete_pull_request_comment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_delete_repository_sync.py
+++ b/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_delete_repository_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_fetch_blob_async.py
+++ b/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_fetch_blob_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_fetch_blob_sync.py
+++ b/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_fetch_blob_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_fetch_tree_async.py
+++ b/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_fetch_tree_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_fetch_tree_sync.py
+++ b/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_fetch_tree_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_get_branch_rule_async.py
+++ b/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_get_branch_rule_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_get_branch_rule_sync.py
+++ b/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_get_branch_rule_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_get_hook_async.py
+++ b/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_get_hook_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_get_hook_sync.py
+++ b/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_get_hook_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_get_iam_policy_repo_async.py
+++ b/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_get_iam_policy_repo_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_get_iam_policy_repo_sync.py
+++ b/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_get_iam_policy_repo_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_get_instance_async.py
+++ b/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_get_instance_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_get_instance_sync.py
+++ b/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_get_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_get_issue_async.py
+++ b/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_get_issue_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_get_issue_comment_async.py
+++ b/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_get_issue_comment_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_get_issue_comment_sync.py
+++ b/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_get_issue_comment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_get_issue_sync.py
+++ b/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_get_issue_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_get_pull_request_async.py
+++ b/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_get_pull_request_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_get_pull_request_comment_async.py
+++ b/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_get_pull_request_comment_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_get_pull_request_comment_sync.py
+++ b/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_get_pull_request_comment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_get_pull_request_sync.py
+++ b/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_get_pull_request_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_get_repository_async.py
+++ b/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_get_repository_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_get_repository_sync.py
+++ b/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_get_repository_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_list_branch_rules_async.py
+++ b/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_list_branch_rules_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_list_branch_rules_sync.py
+++ b/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_list_branch_rules_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_list_hooks_async.py
+++ b/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_list_hooks_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_list_hooks_sync.py
+++ b/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_list_hooks_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_list_instances_async.py
+++ b/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_list_instances_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_list_instances_sync.py
+++ b/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_list_instances_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_list_issue_comments_async.py
+++ b/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_list_issue_comments_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_list_issue_comments_sync.py
+++ b/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_list_issue_comments_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_list_issues_async.py
+++ b/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_list_issues_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_list_issues_sync.py
+++ b/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_list_issues_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_list_pull_request_comments_async.py
+++ b/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_list_pull_request_comments_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_list_pull_request_comments_sync.py
+++ b/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_list_pull_request_comments_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_list_pull_request_file_diffs_async.py
+++ b/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_list_pull_request_file_diffs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_list_pull_request_file_diffs_sync.py
+++ b/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_list_pull_request_file_diffs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_list_pull_requests_async.py
+++ b/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_list_pull_requests_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_list_pull_requests_sync.py
+++ b/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_list_pull_requests_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_list_repositories_async.py
+++ b/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_list_repositories_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_list_repositories_sync.py
+++ b/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_list_repositories_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_merge_pull_request_sync.py
+++ b/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_merge_pull_request_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_open_issue_sync.py
+++ b/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_open_issue_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_open_pull_request_sync.py
+++ b/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_open_pull_request_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_resolve_pull_request_comments_sync.py
+++ b/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_resolve_pull_request_comments_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_set_iam_policy_repo_async.py
+++ b/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_set_iam_policy_repo_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_set_iam_policy_repo_sync.py
+++ b/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_set_iam_policy_repo_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_test_iam_permissions_repo_async.py
+++ b/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_test_iam_permissions_repo_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_test_iam_permissions_repo_sync.py
+++ b/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_test_iam_permissions_repo_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_unresolve_pull_request_comments_sync.py
+++ b/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_unresolve_pull_request_comments_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_update_branch_rule_sync.py
+++ b/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_update_branch_rule_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_update_hook_sync.py
+++ b/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_update_hook_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_update_issue_comment_sync.py
+++ b/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_update_issue_comment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_update_issue_sync.py
+++ b/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_update_issue_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_update_pull_request_comment_sync.py
+++ b/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_update_pull_request_comment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_update_pull_request_sync.py
+++ b/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_update_pull_request_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_update_repository_sync.py
+++ b/packages/google-cloud-securesourcemanager/samples/generated_samples/securesourcemanager_v1_generated_secure_source_manager_update_repository_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securesourcemanager/tests/__init__.py
+++ b/packages/google-cloud-securesourcemanager/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securesourcemanager/tests/unit/__init__.py
+++ b/packages/google-cloud-securesourcemanager/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securesourcemanager/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-securesourcemanager/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securesourcemanager/tests/unit/gapic/securesourcemanager_v1/__init__.py
+++ b/packages/google-cloud-securesourcemanager/tests/unit/gapic/securesourcemanager_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-security-publicca/.flake8
+++ b/packages/google-cloud-security-publicca/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-security-publicca/MANIFEST.in
+++ b/packages/google-cloud-security-publicca/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-security-publicca/google/cloud/security/publicca/__init__.py
+++ b/packages/google-cloud-security-publicca/google/cloud/security/publicca/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-security-publicca/google/cloud/security/publicca/gapic_version.py
+++ b/packages/google-cloud-security-publicca/google/cloud/security/publicca/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-security-publicca/google/cloud/security/publicca_v1/gapic_version.py
+++ b/packages/google-cloud-security-publicca/google/cloud/security/publicca_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-security-publicca/google/cloud/security/publicca_v1/services/__init__.py
+++ b/packages/google-cloud-security-publicca/google/cloud/security/publicca_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-security-publicca/google/cloud/security/publicca_v1/services/public_certificate_authority_service/__init__.py
+++ b/packages/google-cloud-security-publicca/google/cloud/security/publicca_v1/services/public_certificate_authority_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-security-publicca/google/cloud/security/publicca_v1/services/public_certificate_authority_service/async_client.py
+++ b/packages/google-cloud-security-publicca/google/cloud/security/publicca_v1/services/public_certificate_authority_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-security-publicca/google/cloud/security/publicca_v1/services/public_certificate_authority_service/client.py
+++ b/packages/google-cloud-security-publicca/google/cloud/security/publicca_v1/services/public_certificate_authority_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-security-publicca/google/cloud/security/publicca_v1/services/public_certificate_authority_service/transports/__init__.py
+++ b/packages/google-cloud-security-publicca/google/cloud/security/publicca_v1/services/public_certificate_authority_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-security-publicca/google/cloud/security/publicca_v1/services/public_certificate_authority_service/transports/base.py
+++ b/packages/google-cloud-security-publicca/google/cloud/security/publicca_v1/services/public_certificate_authority_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-security-publicca/google/cloud/security/publicca_v1/services/public_certificate_authority_service/transports/grpc.py
+++ b/packages/google-cloud-security-publicca/google/cloud/security/publicca_v1/services/public_certificate_authority_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-security-publicca/google/cloud/security/publicca_v1/services/public_certificate_authority_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-security-publicca/google/cloud/security/publicca_v1/services/public_certificate_authority_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-security-publicca/google/cloud/security/publicca_v1/services/public_certificate_authority_service/transports/rest.py
+++ b/packages/google-cloud-security-publicca/google/cloud/security/publicca_v1/services/public_certificate_authority_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-security-publicca/google/cloud/security/publicca_v1/services/public_certificate_authority_service/transports/rest_base.py
+++ b/packages/google-cloud-security-publicca/google/cloud/security/publicca_v1/services/public_certificate_authority_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-security-publicca/google/cloud/security/publicca_v1/types/__init__.py
+++ b/packages/google-cloud-security-publicca/google/cloud/security/publicca_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-security-publicca/google/cloud/security/publicca_v1/types/resources.py
+++ b/packages/google-cloud-security-publicca/google/cloud/security/publicca_v1/types/resources.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-security-publicca/google/cloud/security/publicca_v1/types/service.py
+++ b/packages/google-cloud-security-publicca/google/cloud/security/publicca_v1/types/service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-security-publicca/google/cloud/security/publicca_v1beta1/gapic_version.py
+++ b/packages/google-cloud-security-publicca/google/cloud/security/publicca_v1beta1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-security-publicca/google/cloud/security/publicca_v1beta1/services/__init__.py
+++ b/packages/google-cloud-security-publicca/google/cloud/security/publicca_v1beta1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-security-publicca/google/cloud/security/publicca_v1beta1/services/public_certificate_authority_service/__init__.py
+++ b/packages/google-cloud-security-publicca/google/cloud/security/publicca_v1beta1/services/public_certificate_authority_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-security-publicca/google/cloud/security/publicca_v1beta1/services/public_certificate_authority_service/async_client.py
+++ b/packages/google-cloud-security-publicca/google/cloud/security/publicca_v1beta1/services/public_certificate_authority_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-security-publicca/google/cloud/security/publicca_v1beta1/services/public_certificate_authority_service/client.py
+++ b/packages/google-cloud-security-publicca/google/cloud/security/publicca_v1beta1/services/public_certificate_authority_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-security-publicca/google/cloud/security/publicca_v1beta1/services/public_certificate_authority_service/transports/__init__.py
+++ b/packages/google-cloud-security-publicca/google/cloud/security/publicca_v1beta1/services/public_certificate_authority_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-security-publicca/google/cloud/security/publicca_v1beta1/services/public_certificate_authority_service/transports/base.py
+++ b/packages/google-cloud-security-publicca/google/cloud/security/publicca_v1beta1/services/public_certificate_authority_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-security-publicca/google/cloud/security/publicca_v1beta1/services/public_certificate_authority_service/transports/grpc.py
+++ b/packages/google-cloud-security-publicca/google/cloud/security/publicca_v1beta1/services/public_certificate_authority_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-security-publicca/google/cloud/security/publicca_v1beta1/services/public_certificate_authority_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-security-publicca/google/cloud/security/publicca_v1beta1/services/public_certificate_authority_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-security-publicca/google/cloud/security/publicca_v1beta1/services/public_certificate_authority_service/transports/rest.py
+++ b/packages/google-cloud-security-publicca/google/cloud/security/publicca_v1beta1/services/public_certificate_authority_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-security-publicca/google/cloud/security/publicca_v1beta1/services/public_certificate_authority_service/transports/rest_base.py
+++ b/packages/google-cloud-security-publicca/google/cloud/security/publicca_v1beta1/services/public_certificate_authority_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-security-publicca/google/cloud/security/publicca_v1beta1/types/__init__.py
+++ b/packages/google-cloud-security-publicca/google/cloud/security/publicca_v1beta1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-security-publicca/google/cloud/security/publicca_v1beta1/types/resources.py
+++ b/packages/google-cloud-security-publicca/google/cloud/security/publicca_v1beta1/types/resources.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-security-publicca/google/cloud/security/publicca_v1beta1/types/service.py
+++ b/packages/google-cloud-security-publicca/google/cloud/security/publicca_v1beta1/types/service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-security-publicca/samples/generated_samples/publicca_v1_generated_public_certificate_authority_service_create_external_account_key_async.py
+++ b/packages/google-cloud-security-publicca/samples/generated_samples/publicca_v1_generated_public_certificate_authority_service_create_external_account_key_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-security-publicca/samples/generated_samples/publicca_v1_generated_public_certificate_authority_service_create_external_account_key_sync.py
+++ b/packages/google-cloud-security-publicca/samples/generated_samples/publicca_v1_generated_public_certificate_authority_service_create_external_account_key_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-security-publicca/samples/generated_samples/publicca_v1beta1_generated_public_certificate_authority_service_create_external_account_key_async.py
+++ b/packages/google-cloud-security-publicca/samples/generated_samples/publicca_v1beta1_generated_public_certificate_authority_service_create_external_account_key_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-security-publicca/samples/generated_samples/publicca_v1beta1_generated_public_certificate_authority_service_create_external_account_key_sync.py
+++ b/packages/google-cloud-security-publicca/samples/generated_samples/publicca_v1beta1_generated_public_certificate_authority_service_create_external_account_key_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-security-publicca/tests/__init__.py
+++ b/packages/google-cloud-security-publicca/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-security-publicca/tests/unit/__init__.py
+++ b/packages/google-cloud-security-publicca/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-security-publicca/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-security-publicca/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-security-publicca/tests/unit/gapic/publicca_v1/__init__.py
+++ b/packages/google-cloud-security-publicca/tests/unit/gapic/publicca_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-security-publicca/tests/unit/gapic/publicca_v1beta1/__init__.py
+++ b/packages/google-cloud-security-publicca/tests/unit/gapic/publicca_v1beta1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/.flake8
+++ b/packages/google-cloud-securitycenter/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/MANIFEST.in
+++ b/packages/google-cloud-securitycenter/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter/__init__.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter/gapic_version.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/gapic_version.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/services/__init__.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/services/security_center/__init__.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/services/security_center/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/services/security_center/client.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/services/security_center/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/services/security_center/pagers.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/services/security_center/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/services/security_center/transports/__init__.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/services/security_center/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/services/security_center/transports/base.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/services/security_center/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/services/security_center/transports/grpc.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/services/security_center/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/services/security_center/transports/grpc_asyncio.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/services/security_center/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/services/security_center/transports/rest.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/services/security_center/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/services/security_center/transports/rest_base.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/services/security_center/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/types/__init__.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/types/access.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/types/access.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/types/application.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/types/application.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/types/asset.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/types/asset.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/types/attack_exposure.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/types/attack_exposure.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/types/attack_path.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/types/attack_path.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/types/backup_disaster_recovery.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/types/backup_disaster_recovery.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/types/bigquery_export.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/types/bigquery_export.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/types/chokepoint.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/types/chokepoint.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/types/cloud_armor.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/types/cloud_armor.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/types/cloud_dlp_data_profile.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/types/cloud_dlp_data_profile.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/types/cloud_dlp_inspection.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/types/cloud_dlp_inspection.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/types/compliance.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/types/compliance.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/types/connection.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/types/connection.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/types/contact_details.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/types/contact_details.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/types/container.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/types/container.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/types/database.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/types/database.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/types/effective_event_threat_detection_custom_module.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/types/effective_event_threat_detection_custom_module.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/types/effective_security_health_analytics_custom_module.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/types/effective_security_health_analytics_custom_module.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/types/event_threat_detection_custom_module.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/types/event_threat_detection_custom_module.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/types/event_threat_detection_custom_module_validation_errors.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/types/event_threat_detection_custom_module_validation_errors.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/types/exfiltration.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/types/exfiltration.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/types/external_exposure.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/types/external_exposure.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/types/external_system.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/types/external_system.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/types/file.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/types/file.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/types/finding.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/types/finding.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/types/folder.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/types/folder.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/types/group_membership.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/types/group_membership.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/types/iam_binding.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/types/iam_binding.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/types/indicator.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/types/indicator.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/types/kernel_rootkit.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/types/kernel_rootkit.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/types/kubernetes.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/types/kubernetes.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/types/label.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/types/label.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/types/load_balancer.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/types/load_balancer.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/types/log_entry.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/types/log_entry.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/types/mitre_attack.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/types/mitre_attack.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/types/mute_config.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/types/mute_config.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/types/notebook.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/types/notebook.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/types/notification_config.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/types/notification_config.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/types/notification_message.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/types/notification_message.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/types/org_policy.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/types/org_policy.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/types/organization_settings.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/types/organization_settings.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/types/process.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/types/process.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/types/resource.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/types/resource.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/types/resource_value_config.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/types/resource_value_config.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/types/run_asset_discovery_response.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/types/run_asset_discovery_response.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/types/security_health_analytics_custom_config.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/types/security_health_analytics_custom_config.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/types/security_health_analytics_custom_module.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/types/security_health_analytics_custom_module.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/types/security_marks.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/types/security_marks.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/types/security_posture.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/types/security_posture.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/types/securitycenter_service.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/types/securitycenter_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/types/simulation.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/types/simulation.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/types/source.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/types/source.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/types/toxic_combination.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/types/toxic_combination.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/types/valued_resource.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/types/valued_resource.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/types/vulnerability.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1/types/vulnerability.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1beta1/gapic_version.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1beta1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1beta1/services/__init__.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1beta1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1beta1/services/security_center/__init__.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1beta1/services/security_center/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1beta1/services/security_center/client.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1beta1/services/security_center/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1beta1/services/security_center/pagers.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1beta1/services/security_center/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1beta1/services/security_center/transports/__init__.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1beta1/services/security_center/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1beta1/services/security_center/transports/base.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1beta1/services/security_center/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1beta1/services/security_center/transports/grpc.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1beta1/services/security_center/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1beta1/services/security_center/transports/grpc_asyncio.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1beta1/services/security_center/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1beta1/services/security_center/transports/rest.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1beta1/services/security_center/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1beta1/services/security_center/transports/rest_base.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1beta1/services/security_center/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1beta1/types/__init__.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1beta1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1beta1/types/asset.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1beta1/types/asset.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1beta1/types/finding.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1beta1/types/finding.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1beta1/types/organization_settings.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1beta1/types/organization_settings.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1beta1/types/run_asset_discovery_response.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1beta1/types/run_asset_discovery_response.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1beta1/types/security_marks.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1beta1/types/security_marks.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1beta1/types/securitycenter_service.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1beta1/types/securitycenter_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1beta1/types/source.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1beta1/types/source.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1p1beta1/gapic_version.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1p1beta1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1p1beta1/services/__init__.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1p1beta1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1p1beta1/services/security_center/__init__.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1p1beta1/services/security_center/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1p1beta1/services/security_center/client.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1p1beta1/services/security_center/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1p1beta1/services/security_center/pagers.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1p1beta1/services/security_center/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1p1beta1/services/security_center/transports/__init__.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1p1beta1/services/security_center/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1p1beta1/services/security_center/transports/base.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1p1beta1/services/security_center/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1p1beta1/services/security_center/transports/grpc.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1p1beta1/services/security_center/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1p1beta1/services/security_center/transports/grpc_asyncio.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1p1beta1/services/security_center/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1p1beta1/services/security_center/transports/rest.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1p1beta1/services/security_center/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1p1beta1/services/security_center/transports/rest_base.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1p1beta1/services/security_center/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1p1beta1/types/__init__.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1p1beta1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1p1beta1/types/asset.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1p1beta1/types/asset.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1p1beta1/types/finding.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1p1beta1/types/finding.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1p1beta1/types/folder.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1p1beta1/types/folder.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1p1beta1/types/notification_config.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1p1beta1/types/notification_config.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1p1beta1/types/notification_message.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1p1beta1/types/notification_message.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1p1beta1/types/organization_settings.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1p1beta1/types/organization_settings.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1p1beta1/types/resource.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1p1beta1/types/resource.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1p1beta1/types/run_asset_discovery_response.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1p1beta1/types/run_asset_discovery_response.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1p1beta1/types/security_marks.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1p1beta1/types/security_marks.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1p1beta1/types/securitycenter_service.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1p1beta1/types/securitycenter_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1p1beta1/types/source.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v1p1beta1/types/source.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/gapic_version.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/services/__init__.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/services/security_center/__init__.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/services/security_center/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/services/security_center/client.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/services/security_center/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/services/security_center/pagers.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/services/security_center/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/services/security_center/transports/__init__.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/services/security_center/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/services/security_center/transports/base.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/services/security_center/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/services/security_center/transports/grpc.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/services/security_center/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/services/security_center/transports/grpc_asyncio.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/services/security_center/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/services/security_center/transports/rest.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/services/security_center/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/services/security_center/transports/rest_base.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/services/security_center/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/types/__init__.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/types/access.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/types/access.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/types/affected_resources.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/types/affected_resources.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/types/ai_model.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/types/ai_model.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/types/application.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/types/application.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/types/attack_exposure.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/types/attack_exposure.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/types/attack_path.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/types/attack_path.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/types/backup_disaster_recovery.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/types/backup_disaster_recovery.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/types/bigquery_export.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/types/bigquery_export.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/types/chokepoint.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/types/chokepoint.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/types/cloud_armor.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/types/cloud_armor.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/types/cloud_dlp_data_profile.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/types/cloud_dlp_data_profile.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/types/cloud_dlp_inspection.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/types/cloud_dlp_inspection.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/types/compliance.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/types/compliance.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/types/connection.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/types/connection.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/types/contact_details.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/types/contact_details.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/types/container.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/types/container.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/types/data_access_event.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/types/data_access_event.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/types/data_flow_event.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/types/data_flow_event.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/types/data_retention_deletion_event.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/types/data_retention_deletion_event.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/types/database.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/types/database.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/types/disk.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/types/disk.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/types/exfiltration.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/types/exfiltration.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/types/external_system.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/types/external_system.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/types/file.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/types/file.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/types/finding.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/types/finding.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/types/folder.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/types/folder.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/types/group_membership.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/types/group_membership.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/types/iam_binding.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/types/iam_binding.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/types/indicator.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/types/indicator.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/types/ip_rules.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/types/ip_rules.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/types/job.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/types/job.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/types/kernel_rootkit.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/types/kernel_rootkit.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/types/kubernetes.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/types/kubernetes.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/types/label.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/types/label.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/types/load_balancer.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/types/load_balancer.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/types/log_entry.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/types/log_entry.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/types/mitre_attack.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/types/mitre_attack.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/types/mute_config.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/types/mute_config.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/types/network.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/types/network.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/types/notebook.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/types/notebook.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/types/notification_config.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/types/notification_config.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/types/notification_message.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/types/notification_message.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/types/org_policy.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/types/org_policy.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/types/process.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/types/process.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/types/resource.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/types/resource.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/types/resource_value_config.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/types/resource_value_config.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/types/security_marks.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/types/security_marks.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/types/security_posture.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/types/security_posture.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/types/securitycenter_service.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/types/securitycenter_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/types/simulation.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/types/simulation.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/types/source.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/types/source.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/types/toxic_combination.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/types/toxic_combination.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/types/valued_resource.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/types/valued_resource.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/types/vertex_ai.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/types/vertex_ai.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/types/vulnerability.py
+++ b/packages/google-cloud-securitycenter/google/cloud/securitycenter_v2/types/vulnerability.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_batch_create_resource_value_configs_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_batch_create_resource_value_configs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_batch_create_resource_value_configs_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_batch_create_resource_value_configs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_bulk_mute_findings_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_bulk_mute_findings_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_create_big_query_export_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_create_big_query_export_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_create_big_query_export_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_create_big_query_export_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_create_event_threat_detection_custom_module_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_create_event_threat_detection_custom_module_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_create_event_threat_detection_custom_module_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_create_event_threat_detection_custom_module_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_create_finding_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_create_finding_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_create_finding_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_create_finding_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_create_mute_config_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_create_mute_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_create_mute_config_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_create_mute_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_create_notification_config_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_create_notification_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_create_notification_config_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_create_notification_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_create_security_health_analytics_custom_module_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_create_security_health_analytics_custom_module_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_create_security_health_analytics_custom_module_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_create_security_health_analytics_custom_module_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_create_source_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_create_source_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_create_source_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_create_source_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_delete_big_query_export_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_delete_big_query_export_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_delete_big_query_export_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_delete_big_query_export_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_delete_event_threat_detection_custom_module_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_delete_event_threat_detection_custom_module_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_delete_event_threat_detection_custom_module_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_delete_event_threat_detection_custom_module_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_delete_mute_config_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_delete_mute_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_delete_mute_config_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_delete_mute_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_delete_notification_config_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_delete_notification_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_delete_notification_config_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_delete_notification_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_delete_resource_value_config_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_delete_resource_value_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_delete_resource_value_config_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_delete_resource_value_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_delete_security_health_analytics_custom_module_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_delete_security_health_analytics_custom_module_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_delete_security_health_analytics_custom_module_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_delete_security_health_analytics_custom_module_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_get_big_query_export_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_get_big_query_export_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_get_big_query_export_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_get_big_query_export_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_get_effective_event_threat_detection_custom_module_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_get_effective_event_threat_detection_custom_module_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_get_effective_event_threat_detection_custom_module_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_get_effective_event_threat_detection_custom_module_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_get_effective_security_health_analytics_custom_module_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_get_effective_security_health_analytics_custom_module_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_get_effective_security_health_analytics_custom_module_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_get_effective_security_health_analytics_custom_module_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_get_event_threat_detection_custom_module_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_get_event_threat_detection_custom_module_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_get_event_threat_detection_custom_module_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_get_event_threat_detection_custom_module_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_get_iam_policy_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_get_iam_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_get_iam_policy_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_get_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_get_mute_config_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_get_mute_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_get_mute_config_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_get_mute_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_get_notification_config_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_get_notification_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_get_notification_config_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_get_notification_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_get_organization_settings_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_get_organization_settings_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_get_organization_settings_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_get_organization_settings_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_get_resource_value_config_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_get_resource_value_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_get_resource_value_config_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_get_resource_value_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_get_security_health_analytics_custom_module_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_get_security_health_analytics_custom_module_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_get_security_health_analytics_custom_module_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_get_security_health_analytics_custom_module_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_get_simulation_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_get_simulation_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_get_simulation_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_get_simulation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_get_source_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_get_source_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_get_source_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_get_source_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_get_valued_resource_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_get_valued_resource_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_get_valued_resource_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_get_valued_resource_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_group_assets_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_group_assets_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_group_assets_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_group_assets_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_group_findings_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_group_findings_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_group_findings_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_group_findings_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_list_assets_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_list_assets_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_list_assets_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_list_assets_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_list_attack_paths_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_list_attack_paths_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_list_attack_paths_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_list_attack_paths_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_list_big_query_exports_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_list_big_query_exports_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_list_big_query_exports_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_list_big_query_exports_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_list_descendant_event_threat_detection_custom_modules_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_list_descendant_event_threat_detection_custom_modules_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_list_descendant_event_threat_detection_custom_modules_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_list_descendant_event_threat_detection_custom_modules_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_list_descendant_security_health_analytics_custom_modules_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_list_descendant_security_health_analytics_custom_modules_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_list_descendant_security_health_analytics_custom_modules_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_list_descendant_security_health_analytics_custom_modules_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_list_effective_event_threat_detection_custom_modules_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_list_effective_event_threat_detection_custom_modules_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_list_effective_event_threat_detection_custom_modules_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_list_effective_event_threat_detection_custom_modules_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_list_effective_security_health_analytics_custom_modules_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_list_effective_security_health_analytics_custom_modules_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_list_effective_security_health_analytics_custom_modules_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_list_effective_security_health_analytics_custom_modules_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_list_event_threat_detection_custom_modules_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_list_event_threat_detection_custom_modules_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_list_event_threat_detection_custom_modules_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_list_event_threat_detection_custom_modules_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_list_findings_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_list_findings_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_list_findings_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_list_findings_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_list_mute_configs_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_list_mute_configs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_list_mute_configs_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_list_mute_configs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_list_notification_configs_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_list_notification_configs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_list_notification_configs_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_list_notification_configs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_list_resource_value_configs_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_list_resource_value_configs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_list_resource_value_configs_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_list_resource_value_configs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_list_security_health_analytics_custom_modules_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_list_security_health_analytics_custom_modules_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_list_security_health_analytics_custom_modules_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_list_security_health_analytics_custom_modules_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_list_sources_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_list_sources_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_list_sources_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_list_sources_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_list_valued_resources_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_list_valued_resources_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_list_valued_resources_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_list_valued_resources_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_run_asset_discovery_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_run_asset_discovery_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_set_finding_state_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_set_finding_state_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_set_finding_state_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_set_finding_state_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_set_iam_policy_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_set_iam_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_set_iam_policy_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_set_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_set_mute_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_set_mute_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_set_mute_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_set_mute_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_simulate_security_health_analytics_custom_module_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_simulate_security_health_analytics_custom_module_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_simulate_security_health_analytics_custom_module_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_simulate_security_health_analytics_custom_module_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_test_iam_permissions_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_test_iam_permissions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_test_iam_permissions_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_update_big_query_export_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_update_big_query_export_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_update_big_query_export_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_update_big_query_export_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_update_event_threat_detection_custom_module_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_update_event_threat_detection_custom_module_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_update_event_threat_detection_custom_module_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_update_event_threat_detection_custom_module_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_update_external_system_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_update_external_system_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_update_external_system_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_update_external_system_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_update_finding_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_update_finding_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_update_finding_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_update_finding_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_update_mute_config_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_update_mute_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_update_mute_config_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_update_mute_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_update_notification_config_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_update_notification_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_update_notification_config_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_update_notification_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_update_organization_settings_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_update_organization_settings_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_update_organization_settings_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_update_organization_settings_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_update_resource_value_config_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_update_resource_value_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_update_resource_value_config_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_update_resource_value_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_update_security_health_analytics_custom_module_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_update_security_health_analytics_custom_module_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_update_security_health_analytics_custom_module_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_update_security_health_analytics_custom_module_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_update_security_marks_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_update_security_marks_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_update_security_marks_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_update_security_marks_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_update_source_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_update_source_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_update_source_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_update_source_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_validate_event_threat_detection_custom_module_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_validate_event_threat_detection_custom_module_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_validate_event_threat_detection_custom_module_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1_generated_security_center_validate_event_threat_detection_custom_module_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1beta1_generated_security_center_create_finding_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1beta1_generated_security_center_create_finding_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1beta1_generated_security_center_create_finding_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1beta1_generated_security_center_create_finding_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1beta1_generated_security_center_create_source_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1beta1_generated_security_center_create_source_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1beta1_generated_security_center_create_source_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1beta1_generated_security_center_create_source_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1beta1_generated_security_center_get_iam_policy_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1beta1_generated_security_center_get_iam_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1beta1_generated_security_center_get_iam_policy_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1beta1_generated_security_center_get_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1beta1_generated_security_center_get_organization_settings_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1beta1_generated_security_center_get_organization_settings_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1beta1_generated_security_center_get_organization_settings_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1beta1_generated_security_center_get_organization_settings_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1beta1_generated_security_center_get_source_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1beta1_generated_security_center_get_source_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1beta1_generated_security_center_get_source_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1beta1_generated_security_center_get_source_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1beta1_generated_security_center_group_assets_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1beta1_generated_security_center_group_assets_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1beta1_generated_security_center_group_assets_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1beta1_generated_security_center_group_assets_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1beta1_generated_security_center_group_findings_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1beta1_generated_security_center_group_findings_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1beta1_generated_security_center_group_findings_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1beta1_generated_security_center_group_findings_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1beta1_generated_security_center_list_assets_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1beta1_generated_security_center_list_assets_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1beta1_generated_security_center_list_assets_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1beta1_generated_security_center_list_assets_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1beta1_generated_security_center_list_findings_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1beta1_generated_security_center_list_findings_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1beta1_generated_security_center_list_findings_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1beta1_generated_security_center_list_findings_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1beta1_generated_security_center_list_sources_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1beta1_generated_security_center_list_sources_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1beta1_generated_security_center_list_sources_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1beta1_generated_security_center_list_sources_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1beta1_generated_security_center_run_asset_discovery_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1beta1_generated_security_center_run_asset_discovery_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1beta1_generated_security_center_set_finding_state_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1beta1_generated_security_center_set_finding_state_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1beta1_generated_security_center_set_finding_state_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1beta1_generated_security_center_set_finding_state_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1beta1_generated_security_center_set_iam_policy_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1beta1_generated_security_center_set_iam_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1beta1_generated_security_center_set_iam_policy_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1beta1_generated_security_center_set_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1beta1_generated_security_center_test_iam_permissions_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1beta1_generated_security_center_test_iam_permissions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1beta1_generated_security_center_test_iam_permissions_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1beta1_generated_security_center_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1beta1_generated_security_center_update_finding_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1beta1_generated_security_center_update_finding_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1beta1_generated_security_center_update_finding_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1beta1_generated_security_center_update_finding_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1beta1_generated_security_center_update_organization_settings_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1beta1_generated_security_center_update_organization_settings_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1beta1_generated_security_center_update_organization_settings_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1beta1_generated_security_center_update_organization_settings_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1beta1_generated_security_center_update_security_marks_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1beta1_generated_security_center_update_security_marks_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1beta1_generated_security_center_update_security_marks_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1beta1_generated_security_center_update_security_marks_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1beta1_generated_security_center_update_source_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1beta1_generated_security_center_update_source_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1beta1_generated_security_center_update_source_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1beta1_generated_security_center_update_source_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1p1beta1_generated_security_center_create_finding_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1p1beta1_generated_security_center_create_finding_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1p1beta1_generated_security_center_create_finding_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1p1beta1_generated_security_center_create_finding_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1p1beta1_generated_security_center_create_notification_config_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1p1beta1_generated_security_center_create_notification_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1p1beta1_generated_security_center_create_notification_config_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1p1beta1_generated_security_center_create_notification_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1p1beta1_generated_security_center_create_source_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1p1beta1_generated_security_center_create_source_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1p1beta1_generated_security_center_create_source_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1p1beta1_generated_security_center_create_source_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1p1beta1_generated_security_center_delete_notification_config_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1p1beta1_generated_security_center_delete_notification_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1p1beta1_generated_security_center_delete_notification_config_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1p1beta1_generated_security_center_delete_notification_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1p1beta1_generated_security_center_get_iam_policy_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1p1beta1_generated_security_center_get_iam_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1p1beta1_generated_security_center_get_iam_policy_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1p1beta1_generated_security_center_get_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1p1beta1_generated_security_center_get_notification_config_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1p1beta1_generated_security_center_get_notification_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1p1beta1_generated_security_center_get_notification_config_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1p1beta1_generated_security_center_get_notification_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1p1beta1_generated_security_center_get_organization_settings_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1p1beta1_generated_security_center_get_organization_settings_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1p1beta1_generated_security_center_get_organization_settings_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1p1beta1_generated_security_center_get_organization_settings_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1p1beta1_generated_security_center_get_source_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1p1beta1_generated_security_center_get_source_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1p1beta1_generated_security_center_get_source_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1p1beta1_generated_security_center_get_source_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1p1beta1_generated_security_center_group_assets_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1p1beta1_generated_security_center_group_assets_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1p1beta1_generated_security_center_group_assets_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1p1beta1_generated_security_center_group_assets_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1p1beta1_generated_security_center_group_findings_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1p1beta1_generated_security_center_group_findings_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1p1beta1_generated_security_center_group_findings_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1p1beta1_generated_security_center_group_findings_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1p1beta1_generated_security_center_list_assets_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1p1beta1_generated_security_center_list_assets_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1p1beta1_generated_security_center_list_assets_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1p1beta1_generated_security_center_list_assets_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1p1beta1_generated_security_center_list_findings_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1p1beta1_generated_security_center_list_findings_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1p1beta1_generated_security_center_list_findings_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1p1beta1_generated_security_center_list_findings_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1p1beta1_generated_security_center_list_notification_configs_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1p1beta1_generated_security_center_list_notification_configs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1p1beta1_generated_security_center_list_notification_configs_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1p1beta1_generated_security_center_list_notification_configs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1p1beta1_generated_security_center_list_sources_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1p1beta1_generated_security_center_list_sources_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1p1beta1_generated_security_center_list_sources_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1p1beta1_generated_security_center_list_sources_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1p1beta1_generated_security_center_run_asset_discovery_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1p1beta1_generated_security_center_run_asset_discovery_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1p1beta1_generated_security_center_set_finding_state_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1p1beta1_generated_security_center_set_finding_state_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1p1beta1_generated_security_center_set_finding_state_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1p1beta1_generated_security_center_set_finding_state_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1p1beta1_generated_security_center_set_iam_policy_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1p1beta1_generated_security_center_set_iam_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1p1beta1_generated_security_center_set_iam_policy_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1p1beta1_generated_security_center_set_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1p1beta1_generated_security_center_test_iam_permissions_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1p1beta1_generated_security_center_test_iam_permissions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1p1beta1_generated_security_center_test_iam_permissions_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1p1beta1_generated_security_center_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1p1beta1_generated_security_center_update_finding_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1p1beta1_generated_security_center_update_finding_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1p1beta1_generated_security_center_update_finding_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1p1beta1_generated_security_center_update_finding_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1p1beta1_generated_security_center_update_notification_config_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1p1beta1_generated_security_center_update_notification_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1p1beta1_generated_security_center_update_notification_config_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1p1beta1_generated_security_center_update_notification_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1p1beta1_generated_security_center_update_organization_settings_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1p1beta1_generated_security_center_update_organization_settings_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1p1beta1_generated_security_center_update_organization_settings_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1p1beta1_generated_security_center_update_organization_settings_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1p1beta1_generated_security_center_update_security_marks_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1p1beta1_generated_security_center_update_security_marks_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1p1beta1_generated_security_center_update_security_marks_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1p1beta1_generated_security_center_update_security_marks_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1p1beta1_generated_security_center_update_source_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1p1beta1_generated_security_center_update_source_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1p1beta1_generated_security_center_update_source_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v1p1beta1_generated_security_center_update_source_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_batch_create_resource_value_configs_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_batch_create_resource_value_configs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_batch_create_resource_value_configs_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_batch_create_resource_value_configs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_bulk_mute_findings_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_bulk_mute_findings_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_create_big_query_export_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_create_big_query_export_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_create_big_query_export_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_create_big_query_export_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_create_finding_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_create_finding_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_create_finding_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_create_finding_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_create_mute_config_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_create_mute_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_create_mute_config_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_create_mute_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_create_notification_config_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_create_notification_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_create_notification_config_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_create_notification_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_create_source_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_create_source_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_create_source_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_create_source_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_delete_big_query_export_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_delete_big_query_export_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_delete_big_query_export_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_delete_big_query_export_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_delete_mute_config_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_delete_mute_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_delete_mute_config_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_delete_mute_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_delete_notification_config_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_delete_notification_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_delete_notification_config_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_delete_notification_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_delete_resource_value_config_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_delete_resource_value_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_delete_resource_value_config_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_delete_resource_value_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_get_big_query_export_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_get_big_query_export_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_get_big_query_export_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_get_big_query_export_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_get_iam_policy_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_get_iam_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_get_iam_policy_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_get_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_get_mute_config_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_get_mute_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_get_mute_config_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_get_mute_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_get_notification_config_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_get_notification_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_get_notification_config_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_get_notification_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_get_resource_value_config_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_get_resource_value_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_get_resource_value_config_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_get_resource_value_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_get_simulation_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_get_simulation_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_get_simulation_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_get_simulation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_get_source_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_get_source_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_get_source_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_get_source_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_get_valued_resource_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_get_valued_resource_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_get_valued_resource_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_get_valued_resource_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_group_findings_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_group_findings_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_group_findings_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_group_findings_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_list_attack_paths_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_list_attack_paths_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_list_attack_paths_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_list_attack_paths_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_list_big_query_exports_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_list_big_query_exports_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_list_big_query_exports_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_list_big_query_exports_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_list_findings_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_list_findings_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_list_findings_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_list_findings_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_list_mute_configs_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_list_mute_configs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_list_mute_configs_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_list_mute_configs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_list_notification_configs_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_list_notification_configs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_list_notification_configs_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_list_notification_configs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_list_resource_value_configs_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_list_resource_value_configs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_list_resource_value_configs_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_list_resource_value_configs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_list_sources_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_list_sources_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_list_sources_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_list_sources_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_list_valued_resources_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_list_valued_resources_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_list_valued_resources_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_list_valued_resources_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_set_finding_state_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_set_finding_state_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_set_finding_state_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_set_finding_state_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_set_iam_policy_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_set_iam_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_set_iam_policy_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_set_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_set_mute_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_set_mute_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_set_mute_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_set_mute_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_test_iam_permissions_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_test_iam_permissions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_test_iam_permissions_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_update_big_query_export_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_update_big_query_export_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_update_big_query_export_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_update_big_query_export_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_update_external_system_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_update_external_system_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_update_external_system_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_update_external_system_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_update_finding_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_update_finding_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_update_finding_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_update_finding_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_update_mute_config_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_update_mute_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_update_mute_config_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_update_mute_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_update_notification_config_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_update_notification_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_update_notification_config_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_update_notification_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_update_resource_value_config_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_update_resource_value_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_update_resource_value_config_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_update_resource_value_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_update_security_marks_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_update_security_marks_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_update_security_marks_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_update_security_marks_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_update_source_async.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_update_source_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_update_source_sync.py
+++ b/packages/google-cloud-securitycenter/samples/generated_samples/securitycenter_v2_generated_security_center_update_source_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/tests/__init__.py
+++ b/packages/google-cloud-securitycenter/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/tests/unit/__init__.py
+++ b/packages/google-cloud-securitycenter/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-securitycenter/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/tests/unit/gapic/securitycenter_v1/__init__.py
+++ b/packages/google-cloud-securitycenter/tests/unit/gapic/securitycenter_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/tests/unit/gapic/securitycenter_v1beta1/__init__.py
+++ b/packages/google-cloud-securitycenter/tests/unit/gapic/securitycenter_v1beta1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/tests/unit/gapic/securitycenter_v1p1beta1/__init__.py
+++ b/packages/google-cloud-securitycenter/tests/unit/gapic/securitycenter_v1p1beta1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycenter/tests/unit/gapic/securitycenter_v2/__init__.py
+++ b/packages/google-cloud-securitycenter/tests/unit/gapic/securitycenter_v2/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycentermanagement/.flake8
+++ b/packages/google-cloud-securitycentermanagement/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycentermanagement/MANIFEST.in
+++ b/packages/google-cloud-securitycentermanagement/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycentermanagement/google/cloud/securitycentermanagement/__init__.py
+++ b/packages/google-cloud-securitycentermanagement/google/cloud/securitycentermanagement/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycentermanagement/google/cloud/securitycentermanagement/gapic_version.py
+++ b/packages/google-cloud-securitycentermanagement/google/cloud/securitycentermanagement/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycentermanagement/google/cloud/securitycentermanagement_v1/gapic_version.py
+++ b/packages/google-cloud-securitycentermanagement/google/cloud/securitycentermanagement_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycentermanagement/google/cloud/securitycentermanagement_v1/services/__init__.py
+++ b/packages/google-cloud-securitycentermanagement/google/cloud/securitycentermanagement_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycentermanagement/google/cloud/securitycentermanagement_v1/services/security_center_management/__init__.py
+++ b/packages/google-cloud-securitycentermanagement/google/cloud/securitycentermanagement_v1/services/security_center_management/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycentermanagement/google/cloud/securitycentermanagement_v1/services/security_center_management/async_client.py
+++ b/packages/google-cloud-securitycentermanagement/google/cloud/securitycentermanagement_v1/services/security_center_management/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycentermanagement/google/cloud/securitycentermanagement_v1/services/security_center_management/client.py
+++ b/packages/google-cloud-securitycentermanagement/google/cloud/securitycentermanagement_v1/services/security_center_management/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycentermanagement/google/cloud/securitycentermanagement_v1/services/security_center_management/pagers.py
+++ b/packages/google-cloud-securitycentermanagement/google/cloud/securitycentermanagement_v1/services/security_center_management/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycentermanagement/google/cloud/securitycentermanagement_v1/services/security_center_management/transports/__init__.py
+++ b/packages/google-cloud-securitycentermanagement/google/cloud/securitycentermanagement_v1/services/security_center_management/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycentermanagement/google/cloud/securitycentermanagement_v1/services/security_center_management/transports/base.py
+++ b/packages/google-cloud-securitycentermanagement/google/cloud/securitycentermanagement_v1/services/security_center_management/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycentermanagement/google/cloud/securitycentermanagement_v1/services/security_center_management/transports/grpc.py
+++ b/packages/google-cloud-securitycentermanagement/google/cloud/securitycentermanagement_v1/services/security_center_management/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycentermanagement/google/cloud/securitycentermanagement_v1/services/security_center_management/transports/grpc_asyncio.py
+++ b/packages/google-cloud-securitycentermanagement/google/cloud/securitycentermanagement_v1/services/security_center_management/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycentermanagement/google/cloud/securitycentermanagement_v1/services/security_center_management/transports/rest.py
+++ b/packages/google-cloud-securitycentermanagement/google/cloud/securitycentermanagement_v1/services/security_center_management/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycentermanagement/google/cloud/securitycentermanagement_v1/services/security_center_management/transports/rest_base.py
+++ b/packages/google-cloud-securitycentermanagement/google/cloud/securitycentermanagement_v1/services/security_center_management/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycentermanagement/google/cloud/securitycentermanagement_v1/types/__init__.py
+++ b/packages/google-cloud-securitycentermanagement/google/cloud/securitycentermanagement_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycentermanagement/google/cloud/securitycentermanagement_v1/types/security_center_management.py
+++ b/packages/google-cloud-securitycentermanagement/google/cloud/securitycentermanagement_v1/types/security_center_management.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycentermanagement/samples/generated_samples/securitycentermanagement_v1_generated_security_center_management_create_event_threat_detection_custom_module_async.py
+++ b/packages/google-cloud-securitycentermanagement/samples/generated_samples/securitycentermanagement_v1_generated_security_center_management_create_event_threat_detection_custom_module_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycentermanagement/samples/generated_samples/securitycentermanagement_v1_generated_security_center_management_create_event_threat_detection_custom_module_sync.py
+++ b/packages/google-cloud-securitycentermanagement/samples/generated_samples/securitycentermanagement_v1_generated_security_center_management_create_event_threat_detection_custom_module_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycentermanagement/samples/generated_samples/securitycentermanagement_v1_generated_security_center_management_create_security_health_analytics_custom_module_async.py
+++ b/packages/google-cloud-securitycentermanagement/samples/generated_samples/securitycentermanagement_v1_generated_security_center_management_create_security_health_analytics_custom_module_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycentermanagement/samples/generated_samples/securitycentermanagement_v1_generated_security_center_management_create_security_health_analytics_custom_module_sync.py
+++ b/packages/google-cloud-securitycentermanagement/samples/generated_samples/securitycentermanagement_v1_generated_security_center_management_create_security_health_analytics_custom_module_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycentermanagement/samples/generated_samples/securitycentermanagement_v1_generated_security_center_management_delete_event_threat_detection_custom_module_async.py
+++ b/packages/google-cloud-securitycentermanagement/samples/generated_samples/securitycentermanagement_v1_generated_security_center_management_delete_event_threat_detection_custom_module_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycentermanagement/samples/generated_samples/securitycentermanagement_v1_generated_security_center_management_delete_event_threat_detection_custom_module_sync.py
+++ b/packages/google-cloud-securitycentermanagement/samples/generated_samples/securitycentermanagement_v1_generated_security_center_management_delete_event_threat_detection_custom_module_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycentermanagement/samples/generated_samples/securitycentermanagement_v1_generated_security_center_management_delete_security_health_analytics_custom_module_async.py
+++ b/packages/google-cloud-securitycentermanagement/samples/generated_samples/securitycentermanagement_v1_generated_security_center_management_delete_security_health_analytics_custom_module_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycentermanagement/samples/generated_samples/securitycentermanagement_v1_generated_security_center_management_delete_security_health_analytics_custom_module_sync.py
+++ b/packages/google-cloud-securitycentermanagement/samples/generated_samples/securitycentermanagement_v1_generated_security_center_management_delete_security_health_analytics_custom_module_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycentermanagement/samples/generated_samples/securitycentermanagement_v1_generated_security_center_management_get_effective_event_threat_detection_custom_module_async.py
+++ b/packages/google-cloud-securitycentermanagement/samples/generated_samples/securitycentermanagement_v1_generated_security_center_management_get_effective_event_threat_detection_custom_module_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycentermanagement/samples/generated_samples/securitycentermanagement_v1_generated_security_center_management_get_effective_event_threat_detection_custom_module_sync.py
+++ b/packages/google-cloud-securitycentermanagement/samples/generated_samples/securitycentermanagement_v1_generated_security_center_management_get_effective_event_threat_detection_custom_module_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycentermanagement/samples/generated_samples/securitycentermanagement_v1_generated_security_center_management_get_effective_security_health_analytics_custom_module_async.py
+++ b/packages/google-cloud-securitycentermanagement/samples/generated_samples/securitycentermanagement_v1_generated_security_center_management_get_effective_security_health_analytics_custom_module_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycentermanagement/samples/generated_samples/securitycentermanagement_v1_generated_security_center_management_get_effective_security_health_analytics_custom_module_sync.py
+++ b/packages/google-cloud-securitycentermanagement/samples/generated_samples/securitycentermanagement_v1_generated_security_center_management_get_effective_security_health_analytics_custom_module_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycentermanagement/samples/generated_samples/securitycentermanagement_v1_generated_security_center_management_get_event_threat_detection_custom_module_async.py
+++ b/packages/google-cloud-securitycentermanagement/samples/generated_samples/securitycentermanagement_v1_generated_security_center_management_get_event_threat_detection_custom_module_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycentermanagement/samples/generated_samples/securitycentermanagement_v1_generated_security_center_management_get_event_threat_detection_custom_module_sync.py
+++ b/packages/google-cloud-securitycentermanagement/samples/generated_samples/securitycentermanagement_v1_generated_security_center_management_get_event_threat_detection_custom_module_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycentermanagement/samples/generated_samples/securitycentermanagement_v1_generated_security_center_management_get_security_center_service_async.py
+++ b/packages/google-cloud-securitycentermanagement/samples/generated_samples/securitycentermanagement_v1_generated_security_center_management_get_security_center_service_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycentermanagement/samples/generated_samples/securitycentermanagement_v1_generated_security_center_management_get_security_center_service_sync.py
+++ b/packages/google-cloud-securitycentermanagement/samples/generated_samples/securitycentermanagement_v1_generated_security_center_management_get_security_center_service_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycentermanagement/samples/generated_samples/securitycentermanagement_v1_generated_security_center_management_get_security_health_analytics_custom_module_async.py
+++ b/packages/google-cloud-securitycentermanagement/samples/generated_samples/securitycentermanagement_v1_generated_security_center_management_get_security_health_analytics_custom_module_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycentermanagement/samples/generated_samples/securitycentermanagement_v1_generated_security_center_management_get_security_health_analytics_custom_module_sync.py
+++ b/packages/google-cloud-securitycentermanagement/samples/generated_samples/securitycentermanagement_v1_generated_security_center_management_get_security_health_analytics_custom_module_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycentermanagement/samples/generated_samples/securitycentermanagement_v1_generated_security_center_management_list_descendant_event_threat_detection_custom_modules_async.py
+++ b/packages/google-cloud-securitycentermanagement/samples/generated_samples/securitycentermanagement_v1_generated_security_center_management_list_descendant_event_threat_detection_custom_modules_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycentermanagement/samples/generated_samples/securitycentermanagement_v1_generated_security_center_management_list_descendant_event_threat_detection_custom_modules_sync.py
+++ b/packages/google-cloud-securitycentermanagement/samples/generated_samples/securitycentermanagement_v1_generated_security_center_management_list_descendant_event_threat_detection_custom_modules_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycentermanagement/samples/generated_samples/securitycentermanagement_v1_generated_security_center_management_list_descendant_security_health_analytics_custom_modules_async.py
+++ b/packages/google-cloud-securitycentermanagement/samples/generated_samples/securitycentermanagement_v1_generated_security_center_management_list_descendant_security_health_analytics_custom_modules_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycentermanagement/samples/generated_samples/securitycentermanagement_v1_generated_security_center_management_list_descendant_security_health_analytics_custom_modules_sync.py
+++ b/packages/google-cloud-securitycentermanagement/samples/generated_samples/securitycentermanagement_v1_generated_security_center_management_list_descendant_security_health_analytics_custom_modules_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycentermanagement/samples/generated_samples/securitycentermanagement_v1_generated_security_center_management_list_effective_event_threat_detection_custom_modules_async.py
+++ b/packages/google-cloud-securitycentermanagement/samples/generated_samples/securitycentermanagement_v1_generated_security_center_management_list_effective_event_threat_detection_custom_modules_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycentermanagement/samples/generated_samples/securitycentermanagement_v1_generated_security_center_management_list_effective_event_threat_detection_custom_modules_sync.py
+++ b/packages/google-cloud-securitycentermanagement/samples/generated_samples/securitycentermanagement_v1_generated_security_center_management_list_effective_event_threat_detection_custom_modules_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycentermanagement/samples/generated_samples/securitycentermanagement_v1_generated_security_center_management_list_effective_security_health_analytics_custom_modules_async.py
+++ b/packages/google-cloud-securitycentermanagement/samples/generated_samples/securitycentermanagement_v1_generated_security_center_management_list_effective_security_health_analytics_custom_modules_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycentermanagement/samples/generated_samples/securitycentermanagement_v1_generated_security_center_management_list_effective_security_health_analytics_custom_modules_sync.py
+++ b/packages/google-cloud-securitycentermanagement/samples/generated_samples/securitycentermanagement_v1_generated_security_center_management_list_effective_security_health_analytics_custom_modules_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycentermanagement/samples/generated_samples/securitycentermanagement_v1_generated_security_center_management_list_event_threat_detection_custom_modules_async.py
+++ b/packages/google-cloud-securitycentermanagement/samples/generated_samples/securitycentermanagement_v1_generated_security_center_management_list_event_threat_detection_custom_modules_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycentermanagement/samples/generated_samples/securitycentermanagement_v1_generated_security_center_management_list_event_threat_detection_custom_modules_sync.py
+++ b/packages/google-cloud-securitycentermanagement/samples/generated_samples/securitycentermanagement_v1_generated_security_center_management_list_event_threat_detection_custom_modules_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycentermanagement/samples/generated_samples/securitycentermanagement_v1_generated_security_center_management_list_security_center_services_async.py
+++ b/packages/google-cloud-securitycentermanagement/samples/generated_samples/securitycentermanagement_v1_generated_security_center_management_list_security_center_services_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycentermanagement/samples/generated_samples/securitycentermanagement_v1_generated_security_center_management_list_security_center_services_sync.py
+++ b/packages/google-cloud-securitycentermanagement/samples/generated_samples/securitycentermanagement_v1_generated_security_center_management_list_security_center_services_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycentermanagement/samples/generated_samples/securitycentermanagement_v1_generated_security_center_management_list_security_health_analytics_custom_modules_async.py
+++ b/packages/google-cloud-securitycentermanagement/samples/generated_samples/securitycentermanagement_v1_generated_security_center_management_list_security_health_analytics_custom_modules_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycentermanagement/samples/generated_samples/securitycentermanagement_v1_generated_security_center_management_list_security_health_analytics_custom_modules_sync.py
+++ b/packages/google-cloud-securitycentermanagement/samples/generated_samples/securitycentermanagement_v1_generated_security_center_management_list_security_health_analytics_custom_modules_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycentermanagement/samples/generated_samples/securitycentermanagement_v1_generated_security_center_management_simulate_security_health_analytics_custom_module_async.py
+++ b/packages/google-cloud-securitycentermanagement/samples/generated_samples/securitycentermanagement_v1_generated_security_center_management_simulate_security_health_analytics_custom_module_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycentermanagement/samples/generated_samples/securitycentermanagement_v1_generated_security_center_management_simulate_security_health_analytics_custom_module_sync.py
+++ b/packages/google-cloud-securitycentermanagement/samples/generated_samples/securitycentermanagement_v1_generated_security_center_management_simulate_security_health_analytics_custom_module_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycentermanagement/samples/generated_samples/securitycentermanagement_v1_generated_security_center_management_update_event_threat_detection_custom_module_async.py
+++ b/packages/google-cloud-securitycentermanagement/samples/generated_samples/securitycentermanagement_v1_generated_security_center_management_update_event_threat_detection_custom_module_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycentermanagement/samples/generated_samples/securitycentermanagement_v1_generated_security_center_management_update_event_threat_detection_custom_module_sync.py
+++ b/packages/google-cloud-securitycentermanagement/samples/generated_samples/securitycentermanagement_v1_generated_security_center_management_update_event_threat_detection_custom_module_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycentermanagement/samples/generated_samples/securitycentermanagement_v1_generated_security_center_management_update_security_center_service_async.py
+++ b/packages/google-cloud-securitycentermanagement/samples/generated_samples/securitycentermanagement_v1_generated_security_center_management_update_security_center_service_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycentermanagement/samples/generated_samples/securitycentermanagement_v1_generated_security_center_management_update_security_center_service_sync.py
+++ b/packages/google-cloud-securitycentermanagement/samples/generated_samples/securitycentermanagement_v1_generated_security_center_management_update_security_center_service_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycentermanagement/samples/generated_samples/securitycentermanagement_v1_generated_security_center_management_update_security_health_analytics_custom_module_async.py
+++ b/packages/google-cloud-securitycentermanagement/samples/generated_samples/securitycentermanagement_v1_generated_security_center_management_update_security_health_analytics_custom_module_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycentermanagement/samples/generated_samples/securitycentermanagement_v1_generated_security_center_management_update_security_health_analytics_custom_module_sync.py
+++ b/packages/google-cloud-securitycentermanagement/samples/generated_samples/securitycentermanagement_v1_generated_security_center_management_update_security_health_analytics_custom_module_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycentermanagement/samples/generated_samples/securitycentermanagement_v1_generated_security_center_management_validate_event_threat_detection_custom_module_async.py
+++ b/packages/google-cloud-securitycentermanagement/samples/generated_samples/securitycentermanagement_v1_generated_security_center_management_validate_event_threat_detection_custom_module_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycentermanagement/samples/generated_samples/securitycentermanagement_v1_generated_security_center_management_validate_event_threat_detection_custom_module_sync.py
+++ b/packages/google-cloud-securitycentermanagement/samples/generated_samples/securitycentermanagement_v1_generated_security_center_management_validate_event_threat_detection_custom_module_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycentermanagement/tests/__init__.py
+++ b/packages/google-cloud-securitycentermanagement/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycentermanagement/tests/unit/__init__.py
+++ b/packages/google-cloud-securitycentermanagement/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycentermanagement/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-securitycentermanagement/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-securitycentermanagement/tests/unit/gapic/securitycentermanagement_v1/__init__.py
+++ b/packages/google-cloud-securitycentermanagement/tests/unit/gapic/securitycentermanagement_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-control/.flake8
+++ b/packages/google-cloud-service-control/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-control/MANIFEST.in
+++ b/packages/google-cloud-service-control/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-control/google/cloud/servicecontrol/__init__.py
+++ b/packages/google-cloud-service-control/google/cloud/servicecontrol/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-control/google/cloud/servicecontrol/gapic_version.py
+++ b/packages/google-cloud-service-control/google/cloud/servicecontrol/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-control/google/cloud/servicecontrol_v1/gapic_version.py
+++ b/packages/google-cloud-service-control/google/cloud/servicecontrol_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-control/google/cloud/servicecontrol_v1/services/__init__.py
+++ b/packages/google-cloud-service-control/google/cloud/servicecontrol_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-control/google/cloud/servicecontrol_v1/services/quota_controller/__init__.py
+++ b/packages/google-cloud-service-control/google/cloud/servicecontrol_v1/services/quota_controller/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-control/google/cloud/servicecontrol_v1/services/quota_controller/async_client.py
+++ b/packages/google-cloud-service-control/google/cloud/servicecontrol_v1/services/quota_controller/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-control/google/cloud/servicecontrol_v1/services/quota_controller/client.py
+++ b/packages/google-cloud-service-control/google/cloud/servicecontrol_v1/services/quota_controller/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-control/google/cloud/servicecontrol_v1/services/quota_controller/transports/__init__.py
+++ b/packages/google-cloud-service-control/google/cloud/servicecontrol_v1/services/quota_controller/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-control/google/cloud/servicecontrol_v1/services/quota_controller/transports/base.py
+++ b/packages/google-cloud-service-control/google/cloud/servicecontrol_v1/services/quota_controller/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-control/google/cloud/servicecontrol_v1/services/quota_controller/transports/grpc.py
+++ b/packages/google-cloud-service-control/google/cloud/servicecontrol_v1/services/quota_controller/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-control/google/cloud/servicecontrol_v1/services/quota_controller/transports/grpc_asyncio.py
+++ b/packages/google-cloud-service-control/google/cloud/servicecontrol_v1/services/quota_controller/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-control/google/cloud/servicecontrol_v1/services/quota_controller/transports/rest.py
+++ b/packages/google-cloud-service-control/google/cloud/servicecontrol_v1/services/quota_controller/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-control/google/cloud/servicecontrol_v1/services/quota_controller/transports/rest_base.py
+++ b/packages/google-cloud-service-control/google/cloud/servicecontrol_v1/services/quota_controller/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-control/google/cloud/servicecontrol_v1/services/service_controller/__init__.py
+++ b/packages/google-cloud-service-control/google/cloud/servicecontrol_v1/services/service_controller/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-control/google/cloud/servicecontrol_v1/services/service_controller/async_client.py
+++ b/packages/google-cloud-service-control/google/cloud/servicecontrol_v1/services/service_controller/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-control/google/cloud/servicecontrol_v1/services/service_controller/client.py
+++ b/packages/google-cloud-service-control/google/cloud/servicecontrol_v1/services/service_controller/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-control/google/cloud/servicecontrol_v1/services/service_controller/transports/__init__.py
+++ b/packages/google-cloud-service-control/google/cloud/servicecontrol_v1/services/service_controller/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-control/google/cloud/servicecontrol_v1/services/service_controller/transports/base.py
+++ b/packages/google-cloud-service-control/google/cloud/servicecontrol_v1/services/service_controller/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-control/google/cloud/servicecontrol_v1/services/service_controller/transports/grpc.py
+++ b/packages/google-cloud-service-control/google/cloud/servicecontrol_v1/services/service_controller/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-control/google/cloud/servicecontrol_v1/services/service_controller/transports/grpc_asyncio.py
+++ b/packages/google-cloud-service-control/google/cloud/servicecontrol_v1/services/service_controller/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-control/google/cloud/servicecontrol_v1/services/service_controller/transports/rest.py
+++ b/packages/google-cloud-service-control/google/cloud/servicecontrol_v1/services/service_controller/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-control/google/cloud/servicecontrol_v1/services/service_controller/transports/rest_base.py
+++ b/packages/google-cloud-service-control/google/cloud/servicecontrol_v1/services/service_controller/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-control/google/cloud/servicecontrol_v1/types/__init__.py
+++ b/packages/google-cloud-service-control/google/cloud/servicecontrol_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-control/google/cloud/servicecontrol_v1/types/check_error.py
+++ b/packages/google-cloud-service-control/google/cloud/servicecontrol_v1/types/check_error.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-control/google/cloud/servicecontrol_v1/types/distribution.py
+++ b/packages/google-cloud-service-control/google/cloud/servicecontrol_v1/types/distribution.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-control/google/cloud/servicecontrol_v1/types/http_request.py
+++ b/packages/google-cloud-service-control/google/cloud/servicecontrol_v1/types/http_request.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-control/google/cloud/servicecontrol_v1/types/log_entry.py
+++ b/packages/google-cloud-service-control/google/cloud/servicecontrol_v1/types/log_entry.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-control/google/cloud/servicecontrol_v1/types/metric_value.py
+++ b/packages/google-cloud-service-control/google/cloud/servicecontrol_v1/types/metric_value.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-control/google/cloud/servicecontrol_v1/types/operation.py
+++ b/packages/google-cloud-service-control/google/cloud/servicecontrol_v1/types/operation.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-control/google/cloud/servicecontrol_v1/types/quota_controller.py
+++ b/packages/google-cloud-service-control/google/cloud/servicecontrol_v1/types/quota_controller.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-control/google/cloud/servicecontrol_v2/gapic_version.py
+++ b/packages/google-cloud-service-control/google/cloud/servicecontrol_v2/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-control/google/cloud/servicecontrol_v2/services/__init__.py
+++ b/packages/google-cloud-service-control/google/cloud/servicecontrol_v2/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-control/google/cloud/servicecontrol_v2/services/service_controller/__init__.py
+++ b/packages/google-cloud-service-control/google/cloud/servicecontrol_v2/services/service_controller/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-control/google/cloud/servicecontrol_v2/services/service_controller/async_client.py
+++ b/packages/google-cloud-service-control/google/cloud/servicecontrol_v2/services/service_controller/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-control/google/cloud/servicecontrol_v2/services/service_controller/client.py
+++ b/packages/google-cloud-service-control/google/cloud/servicecontrol_v2/services/service_controller/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-control/google/cloud/servicecontrol_v2/services/service_controller/transports/__init__.py
+++ b/packages/google-cloud-service-control/google/cloud/servicecontrol_v2/services/service_controller/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-control/google/cloud/servicecontrol_v2/services/service_controller/transports/base.py
+++ b/packages/google-cloud-service-control/google/cloud/servicecontrol_v2/services/service_controller/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-control/google/cloud/servicecontrol_v2/services/service_controller/transports/grpc.py
+++ b/packages/google-cloud-service-control/google/cloud/servicecontrol_v2/services/service_controller/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-control/google/cloud/servicecontrol_v2/services/service_controller/transports/grpc_asyncio.py
+++ b/packages/google-cloud-service-control/google/cloud/servicecontrol_v2/services/service_controller/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-control/google/cloud/servicecontrol_v2/services/service_controller/transports/rest.py
+++ b/packages/google-cloud-service-control/google/cloud/servicecontrol_v2/services/service_controller/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-control/google/cloud/servicecontrol_v2/services/service_controller/transports/rest_base.py
+++ b/packages/google-cloud-service-control/google/cloud/servicecontrol_v2/services/service_controller/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-control/google/cloud/servicecontrol_v2/types/__init__.py
+++ b/packages/google-cloud-service-control/google/cloud/servicecontrol_v2/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-control/google/cloud/servicecontrol_v2/types/service_controller.py
+++ b/packages/google-cloud-service-control/google/cloud/servicecontrol_v2/types/service_controller.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-control/samples/generated_samples/servicecontrol_v1_generated_quota_controller_allocate_quota_async.py
+++ b/packages/google-cloud-service-control/samples/generated_samples/servicecontrol_v1_generated_quota_controller_allocate_quota_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-control/samples/generated_samples/servicecontrol_v1_generated_quota_controller_allocate_quota_sync.py
+++ b/packages/google-cloud-service-control/samples/generated_samples/servicecontrol_v1_generated_quota_controller_allocate_quota_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-control/samples/generated_samples/servicecontrol_v1_generated_service_controller_check_async.py
+++ b/packages/google-cloud-service-control/samples/generated_samples/servicecontrol_v1_generated_service_controller_check_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-control/samples/generated_samples/servicecontrol_v1_generated_service_controller_check_sync.py
+++ b/packages/google-cloud-service-control/samples/generated_samples/servicecontrol_v1_generated_service_controller_check_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-control/samples/generated_samples/servicecontrol_v1_generated_service_controller_report_async.py
+++ b/packages/google-cloud-service-control/samples/generated_samples/servicecontrol_v1_generated_service_controller_report_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-control/samples/generated_samples/servicecontrol_v1_generated_service_controller_report_sync.py
+++ b/packages/google-cloud-service-control/samples/generated_samples/servicecontrol_v1_generated_service_controller_report_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-control/samples/generated_samples/servicecontrol_v2_generated_service_controller_check_async.py
+++ b/packages/google-cloud-service-control/samples/generated_samples/servicecontrol_v2_generated_service_controller_check_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-control/samples/generated_samples/servicecontrol_v2_generated_service_controller_check_sync.py
+++ b/packages/google-cloud-service-control/samples/generated_samples/servicecontrol_v2_generated_service_controller_check_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-control/samples/generated_samples/servicecontrol_v2_generated_service_controller_report_async.py
+++ b/packages/google-cloud-service-control/samples/generated_samples/servicecontrol_v2_generated_service_controller_report_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-control/samples/generated_samples/servicecontrol_v2_generated_service_controller_report_sync.py
+++ b/packages/google-cloud-service-control/samples/generated_samples/servicecontrol_v2_generated_service_controller_report_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-control/tests/__init__.py
+++ b/packages/google-cloud-service-control/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-control/tests/unit/__init__.py
+++ b/packages/google-cloud-service-control/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-control/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-service-control/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-control/tests/unit/gapic/servicecontrol_v1/__init__.py
+++ b/packages/google-cloud-service-control/tests/unit/gapic/servicecontrol_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-control/tests/unit/gapic/servicecontrol_v2/__init__.py
+++ b/packages/google-cloud-service-control/tests/unit/gapic/servicecontrol_v2/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/.flake8
+++ b/packages/google-cloud-service-directory/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/MANIFEST.in
+++ b/packages/google-cloud-service-directory/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/google/cloud/servicedirectory/__init__.py
+++ b/packages/google-cloud-service-directory/google/cloud/servicedirectory/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/google/cloud/servicedirectory/gapic_version.py
+++ b/packages/google-cloud-service-directory/google/cloud/servicedirectory/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/google/cloud/servicedirectory_v1/gapic_version.py
+++ b/packages/google-cloud-service-directory/google/cloud/servicedirectory_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/google/cloud/servicedirectory_v1/services/__init__.py
+++ b/packages/google-cloud-service-directory/google/cloud/servicedirectory_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/google/cloud/servicedirectory_v1/services/lookup_service/__init__.py
+++ b/packages/google-cloud-service-directory/google/cloud/servicedirectory_v1/services/lookup_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/google/cloud/servicedirectory_v1/services/lookup_service/async_client.py
+++ b/packages/google-cloud-service-directory/google/cloud/servicedirectory_v1/services/lookup_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/google/cloud/servicedirectory_v1/services/lookup_service/client.py
+++ b/packages/google-cloud-service-directory/google/cloud/servicedirectory_v1/services/lookup_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/google/cloud/servicedirectory_v1/services/lookup_service/transports/__init__.py
+++ b/packages/google-cloud-service-directory/google/cloud/servicedirectory_v1/services/lookup_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/google/cloud/servicedirectory_v1/services/lookup_service/transports/base.py
+++ b/packages/google-cloud-service-directory/google/cloud/servicedirectory_v1/services/lookup_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/google/cloud/servicedirectory_v1/services/lookup_service/transports/grpc.py
+++ b/packages/google-cloud-service-directory/google/cloud/servicedirectory_v1/services/lookup_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/google/cloud/servicedirectory_v1/services/lookup_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-service-directory/google/cloud/servicedirectory_v1/services/lookup_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/google/cloud/servicedirectory_v1/services/lookup_service/transports/rest.py
+++ b/packages/google-cloud-service-directory/google/cloud/servicedirectory_v1/services/lookup_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/google/cloud/servicedirectory_v1/services/lookup_service/transports/rest_base.py
+++ b/packages/google-cloud-service-directory/google/cloud/servicedirectory_v1/services/lookup_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/google/cloud/servicedirectory_v1/services/registration_service/__init__.py
+++ b/packages/google-cloud-service-directory/google/cloud/servicedirectory_v1/services/registration_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/google/cloud/servicedirectory_v1/services/registration_service/async_client.py
+++ b/packages/google-cloud-service-directory/google/cloud/servicedirectory_v1/services/registration_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/google/cloud/servicedirectory_v1/services/registration_service/client.py
+++ b/packages/google-cloud-service-directory/google/cloud/servicedirectory_v1/services/registration_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/google/cloud/servicedirectory_v1/services/registration_service/pagers.py
+++ b/packages/google-cloud-service-directory/google/cloud/servicedirectory_v1/services/registration_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/google/cloud/servicedirectory_v1/services/registration_service/transports/__init__.py
+++ b/packages/google-cloud-service-directory/google/cloud/servicedirectory_v1/services/registration_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/google/cloud/servicedirectory_v1/services/registration_service/transports/base.py
+++ b/packages/google-cloud-service-directory/google/cloud/servicedirectory_v1/services/registration_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/google/cloud/servicedirectory_v1/services/registration_service/transports/grpc.py
+++ b/packages/google-cloud-service-directory/google/cloud/servicedirectory_v1/services/registration_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/google/cloud/servicedirectory_v1/services/registration_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-service-directory/google/cloud/servicedirectory_v1/services/registration_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/google/cloud/servicedirectory_v1/services/registration_service/transports/rest.py
+++ b/packages/google-cloud-service-directory/google/cloud/servicedirectory_v1/services/registration_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/google/cloud/servicedirectory_v1/services/registration_service/transports/rest_base.py
+++ b/packages/google-cloud-service-directory/google/cloud/servicedirectory_v1/services/registration_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/google/cloud/servicedirectory_v1/types/__init__.py
+++ b/packages/google-cloud-service-directory/google/cloud/servicedirectory_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/google/cloud/servicedirectory_v1/types/endpoint.py
+++ b/packages/google-cloud-service-directory/google/cloud/servicedirectory_v1/types/endpoint.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/google/cloud/servicedirectory_v1/types/lookup_service.py
+++ b/packages/google-cloud-service-directory/google/cloud/servicedirectory_v1/types/lookup_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/google/cloud/servicedirectory_v1/types/namespace.py
+++ b/packages/google-cloud-service-directory/google/cloud/servicedirectory_v1/types/namespace.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/google/cloud/servicedirectory_v1/types/registration_service.py
+++ b/packages/google-cloud-service-directory/google/cloud/servicedirectory_v1/types/registration_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/google/cloud/servicedirectory_v1/types/service.py
+++ b/packages/google-cloud-service-directory/google/cloud/servicedirectory_v1/types/service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/google/cloud/servicedirectory_v1beta1/gapic_version.py
+++ b/packages/google-cloud-service-directory/google/cloud/servicedirectory_v1beta1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/google/cloud/servicedirectory_v1beta1/services/__init__.py
+++ b/packages/google-cloud-service-directory/google/cloud/servicedirectory_v1beta1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/google/cloud/servicedirectory_v1beta1/services/lookup_service/__init__.py
+++ b/packages/google-cloud-service-directory/google/cloud/servicedirectory_v1beta1/services/lookup_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/google/cloud/servicedirectory_v1beta1/services/lookup_service/async_client.py
+++ b/packages/google-cloud-service-directory/google/cloud/servicedirectory_v1beta1/services/lookup_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/google/cloud/servicedirectory_v1beta1/services/lookup_service/client.py
+++ b/packages/google-cloud-service-directory/google/cloud/servicedirectory_v1beta1/services/lookup_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/google/cloud/servicedirectory_v1beta1/services/lookup_service/transports/__init__.py
+++ b/packages/google-cloud-service-directory/google/cloud/servicedirectory_v1beta1/services/lookup_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/google/cloud/servicedirectory_v1beta1/services/lookup_service/transports/base.py
+++ b/packages/google-cloud-service-directory/google/cloud/servicedirectory_v1beta1/services/lookup_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/google/cloud/servicedirectory_v1beta1/services/lookup_service/transports/grpc.py
+++ b/packages/google-cloud-service-directory/google/cloud/servicedirectory_v1beta1/services/lookup_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/google/cloud/servicedirectory_v1beta1/services/lookup_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-service-directory/google/cloud/servicedirectory_v1beta1/services/lookup_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/google/cloud/servicedirectory_v1beta1/services/lookup_service/transports/rest.py
+++ b/packages/google-cloud-service-directory/google/cloud/servicedirectory_v1beta1/services/lookup_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/google/cloud/servicedirectory_v1beta1/services/lookup_service/transports/rest_base.py
+++ b/packages/google-cloud-service-directory/google/cloud/servicedirectory_v1beta1/services/lookup_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/google/cloud/servicedirectory_v1beta1/services/registration_service/__init__.py
+++ b/packages/google-cloud-service-directory/google/cloud/servicedirectory_v1beta1/services/registration_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/google/cloud/servicedirectory_v1beta1/services/registration_service/async_client.py
+++ b/packages/google-cloud-service-directory/google/cloud/servicedirectory_v1beta1/services/registration_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/google/cloud/servicedirectory_v1beta1/services/registration_service/client.py
+++ b/packages/google-cloud-service-directory/google/cloud/servicedirectory_v1beta1/services/registration_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/google/cloud/servicedirectory_v1beta1/services/registration_service/pagers.py
+++ b/packages/google-cloud-service-directory/google/cloud/servicedirectory_v1beta1/services/registration_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/google/cloud/servicedirectory_v1beta1/services/registration_service/transports/__init__.py
+++ b/packages/google-cloud-service-directory/google/cloud/servicedirectory_v1beta1/services/registration_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/google/cloud/servicedirectory_v1beta1/services/registration_service/transports/base.py
+++ b/packages/google-cloud-service-directory/google/cloud/servicedirectory_v1beta1/services/registration_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/google/cloud/servicedirectory_v1beta1/services/registration_service/transports/grpc.py
+++ b/packages/google-cloud-service-directory/google/cloud/servicedirectory_v1beta1/services/registration_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/google/cloud/servicedirectory_v1beta1/services/registration_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-service-directory/google/cloud/servicedirectory_v1beta1/services/registration_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/google/cloud/servicedirectory_v1beta1/services/registration_service/transports/rest.py
+++ b/packages/google-cloud-service-directory/google/cloud/servicedirectory_v1beta1/services/registration_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/google/cloud/servicedirectory_v1beta1/services/registration_service/transports/rest_base.py
+++ b/packages/google-cloud-service-directory/google/cloud/servicedirectory_v1beta1/services/registration_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/google/cloud/servicedirectory_v1beta1/types/__init__.py
+++ b/packages/google-cloud-service-directory/google/cloud/servicedirectory_v1beta1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/google/cloud/servicedirectory_v1beta1/types/endpoint.py
+++ b/packages/google-cloud-service-directory/google/cloud/servicedirectory_v1beta1/types/endpoint.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/google/cloud/servicedirectory_v1beta1/types/lookup_service.py
+++ b/packages/google-cloud-service-directory/google/cloud/servicedirectory_v1beta1/types/lookup_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/google/cloud/servicedirectory_v1beta1/types/namespace.py
+++ b/packages/google-cloud-service-directory/google/cloud/servicedirectory_v1beta1/types/namespace.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/google/cloud/servicedirectory_v1beta1/types/registration_service.py
+++ b/packages/google-cloud-service-directory/google/cloud/servicedirectory_v1beta1/types/registration_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/google/cloud/servicedirectory_v1beta1/types/service.py
+++ b/packages/google-cloud-service-directory/google/cloud/servicedirectory_v1beta1/types/service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1_generated_lookup_service_resolve_service_async.py
+++ b/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1_generated_lookup_service_resolve_service_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1_generated_lookup_service_resolve_service_sync.py
+++ b/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1_generated_lookup_service_resolve_service_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1_generated_registration_service_create_endpoint_async.py
+++ b/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1_generated_registration_service_create_endpoint_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1_generated_registration_service_create_endpoint_sync.py
+++ b/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1_generated_registration_service_create_endpoint_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1_generated_registration_service_create_namespace_async.py
+++ b/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1_generated_registration_service_create_namespace_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1_generated_registration_service_create_namespace_sync.py
+++ b/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1_generated_registration_service_create_namespace_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1_generated_registration_service_create_service_async.py
+++ b/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1_generated_registration_service_create_service_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1_generated_registration_service_create_service_sync.py
+++ b/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1_generated_registration_service_create_service_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1_generated_registration_service_delete_endpoint_async.py
+++ b/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1_generated_registration_service_delete_endpoint_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1_generated_registration_service_delete_endpoint_sync.py
+++ b/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1_generated_registration_service_delete_endpoint_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1_generated_registration_service_delete_namespace_async.py
+++ b/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1_generated_registration_service_delete_namespace_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1_generated_registration_service_delete_namespace_sync.py
+++ b/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1_generated_registration_service_delete_namespace_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1_generated_registration_service_delete_service_async.py
+++ b/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1_generated_registration_service_delete_service_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1_generated_registration_service_delete_service_sync.py
+++ b/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1_generated_registration_service_delete_service_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1_generated_registration_service_get_endpoint_async.py
+++ b/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1_generated_registration_service_get_endpoint_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1_generated_registration_service_get_endpoint_sync.py
+++ b/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1_generated_registration_service_get_endpoint_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1_generated_registration_service_get_iam_policy_async.py
+++ b/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1_generated_registration_service_get_iam_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1_generated_registration_service_get_iam_policy_sync.py
+++ b/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1_generated_registration_service_get_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1_generated_registration_service_get_namespace_async.py
+++ b/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1_generated_registration_service_get_namespace_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1_generated_registration_service_get_namespace_sync.py
+++ b/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1_generated_registration_service_get_namespace_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1_generated_registration_service_get_service_async.py
+++ b/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1_generated_registration_service_get_service_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1_generated_registration_service_get_service_sync.py
+++ b/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1_generated_registration_service_get_service_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1_generated_registration_service_list_endpoints_async.py
+++ b/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1_generated_registration_service_list_endpoints_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1_generated_registration_service_list_endpoints_sync.py
+++ b/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1_generated_registration_service_list_endpoints_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1_generated_registration_service_list_namespaces_async.py
+++ b/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1_generated_registration_service_list_namespaces_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1_generated_registration_service_list_namespaces_sync.py
+++ b/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1_generated_registration_service_list_namespaces_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1_generated_registration_service_list_services_async.py
+++ b/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1_generated_registration_service_list_services_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1_generated_registration_service_list_services_sync.py
+++ b/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1_generated_registration_service_list_services_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1_generated_registration_service_set_iam_policy_async.py
+++ b/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1_generated_registration_service_set_iam_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1_generated_registration_service_set_iam_policy_sync.py
+++ b/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1_generated_registration_service_set_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1_generated_registration_service_test_iam_permissions_async.py
+++ b/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1_generated_registration_service_test_iam_permissions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1_generated_registration_service_test_iam_permissions_sync.py
+++ b/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1_generated_registration_service_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1_generated_registration_service_update_endpoint_async.py
+++ b/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1_generated_registration_service_update_endpoint_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1_generated_registration_service_update_endpoint_sync.py
+++ b/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1_generated_registration_service_update_endpoint_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1_generated_registration_service_update_namespace_async.py
+++ b/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1_generated_registration_service_update_namespace_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1_generated_registration_service_update_namespace_sync.py
+++ b/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1_generated_registration_service_update_namespace_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1_generated_registration_service_update_service_async.py
+++ b/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1_generated_registration_service_update_service_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1_generated_registration_service_update_service_sync.py
+++ b/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1_generated_registration_service_update_service_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1beta1_generated_lookup_service_resolve_service_async.py
+++ b/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1beta1_generated_lookup_service_resolve_service_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1beta1_generated_lookup_service_resolve_service_sync.py
+++ b/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1beta1_generated_lookup_service_resolve_service_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1beta1_generated_registration_service_create_endpoint_async.py
+++ b/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1beta1_generated_registration_service_create_endpoint_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1beta1_generated_registration_service_create_endpoint_sync.py
+++ b/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1beta1_generated_registration_service_create_endpoint_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1beta1_generated_registration_service_create_namespace_async.py
+++ b/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1beta1_generated_registration_service_create_namespace_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1beta1_generated_registration_service_create_namespace_sync.py
+++ b/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1beta1_generated_registration_service_create_namespace_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1beta1_generated_registration_service_create_service_async.py
+++ b/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1beta1_generated_registration_service_create_service_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1beta1_generated_registration_service_create_service_sync.py
+++ b/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1beta1_generated_registration_service_create_service_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1beta1_generated_registration_service_delete_endpoint_async.py
+++ b/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1beta1_generated_registration_service_delete_endpoint_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1beta1_generated_registration_service_delete_endpoint_sync.py
+++ b/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1beta1_generated_registration_service_delete_endpoint_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1beta1_generated_registration_service_delete_namespace_async.py
+++ b/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1beta1_generated_registration_service_delete_namespace_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1beta1_generated_registration_service_delete_namespace_sync.py
+++ b/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1beta1_generated_registration_service_delete_namespace_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1beta1_generated_registration_service_delete_service_async.py
+++ b/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1beta1_generated_registration_service_delete_service_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1beta1_generated_registration_service_delete_service_sync.py
+++ b/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1beta1_generated_registration_service_delete_service_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1beta1_generated_registration_service_get_endpoint_async.py
+++ b/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1beta1_generated_registration_service_get_endpoint_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1beta1_generated_registration_service_get_endpoint_sync.py
+++ b/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1beta1_generated_registration_service_get_endpoint_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1beta1_generated_registration_service_get_iam_policy_async.py
+++ b/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1beta1_generated_registration_service_get_iam_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1beta1_generated_registration_service_get_iam_policy_sync.py
+++ b/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1beta1_generated_registration_service_get_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1beta1_generated_registration_service_get_namespace_async.py
+++ b/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1beta1_generated_registration_service_get_namespace_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1beta1_generated_registration_service_get_namespace_sync.py
+++ b/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1beta1_generated_registration_service_get_namespace_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1beta1_generated_registration_service_get_service_async.py
+++ b/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1beta1_generated_registration_service_get_service_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1beta1_generated_registration_service_get_service_sync.py
+++ b/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1beta1_generated_registration_service_get_service_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1beta1_generated_registration_service_list_endpoints_async.py
+++ b/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1beta1_generated_registration_service_list_endpoints_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1beta1_generated_registration_service_list_endpoints_sync.py
+++ b/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1beta1_generated_registration_service_list_endpoints_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1beta1_generated_registration_service_list_namespaces_async.py
+++ b/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1beta1_generated_registration_service_list_namespaces_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1beta1_generated_registration_service_list_namespaces_sync.py
+++ b/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1beta1_generated_registration_service_list_namespaces_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1beta1_generated_registration_service_list_services_async.py
+++ b/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1beta1_generated_registration_service_list_services_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1beta1_generated_registration_service_list_services_sync.py
+++ b/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1beta1_generated_registration_service_list_services_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1beta1_generated_registration_service_set_iam_policy_async.py
+++ b/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1beta1_generated_registration_service_set_iam_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1beta1_generated_registration_service_set_iam_policy_sync.py
+++ b/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1beta1_generated_registration_service_set_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1beta1_generated_registration_service_test_iam_permissions_async.py
+++ b/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1beta1_generated_registration_service_test_iam_permissions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1beta1_generated_registration_service_test_iam_permissions_sync.py
+++ b/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1beta1_generated_registration_service_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1beta1_generated_registration_service_update_endpoint_async.py
+++ b/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1beta1_generated_registration_service_update_endpoint_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1beta1_generated_registration_service_update_endpoint_sync.py
+++ b/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1beta1_generated_registration_service_update_endpoint_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1beta1_generated_registration_service_update_namespace_async.py
+++ b/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1beta1_generated_registration_service_update_namespace_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1beta1_generated_registration_service_update_namespace_sync.py
+++ b/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1beta1_generated_registration_service_update_namespace_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1beta1_generated_registration_service_update_service_async.py
+++ b/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1beta1_generated_registration_service_update_service_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1beta1_generated_registration_service_update_service_sync.py
+++ b/packages/google-cloud-service-directory/samples/generated_samples/servicedirectory_v1beta1_generated_registration_service_update_service_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/tests/__init__.py
+++ b/packages/google-cloud-service-directory/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/tests/unit/__init__.py
+++ b/packages/google-cloud-service-directory/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-service-directory/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/tests/unit/gapic/servicedirectory_v1/__init__.py
+++ b/packages/google-cloud-service-directory/tests/unit/gapic/servicedirectory_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-directory/tests/unit/gapic/servicedirectory_v1beta1/__init__.py
+++ b/packages/google-cloud-service-directory/tests/unit/gapic/servicedirectory_v1beta1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-management/.flake8
+++ b/packages/google-cloud-service-management/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-management/MANIFEST.in
+++ b/packages/google-cloud-service-management/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-management/google/cloud/servicemanagement/__init__.py
+++ b/packages/google-cloud-service-management/google/cloud/servicemanagement/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-management/google/cloud/servicemanagement/gapic_version.py
+++ b/packages/google-cloud-service-management/google/cloud/servicemanagement/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-management/google/cloud/servicemanagement_v1/gapic_version.py
+++ b/packages/google-cloud-service-management/google/cloud/servicemanagement_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-management/google/cloud/servicemanagement_v1/services/__init__.py
+++ b/packages/google-cloud-service-management/google/cloud/servicemanagement_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-management/google/cloud/servicemanagement_v1/services/service_manager/__init__.py
+++ b/packages/google-cloud-service-management/google/cloud/servicemanagement_v1/services/service_manager/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-management/google/cloud/servicemanagement_v1/services/service_manager/client.py
+++ b/packages/google-cloud-service-management/google/cloud/servicemanagement_v1/services/service_manager/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-management/google/cloud/servicemanagement_v1/services/service_manager/pagers.py
+++ b/packages/google-cloud-service-management/google/cloud/servicemanagement_v1/services/service_manager/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-management/google/cloud/servicemanagement_v1/services/service_manager/transports/__init__.py
+++ b/packages/google-cloud-service-management/google/cloud/servicemanagement_v1/services/service_manager/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-management/google/cloud/servicemanagement_v1/services/service_manager/transports/base.py
+++ b/packages/google-cloud-service-management/google/cloud/servicemanagement_v1/services/service_manager/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-management/google/cloud/servicemanagement_v1/services/service_manager/transports/grpc.py
+++ b/packages/google-cloud-service-management/google/cloud/servicemanagement_v1/services/service_manager/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-management/google/cloud/servicemanagement_v1/services/service_manager/transports/grpc_asyncio.py
+++ b/packages/google-cloud-service-management/google/cloud/servicemanagement_v1/services/service_manager/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-management/google/cloud/servicemanagement_v1/services/service_manager/transports/rest.py
+++ b/packages/google-cloud-service-management/google/cloud/servicemanagement_v1/services/service_manager/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-management/google/cloud/servicemanagement_v1/services/service_manager/transports/rest_base.py
+++ b/packages/google-cloud-service-management/google/cloud/servicemanagement_v1/services/service_manager/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-management/google/cloud/servicemanagement_v1/types/__init__.py
+++ b/packages/google-cloud-service-management/google/cloud/servicemanagement_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-management/google/cloud/servicemanagement_v1/types/resources.py
+++ b/packages/google-cloud-service-management/google/cloud/servicemanagement_v1/types/resources.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-management/google/cloud/servicemanagement_v1/types/servicemanager.py
+++ b/packages/google-cloud-service-management/google/cloud/servicemanagement_v1/types/servicemanager.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-management/samples/generated_samples/servicemanagement_v1_generated_service_manager_create_service_config_async.py
+++ b/packages/google-cloud-service-management/samples/generated_samples/servicemanagement_v1_generated_service_manager_create_service_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-management/samples/generated_samples/servicemanagement_v1_generated_service_manager_create_service_config_sync.py
+++ b/packages/google-cloud-service-management/samples/generated_samples/servicemanagement_v1_generated_service_manager_create_service_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-management/samples/generated_samples/servicemanagement_v1_generated_service_manager_create_service_rollout_sync.py
+++ b/packages/google-cloud-service-management/samples/generated_samples/servicemanagement_v1_generated_service_manager_create_service_rollout_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-management/samples/generated_samples/servicemanagement_v1_generated_service_manager_create_service_sync.py
+++ b/packages/google-cloud-service-management/samples/generated_samples/servicemanagement_v1_generated_service_manager_create_service_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-management/samples/generated_samples/servicemanagement_v1_generated_service_manager_delete_service_sync.py
+++ b/packages/google-cloud-service-management/samples/generated_samples/servicemanagement_v1_generated_service_manager_delete_service_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-management/samples/generated_samples/servicemanagement_v1_generated_service_manager_generate_config_report_async.py
+++ b/packages/google-cloud-service-management/samples/generated_samples/servicemanagement_v1_generated_service_manager_generate_config_report_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-management/samples/generated_samples/servicemanagement_v1_generated_service_manager_generate_config_report_sync.py
+++ b/packages/google-cloud-service-management/samples/generated_samples/servicemanagement_v1_generated_service_manager_generate_config_report_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-management/samples/generated_samples/servicemanagement_v1_generated_service_manager_get_service_async.py
+++ b/packages/google-cloud-service-management/samples/generated_samples/servicemanagement_v1_generated_service_manager_get_service_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-management/samples/generated_samples/servicemanagement_v1_generated_service_manager_get_service_config_async.py
+++ b/packages/google-cloud-service-management/samples/generated_samples/servicemanagement_v1_generated_service_manager_get_service_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-management/samples/generated_samples/servicemanagement_v1_generated_service_manager_get_service_config_sync.py
+++ b/packages/google-cloud-service-management/samples/generated_samples/servicemanagement_v1_generated_service_manager_get_service_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-management/samples/generated_samples/servicemanagement_v1_generated_service_manager_get_service_rollout_async.py
+++ b/packages/google-cloud-service-management/samples/generated_samples/servicemanagement_v1_generated_service_manager_get_service_rollout_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-management/samples/generated_samples/servicemanagement_v1_generated_service_manager_get_service_rollout_sync.py
+++ b/packages/google-cloud-service-management/samples/generated_samples/servicemanagement_v1_generated_service_manager_get_service_rollout_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-management/samples/generated_samples/servicemanagement_v1_generated_service_manager_get_service_sync.py
+++ b/packages/google-cloud-service-management/samples/generated_samples/servicemanagement_v1_generated_service_manager_get_service_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-management/samples/generated_samples/servicemanagement_v1_generated_service_manager_list_service_configs_async.py
+++ b/packages/google-cloud-service-management/samples/generated_samples/servicemanagement_v1_generated_service_manager_list_service_configs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-management/samples/generated_samples/servicemanagement_v1_generated_service_manager_list_service_configs_sync.py
+++ b/packages/google-cloud-service-management/samples/generated_samples/servicemanagement_v1_generated_service_manager_list_service_configs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-management/samples/generated_samples/servicemanagement_v1_generated_service_manager_list_service_rollouts_async.py
+++ b/packages/google-cloud-service-management/samples/generated_samples/servicemanagement_v1_generated_service_manager_list_service_rollouts_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-management/samples/generated_samples/servicemanagement_v1_generated_service_manager_list_service_rollouts_sync.py
+++ b/packages/google-cloud-service-management/samples/generated_samples/servicemanagement_v1_generated_service_manager_list_service_rollouts_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-management/samples/generated_samples/servicemanagement_v1_generated_service_manager_list_services_async.py
+++ b/packages/google-cloud-service-management/samples/generated_samples/servicemanagement_v1_generated_service_manager_list_services_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-management/samples/generated_samples/servicemanagement_v1_generated_service_manager_list_services_sync.py
+++ b/packages/google-cloud-service-management/samples/generated_samples/servicemanagement_v1_generated_service_manager_list_services_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-management/samples/generated_samples/servicemanagement_v1_generated_service_manager_submit_config_source_sync.py
+++ b/packages/google-cloud-service-management/samples/generated_samples/servicemanagement_v1_generated_service_manager_submit_config_source_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-management/samples/generated_samples/servicemanagement_v1_generated_service_manager_undelete_service_sync.py
+++ b/packages/google-cloud-service-management/samples/generated_samples/servicemanagement_v1_generated_service_manager_undelete_service_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-management/tests/__init__.py
+++ b/packages/google-cloud-service-management/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-management/tests/unit/__init__.py
+++ b/packages/google-cloud-service-management/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-management/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-service-management/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-management/tests/unit/gapic/servicemanagement_v1/__init__.py
+++ b/packages/google-cloud-service-management/tests/unit/gapic/servicemanagement_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-usage/.flake8
+++ b/packages/google-cloud-service-usage/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-usage/MANIFEST.in
+++ b/packages/google-cloud-service-usage/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-usage/google/cloud/service_usage/__init__.py
+++ b/packages/google-cloud-service-usage/google/cloud/service_usage/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-usage/google/cloud/service_usage/gapic_version.py
+++ b/packages/google-cloud-service-usage/google/cloud/service_usage/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-usage/google/cloud/service_usage_v1/gapic_version.py
+++ b/packages/google-cloud-service-usage/google/cloud/service_usage_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-usage/google/cloud/service_usage_v1/services/__init__.py
+++ b/packages/google-cloud-service-usage/google/cloud/service_usage_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-usage/google/cloud/service_usage_v1/services/service_usage/__init__.py
+++ b/packages/google-cloud-service-usage/google/cloud/service_usage_v1/services/service_usage/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-usage/google/cloud/service_usage_v1/services/service_usage/client.py
+++ b/packages/google-cloud-service-usage/google/cloud/service_usage_v1/services/service_usage/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-usage/google/cloud/service_usage_v1/services/service_usage/pagers.py
+++ b/packages/google-cloud-service-usage/google/cloud/service_usage_v1/services/service_usage/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-usage/google/cloud/service_usage_v1/services/service_usage/transports/__init__.py
+++ b/packages/google-cloud-service-usage/google/cloud/service_usage_v1/services/service_usage/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-usage/google/cloud/service_usage_v1/services/service_usage/transports/base.py
+++ b/packages/google-cloud-service-usage/google/cloud/service_usage_v1/services/service_usage/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-usage/google/cloud/service_usage_v1/services/service_usage/transports/grpc.py
+++ b/packages/google-cloud-service-usage/google/cloud/service_usage_v1/services/service_usage/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-usage/google/cloud/service_usage_v1/services/service_usage/transports/grpc_asyncio.py
+++ b/packages/google-cloud-service-usage/google/cloud/service_usage_v1/services/service_usage/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-usage/google/cloud/service_usage_v1/services/service_usage/transports/rest.py
+++ b/packages/google-cloud-service-usage/google/cloud/service_usage_v1/services/service_usage/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-usage/google/cloud/service_usage_v1/services/service_usage/transports/rest_base.py
+++ b/packages/google-cloud-service-usage/google/cloud/service_usage_v1/services/service_usage/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-usage/google/cloud/service_usage_v1/types/__init__.py
+++ b/packages/google-cloud-service-usage/google/cloud/service_usage_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-usage/google/cloud/service_usage_v1/types/resources.py
+++ b/packages/google-cloud-service-usage/google/cloud/service_usage_v1/types/resources.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-usage/google/cloud/service_usage_v1/types/serviceusage.py
+++ b/packages/google-cloud-service-usage/google/cloud/service_usage_v1/types/serviceusage.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-usage/samples/generated_samples/serviceusage_v1_generated_service_usage_batch_enable_services_sync.py
+++ b/packages/google-cloud-service-usage/samples/generated_samples/serviceusage_v1_generated_service_usage_batch_enable_services_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-usage/samples/generated_samples/serviceusage_v1_generated_service_usage_batch_get_services_async.py
+++ b/packages/google-cloud-service-usage/samples/generated_samples/serviceusage_v1_generated_service_usage_batch_get_services_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-usage/samples/generated_samples/serviceusage_v1_generated_service_usage_batch_get_services_sync.py
+++ b/packages/google-cloud-service-usage/samples/generated_samples/serviceusage_v1_generated_service_usage_batch_get_services_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-usage/samples/generated_samples/serviceusage_v1_generated_service_usage_disable_service_sync.py
+++ b/packages/google-cloud-service-usage/samples/generated_samples/serviceusage_v1_generated_service_usage_disable_service_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-usage/samples/generated_samples/serviceusage_v1_generated_service_usage_enable_service_sync.py
+++ b/packages/google-cloud-service-usage/samples/generated_samples/serviceusage_v1_generated_service_usage_enable_service_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-usage/samples/generated_samples/serviceusage_v1_generated_service_usage_get_service_async.py
+++ b/packages/google-cloud-service-usage/samples/generated_samples/serviceusage_v1_generated_service_usage_get_service_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-usage/samples/generated_samples/serviceusage_v1_generated_service_usage_get_service_sync.py
+++ b/packages/google-cloud-service-usage/samples/generated_samples/serviceusage_v1_generated_service_usage_get_service_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-usage/samples/generated_samples/serviceusage_v1_generated_service_usage_list_services_async.py
+++ b/packages/google-cloud-service-usage/samples/generated_samples/serviceusage_v1_generated_service_usage_list_services_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-usage/samples/generated_samples/serviceusage_v1_generated_service_usage_list_services_sync.py
+++ b/packages/google-cloud-service-usage/samples/generated_samples/serviceusage_v1_generated_service_usage_list_services_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-usage/tests/__init__.py
+++ b/packages/google-cloud-service-usage/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-usage/tests/unit/__init__.py
+++ b/packages/google-cloud-service-usage/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-usage/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-service-usage/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-service-usage/tests/unit/gapic/service_usage_v1/__init__.py
+++ b/packages/google-cloud-service-usage/tests/unit/gapic/service_usage_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-servicehealth/.flake8
+++ b/packages/google-cloud-servicehealth/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-servicehealth/MANIFEST.in
+++ b/packages/google-cloud-servicehealth/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-servicehealth/google/cloud/servicehealth/__init__.py
+++ b/packages/google-cloud-servicehealth/google/cloud/servicehealth/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-servicehealth/google/cloud/servicehealth/gapic_version.py
+++ b/packages/google-cloud-servicehealth/google/cloud/servicehealth/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-servicehealth/google/cloud/servicehealth_v1/gapic_version.py
+++ b/packages/google-cloud-servicehealth/google/cloud/servicehealth_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-servicehealth/google/cloud/servicehealth_v1/services/__init__.py
+++ b/packages/google-cloud-servicehealth/google/cloud/servicehealth_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-servicehealth/google/cloud/servicehealth_v1/services/service_health/__init__.py
+++ b/packages/google-cloud-servicehealth/google/cloud/servicehealth_v1/services/service_health/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-servicehealth/google/cloud/servicehealth_v1/services/service_health/async_client.py
+++ b/packages/google-cloud-servicehealth/google/cloud/servicehealth_v1/services/service_health/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-servicehealth/google/cloud/servicehealth_v1/services/service_health/client.py
+++ b/packages/google-cloud-servicehealth/google/cloud/servicehealth_v1/services/service_health/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-servicehealth/google/cloud/servicehealth_v1/services/service_health/pagers.py
+++ b/packages/google-cloud-servicehealth/google/cloud/servicehealth_v1/services/service_health/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-servicehealth/google/cloud/servicehealth_v1/services/service_health/transports/__init__.py
+++ b/packages/google-cloud-servicehealth/google/cloud/servicehealth_v1/services/service_health/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-servicehealth/google/cloud/servicehealth_v1/services/service_health/transports/base.py
+++ b/packages/google-cloud-servicehealth/google/cloud/servicehealth_v1/services/service_health/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-servicehealth/google/cloud/servicehealth_v1/services/service_health/transports/grpc.py
+++ b/packages/google-cloud-servicehealth/google/cloud/servicehealth_v1/services/service_health/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-servicehealth/google/cloud/servicehealth_v1/services/service_health/transports/grpc_asyncio.py
+++ b/packages/google-cloud-servicehealth/google/cloud/servicehealth_v1/services/service_health/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-servicehealth/google/cloud/servicehealth_v1/services/service_health/transports/rest.py
+++ b/packages/google-cloud-servicehealth/google/cloud/servicehealth_v1/services/service_health/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-servicehealth/google/cloud/servicehealth_v1/services/service_health/transports/rest_base.py
+++ b/packages/google-cloud-servicehealth/google/cloud/servicehealth_v1/services/service_health/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-servicehealth/google/cloud/servicehealth_v1/types/__init__.py
+++ b/packages/google-cloud-servicehealth/google/cloud/servicehealth_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-servicehealth/google/cloud/servicehealth_v1/types/event_resources.py
+++ b/packages/google-cloud-servicehealth/google/cloud/servicehealth_v1/types/event_resources.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-servicehealth/google/cloud/servicehealth_v1/types/event_service.py
+++ b/packages/google-cloud-servicehealth/google/cloud/servicehealth_v1/types/event_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-servicehealth/samples/generated_samples/servicehealth_v1_generated_service_health_get_event_async.py
+++ b/packages/google-cloud-servicehealth/samples/generated_samples/servicehealth_v1_generated_service_health_get_event_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-servicehealth/samples/generated_samples/servicehealth_v1_generated_service_health_get_event_sync.py
+++ b/packages/google-cloud-servicehealth/samples/generated_samples/servicehealth_v1_generated_service_health_get_event_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-servicehealth/samples/generated_samples/servicehealth_v1_generated_service_health_get_organization_event_async.py
+++ b/packages/google-cloud-servicehealth/samples/generated_samples/servicehealth_v1_generated_service_health_get_organization_event_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-servicehealth/samples/generated_samples/servicehealth_v1_generated_service_health_get_organization_event_sync.py
+++ b/packages/google-cloud-servicehealth/samples/generated_samples/servicehealth_v1_generated_service_health_get_organization_event_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-servicehealth/samples/generated_samples/servicehealth_v1_generated_service_health_get_organization_impact_async.py
+++ b/packages/google-cloud-servicehealth/samples/generated_samples/servicehealth_v1_generated_service_health_get_organization_impact_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-servicehealth/samples/generated_samples/servicehealth_v1_generated_service_health_get_organization_impact_sync.py
+++ b/packages/google-cloud-servicehealth/samples/generated_samples/servicehealth_v1_generated_service_health_get_organization_impact_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-servicehealth/samples/generated_samples/servicehealth_v1_generated_service_health_list_events_async.py
+++ b/packages/google-cloud-servicehealth/samples/generated_samples/servicehealth_v1_generated_service_health_list_events_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-servicehealth/samples/generated_samples/servicehealth_v1_generated_service_health_list_events_sync.py
+++ b/packages/google-cloud-servicehealth/samples/generated_samples/servicehealth_v1_generated_service_health_list_events_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-servicehealth/samples/generated_samples/servicehealth_v1_generated_service_health_list_organization_events_async.py
+++ b/packages/google-cloud-servicehealth/samples/generated_samples/servicehealth_v1_generated_service_health_list_organization_events_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-servicehealth/samples/generated_samples/servicehealth_v1_generated_service_health_list_organization_events_sync.py
+++ b/packages/google-cloud-servicehealth/samples/generated_samples/servicehealth_v1_generated_service_health_list_organization_events_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-servicehealth/samples/generated_samples/servicehealth_v1_generated_service_health_list_organization_impacts_async.py
+++ b/packages/google-cloud-servicehealth/samples/generated_samples/servicehealth_v1_generated_service_health_list_organization_impacts_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-servicehealth/samples/generated_samples/servicehealth_v1_generated_service_health_list_organization_impacts_sync.py
+++ b/packages/google-cloud-servicehealth/samples/generated_samples/servicehealth_v1_generated_service_health_list_organization_impacts_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-servicehealth/tests/__init__.py
+++ b/packages/google-cloud-servicehealth/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-servicehealth/tests/unit/__init__.py
+++ b/packages/google-cloud-servicehealth/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-servicehealth/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-servicehealth/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-servicehealth/tests/unit/gapic/servicehealth_v1/__init__.py
+++ b/packages/google-cloud-servicehealth/tests/unit/gapic/servicehealth_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-shell/.flake8
+++ b/packages/google-cloud-shell/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-shell/MANIFEST.in
+++ b/packages/google-cloud-shell/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-shell/google/cloud/shell/__init__.py
+++ b/packages/google-cloud-shell/google/cloud/shell/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-shell/google/cloud/shell/gapic_version.py
+++ b/packages/google-cloud-shell/google/cloud/shell/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-shell/google/cloud/shell_v1/gapic_version.py
+++ b/packages/google-cloud-shell/google/cloud/shell_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-shell/google/cloud/shell_v1/services/__init__.py
+++ b/packages/google-cloud-shell/google/cloud/shell_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-shell/google/cloud/shell_v1/services/cloud_shell_service/__init__.py
+++ b/packages/google-cloud-shell/google/cloud/shell_v1/services/cloud_shell_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-shell/google/cloud/shell_v1/services/cloud_shell_service/client.py
+++ b/packages/google-cloud-shell/google/cloud/shell_v1/services/cloud_shell_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-shell/google/cloud/shell_v1/services/cloud_shell_service/transports/__init__.py
+++ b/packages/google-cloud-shell/google/cloud/shell_v1/services/cloud_shell_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-shell/google/cloud/shell_v1/services/cloud_shell_service/transports/base.py
+++ b/packages/google-cloud-shell/google/cloud/shell_v1/services/cloud_shell_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-shell/google/cloud/shell_v1/services/cloud_shell_service/transports/grpc.py
+++ b/packages/google-cloud-shell/google/cloud/shell_v1/services/cloud_shell_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-shell/google/cloud/shell_v1/services/cloud_shell_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-shell/google/cloud/shell_v1/services/cloud_shell_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-shell/google/cloud/shell_v1/services/cloud_shell_service/transports/rest.py
+++ b/packages/google-cloud-shell/google/cloud/shell_v1/services/cloud_shell_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-shell/google/cloud/shell_v1/services/cloud_shell_service/transports/rest_base.py
+++ b/packages/google-cloud-shell/google/cloud/shell_v1/services/cloud_shell_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-shell/google/cloud/shell_v1/types/__init__.py
+++ b/packages/google-cloud-shell/google/cloud/shell_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-shell/google/cloud/shell_v1/types/cloudshell.py
+++ b/packages/google-cloud-shell/google/cloud/shell_v1/types/cloudshell.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-shell/samples/generated_samples/cloudshell_v1_generated_cloud_shell_service_add_public_key_sync.py
+++ b/packages/google-cloud-shell/samples/generated_samples/cloudshell_v1_generated_cloud_shell_service_add_public_key_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-shell/samples/generated_samples/cloudshell_v1_generated_cloud_shell_service_authorize_environment_sync.py
+++ b/packages/google-cloud-shell/samples/generated_samples/cloudshell_v1_generated_cloud_shell_service_authorize_environment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-shell/samples/generated_samples/cloudshell_v1_generated_cloud_shell_service_get_environment_async.py
+++ b/packages/google-cloud-shell/samples/generated_samples/cloudshell_v1_generated_cloud_shell_service_get_environment_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-shell/samples/generated_samples/cloudshell_v1_generated_cloud_shell_service_get_environment_sync.py
+++ b/packages/google-cloud-shell/samples/generated_samples/cloudshell_v1_generated_cloud_shell_service_get_environment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-shell/samples/generated_samples/cloudshell_v1_generated_cloud_shell_service_remove_public_key_sync.py
+++ b/packages/google-cloud-shell/samples/generated_samples/cloudshell_v1_generated_cloud_shell_service_remove_public_key_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-shell/samples/generated_samples/cloudshell_v1_generated_cloud_shell_service_start_environment_sync.py
+++ b/packages/google-cloud-shell/samples/generated_samples/cloudshell_v1_generated_cloud_shell_service_start_environment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-shell/tests/__init__.py
+++ b/packages/google-cloud-shell/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-shell/tests/unit/__init__.py
+++ b/packages/google-cloud-shell/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-shell/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-shell/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-shell/tests/unit/gapic/shell_v1/__init__.py
+++ b/packages/google-cloud-shell/tests/unit/gapic/shell_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-source-context/.flake8
+++ b/packages/google-cloud-source-context/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-source-context/MANIFEST.in
+++ b/packages/google-cloud-source-context/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-source-context/google/cloud/source_context/__init__.py
+++ b/packages/google-cloud-source-context/google/cloud/source_context/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-source-context/google/cloud/source_context/gapic_version.py
+++ b/packages/google-cloud-source-context/google/cloud/source_context/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-source-context/google/cloud/source_context_v1/gapic_version.py
+++ b/packages/google-cloud-source-context/google/cloud/source_context_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-source-context/google/cloud/source_context_v1/services/__init__.py
+++ b/packages/google-cloud-source-context/google/cloud/source_context_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-source-context/google/cloud/source_context_v1/types/__init__.py
+++ b/packages/google-cloud-source-context/google/cloud/source_context_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-source-context/google/cloud/source_context_v1/types/source_context.py
+++ b/packages/google-cloud-source-context/google/cloud/source_context_v1/types/source_context.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-source-context/tests/__init__.py
+++ b/packages/google-cloud-source-context/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-source-context/tests/unit/__init__.py
+++ b/packages/google-cloud-source-context/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-source-context/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-source-context/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-source-context/tests/unit/gapic/source_context_v1/__init__.py
+++ b/packages/google-cloud-source-context/tests/unit/gapic/source_context_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/.flake8
+++ b/packages/google-cloud-spanner/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/MANIFEST.in
+++ b/packages/google-cloud-spanner/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/google/cloud/spanner/__init__.py
+++ b/packages/google-cloud-spanner/google/cloud/spanner/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/google/cloud/spanner/gapic_version.py
+++ b/packages/google-cloud-spanner/google/cloud/spanner/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/google/cloud/spanner_admin_database/__init__.py
+++ b/packages/google-cloud-spanner/google/cloud/spanner_admin_database/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/google/cloud/spanner_admin_database/gapic_version.py
+++ b/packages/google-cloud-spanner/google/cloud/spanner_admin_database/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/google/cloud/spanner_admin_database_v1/gapic_version.py
+++ b/packages/google-cloud-spanner/google/cloud/spanner_admin_database_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/google/cloud/spanner_admin_database_v1/services/__init__.py
+++ b/packages/google-cloud-spanner/google/cloud/spanner_admin_database_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/google/cloud/spanner_admin_database_v1/services/database_admin/__init__.py
+++ b/packages/google-cloud-spanner/google/cloud/spanner_admin_database_v1/services/database_admin/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/google/cloud/spanner_admin_database_v1/services/database_admin/client.py
+++ b/packages/google-cloud-spanner/google/cloud/spanner_admin_database_v1/services/database_admin/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/google/cloud/spanner_admin_database_v1/services/database_admin/pagers.py
+++ b/packages/google-cloud-spanner/google/cloud/spanner_admin_database_v1/services/database_admin/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/google/cloud/spanner_admin_database_v1/services/database_admin/transports/__init__.py
+++ b/packages/google-cloud-spanner/google/cloud/spanner_admin_database_v1/services/database_admin/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/google/cloud/spanner_admin_database_v1/services/database_admin/transports/base.py
+++ b/packages/google-cloud-spanner/google/cloud/spanner_admin_database_v1/services/database_admin/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/google/cloud/spanner_admin_database_v1/services/database_admin/transports/grpc.py
+++ b/packages/google-cloud-spanner/google/cloud/spanner_admin_database_v1/services/database_admin/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/google/cloud/spanner_admin_database_v1/services/database_admin/transports/grpc_asyncio.py
+++ b/packages/google-cloud-spanner/google/cloud/spanner_admin_database_v1/services/database_admin/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/google/cloud/spanner_admin_database_v1/services/database_admin/transports/rest.py
+++ b/packages/google-cloud-spanner/google/cloud/spanner_admin_database_v1/services/database_admin/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/google/cloud/spanner_admin_database_v1/services/database_admin/transports/rest_base.py
+++ b/packages/google-cloud-spanner/google/cloud/spanner_admin_database_v1/services/database_admin/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/google/cloud/spanner_admin_database_v1/types/__init__.py
+++ b/packages/google-cloud-spanner/google/cloud/spanner_admin_database_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/google/cloud/spanner_admin_database_v1/types/backup.py
+++ b/packages/google-cloud-spanner/google/cloud/spanner_admin_database_v1/types/backup.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/google/cloud/spanner_admin_database_v1/types/backup_schedule.py
+++ b/packages/google-cloud-spanner/google/cloud/spanner_admin_database_v1/types/backup_schedule.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/google/cloud/spanner_admin_database_v1/types/common.py
+++ b/packages/google-cloud-spanner/google/cloud/spanner_admin_database_v1/types/common.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/google/cloud/spanner_admin_database_v1/types/spanner_database_admin.py
+++ b/packages/google-cloud-spanner/google/cloud/spanner_admin_database_v1/types/spanner_database_admin.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/google/cloud/spanner_admin_instance/__init__.py
+++ b/packages/google-cloud-spanner/google/cloud/spanner_admin_instance/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/google/cloud/spanner_admin_instance/gapic_version.py
+++ b/packages/google-cloud-spanner/google/cloud/spanner_admin_instance/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/google/cloud/spanner_admin_instance_v1/gapic_version.py
+++ b/packages/google-cloud-spanner/google/cloud/spanner_admin_instance_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/google/cloud/spanner_admin_instance_v1/services/__init__.py
+++ b/packages/google-cloud-spanner/google/cloud/spanner_admin_instance_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/google/cloud/spanner_admin_instance_v1/services/instance_admin/__init__.py
+++ b/packages/google-cloud-spanner/google/cloud/spanner_admin_instance_v1/services/instance_admin/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/google/cloud/spanner_admin_instance_v1/services/instance_admin/client.py
+++ b/packages/google-cloud-spanner/google/cloud/spanner_admin_instance_v1/services/instance_admin/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/google/cloud/spanner_admin_instance_v1/services/instance_admin/pagers.py
+++ b/packages/google-cloud-spanner/google/cloud/spanner_admin_instance_v1/services/instance_admin/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/google/cloud/spanner_admin_instance_v1/services/instance_admin/transports/__init__.py
+++ b/packages/google-cloud-spanner/google/cloud/spanner_admin_instance_v1/services/instance_admin/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/google/cloud/spanner_admin_instance_v1/services/instance_admin/transports/base.py
+++ b/packages/google-cloud-spanner/google/cloud/spanner_admin_instance_v1/services/instance_admin/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/google/cloud/spanner_admin_instance_v1/services/instance_admin/transports/grpc.py
+++ b/packages/google-cloud-spanner/google/cloud/spanner_admin_instance_v1/services/instance_admin/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/google/cloud/spanner_admin_instance_v1/services/instance_admin/transports/grpc_asyncio.py
+++ b/packages/google-cloud-spanner/google/cloud/spanner_admin_instance_v1/services/instance_admin/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/google/cloud/spanner_admin_instance_v1/services/instance_admin/transports/rest.py
+++ b/packages/google-cloud-spanner/google/cloud/spanner_admin_instance_v1/services/instance_admin/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/google/cloud/spanner_admin_instance_v1/services/instance_admin/transports/rest_base.py
+++ b/packages/google-cloud-spanner/google/cloud/spanner_admin_instance_v1/services/instance_admin/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/google/cloud/spanner_admin_instance_v1/types/__init__.py
+++ b/packages/google-cloud-spanner/google/cloud/spanner_admin_instance_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/google/cloud/spanner_admin_instance_v1/types/common.py
+++ b/packages/google-cloud-spanner/google/cloud/spanner_admin_instance_v1/types/common.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/google/cloud/spanner_admin_instance_v1/types/spanner_instance_admin.py
+++ b/packages/google-cloud-spanner/google/cloud/spanner_admin_instance_v1/types/spanner_instance_admin.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/google/cloud/spanner_v1/__init__.py
+++ b/packages/google-cloud-spanner/google/cloud/spanner_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/google/cloud/spanner_v1/gapic_version.py
+++ b/packages/google-cloud-spanner/google/cloud/spanner_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/google/cloud/spanner_v1/services/__init__.py
+++ b/packages/google-cloud-spanner/google/cloud/spanner_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/google/cloud/spanner_v1/services/spanner/__init__.py
+++ b/packages/google-cloud-spanner/google/cloud/spanner_v1/services/spanner/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/google/cloud/spanner_v1/services/spanner/async_client.py
+++ b/packages/google-cloud-spanner/google/cloud/spanner_v1/services/spanner/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/google/cloud/spanner_v1/services/spanner/client.py
+++ b/packages/google-cloud-spanner/google/cloud/spanner_v1/services/spanner/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/google/cloud/spanner_v1/services/spanner/pagers.py
+++ b/packages/google-cloud-spanner/google/cloud/spanner_v1/services/spanner/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/google/cloud/spanner_v1/services/spanner/transports/__init__.py
+++ b/packages/google-cloud-spanner/google/cloud/spanner_v1/services/spanner/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/google/cloud/spanner_v1/services/spanner/transports/base.py
+++ b/packages/google-cloud-spanner/google/cloud/spanner_v1/services/spanner/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/google/cloud/spanner_v1/services/spanner/transports/grpc.py
+++ b/packages/google-cloud-spanner/google/cloud/spanner_v1/services/spanner/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/google/cloud/spanner_v1/services/spanner/transports/grpc_asyncio.py
+++ b/packages/google-cloud-spanner/google/cloud/spanner_v1/services/spanner/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/google/cloud/spanner_v1/services/spanner/transports/rest.py
+++ b/packages/google-cloud-spanner/google/cloud/spanner_v1/services/spanner/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/google/cloud/spanner_v1/services/spanner/transports/rest_base.py
+++ b/packages/google-cloud-spanner/google/cloud/spanner_v1/services/spanner/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/google/cloud/spanner_v1/types/__init__.py
+++ b/packages/google-cloud-spanner/google/cloud/spanner_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/google/cloud/spanner_v1/types/change_stream.py
+++ b/packages/google-cloud-spanner/google/cloud/spanner_v1/types/change_stream.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/google/cloud/spanner_v1/types/commit_response.py
+++ b/packages/google-cloud-spanner/google/cloud/spanner_v1/types/commit_response.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/google/cloud/spanner_v1/types/keys.py
+++ b/packages/google-cloud-spanner/google/cloud/spanner_v1/types/keys.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/google/cloud/spanner_v1/types/location.py
+++ b/packages/google-cloud-spanner/google/cloud/spanner_v1/types/location.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/google/cloud/spanner_v1/types/mutation.py
+++ b/packages/google-cloud-spanner/google/cloud/spanner_v1/types/mutation.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/google/cloud/spanner_v1/types/query_plan.py
+++ b/packages/google-cloud-spanner/google/cloud/spanner_v1/types/query_plan.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/google/cloud/spanner_v1/types/result_set.py
+++ b/packages/google-cloud-spanner/google/cloud/spanner_v1/types/result_set.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/google/cloud/spanner_v1/types/spanner.py
+++ b/packages/google-cloud-spanner/google/cloud/spanner_v1/types/spanner.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/google/cloud/spanner_v1/types/transaction.py
+++ b/packages/google-cloud-spanner/google/cloud/spanner_v1/types/transaction.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/google/cloud/spanner_v1/types/type.py
+++ b/packages/google-cloud-spanner/google/cloud/spanner_v1/types/type.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_add_split_points_async.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_add_split_points_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_add_split_points_sync.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_add_split_points_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_copy_backup_sync.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_copy_backup_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_create_backup_schedule_async.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_create_backup_schedule_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_create_backup_schedule_sync.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_create_backup_schedule_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_create_backup_sync.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_create_backup_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_create_database_sync.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_create_database_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_delete_backup_async.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_delete_backup_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_delete_backup_schedule_async.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_delete_backup_schedule_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_delete_backup_schedule_sync.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_delete_backup_schedule_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_delete_backup_sync.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_delete_backup_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_drop_database_async.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_drop_database_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_drop_database_sync.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_drop_database_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_get_backup_async.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_get_backup_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_get_backup_schedule_async.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_get_backup_schedule_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_get_backup_schedule_sync.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_get_backup_schedule_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_get_backup_sync.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_get_backup_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_get_database_async.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_get_database_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_get_database_ddl_async.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_get_database_ddl_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_get_database_ddl_sync.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_get_database_ddl_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_get_database_sync.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_get_database_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_get_iam_policy_async.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_get_iam_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_get_iam_policy_sync.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_get_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_internal_update_graph_operation_async.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_internal_update_graph_operation_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_internal_update_graph_operation_sync.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_internal_update_graph_operation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_list_backup_operations_async.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_list_backup_operations_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_list_backup_operations_sync.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_list_backup_operations_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_list_backup_schedules_async.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_list_backup_schedules_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_list_backup_schedules_sync.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_list_backup_schedules_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_list_backups_async.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_list_backups_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_list_backups_sync.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_list_backups_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_list_database_operations_async.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_list_database_operations_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_list_database_operations_sync.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_list_database_operations_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_list_database_roles_async.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_list_database_roles_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_list_database_roles_sync.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_list_database_roles_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_list_databases_async.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_list_databases_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_list_databases_sync.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_list_databases_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_restore_database_sync.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_restore_database_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_set_iam_policy_async.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_set_iam_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_set_iam_policy_sync.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_set_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_test_iam_permissions_async.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_test_iam_permissions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_test_iam_permissions_sync.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_update_backup_async.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_update_backup_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_update_backup_schedule_async.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_update_backup_schedule_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_update_backup_schedule_sync.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_update_backup_schedule_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_update_backup_sync.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_update_backup_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_update_database_ddl_sync.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_update_database_ddl_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_update_database_sync.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_database_admin_update_database_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_instance_admin_create_instance_config_sync.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_instance_admin_create_instance_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_instance_admin_create_instance_partition_sync.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_instance_admin_create_instance_partition_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_instance_admin_create_instance_sync.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_instance_admin_create_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_instance_admin_delete_instance_async.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_instance_admin_delete_instance_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_instance_admin_delete_instance_config_async.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_instance_admin_delete_instance_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_instance_admin_delete_instance_config_sync.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_instance_admin_delete_instance_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_instance_admin_delete_instance_partition_async.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_instance_admin_delete_instance_partition_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_instance_admin_delete_instance_partition_sync.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_instance_admin_delete_instance_partition_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_instance_admin_delete_instance_sync.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_instance_admin_delete_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_instance_admin_get_iam_policy_async.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_instance_admin_get_iam_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_instance_admin_get_iam_policy_sync.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_instance_admin_get_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_instance_admin_get_instance_async.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_instance_admin_get_instance_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_instance_admin_get_instance_config_async.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_instance_admin_get_instance_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_instance_admin_get_instance_config_sync.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_instance_admin_get_instance_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_instance_admin_get_instance_partition_async.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_instance_admin_get_instance_partition_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_instance_admin_get_instance_partition_sync.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_instance_admin_get_instance_partition_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_instance_admin_get_instance_sync.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_instance_admin_get_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_instance_admin_list_instance_config_operations_async.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_instance_admin_list_instance_config_operations_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_instance_admin_list_instance_config_operations_sync.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_instance_admin_list_instance_config_operations_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_instance_admin_list_instance_configs_async.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_instance_admin_list_instance_configs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_instance_admin_list_instance_configs_sync.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_instance_admin_list_instance_configs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_instance_admin_list_instance_partition_operations_async.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_instance_admin_list_instance_partition_operations_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_instance_admin_list_instance_partition_operations_sync.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_instance_admin_list_instance_partition_operations_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_instance_admin_list_instance_partitions_async.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_instance_admin_list_instance_partitions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_instance_admin_list_instance_partitions_sync.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_instance_admin_list_instance_partitions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_instance_admin_list_instances_async.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_instance_admin_list_instances_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_instance_admin_list_instances_sync.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_instance_admin_list_instances_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_instance_admin_move_instance_sync.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_instance_admin_move_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_instance_admin_set_iam_policy_async.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_instance_admin_set_iam_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_instance_admin_set_iam_policy_sync.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_instance_admin_set_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_instance_admin_test_iam_permissions_async.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_instance_admin_test_iam_permissions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_instance_admin_test_iam_permissions_sync.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_instance_admin_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_instance_admin_update_instance_config_sync.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_instance_admin_update_instance_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_instance_admin_update_instance_partition_sync.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_instance_admin_update_instance_partition_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_instance_admin_update_instance_sync.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_instance_admin_update_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_spanner_batch_create_sessions_async.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_spanner_batch_create_sessions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_spanner_batch_create_sessions_sync.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_spanner_batch_create_sessions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_spanner_batch_write_async.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_spanner_batch_write_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_spanner_batch_write_sync.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_spanner_batch_write_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_spanner_begin_transaction_async.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_spanner_begin_transaction_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_spanner_begin_transaction_sync.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_spanner_begin_transaction_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_spanner_commit_async.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_spanner_commit_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_spanner_commit_sync.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_spanner_commit_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_spanner_create_session_async.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_spanner_create_session_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_spanner_create_session_sync.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_spanner_create_session_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_spanner_delete_session_async.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_spanner_delete_session_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_spanner_delete_session_sync.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_spanner_delete_session_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_spanner_execute_batch_dml_async.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_spanner_execute_batch_dml_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_spanner_execute_batch_dml_sync.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_spanner_execute_batch_dml_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_spanner_execute_sql_async.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_spanner_execute_sql_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_spanner_execute_sql_sync.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_spanner_execute_sql_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_spanner_execute_streaming_sql_async.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_spanner_execute_streaming_sql_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_spanner_execute_streaming_sql_sync.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_spanner_execute_streaming_sql_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_spanner_fetch_cache_update_async.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_spanner_fetch_cache_update_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_spanner_fetch_cache_update_sync.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_spanner_fetch_cache_update_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_spanner_get_session_async.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_spanner_get_session_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_spanner_get_session_sync.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_spanner_get_session_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_spanner_list_sessions_async.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_spanner_list_sessions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_spanner_list_sessions_sync.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_spanner_list_sessions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_spanner_partition_query_async.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_spanner_partition_query_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_spanner_partition_query_sync.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_spanner_partition_query_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_spanner_partition_read_async.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_spanner_partition_read_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_spanner_partition_read_sync.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_spanner_partition_read_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_spanner_read_async.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_spanner_read_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_spanner_read_sync.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_spanner_read_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_spanner_rollback_async.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_spanner_rollback_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_spanner_rollback_sync.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_spanner_rollback_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_spanner_streaming_read_async.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_spanner_streaming_read_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_spanner_streaming_read_sync.py
+++ b/packages/google-cloud-spanner/samples/generated_samples/spanner_v1_generated_spanner_streaming_read_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/tests/__init__.py
+++ b/packages/google-cloud-spanner/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/tests/unit/__init__.py
+++ b/packages/google-cloud-spanner/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-spanner/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/tests/unit/gapic/spanner_admin_database_v1/__init__.py
+++ b/packages/google-cloud-spanner/tests/unit/gapic/spanner_admin_database_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/tests/unit/gapic/spanner_admin_instance_v1/__init__.py
+++ b/packages/google-cloud-spanner/tests/unit/gapic/spanner_admin_instance_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-spanner/tests/unit/gapic/spanner_v1/__init__.py
+++ b/packages/google-cloud-spanner/tests/unit/gapic/spanner_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/.flake8
+++ b/packages/google-cloud-speech/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/MANIFEST.in
+++ b/packages/google-cloud-speech/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/google/cloud/speech/__init__.py
+++ b/packages/google-cloud-speech/google/cloud/speech/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/google/cloud/speech/gapic_version.py
+++ b/packages/google-cloud-speech/google/cloud/speech/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/google/cloud/speech_v1/gapic_version.py
+++ b/packages/google-cloud-speech/google/cloud/speech_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/google/cloud/speech_v1/services/__init__.py
+++ b/packages/google-cloud-speech/google/cloud/speech_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/google/cloud/speech_v1/services/adaptation/__init__.py
+++ b/packages/google-cloud-speech/google/cloud/speech_v1/services/adaptation/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/google/cloud/speech_v1/services/adaptation/async_client.py
+++ b/packages/google-cloud-speech/google/cloud/speech_v1/services/adaptation/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/google/cloud/speech_v1/services/adaptation/client.py
+++ b/packages/google-cloud-speech/google/cloud/speech_v1/services/adaptation/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/google/cloud/speech_v1/services/adaptation/pagers.py
+++ b/packages/google-cloud-speech/google/cloud/speech_v1/services/adaptation/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/google/cloud/speech_v1/services/adaptation/transports/__init__.py
+++ b/packages/google-cloud-speech/google/cloud/speech_v1/services/adaptation/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/google/cloud/speech_v1/services/adaptation/transports/base.py
+++ b/packages/google-cloud-speech/google/cloud/speech_v1/services/adaptation/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/google/cloud/speech_v1/services/adaptation/transports/grpc.py
+++ b/packages/google-cloud-speech/google/cloud/speech_v1/services/adaptation/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/google/cloud/speech_v1/services/adaptation/transports/grpc_asyncio.py
+++ b/packages/google-cloud-speech/google/cloud/speech_v1/services/adaptation/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/google/cloud/speech_v1/services/adaptation/transports/rest.py
+++ b/packages/google-cloud-speech/google/cloud/speech_v1/services/adaptation/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/google/cloud/speech_v1/services/adaptation/transports/rest_base.py
+++ b/packages/google-cloud-speech/google/cloud/speech_v1/services/adaptation/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/google/cloud/speech_v1/services/speech/__init__.py
+++ b/packages/google-cloud-speech/google/cloud/speech_v1/services/speech/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/google/cloud/speech_v1/services/speech/client.py
+++ b/packages/google-cloud-speech/google/cloud/speech_v1/services/speech/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/google/cloud/speech_v1/services/speech/transports/__init__.py
+++ b/packages/google-cloud-speech/google/cloud/speech_v1/services/speech/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/google/cloud/speech_v1/services/speech/transports/base.py
+++ b/packages/google-cloud-speech/google/cloud/speech_v1/services/speech/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/google/cloud/speech_v1/services/speech/transports/grpc.py
+++ b/packages/google-cloud-speech/google/cloud/speech_v1/services/speech/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/google/cloud/speech_v1/services/speech/transports/grpc_asyncio.py
+++ b/packages/google-cloud-speech/google/cloud/speech_v1/services/speech/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/google/cloud/speech_v1/services/speech/transports/rest.py
+++ b/packages/google-cloud-speech/google/cloud/speech_v1/services/speech/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/google/cloud/speech_v1/services/speech/transports/rest_base.py
+++ b/packages/google-cloud-speech/google/cloud/speech_v1/services/speech/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/google/cloud/speech_v1/types/__init__.py
+++ b/packages/google-cloud-speech/google/cloud/speech_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/google/cloud/speech_v1/types/cloud_speech.py
+++ b/packages/google-cloud-speech/google/cloud/speech_v1/types/cloud_speech.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/google/cloud/speech_v1/types/cloud_speech_adaptation.py
+++ b/packages/google-cloud-speech/google/cloud/speech_v1/types/cloud_speech_adaptation.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/google/cloud/speech_v1/types/resource.py
+++ b/packages/google-cloud-speech/google/cloud/speech_v1/types/resource.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/google/cloud/speech_v1p1beta1/gapic_version.py
+++ b/packages/google-cloud-speech/google/cloud/speech_v1p1beta1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/google/cloud/speech_v1p1beta1/services/__init__.py
+++ b/packages/google-cloud-speech/google/cloud/speech_v1p1beta1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/google/cloud/speech_v1p1beta1/services/adaptation/__init__.py
+++ b/packages/google-cloud-speech/google/cloud/speech_v1p1beta1/services/adaptation/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/google/cloud/speech_v1p1beta1/services/adaptation/async_client.py
+++ b/packages/google-cloud-speech/google/cloud/speech_v1p1beta1/services/adaptation/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/google/cloud/speech_v1p1beta1/services/adaptation/client.py
+++ b/packages/google-cloud-speech/google/cloud/speech_v1p1beta1/services/adaptation/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/google/cloud/speech_v1p1beta1/services/adaptation/pagers.py
+++ b/packages/google-cloud-speech/google/cloud/speech_v1p1beta1/services/adaptation/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/google/cloud/speech_v1p1beta1/services/adaptation/transports/__init__.py
+++ b/packages/google-cloud-speech/google/cloud/speech_v1p1beta1/services/adaptation/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/google/cloud/speech_v1p1beta1/services/adaptation/transports/base.py
+++ b/packages/google-cloud-speech/google/cloud/speech_v1p1beta1/services/adaptation/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/google/cloud/speech_v1p1beta1/services/adaptation/transports/grpc.py
+++ b/packages/google-cloud-speech/google/cloud/speech_v1p1beta1/services/adaptation/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/google/cloud/speech_v1p1beta1/services/adaptation/transports/grpc_asyncio.py
+++ b/packages/google-cloud-speech/google/cloud/speech_v1p1beta1/services/adaptation/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/google/cloud/speech_v1p1beta1/services/adaptation/transports/rest.py
+++ b/packages/google-cloud-speech/google/cloud/speech_v1p1beta1/services/adaptation/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/google/cloud/speech_v1p1beta1/services/adaptation/transports/rest_base.py
+++ b/packages/google-cloud-speech/google/cloud/speech_v1p1beta1/services/adaptation/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/google/cloud/speech_v1p1beta1/services/speech/__init__.py
+++ b/packages/google-cloud-speech/google/cloud/speech_v1p1beta1/services/speech/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/google/cloud/speech_v1p1beta1/services/speech/client.py
+++ b/packages/google-cloud-speech/google/cloud/speech_v1p1beta1/services/speech/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/google/cloud/speech_v1p1beta1/services/speech/transports/__init__.py
+++ b/packages/google-cloud-speech/google/cloud/speech_v1p1beta1/services/speech/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/google/cloud/speech_v1p1beta1/services/speech/transports/base.py
+++ b/packages/google-cloud-speech/google/cloud/speech_v1p1beta1/services/speech/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/google/cloud/speech_v1p1beta1/services/speech/transports/grpc.py
+++ b/packages/google-cloud-speech/google/cloud/speech_v1p1beta1/services/speech/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/google/cloud/speech_v1p1beta1/services/speech/transports/grpc_asyncio.py
+++ b/packages/google-cloud-speech/google/cloud/speech_v1p1beta1/services/speech/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/google/cloud/speech_v1p1beta1/services/speech/transports/rest.py
+++ b/packages/google-cloud-speech/google/cloud/speech_v1p1beta1/services/speech/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/google/cloud/speech_v1p1beta1/services/speech/transports/rest_base.py
+++ b/packages/google-cloud-speech/google/cloud/speech_v1p1beta1/services/speech/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/google/cloud/speech_v1p1beta1/types/__init__.py
+++ b/packages/google-cloud-speech/google/cloud/speech_v1p1beta1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/google/cloud/speech_v1p1beta1/types/cloud_speech.py
+++ b/packages/google-cloud-speech/google/cloud/speech_v1p1beta1/types/cloud_speech.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/google/cloud/speech_v1p1beta1/types/cloud_speech_adaptation.py
+++ b/packages/google-cloud-speech/google/cloud/speech_v1p1beta1/types/cloud_speech_adaptation.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/google/cloud/speech_v1p1beta1/types/resource.py
+++ b/packages/google-cloud-speech/google/cloud/speech_v1p1beta1/types/resource.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/google/cloud/speech_v2/gapic_version.py
+++ b/packages/google-cloud-speech/google/cloud/speech_v2/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/google/cloud/speech_v2/services/__init__.py
+++ b/packages/google-cloud-speech/google/cloud/speech_v2/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/google/cloud/speech_v2/services/speech/__init__.py
+++ b/packages/google-cloud-speech/google/cloud/speech_v2/services/speech/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/google/cloud/speech_v2/services/speech/client.py
+++ b/packages/google-cloud-speech/google/cloud/speech_v2/services/speech/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/google/cloud/speech_v2/services/speech/pagers.py
+++ b/packages/google-cloud-speech/google/cloud/speech_v2/services/speech/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/google/cloud/speech_v2/services/speech/transports/__init__.py
+++ b/packages/google-cloud-speech/google/cloud/speech_v2/services/speech/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/google/cloud/speech_v2/services/speech/transports/base.py
+++ b/packages/google-cloud-speech/google/cloud/speech_v2/services/speech/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/google/cloud/speech_v2/services/speech/transports/grpc.py
+++ b/packages/google-cloud-speech/google/cloud/speech_v2/services/speech/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/google/cloud/speech_v2/services/speech/transports/grpc_asyncio.py
+++ b/packages/google-cloud-speech/google/cloud/speech_v2/services/speech/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/google/cloud/speech_v2/services/speech/transports/rest.py
+++ b/packages/google-cloud-speech/google/cloud/speech_v2/services/speech/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/google/cloud/speech_v2/services/speech/transports/rest_base.py
+++ b/packages/google-cloud-speech/google/cloud/speech_v2/services/speech/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/google/cloud/speech_v2/types/__init__.py
+++ b/packages/google-cloud-speech/google/cloud/speech_v2/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/google/cloud/speech_v2/types/cloud_speech.py
+++ b/packages/google-cloud-speech/google/cloud/speech_v2/types/cloud_speech.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/google/cloud/speech_v2/types/locations_metadata.py
+++ b/packages/google-cloud-speech/google/cloud/speech_v2/types/locations_metadata.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/samples/generated_samples/speech_v1_generated_adaptation_create_custom_class_async.py
+++ b/packages/google-cloud-speech/samples/generated_samples/speech_v1_generated_adaptation_create_custom_class_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/samples/generated_samples/speech_v1_generated_adaptation_create_custom_class_sync.py
+++ b/packages/google-cloud-speech/samples/generated_samples/speech_v1_generated_adaptation_create_custom_class_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/samples/generated_samples/speech_v1_generated_adaptation_create_phrase_set_async.py
+++ b/packages/google-cloud-speech/samples/generated_samples/speech_v1_generated_adaptation_create_phrase_set_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/samples/generated_samples/speech_v1_generated_adaptation_create_phrase_set_sync.py
+++ b/packages/google-cloud-speech/samples/generated_samples/speech_v1_generated_adaptation_create_phrase_set_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/samples/generated_samples/speech_v1_generated_adaptation_delete_custom_class_async.py
+++ b/packages/google-cloud-speech/samples/generated_samples/speech_v1_generated_adaptation_delete_custom_class_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/samples/generated_samples/speech_v1_generated_adaptation_delete_custom_class_sync.py
+++ b/packages/google-cloud-speech/samples/generated_samples/speech_v1_generated_adaptation_delete_custom_class_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/samples/generated_samples/speech_v1_generated_adaptation_delete_phrase_set_async.py
+++ b/packages/google-cloud-speech/samples/generated_samples/speech_v1_generated_adaptation_delete_phrase_set_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/samples/generated_samples/speech_v1_generated_adaptation_delete_phrase_set_sync.py
+++ b/packages/google-cloud-speech/samples/generated_samples/speech_v1_generated_adaptation_delete_phrase_set_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/samples/generated_samples/speech_v1_generated_adaptation_get_custom_class_async.py
+++ b/packages/google-cloud-speech/samples/generated_samples/speech_v1_generated_adaptation_get_custom_class_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/samples/generated_samples/speech_v1_generated_adaptation_get_custom_class_sync.py
+++ b/packages/google-cloud-speech/samples/generated_samples/speech_v1_generated_adaptation_get_custom_class_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/samples/generated_samples/speech_v1_generated_adaptation_get_phrase_set_async.py
+++ b/packages/google-cloud-speech/samples/generated_samples/speech_v1_generated_adaptation_get_phrase_set_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/samples/generated_samples/speech_v1_generated_adaptation_get_phrase_set_sync.py
+++ b/packages/google-cloud-speech/samples/generated_samples/speech_v1_generated_adaptation_get_phrase_set_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/samples/generated_samples/speech_v1_generated_adaptation_list_custom_classes_async.py
+++ b/packages/google-cloud-speech/samples/generated_samples/speech_v1_generated_adaptation_list_custom_classes_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/samples/generated_samples/speech_v1_generated_adaptation_list_custom_classes_sync.py
+++ b/packages/google-cloud-speech/samples/generated_samples/speech_v1_generated_adaptation_list_custom_classes_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/samples/generated_samples/speech_v1_generated_adaptation_list_phrase_set_async.py
+++ b/packages/google-cloud-speech/samples/generated_samples/speech_v1_generated_adaptation_list_phrase_set_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/samples/generated_samples/speech_v1_generated_adaptation_list_phrase_set_sync.py
+++ b/packages/google-cloud-speech/samples/generated_samples/speech_v1_generated_adaptation_list_phrase_set_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/samples/generated_samples/speech_v1_generated_adaptation_update_custom_class_async.py
+++ b/packages/google-cloud-speech/samples/generated_samples/speech_v1_generated_adaptation_update_custom_class_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/samples/generated_samples/speech_v1_generated_adaptation_update_custom_class_sync.py
+++ b/packages/google-cloud-speech/samples/generated_samples/speech_v1_generated_adaptation_update_custom_class_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/samples/generated_samples/speech_v1_generated_adaptation_update_phrase_set_async.py
+++ b/packages/google-cloud-speech/samples/generated_samples/speech_v1_generated_adaptation_update_phrase_set_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/samples/generated_samples/speech_v1_generated_adaptation_update_phrase_set_sync.py
+++ b/packages/google-cloud-speech/samples/generated_samples/speech_v1_generated_adaptation_update_phrase_set_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/samples/generated_samples/speech_v1_generated_speech_long_running_recognize_sync.py
+++ b/packages/google-cloud-speech/samples/generated_samples/speech_v1_generated_speech_long_running_recognize_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/samples/generated_samples/speech_v1_generated_speech_recognize_async.py
+++ b/packages/google-cloud-speech/samples/generated_samples/speech_v1_generated_speech_recognize_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/samples/generated_samples/speech_v1_generated_speech_recognize_sync.py
+++ b/packages/google-cloud-speech/samples/generated_samples/speech_v1_generated_speech_recognize_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/samples/generated_samples/speech_v1_generated_speech_streaming_recognize_async.py
+++ b/packages/google-cloud-speech/samples/generated_samples/speech_v1_generated_speech_streaming_recognize_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/samples/generated_samples/speech_v1_generated_speech_streaming_recognize_sync.py
+++ b/packages/google-cloud-speech/samples/generated_samples/speech_v1_generated_speech_streaming_recognize_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/samples/generated_samples/speech_v1p1beta1_generated_adaptation_create_custom_class_async.py
+++ b/packages/google-cloud-speech/samples/generated_samples/speech_v1p1beta1_generated_adaptation_create_custom_class_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/samples/generated_samples/speech_v1p1beta1_generated_adaptation_create_custom_class_sync.py
+++ b/packages/google-cloud-speech/samples/generated_samples/speech_v1p1beta1_generated_adaptation_create_custom_class_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/samples/generated_samples/speech_v1p1beta1_generated_adaptation_create_phrase_set_async.py
+++ b/packages/google-cloud-speech/samples/generated_samples/speech_v1p1beta1_generated_adaptation_create_phrase_set_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/samples/generated_samples/speech_v1p1beta1_generated_adaptation_create_phrase_set_sync.py
+++ b/packages/google-cloud-speech/samples/generated_samples/speech_v1p1beta1_generated_adaptation_create_phrase_set_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/samples/generated_samples/speech_v1p1beta1_generated_adaptation_delete_custom_class_async.py
+++ b/packages/google-cloud-speech/samples/generated_samples/speech_v1p1beta1_generated_adaptation_delete_custom_class_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/samples/generated_samples/speech_v1p1beta1_generated_adaptation_delete_custom_class_sync.py
+++ b/packages/google-cloud-speech/samples/generated_samples/speech_v1p1beta1_generated_adaptation_delete_custom_class_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/samples/generated_samples/speech_v1p1beta1_generated_adaptation_delete_phrase_set_async.py
+++ b/packages/google-cloud-speech/samples/generated_samples/speech_v1p1beta1_generated_adaptation_delete_phrase_set_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/samples/generated_samples/speech_v1p1beta1_generated_adaptation_delete_phrase_set_sync.py
+++ b/packages/google-cloud-speech/samples/generated_samples/speech_v1p1beta1_generated_adaptation_delete_phrase_set_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/samples/generated_samples/speech_v1p1beta1_generated_adaptation_get_custom_class_async.py
+++ b/packages/google-cloud-speech/samples/generated_samples/speech_v1p1beta1_generated_adaptation_get_custom_class_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/samples/generated_samples/speech_v1p1beta1_generated_adaptation_get_custom_class_sync.py
+++ b/packages/google-cloud-speech/samples/generated_samples/speech_v1p1beta1_generated_adaptation_get_custom_class_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/samples/generated_samples/speech_v1p1beta1_generated_adaptation_get_phrase_set_async.py
+++ b/packages/google-cloud-speech/samples/generated_samples/speech_v1p1beta1_generated_adaptation_get_phrase_set_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/samples/generated_samples/speech_v1p1beta1_generated_adaptation_get_phrase_set_sync.py
+++ b/packages/google-cloud-speech/samples/generated_samples/speech_v1p1beta1_generated_adaptation_get_phrase_set_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/samples/generated_samples/speech_v1p1beta1_generated_adaptation_list_custom_classes_async.py
+++ b/packages/google-cloud-speech/samples/generated_samples/speech_v1p1beta1_generated_adaptation_list_custom_classes_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/samples/generated_samples/speech_v1p1beta1_generated_adaptation_list_custom_classes_sync.py
+++ b/packages/google-cloud-speech/samples/generated_samples/speech_v1p1beta1_generated_adaptation_list_custom_classes_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/samples/generated_samples/speech_v1p1beta1_generated_adaptation_list_phrase_set_async.py
+++ b/packages/google-cloud-speech/samples/generated_samples/speech_v1p1beta1_generated_adaptation_list_phrase_set_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/samples/generated_samples/speech_v1p1beta1_generated_adaptation_list_phrase_set_sync.py
+++ b/packages/google-cloud-speech/samples/generated_samples/speech_v1p1beta1_generated_adaptation_list_phrase_set_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/samples/generated_samples/speech_v1p1beta1_generated_adaptation_update_custom_class_async.py
+++ b/packages/google-cloud-speech/samples/generated_samples/speech_v1p1beta1_generated_adaptation_update_custom_class_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/samples/generated_samples/speech_v1p1beta1_generated_adaptation_update_custom_class_sync.py
+++ b/packages/google-cloud-speech/samples/generated_samples/speech_v1p1beta1_generated_adaptation_update_custom_class_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/samples/generated_samples/speech_v1p1beta1_generated_adaptation_update_phrase_set_async.py
+++ b/packages/google-cloud-speech/samples/generated_samples/speech_v1p1beta1_generated_adaptation_update_phrase_set_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/samples/generated_samples/speech_v1p1beta1_generated_adaptation_update_phrase_set_sync.py
+++ b/packages/google-cloud-speech/samples/generated_samples/speech_v1p1beta1_generated_adaptation_update_phrase_set_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/samples/generated_samples/speech_v1p1beta1_generated_speech_long_running_recognize_sync.py
+++ b/packages/google-cloud-speech/samples/generated_samples/speech_v1p1beta1_generated_speech_long_running_recognize_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/samples/generated_samples/speech_v1p1beta1_generated_speech_recognize_async.py
+++ b/packages/google-cloud-speech/samples/generated_samples/speech_v1p1beta1_generated_speech_recognize_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/samples/generated_samples/speech_v1p1beta1_generated_speech_recognize_sync.py
+++ b/packages/google-cloud-speech/samples/generated_samples/speech_v1p1beta1_generated_speech_recognize_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/samples/generated_samples/speech_v1p1beta1_generated_speech_streaming_recognize_async.py
+++ b/packages/google-cloud-speech/samples/generated_samples/speech_v1p1beta1_generated_speech_streaming_recognize_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/samples/generated_samples/speech_v1p1beta1_generated_speech_streaming_recognize_sync.py
+++ b/packages/google-cloud-speech/samples/generated_samples/speech_v1p1beta1_generated_speech_streaming_recognize_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/samples/generated_samples/speech_v2_generated_speech_batch_recognize_sync.py
+++ b/packages/google-cloud-speech/samples/generated_samples/speech_v2_generated_speech_batch_recognize_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/samples/generated_samples/speech_v2_generated_speech_create_custom_class_sync.py
+++ b/packages/google-cloud-speech/samples/generated_samples/speech_v2_generated_speech_create_custom_class_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/samples/generated_samples/speech_v2_generated_speech_create_phrase_set_sync.py
+++ b/packages/google-cloud-speech/samples/generated_samples/speech_v2_generated_speech_create_phrase_set_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/samples/generated_samples/speech_v2_generated_speech_create_recognizer_sync.py
+++ b/packages/google-cloud-speech/samples/generated_samples/speech_v2_generated_speech_create_recognizer_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/samples/generated_samples/speech_v2_generated_speech_delete_custom_class_sync.py
+++ b/packages/google-cloud-speech/samples/generated_samples/speech_v2_generated_speech_delete_custom_class_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/samples/generated_samples/speech_v2_generated_speech_delete_phrase_set_sync.py
+++ b/packages/google-cloud-speech/samples/generated_samples/speech_v2_generated_speech_delete_phrase_set_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/samples/generated_samples/speech_v2_generated_speech_delete_recognizer_sync.py
+++ b/packages/google-cloud-speech/samples/generated_samples/speech_v2_generated_speech_delete_recognizer_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/samples/generated_samples/speech_v2_generated_speech_get_config_async.py
+++ b/packages/google-cloud-speech/samples/generated_samples/speech_v2_generated_speech_get_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/samples/generated_samples/speech_v2_generated_speech_get_config_sync.py
+++ b/packages/google-cloud-speech/samples/generated_samples/speech_v2_generated_speech_get_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/samples/generated_samples/speech_v2_generated_speech_get_custom_class_async.py
+++ b/packages/google-cloud-speech/samples/generated_samples/speech_v2_generated_speech_get_custom_class_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/samples/generated_samples/speech_v2_generated_speech_get_custom_class_sync.py
+++ b/packages/google-cloud-speech/samples/generated_samples/speech_v2_generated_speech_get_custom_class_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/samples/generated_samples/speech_v2_generated_speech_get_phrase_set_async.py
+++ b/packages/google-cloud-speech/samples/generated_samples/speech_v2_generated_speech_get_phrase_set_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/samples/generated_samples/speech_v2_generated_speech_get_phrase_set_sync.py
+++ b/packages/google-cloud-speech/samples/generated_samples/speech_v2_generated_speech_get_phrase_set_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/samples/generated_samples/speech_v2_generated_speech_get_recognizer_async.py
+++ b/packages/google-cloud-speech/samples/generated_samples/speech_v2_generated_speech_get_recognizer_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/samples/generated_samples/speech_v2_generated_speech_get_recognizer_sync.py
+++ b/packages/google-cloud-speech/samples/generated_samples/speech_v2_generated_speech_get_recognizer_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/samples/generated_samples/speech_v2_generated_speech_list_custom_classes_async.py
+++ b/packages/google-cloud-speech/samples/generated_samples/speech_v2_generated_speech_list_custom_classes_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/samples/generated_samples/speech_v2_generated_speech_list_custom_classes_sync.py
+++ b/packages/google-cloud-speech/samples/generated_samples/speech_v2_generated_speech_list_custom_classes_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/samples/generated_samples/speech_v2_generated_speech_list_phrase_sets_async.py
+++ b/packages/google-cloud-speech/samples/generated_samples/speech_v2_generated_speech_list_phrase_sets_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/samples/generated_samples/speech_v2_generated_speech_list_phrase_sets_sync.py
+++ b/packages/google-cloud-speech/samples/generated_samples/speech_v2_generated_speech_list_phrase_sets_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/samples/generated_samples/speech_v2_generated_speech_list_recognizers_async.py
+++ b/packages/google-cloud-speech/samples/generated_samples/speech_v2_generated_speech_list_recognizers_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/samples/generated_samples/speech_v2_generated_speech_list_recognizers_sync.py
+++ b/packages/google-cloud-speech/samples/generated_samples/speech_v2_generated_speech_list_recognizers_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/samples/generated_samples/speech_v2_generated_speech_recognize_async.py
+++ b/packages/google-cloud-speech/samples/generated_samples/speech_v2_generated_speech_recognize_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/samples/generated_samples/speech_v2_generated_speech_recognize_sync.py
+++ b/packages/google-cloud-speech/samples/generated_samples/speech_v2_generated_speech_recognize_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/samples/generated_samples/speech_v2_generated_speech_streaming_recognize_async.py
+++ b/packages/google-cloud-speech/samples/generated_samples/speech_v2_generated_speech_streaming_recognize_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/samples/generated_samples/speech_v2_generated_speech_streaming_recognize_sync.py
+++ b/packages/google-cloud-speech/samples/generated_samples/speech_v2_generated_speech_streaming_recognize_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/samples/generated_samples/speech_v2_generated_speech_undelete_custom_class_sync.py
+++ b/packages/google-cloud-speech/samples/generated_samples/speech_v2_generated_speech_undelete_custom_class_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/samples/generated_samples/speech_v2_generated_speech_undelete_phrase_set_sync.py
+++ b/packages/google-cloud-speech/samples/generated_samples/speech_v2_generated_speech_undelete_phrase_set_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/samples/generated_samples/speech_v2_generated_speech_undelete_recognizer_sync.py
+++ b/packages/google-cloud-speech/samples/generated_samples/speech_v2_generated_speech_undelete_recognizer_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/samples/generated_samples/speech_v2_generated_speech_update_config_async.py
+++ b/packages/google-cloud-speech/samples/generated_samples/speech_v2_generated_speech_update_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/samples/generated_samples/speech_v2_generated_speech_update_config_sync.py
+++ b/packages/google-cloud-speech/samples/generated_samples/speech_v2_generated_speech_update_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/samples/generated_samples/speech_v2_generated_speech_update_custom_class_sync.py
+++ b/packages/google-cloud-speech/samples/generated_samples/speech_v2_generated_speech_update_custom_class_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/samples/generated_samples/speech_v2_generated_speech_update_phrase_set_sync.py
+++ b/packages/google-cloud-speech/samples/generated_samples/speech_v2_generated_speech_update_phrase_set_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/samples/generated_samples/speech_v2_generated_speech_update_recognizer_sync.py
+++ b/packages/google-cloud-speech/samples/generated_samples/speech_v2_generated_speech_update_recognizer_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/tests/__init__.py
+++ b/packages/google-cloud-speech/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/tests/unit/__init__.py
+++ b/packages/google-cloud-speech/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-speech/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/tests/unit/gapic/speech_v1/__init__.py
+++ b/packages/google-cloud-speech/tests/unit/gapic/speech_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/tests/unit/gapic/speech_v1p1beta1/__init__.py
+++ b/packages/google-cloud-speech/tests/unit/gapic/speech_v1p1beta1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-speech/tests/unit/gapic/speech_v2/__init__.py
+++ b/packages/google-cloud-speech/tests/unit/gapic/speech_v2/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage-control/.flake8
+++ b/packages/google-cloud-storage-control/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage-control/MANIFEST.in
+++ b/packages/google-cloud-storage-control/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage-control/google/cloud/storage_control/__init__.py
+++ b/packages/google-cloud-storage-control/google/cloud/storage_control/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage-control/google/cloud/storage_control/gapic_version.py
+++ b/packages/google-cloud-storage-control/google/cloud/storage_control/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage-control/google/cloud/storage_control_v2/gapic_version.py
+++ b/packages/google-cloud-storage-control/google/cloud/storage_control_v2/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage-control/google/cloud/storage_control_v2/services/__init__.py
+++ b/packages/google-cloud-storage-control/google/cloud/storage_control_v2/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage-control/google/cloud/storage_control_v2/services/storage_control/__init__.py
+++ b/packages/google-cloud-storage-control/google/cloud/storage_control_v2/services/storage_control/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage-control/google/cloud/storage_control_v2/services/storage_control/client.py
+++ b/packages/google-cloud-storage-control/google/cloud/storage_control_v2/services/storage_control/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage-control/google/cloud/storage_control_v2/services/storage_control/pagers.py
+++ b/packages/google-cloud-storage-control/google/cloud/storage_control_v2/services/storage_control/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage-control/google/cloud/storage_control_v2/services/storage_control/transports/__init__.py
+++ b/packages/google-cloud-storage-control/google/cloud/storage_control_v2/services/storage_control/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage-control/google/cloud/storage_control_v2/services/storage_control/transports/base.py
+++ b/packages/google-cloud-storage-control/google/cloud/storage_control_v2/services/storage_control/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage-control/google/cloud/storage_control_v2/services/storage_control/transports/grpc.py
+++ b/packages/google-cloud-storage-control/google/cloud/storage_control_v2/services/storage_control/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage-control/google/cloud/storage_control_v2/services/storage_control/transports/grpc_asyncio.py
+++ b/packages/google-cloud-storage-control/google/cloud/storage_control_v2/services/storage_control/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage-control/google/cloud/storage_control_v2/services/storage_control/transports/rest.py
+++ b/packages/google-cloud-storage-control/google/cloud/storage_control_v2/services/storage_control/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage-control/google/cloud/storage_control_v2/services/storage_control/transports/rest_base.py
+++ b/packages/google-cloud-storage-control/google/cloud/storage_control_v2/services/storage_control/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage-control/google/cloud/storage_control_v2/types/__init__.py
+++ b/packages/google-cloud-storage-control/google/cloud/storage_control_v2/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage-control/google/cloud/storage_control_v2/types/storage_control.py
+++ b/packages/google-cloud-storage-control/google/cloud/storage_control_v2/types/storage_control.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage-control/samples/generated_samples/storage_v2_generated_storage_control_create_anywhere_cache_sync.py
+++ b/packages/google-cloud-storage-control/samples/generated_samples/storage_v2_generated_storage_control_create_anywhere_cache_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage-control/samples/generated_samples/storage_v2_generated_storage_control_create_folder_async.py
+++ b/packages/google-cloud-storage-control/samples/generated_samples/storage_v2_generated_storage_control_create_folder_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage-control/samples/generated_samples/storage_v2_generated_storage_control_create_folder_sync.py
+++ b/packages/google-cloud-storage-control/samples/generated_samples/storage_v2_generated_storage_control_create_folder_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage-control/samples/generated_samples/storage_v2_generated_storage_control_create_managed_folder_async.py
+++ b/packages/google-cloud-storage-control/samples/generated_samples/storage_v2_generated_storage_control_create_managed_folder_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage-control/samples/generated_samples/storage_v2_generated_storage_control_create_managed_folder_sync.py
+++ b/packages/google-cloud-storage-control/samples/generated_samples/storage_v2_generated_storage_control_create_managed_folder_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage-control/samples/generated_samples/storage_v2_generated_storage_control_delete_folder_async.py
+++ b/packages/google-cloud-storage-control/samples/generated_samples/storage_v2_generated_storage_control_delete_folder_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage-control/samples/generated_samples/storage_v2_generated_storage_control_delete_folder_recursive_sync.py
+++ b/packages/google-cloud-storage-control/samples/generated_samples/storage_v2_generated_storage_control_delete_folder_recursive_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage-control/samples/generated_samples/storage_v2_generated_storage_control_delete_folder_sync.py
+++ b/packages/google-cloud-storage-control/samples/generated_samples/storage_v2_generated_storage_control_delete_folder_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage-control/samples/generated_samples/storage_v2_generated_storage_control_delete_managed_folder_async.py
+++ b/packages/google-cloud-storage-control/samples/generated_samples/storage_v2_generated_storage_control_delete_managed_folder_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage-control/samples/generated_samples/storage_v2_generated_storage_control_delete_managed_folder_sync.py
+++ b/packages/google-cloud-storage-control/samples/generated_samples/storage_v2_generated_storage_control_delete_managed_folder_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage-control/samples/generated_samples/storage_v2_generated_storage_control_disable_anywhere_cache_async.py
+++ b/packages/google-cloud-storage-control/samples/generated_samples/storage_v2_generated_storage_control_disable_anywhere_cache_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage-control/samples/generated_samples/storage_v2_generated_storage_control_disable_anywhere_cache_sync.py
+++ b/packages/google-cloud-storage-control/samples/generated_samples/storage_v2_generated_storage_control_disable_anywhere_cache_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage-control/samples/generated_samples/storage_v2_generated_storage_control_get_anywhere_cache_async.py
+++ b/packages/google-cloud-storage-control/samples/generated_samples/storage_v2_generated_storage_control_get_anywhere_cache_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage-control/samples/generated_samples/storage_v2_generated_storage_control_get_anywhere_cache_sync.py
+++ b/packages/google-cloud-storage-control/samples/generated_samples/storage_v2_generated_storage_control_get_anywhere_cache_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage-control/samples/generated_samples/storage_v2_generated_storage_control_get_folder_async.py
+++ b/packages/google-cloud-storage-control/samples/generated_samples/storage_v2_generated_storage_control_get_folder_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage-control/samples/generated_samples/storage_v2_generated_storage_control_get_folder_intelligence_config_async.py
+++ b/packages/google-cloud-storage-control/samples/generated_samples/storage_v2_generated_storage_control_get_folder_intelligence_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage-control/samples/generated_samples/storage_v2_generated_storage_control_get_folder_intelligence_config_sync.py
+++ b/packages/google-cloud-storage-control/samples/generated_samples/storage_v2_generated_storage_control_get_folder_intelligence_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage-control/samples/generated_samples/storage_v2_generated_storage_control_get_folder_sync.py
+++ b/packages/google-cloud-storage-control/samples/generated_samples/storage_v2_generated_storage_control_get_folder_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage-control/samples/generated_samples/storage_v2_generated_storage_control_get_iam_policy_async.py
+++ b/packages/google-cloud-storage-control/samples/generated_samples/storage_v2_generated_storage_control_get_iam_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage-control/samples/generated_samples/storage_v2_generated_storage_control_get_iam_policy_sync.py
+++ b/packages/google-cloud-storage-control/samples/generated_samples/storage_v2_generated_storage_control_get_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage-control/samples/generated_samples/storage_v2_generated_storage_control_get_managed_folder_async.py
+++ b/packages/google-cloud-storage-control/samples/generated_samples/storage_v2_generated_storage_control_get_managed_folder_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage-control/samples/generated_samples/storage_v2_generated_storage_control_get_managed_folder_sync.py
+++ b/packages/google-cloud-storage-control/samples/generated_samples/storage_v2_generated_storage_control_get_managed_folder_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage-control/samples/generated_samples/storage_v2_generated_storage_control_get_organization_intelligence_config_async.py
+++ b/packages/google-cloud-storage-control/samples/generated_samples/storage_v2_generated_storage_control_get_organization_intelligence_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage-control/samples/generated_samples/storage_v2_generated_storage_control_get_organization_intelligence_config_sync.py
+++ b/packages/google-cloud-storage-control/samples/generated_samples/storage_v2_generated_storage_control_get_organization_intelligence_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage-control/samples/generated_samples/storage_v2_generated_storage_control_get_project_intelligence_config_async.py
+++ b/packages/google-cloud-storage-control/samples/generated_samples/storage_v2_generated_storage_control_get_project_intelligence_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage-control/samples/generated_samples/storage_v2_generated_storage_control_get_project_intelligence_config_sync.py
+++ b/packages/google-cloud-storage-control/samples/generated_samples/storage_v2_generated_storage_control_get_project_intelligence_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage-control/samples/generated_samples/storage_v2_generated_storage_control_get_storage_layout_async.py
+++ b/packages/google-cloud-storage-control/samples/generated_samples/storage_v2_generated_storage_control_get_storage_layout_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage-control/samples/generated_samples/storage_v2_generated_storage_control_get_storage_layout_sync.py
+++ b/packages/google-cloud-storage-control/samples/generated_samples/storage_v2_generated_storage_control_get_storage_layout_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage-control/samples/generated_samples/storage_v2_generated_storage_control_list_anywhere_caches_async.py
+++ b/packages/google-cloud-storage-control/samples/generated_samples/storage_v2_generated_storage_control_list_anywhere_caches_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage-control/samples/generated_samples/storage_v2_generated_storage_control_list_anywhere_caches_sync.py
+++ b/packages/google-cloud-storage-control/samples/generated_samples/storage_v2_generated_storage_control_list_anywhere_caches_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage-control/samples/generated_samples/storage_v2_generated_storage_control_list_folders_async.py
+++ b/packages/google-cloud-storage-control/samples/generated_samples/storage_v2_generated_storage_control_list_folders_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage-control/samples/generated_samples/storage_v2_generated_storage_control_list_folders_sync.py
+++ b/packages/google-cloud-storage-control/samples/generated_samples/storage_v2_generated_storage_control_list_folders_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage-control/samples/generated_samples/storage_v2_generated_storage_control_list_managed_folders_async.py
+++ b/packages/google-cloud-storage-control/samples/generated_samples/storage_v2_generated_storage_control_list_managed_folders_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage-control/samples/generated_samples/storage_v2_generated_storage_control_list_managed_folders_sync.py
+++ b/packages/google-cloud-storage-control/samples/generated_samples/storage_v2_generated_storage_control_list_managed_folders_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage-control/samples/generated_samples/storage_v2_generated_storage_control_pause_anywhere_cache_async.py
+++ b/packages/google-cloud-storage-control/samples/generated_samples/storage_v2_generated_storage_control_pause_anywhere_cache_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage-control/samples/generated_samples/storage_v2_generated_storage_control_pause_anywhere_cache_sync.py
+++ b/packages/google-cloud-storage-control/samples/generated_samples/storage_v2_generated_storage_control_pause_anywhere_cache_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage-control/samples/generated_samples/storage_v2_generated_storage_control_rename_folder_sync.py
+++ b/packages/google-cloud-storage-control/samples/generated_samples/storage_v2_generated_storage_control_rename_folder_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage-control/samples/generated_samples/storage_v2_generated_storage_control_resume_anywhere_cache_async.py
+++ b/packages/google-cloud-storage-control/samples/generated_samples/storage_v2_generated_storage_control_resume_anywhere_cache_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage-control/samples/generated_samples/storage_v2_generated_storage_control_resume_anywhere_cache_sync.py
+++ b/packages/google-cloud-storage-control/samples/generated_samples/storage_v2_generated_storage_control_resume_anywhere_cache_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage-control/samples/generated_samples/storage_v2_generated_storage_control_set_iam_policy_async.py
+++ b/packages/google-cloud-storage-control/samples/generated_samples/storage_v2_generated_storage_control_set_iam_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage-control/samples/generated_samples/storage_v2_generated_storage_control_set_iam_policy_sync.py
+++ b/packages/google-cloud-storage-control/samples/generated_samples/storage_v2_generated_storage_control_set_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage-control/samples/generated_samples/storage_v2_generated_storage_control_test_iam_permissions_async.py
+++ b/packages/google-cloud-storage-control/samples/generated_samples/storage_v2_generated_storage_control_test_iam_permissions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage-control/samples/generated_samples/storage_v2_generated_storage_control_test_iam_permissions_sync.py
+++ b/packages/google-cloud-storage-control/samples/generated_samples/storage_v2_generated_storage_control_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage-control/samples/generated_samples/storage_v2_generated_storage_control_update_anywhere_cache_sync.py
+++ b/packages/google-cloud-storage-control/samples/generated_samples/storage_v2_generated_storage_control_update_anywhere_cache_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage-control/samples/generated_samples/storage_v2_generated_storage_control_update_folder_intelligence_config_async.py
+++ b/packages/google-cloud-storage-control/samples/generated_samples/storage_v2_generated_storage_control_update_folder_intelligence_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage-control/samples/generated_samples/storage_v2_generated_storage_control_update_folder_intelligence_config_sync.py
+++ b/packages/google-cloud-storage-control/samples/generated_samples/storage_v2_generated_storage_control_update_folder_intelligence_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage-control/samples/generated_samples/storage_v2_generated_storage_control_update_organization_intelligence_config_async.py
+++ b/packages/google-cloud-storage-control/samples/generated_samples/storage_v2_generated_storage_control_update_organization_intelligence_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage-control/samples/generated_samples/storage_v2_generated_storage_control_update_organization_intelligence_config_sync.py
+++ b/packages/google-cloud-storage-control/samples/generated_samples/storage_v2_generated_storage_control_update_organization_intelligence_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage-control/samples/generated_samples/storage_v2_generated_storage_control_update_project_intelligence_config_async.py
+++ b/packages/google-cloud-storage-control/samples/generated_samples/storage_v2_generated_storage_control_update_project_intelligence_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage-control/samples/generated_samples/storage_v2_generated_storage_control_update_project_intelligence_config_sync.py
+++ b/packages/google-cloud-storage-control/samples/generated_samples/storage_v2_generated_storage_control_update_project_intelligence_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage-control/tests/__init__.py
+++ b/packages/google-cloud-storage-control/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage-control/tests/unit/__init__.py
+++ b/packages/google-cloud-storage-control/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage-control/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-storage-control/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage-control/tests/unit/gapic/storage_control_v2/__init__.py
+++ b/packages/google-cloud-storage-control/tests/unit/gapic/storage_control_v2/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage-transfer/.flake8
+++ b/packages/google-cloud-storage-transfer/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage-transfer/MANIFEST.in
+++ b/packages/google-cloud-storage-transfer/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage-transfer/google/cloud/storage_transfer/__init__.py
+++ b/packages/google-cloud-storage-transfer/google/cloud/storage_transfer/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage-transfer/google/cloud/storage_transfer/gapic_version.py
+++ b/packages/google-cloud-storage-transfer/google/cloud/storage_transfer/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage-transfer/google/cloud/storage_transfer_v1/gapic_version.py
+++ b/packages/google-cloud-storage-transfer/google/cloud/storage_transfer_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage-transfer/google/cloud/storage_transfer_v1/services/__init__.py
+++ b/packages/google-cloud-storage-transfer/google/cloud/storage_transfer_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage-transfer/google/cloud/storage_transfer_v1/services/storage_transfer_service/__init__.py
+++ b/packages/google-cloud-storage-transfer/google/cloud/storage_transfer_v1/services/storage_transfer_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage-transfer/google/cloud/storage_transfer_v1/services/storage_transfer_service/client.py
+++ b/packages/google-cloud-storage-transfer/google/cloud/storage_transfer_v1/services/storage_transfer_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage-transfer/google/cloud/storage_transfer_v1/services/storage_transfer_service/pagers.py
+++ b/packages/google-cloud-storage-transfer/google/cloud/storage_transfer_v1/services/storage_transfer_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage-transfer/google/cloud/storage_transfer_v1/services/storage_transfer_service/transports/__init__.py
+++ b/packages/google-cloud-storage-transfer/google/cloud/storage_transfer_v1/services/storage_transfer_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage-transfer/google/cloud/storage_transfer_v1/services/storage_transfer_service/transports/base.py
+++ b/packages/google-cloud-storage-transfer/google/cloud/storage_transfer_v1/services/storage_transfer_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage-transfer/google/cloud/storage_transfer_v1/services/storage_transfer_service/transports/grpc.py
+++ b/packages/google-cloud-storage-transfer/google/cloud/storage_transfer_v1/services/storage_transfer_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage-transfer/google/cloud/storage_transfer_v1/services/storage_transfer_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-storage-transfer/google/cloud/storage_transfer_v1/services/storage_transfer_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage-transfer/google/cloud/storage_transfer_v1/services/storage_transfer_service/transports/rest.py
+++ b/packages/google-cloud-storage-transfer/google/cloud/storage_transfer_v1/services/storage_transfer_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage-transfer/google/cloud/storage_transfer_v1/services/storage_transfer_service/transports/rest_base.py
+++ b/packages/google-cloud-storage-transfer/google/cloud/storage_transfer_v1/services/storage_transfer_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage-transfer/google/cloud/storage_transfer_v1/types/__init__.py
+++ b/packages/google-cloud-storage-transfer/google/cloud/storage_transfer_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage-transfer/google/cloud/storage_transfer_v1/types/transfer.py
+++ b/packages/google-cloud-storage-transfer/google/cloud/storage_transfer_v1/types/transfer.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage-transfer/google/cloud/storage_transfer_v1/types/transfer_types.py
+++ b/packages/google-cloud-storage-transfer/google/cloud/storage_transfer_v1/types/transfer_types.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage-transfer/samples/generated_samples/storagetransfer_v1_generated_storage_transfer_service_create_agent_pool_async.py
+++ b/packages/google-cloud-storage-transfer/samples/generated_samples/storagetransfer_v1_generated_storage_transfer_service_create_agent_pool_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage-transfer/samples/generated_samples/storagetransfer_v1_generated_storage_transfer_service_create_agent_pool_sync.py
+++ b/packages/google-cloud-storage-transfer/samples/generated_samples/storagetransfer_v1_generated_storage_transfer_service_create_agent_pool_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage-transfer/samples/generated_samples/storagetransfer_v1_generated_storage_transfer_service_create_transfer_job_async.py
+++ b/packages/google-cloud-storage-transfer/samples/generated_samples/storagetransfer_v1_generated_storage_transfer_service_create_transfer_job_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage-transfer/samples/generated_samples/storagetransfer_v1_generated_storage_transfer_service_create_transfer_job_sync.py
+++ b/packages/google-cloud-storage-transfer/samples/generated_samples/storagetransfer_v1_generated_storage_transfer_service_create_transfer_job_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage-transfer/samples/generated_samples/storagetransfer_v1_generated_storage_transfer_service_delete_agent_pool_async.py
+++ b/packages/google-cloud-storage-transfer/samples/generated_samples/storagetransfer_v1_generated_storage_transfer_service_delete_agent_pool_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage-transfer/samples/generated_samples/storagetransfer_v1_generated_storage_transfer_service_delete_agent_pool_sync.py
+++ b/packages/google-cloud-storage-transfer/samples/generated_samples/storagetransfer_v1_generated_storage_transfer_service_delete_agent_pool_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage-transfer/samples/generated_samples/storagetransfer_v1_generated_storage_transfer_service_delete_transfer_job_async.py
+++ b/packages/google-cloud-storage-transfer/samples/generated_samples/storagetransfer_v1_generated_storage_transfer_service_delete_transfer_job_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage-transfer/samples/generated_samples/storagetransfer_v1_generated_storage_transfer_service_delete_transfer_job_sync.py
+++ b/packages/google-cloud-storage-transfer/samples/generated_samples/storagetransfer_v1_generated_storage_transfer_service_delete_transfer_job_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage-transfer/samples/generated_samples/storagetransfer_v1_generated_storage_transfer_service_get_agent_pool_async.py
+++ b/packages/google-cloud-storage-transfer/samples/generated_samples/storagetransfer_v1_generated_storage_transfer_service_get_agent_pool_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage-transfer/samples/generated_samples/storagetransfer_v1_generated_storage_transfer_service_get_agent_pool_sync.py
+++ b/packages/google-cloud-storage-transfer/samples/generated_samples/storagetransfer_v1_generated_storage_transfer_service_get_agent_pool_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage-transfer/samples/generated_samples/storagetransfer_v1_generated_storage_transfer_service_get_google_service_account_async.py
+++ b/packages/google-cloud-storage-transfer/samples/generated_samples/storagetransfer_v1_generated_storage_transfer_service_get_google_service_account_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage-transfer/samples/generated_samples/storagetransfer_v1_generated_storage_transfer_service_get_google_service_account_sync.py
+++ b/packages/google-cloud-storage-transfer/samples/generated_samples/storagetransfer_v1_generated_storage_transfer_service_get_google_service_account_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage-transfer/samples/generated_samples/storagetransfer_v1_generated_storage_transfer_service_get_transfer_job_async.py
+++ b/packages/google-cloud-storage-transfer/samples/generated_samples/storagetransfer_v1_generated_storage_transfer_service_get_transfer_job_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage-transfer/samples/generated_samples/storagetransfer_v1_generated_storage_transfer_service_get_transfer_job_sync.py
+++ b/packages/google-cloud-storage-transfer/samples/generated_samples/storagetransfer_v1_generated_storage_transfer_service_get_transfer_job_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage-transfer/samples/generated_samples/storagetransfer_v1_generated_storage_transfer_service_list_agent_pools_async.py
+++ b/packages/google-cloud-storage-transfer/samples/generated_samples/storagetransfer_v1_generated_storage_transfer_service_list_agent_pools_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage-transfer/samples/generated_samples/storagetransfer_v1_generated_storage_transfer_service_list_agent_pools_sync.py
+++ b/packages/google-cloud-storage-transfer/samples/generated_samples/storagetransfer_v1_generated_storage_transfer_service_list_agent_pools_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage-transfer/samples/generated_samples/storagetransfer_v1_generated_storage_transfer_service_list_transfer_jobs_async.py
+++ b/packages/google-cloud-storage-transfer/samples/generated_samples/storagetransfer_v1_generated_storage_transfer_service_list_transfer_jobs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage-transfer/samples/generated_samples/storagetransfer_v1_generated_storage_transfer_service_list_transfer_jobs_sync.py
+++ b/packages/google-cloud-storage-transfer/samples/generated_samples/storagetransfer_v1_generated_storage_transfer_service_list_transfer_jobs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage-transfer/samples/generated_samples/storagetransfer_v1_generated_storage_transfer_service_pause_transfer_operation_async.py
+++ b/packages/google-cloud-storage-transfer/samples/generated_samples/storagetransfer_v1_generated_storage_transfer_service_pause_transfer_operation_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage-transfer/samples/generated_samples/storagetransfer_v1_generated_storage_transfer_service_pause_transfer_operation_sync.py
+++ b/packages/google-cloud-storage-transfer/samples/generated_samples/storagetransfer_v1_generated_storage_transfer_service_pause_transfer_operation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage-transfer/samples/generated_samples/storagetransfer_v1_generated_storage_transfer_service_resume_transfer_operation_async.py
+++ b/packages/google-cloud-storage-transfer/samples/generated_samples/storagetransfer_v1_generated_storage_transfer_service_resume_transfer_operation_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage-transfer/samples/generated_samples/storagetransfer_v1_generated_storage_transfer_service_resume_transfer_operation_sync.py
+++ b/packages/google-cloud-storage-transfer/samples/generated_samples/storagetransfer_v1_generated_storage_transfer_service_resume_transfer_operation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage-transfer/samples/generated_samples/storagetransfer_v1_generated_storage_transfer_service_run_transfer_job_sync.py
+++ b/packages/google-cloud-storage-transfer/samples/generated_samples/storagetransfer_v1_generated_storage_transfer_service_run_transfer_job_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage-transfer/samples/generated_samples/storagetransfer_v1_generated_storage_transfer_service_update_agent_pool_async.py
+++ b/packages/google-cloud-storage-transfer/samples/generated_samples/storagetransfer_v1_generated_storage_transfer_service_update_agent_pool_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage-transfer/samples/generated_samples/storagetransfer_v1_generated_storage_transfer_service_update_agent_pool_sync.py
+++ b/packages/google-cloud-storage-transfer/samples/generated_samples/storagetransfer_v1_generated_storage_transfer_service_update_agent_pool_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage-transfer/samples/generated_samples/storagetransfer_v1_generated_storage_transfer_service_update_transfer_job_async.py
+++ b/packages/google-cloud-storage-transfer/samples/generated_samples/storagetransfer_v1_generated_storage_transfer_service_update_transfer_job_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage-transfer/samples/generated_samples/storagetransfer_v1_generated_storage_transfer_service_update_transfer_job_sync.py
+++ b/packages/google-cloud-storage-transfer/samples/generated_samples/storagetransfer_v1_generated_storage_transfer_service_update_transfer_job_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage-transfer/tests/__init__.py
+++ b/packages/google-cloud-storage-transfer/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage-transfer/tests/unit/__init__.py
+++ b/packages/google-cloud-storage-transfer/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage-transfer/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-storage-transfer/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage-transfer/tests/unit/gapic/storage_transfer_v1/__init__.py
+++ b/packages/google-cloud-storage-transfer/tests/unit/gapic/storage_transfer_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage/.flake8
+++ b/packages/google-cloud-storage/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage/MANIFEST.in
+++ b/packages/google-cloud-storage/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage/google/cloud/_storage/__init__.py
+++ b/packages/google-cloud-storage/google/cloud/_storage/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage/google/cloud/_storage/gapic_version.py
+++ b/packages/google-cloud-storage/google/cloud/_storage/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage/google/cloud/_storage_v2/gapic_version.py
+++ b/packages/google-cloud-storage/google/cloud/_storage_v2/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage/google/cloud/_storage_v2/services/__init__.py
+++ b/packages/google-cloud-storage/google/cloud/_storage_v2/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage/google/cloud/_storage_v2/services/storage/__init__.py
+++ b/packages/google-cloud-storage/google/cloud/_storage_v2/services/storage/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage/google/cloud/_storage_v2/services/storage/async_client.py
+++ b/packages/google-cloud-storage/google/cloud/_storage_v2/services/storage/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage/google/cloud/_storage_v2/services/storage/client.py
+++ b/packages/google-cloud-storage/google/cloud/_storage_v2/services/storage/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage/google/cloud/_storage_v2/services/storage/pagers.py
+++ b/packages/google-cloud-storage/google/cloud/_storage_v2/services/storage/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage/google/cloud/_storage_v2/services/storage/transports/__init__.py
+++ b/packages/google-cloud-storage/google/cloud/_storage_v2/services/storage/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage/google/cloud/_storage_v2/services/storage/transports/base.py
+++ b/packages/google-cloud-storage/google/cloud/_storage_v2/services/storage/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage/google/cloud/_storage_v2/services/storage/transports/grpc.py
+++ b/packages/google-cloud-storage/google/cloud/_storage_v2/services/storage/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage/google/cloud/_storage_v2/services/storage/transports/grpc_asyncio.py
+++ b/packages/google-cloud-storage/google/cloud/_storage_v2/services/storage/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage/google/cloud/_storage_v2/types/__init__.py
+++ b/packages/google-cloud-storage/google/cloud/_storage_v2/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage/google/cloud/_storage_v2/types/storage.py
+++ b/packages/google-cloud-storage/google/cloud/_storage_v2/types/storage.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage/samples/generated_samples/storage_v2_generated_storage_bidi_read_object_async.py
+++ b/packages/google-cloud-storage/samples/generated_samples/storage_v2_generated_storage_bidi_read_object_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage/samples/generated_samples/storage_v2_generated_storage_bidi_read_object_sync.py
+++ b/packages/google-cloud-storage/samples/generated_samples/storage_v2_generated_storage_bidi_read_object_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage/samples/generated_samples/storage_v2_generated_storage_bidi_write_object_async.py
+++ b/packages/google-cloud-storage/samples/generated_samples/storage_v2_generated_storage_bidi_write_object_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage/samples/generated_samples/storage_v2_generated_storage_bidi_write_object_sync.py
+++ b/packages/google-cloud-storage/samples/generated_samples/storage_v2_generated_storage_bidi_write_object_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage/samples/generated_samples/storage_v2_generated_storage_cancel_resumable_write_async.py
+++ b/packages/google-cloud-storage/samples/generated_samples/storage_v2_generated_storage_cancel_resumable_write_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage/samples/generated_samples/storage_v2_generated_storage_cancel_resumable_write_sync.py
+++ b/packages/google-cloud-storage/samples/generated_samples/storage_v2_generated_storage_cancel_resumable_write_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage/samples/generated_samples/storage_v2_generated_storage_compose_object_async.py
+++ b/packages/google-cloud-storage/samples/generated_samples/storage_v2_generated_storage_compose_object_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage/samples/generated_samples/storage_v2_generated_storage_compose_object_sync.py
+++ b/packages/google-cloud-storage/samples/generated_samples/storage_v2_generated_storage_compose_object_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage/samples/generated_samples/storage_v2_generated_storage_create_bucket_async.py
+++ b/packages/google-cloud-storage/samples/generated_samples/storage_v2_generated_storage_create_bucket_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage/samples/generated_samples/storage_v2_generated_storage_create_bucket_sync.py
+++ b/packages/google-cloud-storage/samples/generated_samples/storage_v2_generated_storage_create_bucket_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage/samples/generated_samples/storage_v2_generated_storage_delete_bucket_async.py
+++ b/packages/google-cloud-storage/samples/generated_samples/storage_v2_generated_storage_delete_bucket_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage/samples/generated_samples/storage_v2_generated_storage_delete_bucket_sync.py
+++ b/packages/google-cloud-storage/samples/generated_samples/storage_v2_generated_storage_delete_bucket_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage/samples/generated_samples/storage_v2_generated_storage_delete_object_async.py
+++ b/packages/google-cloud-storage/samples/generated_samples/storage_v2_generated_storage_delete_object_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage/samples/generated_samples/storage_v2_generated_storage_delete_object_sync.py
+++ b/packages/google-cloud-storage/samples/generated_samples/storage_v2_generated_storage_delete_object_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage/samples/generated_samples/storage_v2_generated_storage_get_bucket_async.py
+++ b/packages/google-cloud-storage/samples/generated_samples/storage_v2_generated_storage_get_bucket_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage/samples/generated_samples/storage_v2_generated_storage_get_bucket_sync.py
+++ b/packages/google-cloud-storage/samples/generated_samples/storage_v2_generated_storage_get_bucket_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage/samples/generated_samples/storage_v2_generated_storage_get_iam_policy_async.py
+++ b/packages/google-cloud-storage/samples/generated_samples/storage_v2_generated_storage_get_iam_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage/samples/generated_samples/storage_v2_generated_storage_get_iam_policy_sync.py
+++ b/packages/google-cloud-storage/samples/generated_samples/storage_v2_generated_storage_get_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage/samples/generated_samples/storage_v2_generated_storage_get_object_async.py
+++ b/packages/google-cloud-storage/samples/generated_samples/storage_v2_generated_storage_get_object_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage/samples/generated_samples/storage_v2_generated_storage_get_object_sync.py
+++ b/packages/google-cloud-storage/samples/generated_samples/storage_v2_generated_storage_get_object_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage/samples/generated_samples/storage_v2_generated_storage_list_buckets_async.py
+++ b/packages/google-cloud-storage/samples/generated_samples/storage_v2_generated_storage_list_buckets_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage/samples/generated_samples/storage_v2_generated_storage_list_buckets_sync.py
+++ b/packages/google-cloud-storage/samples/generated_samples/storage_v2_generated_storage_list_buckets_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage/samples/generated_samples/storage_v2_generated_storage_list_objects_async.py
+++ b/packages/google-cloud-storage/samples/generated_samples/storage_v2_generated_storage_list_objects_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage/samples/generated_samples/storage_v2_generated_storage_list_objects_sync.py
+++ b/packages/google-cloud-storage/samples/generated_samples/storage_v2_generated_storage_list_objects_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage/samples/generated_samples/storage_v2_generated_storage_lock_bucket_retention_policy_async.py
+++ b/packages/google-cloud-storage/samples/generated_samples/storage_v2_generated_storage_lock_bucket_retention_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage/samples/generated_samples/storage_v2_generated_storage_lock_bucket_retention_policy_sync.py
+++ b/packages/google-cloud-storage/samples/generated_samples/storage_v2_generated_storage_lock_bucket_retention_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage/samples/generated_samples/storage_v2_generated_storage_move_object_async.py
+++ b/packages/google-cloud-storage/samples/generated_samples/storage_v2_generated_storage_move_object_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage/samples/generated_samples/storage_v2_generated_storage_move_object_sync.py
+++ b/packages/google-cloud-storage/samples/generated_samples/storage_v2_generated_storage_move_object_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage/samples/generated_samples/storage_v2_generated_storage_query_write_status_async.py
+++ b/packages/google-cloud-storage/samples/generated_samples/storage_v2_generated_storage_query_write_status_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage/samples/generated_samples/storage_v2_generated_storage_query_write_status_sync.py
+++ b/packages/google-cloud-storage/samples/generated_samples/storage_v2_generated_storage_query_write_status_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage/samples/generated_samples/storage_v2_generated_storage_read_object_async.py
+++ b/packages/google-cloud-storage/samples/generated_samples/storage_v2_generated_storage_read_object_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage/samples/generated_samples/storage_v2_generated_storage_read_object_sync.py
+++ b/packages/google-cloud-storage/samples/generated_samples/storage_v2_generated_storage_read_object_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage/samples/generated_samples/storage_v2_generated_storage_restore_object_async.py
+++ b/packages/google-cloud-storage/samples/generated_samples/storage_v2_generated_storage_restore_object_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage/samples/generated_samples/storage_v2_generated_storage_restore_object_sync.py
+++ b/packages/google-cloud-storage/samples/generated_samples/storage_v2_generated_storage_restore_object_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage/samples/generated_samples/storage_v2_generated_storage_rewrite_object_async.py
+++ b/packages/google-cloud-storage/samples/generated_samples/storage_v2_generated_storage_rewrite_object_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage/samples/generated_samples/storage_v2_generated_storage_rewrite_object_sync.py
+++ b/packages/google-cloud-storage/samples/generated_samples/storage_v2_generated_storage_rewrite_object_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage/samples/generated_samples/storage_v2_generated_storage_set_iam_policy_async.py
+++ b/packages/google-cloud-storage/samples/generated_samples/storage_v2_generated_storage_set_iam_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage/samples/generated_samples/storage_v2_generated_storage_set_iam_policy_sync.py
+++ b/packages/google-cloud-storage/samples/generated_samples/storage_v2_generated_storage_set_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage/samples/generated_samples/storage_v2_generated_storage_start_resumable_write_async.py
+++ b/packages/google-cloud-storage/samples/generated_samples/storage_v2_generated_storage_start_resumable_write_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage/samples/generated_samples/storage_v2_generated_storage_start_resumable_write_sync.py
+++ b/packages/google-cloud-storage/samples/generated_samples/storage_v2_generated_storage_start_resumable_write_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage/samples/generated_samples/storage_v2_generated_storage_test_iam_permissions_async.py
+++ b/packages/google-cloud-storage/samples/generated_samples/storage_v2_generated_storage_test_iam_permissions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage/samples/generated_samples/storage_v2_generated_storage_test_iam_permissions_sync.py
+++ b/packages/google-cloud-storage/samples/generated_samples/storage_v2_generated_storage_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage/samples/generated_samples/storage_v2_generated_storage_update_bucket_async.py
+++ b/packages/google-cloud-storage/samples/generated_samples/storage_v2_generated_storage_update_bucket_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage/samples/generated_samples/storage_v2_generated_storage_update_bucket_sync.py
+++ b/packages/google-cloud-storage/samples/generated_samples/storage_v2_generated_storage_update_bucket_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage/samples/generated_samples/storage_v2_generated_storage_update_object_async.py
+++ b/packages/google-cloud-storage/samples/generated_samples/storage_v2_generated_storage_update_object_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage/samples/generated_samples/storage_v2_generated_storage_update_object_sync.py
+++ b/packages/google-cloud-storage/samples/generated_samples/storage_v2_generated_storage_update_object_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage/samples/generated_samples/storage_v2_generated_storage_write_object_async.py
+++ b/packages/google-cloud-storage/samples/generated_samples/storage_v2_generated_storage_write_object_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage/samples/generated_samples/storage_v2_generated_storage_write_object_sync.py
+++ b/packages/google-cloud-storage/samples/generated_samples/storage_v2_generated_storage_write_object_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage/tests/__init__.py
+++ b/packages/google-cloud-storage/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage/tests/unit/__init__.py
+++ b/packages/google-cloud-storage/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-storage/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storage/tests/unit/gapic/_storage_v2/__init__.py
+++ b/packages/google-cloud-storage/tests/unit/gapic/_storage_v2/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storagebatchoperations/.flake8
+++ b/packages/google-cloud-storagebatchoperations/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storagebatchoperations/MANIFEST.in
+++ b/packages/google-cloud-storagebatchoperations/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storagebatchoperations/google/cloud/storagebatchoperations/__init__.py
+++ b/packages/google-cloud-storagebatchoperations/google/cloud/storagebatchoperations/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storagebatchoperations/google/cloud/storagebatchoperations/gapic_version.py
+++ b/packages/google-cloud-storagebatchoperations/google/cloud/storagebatchoperations/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storagebatchoperations/google/cloud/storagebatchoperations_v1/gapic_version.py
+++ b/packages/google-cloud-storagebatchoperations/google/cloud/storagebatchoperations_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storagebatchoperations/google/cloud/storagebatchoperations_v1/services/__init__.py
+++ b/packages/google-cloud-storagebatchoperations/google/cloud/storagebatchoperations_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storagebatchoperations/google/cloud/storagebatchoperations_v1/services/storage_batch_operations/__init__.py
+++ b/packages/google-cloud-storagebatchoperations/google/cloud/storagebatchoperations_v1/services/storage_batch_operations/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storagebatchoperations/google/cloud/storagebatchoperations_v1/services/storage_batch_operations/client.py
+++ b/packages/google-cloud-storagebatchoperations/google/cloud/storagebatchoperations_v1/services/storage_batch_operations/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storagebatchoperations/google/cloud/storagebatchoperations_v1/services/storage_batch_operations/pagers.py
+++ b/packages/google-cloud-storagebatchoperations/google/cloud/storagebatchoperations_v1/services/storage_batch_operations/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storagebatchoperations/google/cloud/storagebatchoperations_v1/services/storage_batch_operations/transports/__init__.py
+++ b/packages/google-cloud-storagebatchoperations/google/cloud/storagebatchoperations_v1/services/storage_batch_operations/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storagebatchoperations/google/cloud/storagebatchoperations_v1/services/storage_batch_operations/transports/base.py
+++ b/packages/google-cloud-storagebatchoperations/google/cloud/storagebatchoperations_v1/services/storage_batch_operations/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storagebatchoperations/google/cloud/storagebatchoperations_v1/services/storage_batch_operations/transports/grpc.py
+++ b/packages/google-cloud-storagebatchoperations/google/cloud/storagebatchoperations_v1/services/storage_batch_operations/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storagebatchoperations/google/cloud/storagebatchoperations_v1/services/storage_batch_operations/transports/grpc_asyncio.py
+++ b/packages/google-cloud-storagebatchoperations/google/cloud/storagebatchoperations_v1/services/storage_batch_operations/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storagebatchoperations/google/cloud/storagebatchoperations_v1/services/storage_batch_operations/transports/rest.py
+++ b/packages/google-cloud-storagebatchoperations/google/cloud/storagebatchoperations_v1/services/storage_batch_operations/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storagebatchoperations/google/cloud/storagebatchoperations_v1/services/storage_batch_operations/transports/rest_base.py
+++ b/packages/google-cloud-storagebatchoperations/google/cloud/storagebatchoperations_v1/services/storage_batch_operations/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storagebatchoperations/google/cloud/storagebatchoperations_v1/types/__init__.py
+++ b/packages/google-cloud-storagebatchoperations/google/cloud/storagebatchoperations_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storagebatchoperations/google/cloud/storagebatchoperations_v1/types/storage_batch_operations.py
+++ b/packages/google-cloud-storagebatchoperations/google/cloud/storagebatchoperations_v1/types/storage_batch_operations.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storagebatchoperations/google/cloud/storagebatchoperations_v1/types/storage_batch_operations_types.py
+++ b/packages/google-cloud-storagebatchoperations/google/cloud/storagebatchoperations_v1/types/storage_batch_operations_types.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storagebatchoperations/samples/generated_samples/storagebatchoperations_v1_generated_storage_batch_operations_cancel_job_async.py
+++ b/packages/google-cloud-storagebatchoperations/samples/generated_samples/storagebatchoperations_v1_generated_storage_batch_operations_cancel_job_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storagebatchoperations/samples/generated_samples/storagebatchoperations_v1_generated_storage_batch_operations_cancel_job_sync.py
+++ b/packages/google-cloud-storagebatchoperations/samples/generated_samples/storagebatchoperations_v1_generated_storage_batch_operations_cancel_job_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storagebatchoperations/samples/generated_samples/storagebatchoperations_v1_generated_storage_batch_operations_create_job_sync.py
+++ b/packages/google-cloud-storagebatchoperations/samples/generated_samples/storagebatchoperations_v1_generated_storage_batch_operations_create_job_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storagebatchoperations/samples/generated_samples/storagebatchoperations_v1_generated_storage_batch_operations_delete_job_async.py
+++ b/packages/google-cloud-storagebatchoperations/samples/generated_samples/storagebatchoperations_v1_generated_storage_batch_operations_delete_job_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storagebatchoperations/samples/generated_samples/storagebatchoperations_v1_generated_storage_batch_operations_delete_job_sync.py
+++ b/packages/google-cloud-storagebatchoperations/samples/generated_samples/storagebatchoperations_v1_generated_storage_batch_operations_delete_job_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storagebatchoperations/samples/generated_samples/storagebatchoperations_v1_generated_storage_batch_operations_get_bucket_operation_async.py
+++ b/packages/google-cloud-storagebatchoperations/samples/generated_samples/storagebatchoperations_v1_generated_storage_batch_operations_get_bucket_operation_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storagebatchoperations/samples/generated_samples/storagebatchoperations_v1_generated_storage_batch_operations_get_bucket_operation_sync.py
+++ b/packages/google-cloud-storagebatchoperations/samples/generated_samples/storagebatchoperations_v1_generated_storage_batch_operations_get_bucket_operation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storagebatchoperations/samples/generated_samples/storagebatchoperations_v1_generated_storage_batch_operations_get_job_async.py
+++ b/packages/google-cloud-storagebatchoperations/samples/generated_samples/storagebatchoperations_v1_generated_storage_batch_operations_get_job_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storagebatchoperations/samples/generated_samples/storagebatchoperations_v1_generated_storage_batch_operations_get_job_sync.py
+++ b/packages/google-cloud-storagebatchoperations/samples/generated_samples/storagebatchoperations_v1_generated_storage_batch_operations_get_job_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storagebatchoperations/samples/generated_samples/storagebatchoperations_v1_generated_storage_batch_operations_list_bucket_operations_async.py
+++ b/packages/google-cloud-storagebatchoperations/samples/generated_samples/storagebatchoperations_v1_generated_storage_batch_operations_list_bucket_operations_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storagebatchoperations/samples/generated_samples/storagebatchoperations_v1_generated_storage_batch_operations_list_bucket_operations_sync.py
+++ b/packages/google-cloud-storagebatchoperations/samples/generated_samples/storagebatchoperations_v1_generated_storage_batch_operations_list_bucket_operations_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storagebatchoperations/samples/generated_samples/storagebatchoperations_v1_generated_storage_batch_operations_list_jobs_async.py
+++ b/packages/google-cloud-storagebatchoperations/samples/generated_samples/storagebatchoperations_v1_generated_storage_batch_operations_list_jobs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storagebatchoperations/samples/generated_samples/storagebatchoperations_v1_generated_storage_batch_operations_list_jobs_sync.py
+++ b/packages/google-cloud-storagebatchoperations/samples/generated_samples/storagebatchoperations_v1_generated_storage_batch_operations_list_jobs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storagebatchoperations/tests/__init__.py
+++ b/packages/google-cloud-storagebatchoperations/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storagebatchoperations/tests/unit/__init__.py
+++ b/packages/google-cloud-storagebatchoperations/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storagebatchoperations/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-storagebatchoperations/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storagebatchoperations/tests/unit/gapic/storagebatchoperations_v1/__init__.py
+++ b/packages/google-cloud-storagebatchoperations/tests/unit/gapic/storagebatchoperations_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storageinsights/.flake8
+++ b/packages/google-cloud-storageinsights/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storageinsights/MANIFEST.in
+++ b/packages/google-cloud-storageinsights/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storageinsights/google/cloud/storageinsights/__init__.py
+++ b/packages/google-cloud-storageinsights/google/cloud/storageinsights/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storageinsights/google/cloud/storageinsights/gapic_version.py
+++ b/packages/google-cloud-storageinsights/google/cloud/storageinsights/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storageinsights/google/cloud/storageinsights_v1/gapic_version.py
+++ b/packages/google-cloud-storageinsights/google/cloud/storageinsights_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storageinsights/google/cloud/storageinsights_v1/services/__init__.py
+++ b/packages/google-cloud-storageinsights/google/cloud/storageinsights_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storageinsights/google/cloud/storageinsights_v1/services/storage_insights/__init__.py
+++ b/packages/google-cloud-storageinsights/google/cloud/storageinsights_v1/services/storage_insights/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storageinsights/google/cloud/storageinsights_v1/services/storage_insights/client.py
+++ b/packages/google-cloud-storageinsights/google/cloud/storageinsights_v1/services/storage_insights/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storageinsights/google/cloud/storageinsights_v1/services/storage_insights/pagers.py
+++ b/packages/google-cloud-storageinsights/google/cloud/storageinsights_v1/services/storage_insights/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storageinsights/google/cloud/storageinsights_v1/services/storage_insights/transports/__init__.py
+++ b/packages/google-cloud-storageinsights/google/cloud/storageinsights_v1/services/storage_insights/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storageinsights/google/cloud/storageinsights_v1/services/storage_insights/transports/base.py
+++ b/packages/google-cloud-storageinsights/google/cloud/storageinsights_v1/services/storage_insights/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storageinsights/google/cloud/storageinsights_v1/services/storage_insights/transports/grpc.py
+++ b/packages/google-cloud-storageinsights/google/cloud/storageinsights_v1/services/storage_insights/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storageinsights/google/cloud/storageinsights_v1/services/storage_insights/transports/grpc_asyncio.py
+++ b/packages/google-cloud-storageinsights/google/cloud/storageinsights_v1/services/storage_insights/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storageinsights/google/cloud/storageinsights_v1/services/storage_insights/transports/rest.py
+++ b/packages/google-cloud-storageinsights/google/cloud/storageinsights_v1/services/storage_insights/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storageinsights/google/cloud/storageinsights_v1/services/storage_insights/transports/rest_base.py
+++ b/packages/google-cloud-storageinsights/google/cloud/storageinsights_v1/services/storage_insights/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storageinsights/google/cloud/storageinsights_v1/types/__init__.py
+++ b/packages/google-cloud-storageinsights/google/cloud/storageinsights_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storageinsights/google/cloud/storageinsights_v1/types/storageinsights.py
+++ b/packages/google-cloud-storageinsights/google/cloud/storageinsights_v1/types/storageinsights.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storageinsights/samples/generated_samples/storageinsights_v1_generated_storage_insights_create_dataset_config_sync.py
+++ b/packages/google-cloud-storageinsights/samples/generated_samples/storageinsights_v1_generated_storage_insights_create_dataset_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storageinsights/samples/generated_samples/storageinsights_v1_generated_storage_insights_create_report_config_async.py
+++ b/packages/google-cloud-storageinsights/samples/generated_samples/storageinsights_v1_generated_storage_insights_create_report_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storageinsights/samples/generated_samples/storageinsights_v1_generated_storage_insights_create_report_config_sync.py
+++ b/packages/google-cloud-storageinsights/samples/generated_samples/storageinsights_v1_generated_storage_insights_create_report_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storageinsights/samples/generated_samples/storageinsights_v1_generated_storage_insights_delete_dataset_config_sync.py
+++ b/packages/google-cloud-storageinsights/samples/generated_samples/storageinsights_v1_generated_storage_insights_delete_dataset_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storageinsights/samples/generated_samples/storageinsights_v1_generated_storage_insights_delete_report_config_async.py
+++ b/packages/google-cloud-storageinsights/samples/generated_samples/storageinsights_v1_generated_storage_insights_delete_report_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storageinsights/samples/generated_samples/storageinsights_v1_generated_storage_insights_delete_report_config_sync.py
+++ b/packages/google-cloud-storageinsights/samples/generated_samples/storageinsights_v1_generated_storage_insights_delete_report_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storageinsights/samples/generated_samples/storageinsights_v1_generated_storage_insights_get_dataset_config_async.py
+++ b/packages/google-cloud-storageinsights/samples/generated_samples/storageinsights_v1_generated_storage_insights_get_dataset_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storageinsights/samples/generated_samples/storageinsights_v1_generated_storage_insights_get_dataset_config_sync.py
+++ b/packages/google-cloud-storageinsights/samples/generated_samples/storageinsights_v1_generated_storage_insights_get_dataset_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storageinsights/samples/generated_samples/storageinsights_v1_generated_storage_insights_get_report_config_async.py
+++ b/packages/google-cloud-storageinsights/samples/generated_samples/storageinsights_v1_generated_storage_insights_get_report_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storageinsights/samples/generated_samples/storageinsights_v1_generated_storage_insights_get_report_config_sync.py
+++ b/packages/google-cloud-storageinsights/samples/generated_samples/storageinsights_v1_generated_storage_insights_get_report_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storageinsights/samples/generated_samples/storageinsights_v1_generated_storage_insights_get_report_detail_async.py
+++ b/packages/google-cloud-storageinsights/samples/generated_samples/storageinsights_v1_generated_storage_insights_get_report_detail_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storageinsights/samples/generated_samples/storageinsights_v1_generated_storage_insights_get_report_detail_sync.py
+++ b/packages/google-cloud-storageinsights/samples/generated_samples/storageinsights_v1_generated_storage_insights_get_report_detail_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storageinsights/samples/generated_samples/storageinsights_v1_generated_storage_insights_link_dataset_sync.py
+++ b/packages/google-cloud-storageinsights/samples/generated_samples/storageinsights_v1_generated_storage_insights_link_dataset_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storageinsights/samples/generated_samples/storageinsights_v1_generated_storage_insights_list_dataset_configs_async.py
+++ b/packages/google-cloud-storageinsights/samples/generated_samples/storageinsights_v1_generated_storage_insights_list_dataset_configs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storageinsights/samples/generated_samples/storageinsights_v1_generated_storage_insights_list_dataset_configs_sync.py
+++ b/packages/google-cloud-storageinsights/samples/generated_samples/storageinsights_v1_generated_storage_insights_list_dataset_configs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storageinsights/samples/generated_samples/storageinsights_v1_generated_storage_insights_list_report_configs_async.py
+++ b/packages/google-cloud-storageinsights/samples/generated_samples/storageinsights_v1_generated_storage_insights_list_report_configs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storageinsights/samples/generated_samples/storageinsights_v1_generated_storage_insights_list_report_configs_sync.py
+++ b/packages/google-cloud-storageinsights/samples/generated_samples/storageinsights_v1_generated_storage_insights_list_report_configs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storageinsights/samples/generated_samples/storageinsights_v1_generated_storage_insights_list_report_details_async.py
+++ b/packages/google-cloud-storageinsights/samples/generated_samples/storageinsights_v1_generated_storage_insights_list_report_details_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storageinsights/samples/generated_samples/storageinsights_v1_generated_storage_insights_list_report_details_sync.py
+++ b/packages/google-cloud-storageinsights/samples/generated_samples/storageinsights_v1_generated_storage_insights_list_report_details_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storageinsights/samples/generated_samples/storageinsights_v1_generated_storage_insights_unlink_dataset_sync.py
+++ b/packages/google-cloud-storageinsights/samples/generated_samples/storageinsights_v1_generated_storage_insights_unlink_dataset_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storageinsights/samples/generated_samples/storageinsights_v1_generated_storage_insights_update_dataset_config_sync.py
+++ b/packages/google-cloud-storageinsights/samples/generated_samples/storageinsights_v1_generated_storage_insights_update_dataset_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storageinsights/samples/generated_samples/storageinsights_v1_generated_storage_insights_update_report_config_async.py
+++ b/packages/google-cloud-storageinsights/samples/generated_samples/storageinsights_v1_generated_storage_insights_update_report_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storageinsights/samples/generated_samples/storageinsights_v1_generated_storage_insights_update_report_config_sync.py
+++ b/packages/google-cloud-storageinsights/samples/generated_samples/storageinsights_v1_generated_storage_insights_update_report_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storageinsights/tests/__init__.py
+++ b/packages/google-cloud-storageinsights/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storageinsights/tests/unit/__init__.py
+++ b/packages/google-cloud-storageinsights/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storageinsights/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-storageinsights/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-storageinsights/tests/unit/gapic/storageinsights_v1/__init__.py
+++ b/packages/google-cloud-storageinsights/tests/unit/gapic/storageinsights_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/.flake8
+++ b/packages/google-cloud-support/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/MANIFEST.in
+++ b/packages/google-cloud-support/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/google/cloud/support/__init__.py
+++ b/packages/google-cloud-support/google/cloud/support/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/google/cloud/support/gapic_version.py
+++ b/packages/google-cloud-support/google/cloud/support/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/google/cloud/support_v2/gapic_version.py
+++ b/packages/google-cloud-support/google/cloud/support_v2/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/google/cloud/support_v2/services/__init__.py
+++ b/packages/google-cloud-support/google/cloud/support_v2/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/google/cloud/support_v2/services/case_attachment_service/__init__.py
+++ b/packages/google-cloud-support/google/cloud/support_v2/services/case_attachment_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/google/cloud/support_v2/services/case_attachment_service/async_client.py
+++ b/packages/google-cloud-support/google/cloud/support_v2/services/case_attachment_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/google/cloud/support_v2/services/case_attachment_service/client.py
+++ b/packages/google-cloud-support/google/cloud/support_v2/services/case_attachment_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/google/cloud/support_v2/services/case_attachment_service/pagers.py
+++ b/packages/google-cloud-support/google/cloud/support_v2/services/case_attachment_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/google/cloud/support_v2/services/case_attachment_service/transports/__init__.py
+++ b/packages/google-cloud-support/google/cloud/support_v2/services/case_attachment_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/google/cloud/support_v2/services/case_attachment_service/transports/base.py
+++ b/packages/google-cloud-support/google/cloud/support_v2/services/case_attachment_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/google/cloud/support_v2/services/case_attachment_service/transports/grpc.py
+++ b/packages/google-cloud-support/google/cloud/support_v2/services/case_attachment_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/google/cloud/support_v2/services/case_attachment_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-support/google/cloud/support_v2/services/case_attachment_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/google/cloud/support_v2/services/case_attachment_service/transports/rest.py
+++ b/packages/google-cloud-support/google/cloud/support_v2/services/case_attachment_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/google/cloud/support_v2/services/case_attachment_service/transports/rest_base.py
+++ b/packages/google-cloud-support/google/cloud/support_v2/services/case_attachment_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/google/cloud/support_v2/services/case_service/__init__.py
+++ b/packages/google-cloud-support/google/cloud/support_v2/services/case_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/google/cloud/support_v2/services/case_service/async_client.py
+++ b/packages/google-cloud-support/google/cloud/support_v2/services/case_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/google/cloud/support_v2/services/case_service/client.py
+++ b/packages/google-cloud-support/google/cloud/support_v2/services/case_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/google/cloud/support_v2/services/case_service/pagers.py
+++ b/packages/google-cloud-support/google/cloud/support_v2/services/case_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/google/cloud/support_v2/services/case_service/transports/__init__.py
+++ b/packages/google-cloud-support/google/cloud/support_v2/services/case_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/google/cloud/support_v2/services/case_service/transports/base.py
+++ b/packages/google-cloud-support/google/cloud/support_v2/services/case_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/google/cloud/support_v2/services/case_service/transports/grpc.py
+++ b/packages/google-cloud-support/google/cloud/support_v2/services/case_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/google/cloud/support_v2/services/case_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-support/google/cloud/support_v2/services/case_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/google/cloud/support_v2/services/case_service/transports/rest.py
+++ b/packages/google-cloud-support/google/cloud/support_v2/services/case_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/google/cloud/support_v2/services/case_service/transports/rest_base.py
+++ b/packages/google-cloud-support/google/cloud/support_v2/services/case_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/google/cloud/support_v2/services/comment_service/__init__.py
+++ b/packages/google-cloud-support/google/cloud/support_v2/services/comment_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/google/cloud/support_v2/services/comment_service/async_client.py
+++ b/packages/google-cloud-support/google/cloud/support_v2/services/comment_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/google/cloud/support_v2/services/comment_service/client.py
+++ b/packages/google-cloud-support/google/cloud/support_v2/services/comment_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/google/cloud/support_v2/services/comment_service/pagers.py
+++ b/packages/google-cloud-support/google/cloud/support_v2/services/comment_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/google/cloud/support_v2/services/comment_service/transports/__init__.py
+++ b/packages/google-cloud-support/google/cloud/support_v2/services/comment_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/google/cloud/support_v2/services/comment_service/transports/base.py
+++ b/packages/google-cloud-support/google/cloud/support_v2/services/comment_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/google/cloud/support_v2/services/comment_service/transports/grpc.py
+++ b/packages/google-cloud-support/google/cloud/support_v2/services/comment_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/google/cloud/support_v2/services/comment_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-support/google/cloud/support_v2/services/comment_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/google/cloud/support_v2/services/comment_service/transports/rest.py
+++ b/packages/google-cloud-support/google/cloud/support_v2/services/comment_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/google/cloud/support_v2/services/comment_service/transports/rest_base.py
+++ b/packages/google-cloud-support/google/cloud/support_v2/services/comment_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/google/cloud/support_v2/types/__init__.py
+++ b/packages/google-cloud-support/google/cloud/support_v2/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/google/cloud/support_v2/types/actor.py
+++ b/packages/google-cloud-support/google/cloud/support_v2/types/actor.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/google/cloud/support_v2/types/attachment.py
+++ b/packages/google-cloud-support/google/cloud/support_v2/types/attachment.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/google/cloud/support_v2/types/attachment_service.py
+++ b/packages/google-cloud-support/google/cloud/support_v2/types/attachment_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/google/cloud/support_v2/types/case.py
+++ b/packages/google-cloud-support/google/cloud/support_v2/types/case.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/google/cloud/support_v2/types/case_service.py
+++ b/packages/google-cloud-support/google/cloud/support_v2/types/case_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/google/cloud/support_v2/types/comment.py
+++ b/packages/google-cloud-support/google/cloud/support_v2/types/comment.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/google/cloud/support_v2/types/comment_service.py
+++ b/packages/google-cloud-support/google/cloud/support_v2/types/comment_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/google/cloud/support_v2/types/escalation.py
+++ b/packages/google-cloud-support/google/cloud/support_v2/types/escalation.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/google/cloud/support_v2beta/gapic_version.py
+++ b/packages/google-cloud-support/google/cloud/support_v2beta/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/google/cloud/support_v2beta/services/__init__.py
+++ b/packages/google-cloud-support/google/cloud/support_v2beta/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/google/cloud/support_v2beta/services/case_attachment_service/__init__.py
+++ b/packages/google-cloud-support/google/cloud/support_v2beta/services/case_attachment_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/google/cloud/support_v2beta/services/case_attachment_service/async_client.py
+++ b/packages/google-cloud-support/google/cloud/support_v2beta/services/case_attachment_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/google/cloud/support_v2beta/services/case_attachment_service/client.py
+++ b/packages/google-cloud-support/google/cloud/support_v2beta/services/case_attachment_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/google/cloud/support_v2beta/services/case_attachment_service/pagers.py
+++ b/packages/google-cloud-support/google/cloud/support_v2beta/services/case_attachment_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/google/cloud/support_v2beta/services/case_attachment_service/transports/__init__.py
+++ b/packages/google-cloud-support/google/cloud/support_v2beta/services/case_attachment_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/google/cloud/support_v2beta/services/case_attachment_service/transports/base.py
+++ b/packages/google-cloud-support/google/cloud/support_v2beta/services/case_attachment_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/google/cloud/support_v2beta/services/case_attachment_service/transports/grpc.py
+++ b/packages/google-cloud-support/google/cloud/support_v2beta/services/case_attachment_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/google/cloud/support_v2beta/services/case_attachment_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-support/google/cloud/support_v2beta/services/case_attachment_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/google/cloud/support_v2beta/services/case_attachment_service/transports/rest.py
+++ b/packages/google-cloud-support/google/cloud/support_v2beta/services/case_attachment_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/google/cloud/support_v2beta/services/case_attachment_service/transports/rest_base.py
+++ b/packages/google-cloud-support/google/cloud/support_v2beta/services/case_attachment_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/google/cloud/support_v2beta/services/case_service/__init__.py
+++ b/packages/google-cloud-support/google/cloud/support_v2beta/services/case_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/google/cloud/support_v2beta/services/case_service/async_client.py
+++ b/packages/google-cloud-support/google/cloud/support_v2beta/services/case_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/google/cloud/support_v2beta/services/case_service/client.py
+++ b/packages/google-cloud-support/google/cloud/support_v2beta/services/case_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/google/cloud/support_v2beta/services/case_service/pagers.py
+++ b/packages/google-cloud-support/google/cloud/support_v2beta/services/case_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/google/cloud/support_v2beta/services/case_service/transports/__init__.py
+++ b/packages/google-cloud-support/google/cloud/support_v2beta/services/case_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/google/cloud/support_v2beta/services/case_service/transports/base.py
+++ b/packages/google-cloud-support/google/cloud/support_v2beta/services/case_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/google/cloud/support_v2beta/services/case_service/transports/grpc.py
+++ b/packages/google-cloud-support/google/cloud/support_v2beta/services/case_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/google/cloud/support_v2beta/services/case_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-support/google/cloud/support_v2beta/services/case_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/google/cloud/support_v2beta/services/case_service/transports/rest.py
+++ b/packages/google-cloud-support/google/cloud/support_v2beta/services/case_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/google/cloud/support_v2beta/services/case_service/transports/rest_base.py
+++ b/packages/google-cloud-support/google/cloud/support_v2beta/services/case_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/google/cloud/support_v2beta/services/comment_service/__init__.py
+++ b/packages/google-cloud-support/google/cloud/support_v2beta/services/comment_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/google/cloud/support_v2beta/services/comment_service/async_client.py
+++ b/packages/google-cloud-support/google/cloud/support_v2beta/services/comment_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/google/cloud/support_v2beta/services/comment_service/client.py
+++ b/packages/google-cloud-support/google/cloud/support_v2beta/services/comment_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/google/cloud/support_v2beta/services/comment_service/pagers.py
+++ b/packages/google-cloud-support/google/cloud/support_v2beta/services/comment_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/google/cloud/support_v2beta/services/comment_service/transports/__init__.py
+++ b/packages/google-cloud-support/google/cloud/support_v2beta/services/comment_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/google/cloud/support_v2beta/services/comment_service/transports/base.py
+++ b/packages/google-cloud-support/google/cloud/support_v2beta/services/comment_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/google/cloud/support_v2beta/services/comment_service/transports/grpc.py
+++ b/packages/google-cloud-support/google/cloud/support_v2beta/services/comment_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/google/cloud/support_v2beta/services/comment_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-support/google/cloud/support_v2beta/services/comment_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/google/cloud/support_v2beta/services/comment_service/transports/rest.py
+++ b/packages/google-cloud-support/google/cloud/support_v2beta/services/comment_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/google/cloud/support_v2beta/services/comment_service/transports/rest_base.py
+++ b/packages/google-cloud-support/google/cloud/support_v2beta/services/comment_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/google/cloud/support_v2beta/services/feed_service/__init__.py
+++ b/packages/google-cloud-support/google/cloud/support_v2beta/services/feed_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/google/cloud/support_v2beta/services/feed_service/async_client.py
+++ b/packages/google-cloud-support/google/cloud/support_v2beta/services/feed_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/google/cloud/support_v2beta/services/feed_service/client.py
+++ b/packages/google-cloud-support/google/cloud/support_v2beta/services/feed_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/google/cloud/support_v2beta/services/feed_service/pagers.py
+++ b/packages/google-cloud-support/google/cloud/support_v2beta/services/feed_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/google/cloud/support_v2beta/services/feed_service/transports/__init__.py
+++ b/packages/google-cloud-support/google/cloud/support_v2beta/services/feed_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/google/cloud/support_v2beta/services/feed_service/transports/base.py
+++ b/packages/google-cloud-support/google/cloud/support_v2beta/services/feed_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/google/cloud/support_v2beta/services/feed_service/transports/grpc.py
+++ b/packages/google-cloud-support/google/cloud/support_v2beta/services/feed_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/google/cloud/support_v2beta/services/feed_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-support/google/cloud/support_v2beta/services/feed_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/google/cloud/support_v2beta/services/feed_service/transports/rest.py
+++ b/packages/google-cloud-support/google/cloud/support_v2beta/services/feed_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/google/cloud/support_v2beta/services/feed_service/transports/rest_base.py
+++ b/packages/google-cloud-support/google/cloud/support_v2beta/services/feed_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/google/cloud/support_v2beta/types/__init__.py
+++ b/packages/google-cloud-support/google/cloud/support_v2beta/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/google/cloud/support_v2beta/types/actor.py
+++ b/packages/google-cloud-support/google/cloud/support_v2beta/types/actor.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/google/cloud/support_v2beta/types/attachment.py
+++ b/packages/google-cloud-support/google/cloud/support_v2beta/types/attachment.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/google/cloud/support_v2beta/types/attachment_service.py
+++ b/packages/google-cloud-support/google/cloud/support_v2beta/types/attachment_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/google/cloud/support_v2beta/types/case.py
+++ b/packages/google-cloud-support/google/cloud/support_v2beta/types/case.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/google/cloud/support_v2beta/types/case_service.py
+++ b/packages/google-cloud-support/google/cloud/support_v2beta/types/case_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/google/cloud/support_v2beta/types/comment.py
+++ b/packages/google-cloud-support/google/cloud/support_v2beta/types/comment.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/google/cloud/support_v2beta/types/comment_service.py
+++ b/packages/google-cloud-support/google/cloud/support_v2beta/types/comment_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/google/cloud/support_v2beta/types/content.py
+++ b/packages/google-cloud-support/google/cloud/support_v2beta/types/content.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/google/cloud/support_v2beta/types/email_message.py
+++ b/packages/google-cloud-support/google/cloud/support_v2beta/types/email_message.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/google/cloud/support_v2beta/types/escalation.py
+++ b/packages/google-cloud-support/google/cloud/support_v2beta/types/escalation.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/google/cloud/support_v2beta/types/feed_item.py
+++ b/packages/google-cloud-support/google/cloud/support_v2beta/types/feed_item.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/google/cloud/support_v2beta/types/feed_service.py
+++ b/packages/google-cloud-support/google/cloud/support_v2beta/types/feed_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/samples/generated_samples/cloudsupport_v2_generated_case_attachment_service_list_attachments_async.py
+++ b/packages/google-cloud-support/samples/generated_samples/cloudsupport_v2_generated_case_attachment_service_list_attachments_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/samples/generated_samples/cloudsupport_v2_generated_case_attachment_service_list_attachments_sync.py
+++ b/packages/google-cloud-support/samples/generated_samples/cloudsupport_v2_generated_case_attachment_service_list_attachments_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/samples/generated_samples/cloudsupport_v2_generated_case_service_close_case_async.py
+++ b/packages/google-cloud-support/samples/generated_samples/cloudsupport_v2_generated_case_service_close_case_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/samples/generated_samples/cloudsupport_v2_generated_case_service_close_case_sync.py
+++ b/packages/google-cloud-support/samples/generated_samples/cloudsupport_v2_generated_case_service_close_case_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/samples/generated_samples/cloudsupport_v2_generated_case_service_create_case_async.py
+++ b/packages/google-cloud-support/samples/generated_samples/cloudsupport_v2_generated_case_service_create_case_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/samples/generated_samples/cloudsupport_v2_generated_case_service_create_case_sync.py
+++ b/packages/google-cloud-support/samples/generated_samples/cloudsupport_v2_generated_case_service_create_case_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/samples/generated_samples/cloudsupport_v2_generated_case_service_escalate_case_async.py
+++ b/packages/google-cloud-support/samples/generated_samples/cloudsupport_v2_generated_case_service_escalate_case_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/samples/generated_samples/cloudsupport_v2_generated_case_service_escalate_case_sync.py
+++ b/packages/google-cloud-support/samples/generated_samples/cloudsupport_v2_generated_case_service_escalate_case_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/samples/generated_samples/cloudsupport_v2_generated_case_service_get_case_async.py
+++ b/packages/google-cloud-support/samples/generated_samples/cloudsupport_v2_generated_case_service_get_case_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/samples/generated_samples/cloudsupport_v2_generated_case_service_get_case_sync.py
+++ b/packages/google-cloud-support/samples/generated_samples/cloudsupport_v2_generated_case_service_get_case_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/samples/generated_samples/cloudsupport_v2_generated_case_service_list_cases_async.py
+++ b/packages/google-cloud-support/samples/generated_samples/cloudsupport_v2_generated_case_service_list_cases_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/samples/generated_samples/cloudsupport_v2_generated_case_service_list_cases_sync.py
+++ b/packages/google-cloud-support/samples/generated_samples/cloudsupport_v2_generated_case_service_list_cases_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/samples/generated_samples/cloudsupport_v2_generated_case_service_search_case_classifications_async.py
+++ b/packages/google-cloud-support/samples/generated_samples/cloudsupport_v2_generated_case_service_search_case_classifications_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/samples/generated_samples/cloudsupport_v2_generated_case_service_search_case_classifications_sync.py
+++ b/packages/google-cloud-support/samples/generated_samples/cloudsupport_v2_generated_case_service_search_case_classifications_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/samples/generated_samples/cloudsupport_v2_generated_case_service_search_cases_async.py
+++ b/packages/google-cloud-support/samples/generated_samples/cloudsupport_v2_generated_case_service_search_cases_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/samples/generated_samples/cloudsupport_v2_generated_case_service_search_cases_sync.py
+++ b/packages/google-cloud-support/samples/generated_samples/cloudsupport_v2_generated_case_service_search_cases_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/samples/generated_samples/cloudsupport_v2_generated_case_service_update_case_async.py
+++ b/packages/google-cloud-support/samples/generated_samples/cloudsupport_v2_generated_case_service_update_case_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/samples/generated_samples/cloudsupport_v2_generated_case_service_update_case_sync.py
+++ b/packages/google-cloud-support/samples/generated_samples/cloudsupport_v2_generated_case_service_update_case_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/samples/generated_samples/cloudsupport_v2_generated_comment_service_create_comment_async.py
+++ b/packages/google-cloud-support/samples/generated_samples/cloudsupport_v2_generated_comment_service_create_comment_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/samples/generated_samples/cloudsupport_v2_generated_comment_service_create_comment_sync.py
+++ b/packages/google-cloud-support/samples/generated_samples/cloudsupport_v2_generated_comment_service_create_comment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/samples/generated_samples/cloudsupport_v2_generated_comment_service_list_comments_async.py
+++ b/packages/google-cloud-support/samples/generated_samples/cloudsupport_v2_generated_comment_service_list_comments_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/samples/generated_samples/cloudsupport_v2_generated_comment_service_list_comments_sync.py
+++ b/packages/google-cloud-support/samples/generated_samples/cloudsupport_v2_generated_comment_service_list_comments_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/samples/generated_samples/cloudsupport_v2beta_generated_case_attachment_service_get_attachment_async.py
+++ b/packages/google-cloud-support/samples/generated_samples/cloudsupport_v2beta_generated_case_attachment_service_get_attachment_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/samples/generated_samples/cloudsupport_v2beta_generated_case_attachment_service_get_attachment_sync.py
+++ b/packages/google-cloud-support/samples/generated_samples/cloudsupport_v2beta_generated_case_attachment_service_get_attachment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/samples/generated_samples/cloudsupport_v2beta_generated_case_attachment_service_list_attachments_async.py
+++ b/packages/google-cloud-support/samples/generated_samples/cloudsupport_v2beta_generated_case_attachment_service_list_attachments_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/samples/generated_samples/cloudsupport_v2beta_generated_case_attachment_service_list_attachments_sync.py
+++ b/packages/google-cloud-support/samples/generated_samples/cloudsupport_v2beta_generated_case_attachment_service_list_attachments_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/samples/generated_samples/cloudsupport_v2beta_generated_case_service_close_case_async.py
+++ b/packages/google-cloud-support/samples/generated_samples/cloudsupport_v2beta_generated_case_service_close_case_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/samples/generated_samples/cloudsupport_v2beta_generated_case_service_close_case_sync.py
+++ b/packages/google-cloud-support/samples/generated_samples/cloudsupport_v2beta_generated_case_service_close_case_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/samples/generated_samples/cloudsupport_v2beta_generated_case_service_create_case_async.py
+++ b/packages/google-cloud-support/samples/generated_samples/cloudsupport_v2beta_generated_case_service_create_case_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/samples/generated_samples/cloudsupport_v2beta_generated_case_service_create_case_sync.py
+++ b/packages/google-cloud-support/samples/generated_samples/cloudsupport_v2beta_generated_case_service_create_case_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/samples/generated_samples/cloudsupport_v2beta_generated_case_service_escalate_case_async.py
+++ b/packages/google-cloud-support/samples/generated_samples/cloudsupport_v2beta_generated_case_service_escalate_case_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/samples/generated_samples/cloudsupport_v2beta_generated_case_service_escalate_case_sync.py
+++ b/packages/google-cloud-support/samples/generated_samples/cloudsupport_v2beta_generated_case_service_escalate_case_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/samples/generated_samples/cloudsupport_v2beta_generated_case_service_get_case_async.py
+++ b/packages/google-cloud-support/samples/generated_samples/cloudsupport_v2beta_generated_case_service_get_case_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/samples/generated_samples/cloudsupport_v2beta_generated_case_service_get_case_sync.py
+++ b/packages/google-cloud-support/samples/generated_samples/cloudsupport_v2beta_generated_case_service_get_case_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/samples/generated_samples/cloudsupport_v2beta_generated_case_service_list_cases_async.py
+++ b/packages/google-cloud-support/samples/generated_samples/cloudsupport_v2beta_generated_case_service_list_cases_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/samples/generated_samples/cloudsupport_v2beta_generated_case_service_list_cases_sync.py
+++ b/packages/google-cloud-support/samples/generated_samples/cloudsupport_v2beta_generated_case_service_list_cases_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/samples/generated_samples/cloudsupport_v2beta_generated_case_service_search_case_classifications_async.py
+++ b/packages/google-cloud-support/samples/generated_samples/cloudsupport_v2beta_generated_case_service_search_case_classifications_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/samples/generated_samples/cloudsupport_v2beta_generated_case_service_search_case_classifications_sync.py
+++ b/packages/google-cloud-support/samples/generated_samples/cloudsupport_v2beta_generated_case_service_search_case_classifications_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/samples/generated_samples/cloudsupport_v2beta_generated_case_service_search_cases_async.py
+++ b/packages/google-cloud-support/samples/generated_samples/cloudsupport_v2beta_generated_case_service_search_cases_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/samples/generated_samples/cloudsupport_v2beta_generated_case_service_search_cases_sync.py
+++ b/packages/google-cloud-support/samples/generated_samples/cloudsupport_v2beta_generated_case_service_search_cases_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/samples/generated_samples/cloudsupport_v2beta_generated_case_service_update_case_async.py
+++ b/packages/google-cloud-support/samples/generated_samples/cloudsupport_v2beta_generated_case_service_update_case_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/samples/generated_samples/cloudsupport_v2beta_generated_case_service_update_case_sync.py
+++ b/packages/google-cloud-support/samples/generated_samples/cloudsupport_v2beta_generated_case_service_update_case_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/samples/generated_samples/cloudsupport_v2beta_generated_comment_service_create_comment_async.py
+++ b/packages/google-cloud-support/samples/generated_samples/cloudsupport_v2beta_generated_comment_service_create_comment_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/samples/generated_samples/cloudsupport_v2beta_generated_comment_service_create_comment_sync.py
+++ b/packages/google-cloud-support/samples/generated_samples/cloudsupport_v2beta_generated_comment_service_create_comment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/samples/generated_samples/cloudsupport_v2beta_generated_comment_service_get_comment_async.py
+++ b/packages/google-cloud-support/samples/generated_samples/cloudsupport_v2beta_generated_comment_service_get_comment_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/samples/generated_samples/cloudsupport_v2beta_generated_comment_service_get_comment_sync.py
+++ b/packages/google-cloud-support/samples/generated_samples/cloudsupport_v2beta_generated_comment_service_get_comment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/samples/generated_samples/cloudsupport_v2beta_generated_comment_service_list_comments_async.py
+++ b/packages/google-cloud-support/samples/generated_samples/cloudsupport_v2beta_generated_comment_service_list_comments_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/samples/generated_samples/cloudsupport_v2beta_generated_comment_service_list_comments_sync.py
+++ b/packages/google-cloud-support/samples/generated_samples/cloudsupport_v2beta_generated_comment_service_list_comments_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/samples/generated_samples/cloudsupport_v2beta_generated_feed_service_show_feed_async.py
+++ b/packages/google-cloud-support/samples/generated_samples/cloudsupport_v2beta_generated_feed_service_show_feed_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/samples/generated_samples/cloudsupport_v2beta_generated_feed_service_show_feed_sync.py
+++ b/packages/google-cloud-support/samples/generated_samples/cloudsupport_v2beta_generated_feed_service_show_feed_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/tests/__init__.py
+++ b/packages/google-cloud-support/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/tests/unit/__init__.py
+++ b/packages/google-cloud-support/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-support/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/tests/unit/gapic/support_v2/__init__.py
+++ b/packages/google-cloud-support/tests/unit/gapic/support_v2/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-support/tests/unit/gapic/support_v2beta/__init__.py
+++ b/packages/google-cloud-support/tests/unit/gapic/support_v2beta/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
This is the result of regenerating all packages, but only committing files which have only changed in a single line, and that's a copyright line.