### PR TITLE
chore: regenerate packages in google-cloud-[t-w], copyright changes only

### DIFF
--- a/packages/google-cloud-talent/.flake8
+++ b/packages/google-cloud-talent/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/MANIFEST.in
+++ b/packages/google-cloud-talent/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent/__init__.py
+++ b/packages/google-cloud-talent/google/cloud/talent/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent/gapic_version.py
+++ b/packages/google-cloud-talent/google/cloud/talent/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4/gapic_version.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4/services/__init__.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4/services/company_service/__init__.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4/services/company_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4/services/company_service/async_client.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4/services/company_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4/services/company_service/client.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4/services/company_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4/services/company_service/pagers.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4/services/company_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4/services/company_service/transports/__init__.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4/services/company_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4/services/company_service/transports/base.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4/services/company_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4/services/company_service/transports/grpc.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4/services/company_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4/services/company_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4/services/company_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4/services/company_service/transports/rest.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4/services/company_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4/services/company_service/transports/rest_base.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4/services/company_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4/services/completion/__init__.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4/services/completion/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4/services/completion/async_client.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4/services/completion/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4/services/completion/client.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4/services/completion/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4/services/completion/transports/__init__.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4/services/completion/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4/services/completion/transports/base.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4/services/completion/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4/services/completion/transports/grpc.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4/services/completion/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4/services/completion/transports/grpc_asyncio.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4/services/completion/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4/services/completion/transports/rest.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4/services/completion/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4/services/completion/transports/rest_base.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4/services/completion/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4/services/event_service/__init__.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4/services/event_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4/services/event_service/async_client.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4/services/event_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4/services/event_service/client.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4/services/event_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4/services/event_service/transports/__init__.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4/services/event_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4/services/event_service/transports/base.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4/services/event_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4/services/event_service/transports/grpc.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4/services/event_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4/services/event_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4/services/event_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4/services/event_service/transports/rest.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4/services/event_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4/services/event_service/transports/rest_base.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4/services/event_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4/services/job_service/__init__.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4/services/job_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4/services/job_service/client.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4/services/job_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4/services/job_service/pagers.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4/services/job_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4/services/job_service/transports/__init__.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4/services/job_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4/services/job_service/transports/base.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4/services/job_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4/services/job_service/transports/grpc.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4/services/job_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4/services/job_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4/services/job_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4/services/job_service/transports/rest.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4/services/job_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4/services/job_service/transports/rest_base.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4/services/job_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4/services/tenant_service/__init__.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4/services/tenant_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4/services/tenant_service/async_client.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4/services/tenant_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4/services/tenant_service/client.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4/services/tenant_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4/services/tenant_service/pagers.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4/services/tenant_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4/services/tenant_service/transports/__init__.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4/services/tenant_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4/services/tenant_service/transports/base.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4/services/tenant_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4/services/tenant_service/transports/grpc.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4/services/tenant_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4/services/tenant_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4/services/tenant_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4/services/tenant_service/transports/rest.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4/services/tenant_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4/services/tenant_service/transports/rest_base.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4/services/tenant_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4/types/__init__.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4/types/common.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4/types/common.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4/types/company.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4/types/company.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4/types/company_service.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4/types/company_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4/types/completion_service.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4/types/completion_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4/types/event.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4/types/event.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4/types/event_service.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4/types/event_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4/types/filters.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4/types/filters.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4/types/histogram.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4/types/histogram.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4/types/job.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4/types/job.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4/types/job_service.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4/types/job_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4/types/tenant.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4/types/tenant.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4/types/tenant_service.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4/types/tenant_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4beta1/gapic_version.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4beta1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4beta1/services/__init__.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4beta1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4beta1/services/company_service/__init__.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4beta1/services/company_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4beta1/services/company_service/async_client.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4beta1/services/company_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4beta1/services/company_service/client.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4beta1/services/company_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4beta1/services/company_service/pagers.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4beta1/services/company_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4beta1/services/company_service/transports/__init__.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4beta1/services/company_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4beta1/services/company_service/transports/base.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4beta1/services/company_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4beta1/services/company_service/transports/grpc.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4beta1/services/company_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4beta1/services/company_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4beta1/services/company_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4beta1/services/company_service/transports/rest.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4beta1/services/company_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4beta1/services/company_service/transports/rest_base.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4beta1/services/company_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4beta1/services/completion/__init__.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4beta1/services/completion/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4beta1/services/completion/async_client.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4beta1/services/completion/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4beta1/services/completion/client.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4beta1/services/completion/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4beta1/services/completion/transports/__init__.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4beta1/services/completion/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4beta1/services/completion/transports/base.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4beta1/services/completion/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4beta1/services/completion/transports/grpc.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4beta1/services/completion/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4beta1/services/completion/transports/grpc_asyncio.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4beta1/services/completion/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4beta1/services/completion/transports/rest.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4beta1/services/completion/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4beta1/services/completion/transports/rest_base.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4beta1/services/completion/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4beta1/services/event_service/__init__.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4beta1/services/event_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4beta1/services/event_service/async_client.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4beta1/services/event_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4beta1/services/event_service/client.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4beta1/services/event_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4beta1/services/event_service/transports/__init__.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4beta1/services/event_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4beta1/services/event_service/transports/base.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4beta1/services/event_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4beta1/services/event_service/transports/grpc.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4beta1/services/event_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4beta1/services/event_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4beta1/services/event_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4beta1/services/event_service/transports/rest.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4beta1/services/event_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4beta1/services/event_service/transports/rest_base.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4beta1/services/event_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4beta1/services/job_service/__init__.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4beta1/services/job_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4beta1/services/job_service/client.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4beta1/services/job_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4beta1/services/job_service/pagers.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4beta1/services/job_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4beta1/services/job_service/transports/__init__.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4beta1/services/job_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4beta1/services/job_service/transports/base.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4beta1/services/job_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4beta1/services/job_service/transports/grpc.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4beta1/services/job_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4beta1/services/job_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4beta1/services/job_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4beta1/services/job_service/transports/rest.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4beta1/services/job_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4beta1/services/job_service/transports/rest_base.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4beta1/services/job_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4beta1/services/tenant_service/__init__.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4beta1/services/tenant_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4beta1/services/tenant_service/async_client.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4beta1/services/tenant_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4beta1/services/tenant_service/client.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4beta1/services/tenant_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4beta1/services/tenant_service/pagers.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4beta1/services/tenant_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4beta1/services/tenant_service/transports/__init__.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4beta1/services/tenant_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4beta1/services/tenant_service/transports/base.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4beta1/services/tenant_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4beta1/services/tenant_service/transports/grpc.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4beta1/services/tenant_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4beta1/services/tenant_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4beta1/services/tenant_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4beta1/services/tenant_service/transports/rest.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4beta1/services/tenant_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4beta1/services/tenant_service/transports/rest_base.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4beta1/services/tenant_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4beta1/types/__init__.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4beta1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4beta1/types/batch.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4beta1/types/batch.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4beta1/types/common.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4beta1/types/common.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4beta1/types/company.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4beta1/types/company.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4beta1/types/company_service.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4beta1/types/company_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4beta1/types/completion_service.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4beta1/types/completion_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4beta1/types/event.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4beta1/types/event.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4beta1/types/event_service.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4beta1/types/event_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4beta1/types/filters.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4beta1/types/filters.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4beta1/types/histogram.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4beta1/types/histogram.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4beta1/types/job.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4beta1/types/job.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4beta1/types/job_service.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4beta1/types/job_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4beta1/types/tenant.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4beta1/types/tenant.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/google/cloud/talent_v4beta1/types/tenant_service.py
+++ b/packages/google-cloud-talent/google/cloud/talent_v4beta1/types/tenant_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/samples/generated_samples/jobs_v4_generated_company_service_create_company_async.py
+++ b/packages/google-cloud-talent/samples/generated_samples/jobs_v4_generated_company_service_create_company_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/samples/generated_samples/jobs_v4_generated_company_service_create_company_sync.py
+++ b/packages/google-cloud-talent/samples/generated_samples/jobs_v4_generated_company_service_create_company_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/samples/generated_samples/jobs_v4_generated_company_service_delete_company_async.py
+++ b/packages/google-cloud-talent/samples/generated_samples/jobs_v4_generated_company_service_delete_company_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/samples/generated_samples/jobs_v4_generated_company_service_delete_company_sync.py
+++ b/packages/google-cloud-talent/samples/generated_samples/jobs_v4_generated_company_service_delete_company_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/samples/generated_samples/jobs_v4_generated_company_service_get_company_async.py
+++ b/packages/google-cloud-talent/samples/generated_samples/jobs_v4_generated_company_service_get_company_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/samples/generated_samples/jobs_v4_generated_company_service_get_company_sync.py
+++ b/packages/google-cloud-talent/samples/generated_samples/jobs_v4_generated_company_service_get_company_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/samples/generated_samples/jobs_v4_generated_company_service_list_companies_async.py
+++ b/packages/google-cloud-talent/samples/generated_samples/jobs_v4_generated_company_service_list_companies_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/samples/generated_samples/jobs_v4_generated_company_service_list_companies_sync.py
+++ b/packages/google-cloud-talent/samples/generated_samples/jobs_v4_generated_company_service_list_companies_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/samples/generated_samples/jobs_v4_generated_company_service_update_company_async.py
+++ b/packages/google-cloud-talent/samples/generated_samples/jobs_v4_generated_company_service_update_company_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/samples/generated_samples/jobs_v4_generated_company_service_update_company_sync.py
+++ b/packages/google-cloud-talent/samples/generated_samples/jobs_v4_generated_company_service_update_company_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/samples/generated_samples/jobs_v4_generated_completion_complete_query_async.py
+++ b/packages/google-cloud-talent/samples/generated_samples/jobs_v4_generated_completion_complete_query_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/samples/generated_samples/jobs_v4_generated_completion_complete_query_sync.py
+++ b/packages/google-cloud-talent/samples/generated_samples/jobs_v4_generated_completion_complete_query_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/samples/generated_samples/jobs_v4_generated_event_service_create_client_event_async.py
+++ b/packages/google-cloud-talent/samples/generated_samples/jobs_v4_generated_event_service_create_client_event_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/samples/generated_samples/jobs_v4_generated_event_service_create_client_event_sync.py
+++ b/packages/google-cloud-talent/samples/generated_samples/jobs_v4_generated_event_service_create_client_event_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/samples/generated_samples/jobs_v4_generated_job_service_batch_create_jobs_sync.py
+++ b/packages/google-cloud-talent/samples/generated_samples/jobs_v4_generated_job_service_batch_create_jobs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/samples/generated_samples/jobs_v4_generated_job_service_batch_delete_jobs_sync.py
+++ b/packages/google-cloud-talent/samples/generated_samples/jobs_v4_generated_job_service_batch_delete_jobs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/samples/generated_samples/jobs_v4_generated_job_service_batch_update_jobs_sync.py
+++ b/packages/google-cloud-talent/samples/generated_samples/jobs_v4_generated_job_service_batch_update_jobs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/samples/generated_samples/jobs_v4_generated_job_service_create_job_async.py
+++ b/packages/google-cloud-talent/samples/generated_samples/jobs_v4_generated_job_service_create_job_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/samples/generated_samples/jobs_v4_generated_job_service_create_job_sync.py
+++ b/packages/google-cloud-talent/samples/generated_samples/jobs_v4_generated_job_service_create_job_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/samples/generated_samples/jobs_v4_generated_job_service_delete_job_async.py
+++ b/packages/google-cloud-talent/samples/generated_samples/jobs_v4_generated_job_service_delete_job_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/samples/generated_samples/jobs_v4_generated_job_service_delete_job_sync.py
+++ b/packages/google-cloud-talent/samples/generated_samples/jobs_v4_generated_job_service_delete_job_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/samples/generated_samples/jobs_v4_generated_job_service_get_job_async.py
+++ b/packages/google-cloud-talent/samples/generated_samples/jobs_v4_generated_job_service_get_job_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/samples/generated_samples/jobs_v4_generated_job_service_get_job_sync.py
+++ b/packages/google-cloud-talent/samples/generated_samples/jobs_v4_generated_job_service_get_job_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/samples/generated_samples/jobs_v4_generated_job_service_list_jobs_async.py
+++ b/packages/google-cloud-talent/samples/generated_samples/jobs_v4_generated_job_service_list_jobs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/samples/generated_samples/jobs_v4_generated_job_service_list_jobs_sync.py
+++ b/packages/google-cloud-talent/samples/generated_samples/jobs_v4_generated_job_service_list_jobs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/samples/generated_samples/jobs_v4_generated_job_service_search_jobs_async.py
+++ b/packages/google-cloud-talent/samples/generated_samples/jobs_v4_generated_job_service_search_jobs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/samples/generated_samples/jobs_v4_generated_job_service_search_jobs_for_alert_async.py
+++ b/packages/google-cloud-talent/samples/generated_samples/jobs_v4_generated_job_service_search_jobs_for_alert_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/samples/generated_samples/jobs_v4_generated_job_service_search_jobs_for_alert_sync.py
+++ b/packages/google-cloud-talent/samples/generated_samples/jobs_v4_generated_job_service_search_jobs_for_alert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/samples/generated_samples/jobs_v4_generated_job_service_search_jobs_sync.py
+++ b/packages/google-cloud-talent/samples/generated_samples/jobs_v4_generated_job_service_search_jobs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/samples/generated_samples/jobs_v4_generated_job_service_update_job_async.py
+++ b/packages/google-cloud-talent/samples/generated_samples/jobs_v4_generated_job_service_update_job_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/samples/generated_samples/jobs_v4_generated_job_service_update_job_sync.py
+++ b/packages/google-cloud-talent/samples/generated_samples/jobs_v4_generated_job_service_update_job_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/samples/generated_samples/jobs_v4_generated_tenant_service_create_tenant_async.py
+++ b/packages/google-cloud-talent/samples/generated_samples/jobs_v4_generated_tenant_service_create_tenant_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/samples/generated_samples/jobs_v4_generated_tenant_service_create_tenant_sync.py
+++ b/packages/google-cloud-talent/samples/generated_samples/jobs_v4_generated_tenant_service_create_tenant_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/samples/generated_samples/jobs_v4_generated_tenant_service_delete_tenant_async.py
+++ b/packages/google-cloud-talent/samples/generated_samples/jobs_v4_generated_tenant_service_delete_tenant_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/samples/generated_samples/jobs_v4_generated_tenant_service_delete_tenant_sync.py
+++ b/packages/google-cloud-talent/samples/generated_samples/jobs_v4_generated_tenant_service_delete_tenant_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/samples/generated_samples/jobs_v4_generated_tenant_service_get_tenant_async.py
+++ b/packages/google-cloud-talent/samples/generated_samples/jobs_v4_generated_tenant_service_get_tenant_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/samples/generated_samples/jobs_v4_generated_tenant_service_get_tenant_sync.py
+++ b/packages/google-cloud-talent/samples/generated_samples/jobs_v4_generated_tenant_service_get_tenant_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/samples/generated_samples/jobs_v4_generated_tenant_service_list_tenants_async.py
+++ b/packages/google-cloud-talent/samples/generated_samples/jobs_v4_generated_tenant_service_list_tenants_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/samples/generated_samples/jobs_v4_generated_tenant_service_list_tenants_sync.py
+++ b/packages/google-cloud-talent/samples/generated_samples/jobs_v4_generated_tenant_service_list_tenants_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/samples/generated_samples/jobs_v4_generated_tenant_service_update_tenant_async.py
+++ b/packages/google-cloud-talent/samples/generated_samples/jobs_v4_generated_tenant_service_update_tenant_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/samples/generated_samples/jobs_v4_generated_tenant_service_update_tenant_sync.py
+++ b/packages/google-cloud-talent/samples/generated_samples/jobs_v4_generated_tenant_service_update_tenant_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/samples/generated_samples/jobs_v4beta1_generated_company_service_create_company_async.py
+++ b/packages/google-cloud-talent/samples/generated_samples/jobs_v4beta1_generated_company_service_create_company_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/samples/generated_samples/jobs_v4beta1_generated_company_service_create_company_sync.py
+++ b/packages/google-cloud-talent/samples/generated_samples/jobs_v4beta1_generated_company_service_create_company_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/samples/generated_samples/jobs_v4beta1_generated_company_service_delete_company_async.py
+++ b/packages/google-cloud-talent/samples/generated_samples/jobs_v4beta1_generated_company_service_delete_company_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/samples/generated_samples/jobs_v4beta1_generated_company_service_delete_company_sync.py
+++ b/packages/google-cloud-talent/samples/generated_samples/jobs_v4beta1_generated_company_service_delete_company_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/samples/generated_samples/jobs_v4beta1_generated_company_service_get_company_async.py
+++ b/packages/google-cloud-talent/samples/generated_samples/jobs_v4beta1_generated_company_service_get_company_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/samples/generated_samples/jobs_v4beta1_generated_company_service_get_company_sync.py
+++ b/packages/google-cloud-talent/samples/generated_samples/jobs_v4beta1_generated_company_service_get_company_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/samples/generated_samples/jobs_v4beta1_generated_company_service_list_companies_async.py
+++ b/packages/google-cloud-talent/samples/generated_samples/jobs_v4beta1_generated_company_service_list_companies_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/samples/generated_samples/jobs_v4beta1_generated_company_service_list_companies_sync.py
+++ b/packages/google-cloud-talent/samples/generated_samples/jobs_v4beta1_generated_company_service_list_companies_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/samples/generated_samples/jobs_v4beta1_generated_company_service_update_company_async.py
+++ b/packages/google-cloud-talent/samples/generated_samples/jobs_v4beta1_generated_company_service_update_company_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/samples/generated_samples/jobs_v4beta1_generated_company_service_update_company_sync.py
+++ b/packages/google-cloud-talent/samples/generated_samples/jobs_v4beta1_generated_company_service_update_company_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/samples/generated_samples/jobs_v4beta1_generated_completion_complete_query_async.py
+++ b/packages/google-cloud-talent/samples/generated_samples/jobs_v4beta1_generated_completion_complete_query_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/samples/generated_samples/jobs_v4beta1_generated_completion_complete_query_sync.py
+++ b/packages/google-cloud-talent/samples/generated_samples/jobs_v4beta1_generated_completion_complete_query_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/samples/generated_samples/jobs_v4beta1_generated_event_service_create_client_event_async.py
+++ b/packages/google-cloud-talent/samples/generated_samples/jobs_v4beta1_generated_event_service_create_client_event_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/samples/generated_samples/jobs_v4beta1_generated_event_service_create_client_event_sync.py
+++ b/packages/google-cloud-talent/samples/generated_samples/jobs_v4beta1_generated_event_service_create_client_event_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/samples/generated_samples/jobs_v4beta1_generated_job_service_batch_create_jobs_sync.py
+++ b/packages/google-cloud-talent/samples/generated_samples/jobs_v4beta1_generated_job_service_batch_create_jobs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/samples/generated_samples/jobs_v4beta1_generated_job_service_batch_delete_jobs_async.py
+++ b/packages/google-cloud-talent/samples/generated_samples/jobs_v4beta1_generated_job_service_batch_delete_jobs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/samples/generated_samples/jobs_v4beta1_generated_job_service_batch_delete_jobs_sync.py
+++ b/packages/google-cloud-talent/samples/generated_samples/jobs_v4beta1_generated_job_service_batch_delete_jobs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/samples/generated_samples/jobs_v4beta1_generated_job_service_batch_update_jobs_sync.py
+++ b/packages/google-cloud-talent/samples/generated_samples/jobs_v4beta1_generated_job_service_batch_update_jobs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/samples/generated_samples/jobs_v4beta1_generated_job_service_create_job_async.py
+++ b/packages/google-cloud-talent/samples/generated_samples/jobs_v4beta1_generated_job_service_create_job_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/samples/generated_samples/jobs_v4beta1_generated_job_service_create_job_sync.py
+++ b/packages/google-cloud-talent/samples/generated_samples/jobs_v4beta1_generated_job_service_create_job_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/samples/generated_samples/jobs_v4beta1_generated_job_service_delete_job_async.py
+++ b/packages/google-cloud-talent/samples/generated_samples/jobs_v4beta1_generated_job_service_delete_job_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/samples/generated_samples/jobs_v4beta1_generated_job_service_delete_job_sync.py
+++ b/packages/google-cloud-talent/samples/generated_samples/jobs_v4beta1_generated_job_service_delete_job_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/samples/generated_samples/jobs_v4beta1_generated_job_service_get_job_async.py
+++ b/packages/google-cloud-talent/samples/generated_samples/jobs_v4beta1_generated_job_service_get_job_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/samples/generated_samples/jobs_v4beta1_generated_job_service_get_job_sync.py
+++ b/packages/google-cloud-talent/samples/generated_samples/jobs_v4beta1_generated_job_service_get_job_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/samples/generated_samples/jobs_v4beta1_generated_job_service_list_jobs_async.py
+++ b/packages/google-cloud-talent/samples/generated_samples/jobs_v4beta1_generated_job_service_list_jobs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/samples/generated_samples/jobs_v4beta1_generated_job_service_list_jobs_sync.py
+++ b/packages/google-cloud-talent/samples/generated_samples/jobs_v4beta1_generated_job_service_list_jobs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/samples/generated_samples/jobs_v4beta1_generated_job_service_search_jobs_async.py
+++ b/packages/google-cloud-talent/samples/generated_samples/jobs_v4beta1_generated_job_service_search_jobs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/samples/generated_samples/jobs_v4beta1_generated_job_service_search_jobs_for_alert_async.py
+++ b/packages/google-cloud-talent/samples/generated_samples/jobs_v4beta1_generated_job_service_search_jobs_for_alert_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/samples/generated_samples/jobs_v4beta1_generated_job_service_search_jobs_for_alert_sync.py
+++ b/packages/google-cloud-talent/samples/generated_samples/jobs_v4beta1_generated_job_service_search_jobs_for_alert_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/samples/generated_samples/jobs_v4beta1_generated_job_service_search_jobs_sync.py
+++ b/packages/google-cloud-talent/samples/generated_samples/jobs_v4beta1_generated_job_service_search_jobs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/samples/generated_samples/jobs_v4beta1_generated_job_service_update_job_async.py
+++ b/packages/google-cloud-talent/samples/generated_samples/jobs_v4beta1_generated_job_service_update_job_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/samples/generated_samples/jobs_v4beta1_generated_job_service_update_job_sync.py
+++ b/packages/google-cloud-talent/samples/generated_samples/jobs_v4beta1_generated_job_service_update_job_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/samples/generated_samples/jobs_v4beta1_generated_tenant_service_create_tenant_async.py
+++ b/packages/google-cloud-talent/samples/generated_samples/jobs_v4beta1_generated_tenant_service_create_tenant_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/samples/generated_samples/jobs_v4beta1_generated_tenant_service_create_tenant_sync.py
+++ b/packages/google-cloud-talent/samples/generated_samples/jobs_v4beta1_generated_tenant_service_create_tenant_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/samples/generated_samples/jobs_v4beta1_generated_tenant_service_delete_tenant_async.py
+++ b/packages/google-cloud-talent/samples/generated_samples/jobs_v4beta1_generated_tenant_service_delete_tenant_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/samples/generated_samples/jobs_v4beta1_generated_tenant_service_delete_tenant_sync.py
+++ b/packages/google-cloud-talent/samples/generated_samples/jobs_v4beta1_generated_tenant_service_delete_tenant_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/samples/generated_samples/jobs_v4beta1_generated_tenant_service_get_tenant_async.py
+++ b/packages/google-cloud-talent/samples/generated_samples/jobs_v4beta1_generated_tenant_service_get_tenant_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/samples/generated_samples/jobs_v4beta1_generated_tenant_service_get_tenant_sync.py
+++ b/packages/google-cloud-talent/samples/generated_samples/jobs_v4beta1_generated_tenant_service_get_tenant_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/samples/generated_samples/jobs_v4beta1_generated_tenant_service_list_tenants_async.py
+++ b/packages/google-cloud-talent/samples/generated_samples/jobs_v4beta1_generated_tenant_service_list_tenants_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/samples/generated_samples/jobs_v4beta1_generated_tenant_service_list_tenants_sync.py
+++ b/packages/google-cloud-talent/samples/generated_samples/jobs_v4beta1_generated_tenant_service_list_tenants_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/samples/generated_samples/jobs_v4beta1_generated_tenant_service_update_tenant_async.py
+++ b/packages/google-cloud-talent/samples/generated_samples/jobs_v4beta1_generated_tenant_service_update_tenant_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/samples/generated_samples/jobs_v4beta1_generated_tenant_service_update_tenant_sync.py
+++ b/packages/google-cloud-talent/samples/generated_samples/jobs_v4beta1_generated_tenant_service_update_tenant_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/tests/__init__.py
+++ b/packages/google-cloud-talent/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/tests/unit/__init__.py
+++ b/packages/google-cloud-talent/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-talent/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/tests/unit/gapic/talent_v4/__init__.py
+++ b/packages/google-cloud-talent/tests/unit/gapic/talent_v4/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-talent/tests/unit/gapic/talent_v4beta1/__init__.py
+++ b/packages/google-cloud-talent/tests/unit/gapic/talent_v4beta1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/.flake8
+++ b/packages/google-cloud-tasks/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/MANIFEST.in
+++ b/packages/google-cloud-tasks/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/google/cloud/tasks/__init__.py
+++ b/packages/google-cloud-tasks/google/cloud/tasks/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/google/cloud/tasks/gapic_version.py
+++ b/packages/google-cloud-tasks/google/cloud/tasks/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/google/cloud/tasks_v2/gapic_version.py
+++ b/packages/google-cloud-tasks/google/cloud/tasks_v2/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/google/cloud/tasks_v2/services/__init__.py
+++ b/packages/google-cloud-tasks/google/cloud/tasks_v2/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/google/cloud/tasks_v2/services/cloud_tasks/__init__.py
+++ b/packages/google-cloud-tasks/google/cloud/tasks_v2/services/cloud_tasks/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/google/cloud/tasks_v2/services/cloud_tasks/async_client.py
+++ b/packages/google-cloud-tasks/google/cloud/tasks_v2/services/cloud_tasks/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/google/cloud/tasks_v2/services/cloud_tasks/client.py
+++ b/packages/google-cloud-tasks/google/cloud/tasks_v2/services/cloud_tasks/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/google/cloud/tasks_v2/services/cloud_tasks/pagers.py
+++ b/packages/google-cloud-tasks/google/cloud/tasks_v2/services/cloud_tasks/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/google/cloud/tasks_v2/services/cloud_tasks/transports/__init__.py
+++ b/packages/google-cloud-tasks/google/cloud/tasks_v2/services/cloud_tasks/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/google/cloud/tasks_v2/services/cloud_tasks/transports/base.py
+++ b/packages/google-cloud-tasks/google/cloud/tasks_v2/services/cloud_tasks/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/google/cloud/tasks_v2/services/cloud_tasks/transports/grpc.py
+++ b/packages/google-cloud-tasks/google/cloud/tasks_v2/services/cloud_tasks/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/google/cloud/tasks_v2/services/cloud_tasks/transports/grpc_asyncio.py
+++ b/packages/google-cloud-tasks/google/cloud/tasks_v2/services/cloud_tasks/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/google/cloud/tasks_v2/services/cloud_tasks/transports/rest.py
+++ b/packages/google-cloud-tasks/google/cloud/tasks_v2/services/cloud_tasks/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/google/cloud/tasks_v2/services/cloud_tasks/transports/rest_base.py
+++ b/packages/google-cloud-tasks/google/cloud/tasks_v2/services/cloud_tasks/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/google/cloud/tasks_v2/types/__init__.py
+++ b/packages/google-cloud-tasks/google/cloud/tasks_v2/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/google/cloud/tasks_v2/types/cloudtasks.py
+++ b/packages/google-cloud-tasks/google/cloud/tasks_v2/types/cloudtasks.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/google/cloud/tasks_v2/types/queue.py
+++ b/packages/google-cloud-tasks/google/cloud/tasks_v2/types/queue.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/google/cloud/tasks_v2/types/target.py
+++ b/packages/google-cloud-tasks/google/cloud/tasks_v2/types/target.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/google/cloud/tasks_v2/types/task.py
+++ b/packages/google-cloud-tasks/google/cloud/tasks_v2/types/task.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/google/cloud/tasks_v2beta2/gapic_version.py
+++ b/packages/google-cloud-tasks/google/cloud/tasks_v2beta2/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/google/cloud/tasks_v2beta2/services/__init__.py
+++ b/packages/google-cloud-tasks/google/cloud/tasks_v2beta2/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/google/cloud/tasks_v2beta2/services/cloud_tasks/__init__.py
+++ b/packages/google-cloud-tasks/google/cloud/tasks_v2beta2/services/cloud_tasks/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/google/cloud/tasks_v2beta2/services/cloud_tasks/async_client.py
+++ b/packages/google-cloud-tasks/google/cloud/tasks_v2beta2/services/cloud_tasks/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/google/cloud/tasks_v2beta2/services/cloud_tasks/client.py
+++ b/packages/google-cloud-tasks/google/cloud/tasks_v2beta2/services/cloud_tasks/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/google/cloud/tasks_v2beta2/services/cloud_tasks/pagers.py
+++ b/packages/google-cloud-tasks/google/cloud/tasks_v2beta2/services/cloud_tasks/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/google/cloud/tasks_v2beta2/services/cloud_tasks/transports/__init__.py
+++ b/packages/google-cloud-tasks/google/cloud/tasks_v2beta2/services/cloud_tasks/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/google/cloud/tasks_v2beta2/services/cloud_tasks/transports/base.py
+++ b/packages/google-cloud-tasks/google/cloud/tasks_v2beta2/services/cloud_tasks/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/google/cloud/tasks_v2beta2/services/cloud_tasks/transports/grpc.py
+++ b/packages/google-cloud-tasks/google/cloud/tasks_v2beta2/services/cloud_tasks/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/google/cloud/tasks_v2beta2/services/cloud_tasks/transports/grpc_asyncio.py
+++ b/packages/google-cloud-tasks/google/cloud/tasks_v2beta2/services/cloud_tasks/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/google/cloud/tasks_v2beta2/services/cloud_tasks/transports/rest.py
+++ b/packages/google-cloud-tasks/google/cloud/tasks_v2beta2/services/cloud_tasks/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/google/cloud/tasks_v2beta2/services/cloud_tasks/transports/rest_base.py
+++ b/packages/google-cloud-tasks/google/cloud/tasks_v2beta2/services/cloud_tasks/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/google/cloud/tasks_v2beta2/types/__init__.py
+++ b/packages/google-cloud-tasks/google/cloud/tasks_v2beta2/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/google/cloud/tasks_v2beta2/types/cloudtasks.py
+++ b/packages/google-cloud-tasks/google/cloud/tasks_v2beta2/types/cloudtasks.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/google/cloud/tasks_v2beta2/types/old_target.py
+++ b/packages/google-cloud-tasks/google/cloud/tasks_v2beta2/types/old_target.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/google/cloud/tasks_v2beta2/types/queue.py
+++ b/packages/google-cloud-tasks/google/cloud/tasks_v2beta2/types/queue.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/google/cloud/tasks_v2beta2/types/target.py
+++ b/packages/google-cloud-tasks/google/cloud/tasks_v2beta2/types/target.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/google/cloud/tasks_v2beta2/types/task.py
+++ b/packages/google-cloud-tasks/google/cloud/tasks_v2beta2/types/task.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/google/cloud/tasks_v2beta3/gapic_version.py
+++ b/packages/google-cloud-tasks/google/cloud/tasks_v2beta3/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/google/cloud/tasks_v2beta3/services/__init__.py
+++ b/packages/google-cloud-tasks/google/cloud/tasks_v2beta3/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/google/cloud/tasks_v2beta3/services/cloud_tasks/__init__.py
+++ b/packages/google-cloud-tasks/google/cloud/tasks_v2beta3/services/cloud_tasks/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/google/cloud/tasks_v2beta3/services/cloud_tasks/async_client.py
+++ b/packages/google-cloud-tasks/google/cloud/tasks_v2beta3/services/cloud_tasks/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/google/cloud/tasks_v2beta3/services/cloud_tasks/client.py
+++ b/packages/google-cloud-tasks/google/cloud/tasks_v2beta3/services/cloud_tasks/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/google/cloud/tasks_v2beta3/services/cloud_tasks/pagers.py
+++ b/packages/google-cloud-tasks/google/cloud/tasks_v2beta3/services/cloud_tasks/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/google/cloud/tasks_v2beta3/services/cloud_tasks/transports/__init__.py
+++ b/packages/google-cloud-tasks/google/cloud/tasks_v2beta3/services/cloud_tasks/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/google/cloud/tasks_v2beta3/services/cloud_tasks/transports/base.py
+++ b/packages/google-cloud-tasks/google/cloud/tasks_v2beta3/services/cloud_tasks/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/google/cloud/tasks_v2beta3/services/cloud_tasks/transports/grpc.py
+++ b/packages/google-cloud-tasks/google/cloud/tasks_v2beta3/services/cloud_tasks/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/google/cloud/tasks_v2beta3/services/cloud_tasks/transports/grpc_asyncio.py
+++ b/packages/google-cloud-tasks/google/cloud/tasks_v2beta3/services/cloud_tasks/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/google/cloud/tasks_v2beta3/services/cloud_tasks/transports/rest.py
+++ b/packages/google-cloud-tasks/google/cloud/tasks_v2beta3/services/cloud_tasks/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/google/cloud/tasks_v2beta3/services/cloud_tasks/transports/rest_base.py
+++ b/packages/google-cloud-tasks/google/cloud/tasks_v2beta3/services/cloud_tasks/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/google/cloud/tasks_v2beta3/types/__init__.py
+++ b/packages/google-cloud-tasks/google/cloud/tasks_v2beta3/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/google/cloud/tasks_v2beta3/types/cloudtasks.py
+++ b/packages/google-cloud-tasks/google/cloud/tasks_v2beta3/types/cloudtasks.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/google/cloud/tasks_v2beta3/types/queue.py
+++ b/packages/google-cloud-tasks/google/cloud/tasks_v2beta3/types/queue.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/google/cloud/tasks_v2beta3/types/target.py
+++ b/packages/google-cloud-tasks/google/cloud/tasks_v2beta3/types/target.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/google/cloud/tasks_v2beta3/types/task.py
+++ b/packages/google-cloud-tasks/google/cloud/tasks_v2beta3/types/task.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2_generated_cloud_tasks_create_queue_async.py
+++ b/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2_generated_cloud_tasks_create_queue_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2_generated_cloud_tasks_create_queue_sync.py
+++ b/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2_generated_cloud_tasks_create_queue_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2_generated_cloud_tasks_create_task_async.py
+++ b/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2_generated_cloud_tasks_create_task_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2_generated_cloud_tasks_create_task_sync.py
+++ b/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2_generated_cloud_tasks_create_task_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2_generated_cloud_tasks_delete_queue_async.py
+++ b/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2_generated_cloud_tasks_delete_queue_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2_generated_cloud_tasks_delete_queue_sync.py
+++ b/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2_generated_cloud_tasks_delete_queue_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2_generated_cloud_tasks_delete_task_async.py
+++ b/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2_generated_cloud_tasks_delete_task_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2_generated_cloud_tasks_delete_task_sync.py
+++ b/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2_generated_cloud_tasks_delete_task_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2_generated_cloud_tasks_get_iam_policy_async.py
+++ b/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2_generated_cloud_tasks_get_iam_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2_generated_cloud_tasks_get_iam_policy_sync.py
+++ b/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2_generated_cloud_tasks_get_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2_generated_cloud_tasks_get_queue_async.py
+++ b/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2_generated_cloud_tasks_get_queue_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2_generated_cloud_tasks_get_queue_sync.py
+++ b/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2_generated_cloud_tasks_get_queue_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2_generated_cloud_tasks_get_task_async.py
+++ b/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2_generated_cloud_tasks_get_task_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2_generated_cloud_tasks_get_task_sync.py
+++ b/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2_generated_cloud_tasks_get_task_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2_generated_cloud_tasks_list_queues_async.py
+++ b/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2_generated_cloud_tasks_list_queues_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2_generated_cloud_tasks_list_queues_sync.py
+++ b/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2_generated_cloud_tasks_list_queues_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2_generated_cloud_tasks_list_tasks_async.py
+++ b/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2_generated_cloud_tasks_list_tasks_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2_generated_cloud_tasks_list_tasks_sync.py
+++ b/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2_generated_cloud_tasks_list_tasks_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2_generated_cloud_tasks_pause_queue_async.py
+++ b/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2_generated_cloud_tasks_pause_queue_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2_generated_cloud_tasks_pause_queue_sync.py
+++ b/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2_generated_cloud_tasks_pause_queue_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2_generated_cloud_tasks_purge_queue_async.py
+++ b/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2_generated_cloud_tasks_purge_queue_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2_generated_cloud_tasks_purge_queue_sync.py
+++ b/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2_generated_cloud_tasks_purge_queue_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2_generated_cloud_tasks_resume_queue_async.py
+++ b/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2_generated_cloud_tasks_resume_queue_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2_generated_cloud_tasks_resume_queue_sync.py
+++ b/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2_generated_cloud_tasks_resume_queue_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2_generated_cloud_tasks_run_task_async.py
+++ b/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2_generated_cloud_tasks_run_task_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2_generated_cloud_tasks_run_task_sync.py
+++ b/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2_generated_cloud_tasks_run_task_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2_generated_cloud_tasks_set_iam_policy_async.py
+++ b/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2_generated_cloud_tasks_set_iam_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2_generated_cloud_tasks_set_iam_policy_sync.py
+++ b/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2_generated_cloud_tasks_set_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2_generated_cloud_tasks_test_iam_permissions_async.py
+++ b/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2_generated_cloud_tasks_test_iam_permissions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2_generated_cloud_tasks_test_iam_permissions_sync.py
+++ b/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2_generated_cloud_tasks_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2_generated_cloud_tasks_update_queue_async.py
+++ b/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2_generated_cloud_tasks_update_queue_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2_generated_cloud_tasks_update_queue_sync.py
+++ b/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2_generated_cloud_tasks_update_queue_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta2_generated_cloud_tasks_acknowledge_task_async.py
+++ b/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta2_generated_cloud_tasks_acknowledge_task_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta2_generated_cloud_tasks_acknowledge_task_sync.py
+++ b/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta2_generated_cloud_tasks_acknowledge_task_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta2_generated_cloud_tasks_cancel_lease_async.py
+++ b/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta2_generated_cloud_tasks_cancel_lease_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta2_generated_cloud_tasks_cancel_lease_sync.py
+++ b/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta2_generated_cloud_tasks_cancel_lease_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta2_generated_cloud_tasks_create_queue_async.py
+++ b/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta2_generated_cloud_tasks_create_queue_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta2_generated_cloud_tasks_create_queue_sync.py
+++ b/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta2_generated_cloud_tasks_create_queue_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta2_generated_cloud_tasks_create_task_async.py
+++ b/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta2_generated_cloud_tasks_create_task_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta2_generated_cloud_tasks_create_task_sync.py
+++ b/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta2_generated_cloud_tasks_create_task_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta2_generated_cloud_tasks_delete_queue_async.py
+++ b/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta2_generated_cloud_tasks_delete_queue_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta2_generated_cloud_tasks_delete_queue_sync.py
+++ b/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta2_generated_cloud_tasks_delete_queue_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta2_generated_cloud_tasks_delete_task_async.py
+++ b/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta2_generated_cloud_tasks_delete_task_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta2_generated_cloud_tasks_delete_task_sync.py
+++ b/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta2_generated_cloud_tasks_delete_task_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta2_generated_cloud_tasks_get_iam_policy_async.py
+++ b/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta2_generated_cloud_tasks_get_iam_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta2_generated_cloud_tasks_get_iam_policy_sync.py
+++ b/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta2_generated_cloud_tasks_get_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta2_generated_cloud_tasks_get_queue_async.py
+++ b/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta2_generated_cloud_tasks_get_queue_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta2_generated_cloud_tasks_get_queue_sync.py
+++ b/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta2_generated_cloud_tasks_get_queue_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta2_generated_cloud_tasks_get_task_async.py
+++ b/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta2_generated_cloud_tasks_get_task_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta2_generated_cloud_tasks_get_task_sync.py
+++ b/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta2_generated_cloud_tasks_get_task_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta2_generated_cloud_tasks_lease_tasks_async.py
+++ b/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta2_generated_cloud_tasks_lease_tasks_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta2_generated_cloud_tasks_lease_tasks_sync.py
+++ b/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta2_generated_cloud_tasks_lease_tasks_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta2_generated_cloud_tasks_list_queues_async.py
+++ b/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta2_generated_cloud_tasks_list_queues_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta2_generated_cloud_tasks_list_queues_sync.py
+++ b/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta2_generated_cloud_tasks_list_queues_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta2_generated_cloud_tasks_list_tasks_async.py
+++ b/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta2_generated_cloud_tasks_list_tasks_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta2_generated_cloud_tasks_list_tasks_sync.py
+++ b/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta2_generated_cloud_tasks_list_tasks_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta2_generated_cloud_tasks_pause_queue_async.py
+++ b/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta2_generated_cloud_tasks_pause_queue_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta2_generated_cloud_tasks_pause_queue_sync.py
+++ b/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta2_generated_cloud_tasks_pause_queue_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta2_generated_cloud_tasks_purge_queue_async.py
+++ b/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta2_generated_cloud_tasks_purge_queue_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta2_generated_cloud_tasks_purge_queue_sync.py
+++ b/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta2_generated_cloud_tasks_purge_queue_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta2_generated_cloud_tasks_renew_lease_async.py
+++ b/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta2_generated_cloud_tasks_renew_lease_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta2_generated_cloud_tasks_renew_lease_sync.py
+++ b/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta2_generated_cloud_tasks_renew_lease_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta2_generated_cloud_tasks_resume_queue_async.py
+++ b/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta2_generated_cloud_tasks_resume_queue_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta2_generated_cloud_tasks_resume_queue_sync.py
+++ b/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta2_generated_cloud_tasks_resume_queue_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta2_generated_cloud_tasks_run_task_async.py
+++ b/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta2_generated_cloud_tasks_run_task_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta2_generated_cloud_tasks_run_task_sync.py
+++ b/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta2_generated_cloud_tasks_run_task_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta2_generated_cloud_tasks_set_iam_policy_async.py
+++ b/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta2_generated_cloud_tasks_set_iam_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta2_generated_cloud_tasks_set_iam_policy_sync.py
+++ b/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta2_generated_cloud_tasks_set_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta2_generated_cloud_tasks_test_iam_permissions_async.py
+++ b/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta2_generated_cloud_tasks_test_iam_permissions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta2_generated_cloud_tasks_test_iam_permissions_sync.py
+++ b/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta2_generated_cloud_tasks_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta2_generated_cloud_tasks_update_queue_async.py
+++ b/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta2_generated_cloud_tasks_update_queue_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta2_generated_cloud_tasks_update_queue_sync.py
+++ b/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta2_generated_cloud_tasks_update_queue_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta2_generated_cloud_tasks_upload_queue_yaml_async.py
+++ b/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta2_generated_cloud_tasks_upload_queue_yaml_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta2_generated_cloud_tasks_upload_queue_yaml_sync.py
+++ b/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta2_generated_cloud_tasks_upload_queue_yaml_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta3_generated_cloud_tasks_create_queue_async.py
+++ b/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta3_generated_cloud_tasks_create_queue_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta3_generated_cloud_tasks_create_queue_sync.py
+++ b/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta3_generated_cloud_tasks_create_queue_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta3_generated_cloud_tasks_create_task_async.py
+++ b/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta3_generated_cloud_tasks_create_task_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta3_generated_cloud_tasks_create_task_sync.py
+++ b/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta3_generated_cloud_tasks_create_task_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta3_generated_cloud_tasks_delete_queue_async.py
+++ b/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta3_generated_cloud_tasks_delete_queue_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta3_generated_cloud_tasks_delete_queue_sync.py
+++ b/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta3_generated_cloud_tasks_delete_queue_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta3_generated_cloud_tasks_delete_task_async.py
+++ b/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta3_generated_cloud_tasks_delete_task_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta3_generated_cloud_tasks_delete_task_sync.py
+++ b/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta3_generated_cloud_tasks_delete_task_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta3_generated_cloud_tasks_get_iam_policy_async.py
+++ b/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta3_generated_cloud_tasks_get_iam_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta3_generated_cloud_tasks_get_iam_policy_sync.py
+++ b/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta3_generated_cloud_tasks_get_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta3_generated_cloud_tasks_get_queue_async.py
+++ b/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta3_generated_cloud_tasks_get_queue_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta3_generated_cloud_tasks_get_queue_sync.py
+++ b/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta3_generated_cloud_tasks_get_queue_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta3_generated_cloud_tasks_get_task_async.py
+++ b/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta3_generated_cloud_tasks_get_task_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta3_generated_cloud_tasks_get_task_sync.py
+++ b/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta3_generated_cloud_tasks_get_task_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta3_generated_cloud_tasks_list_queues_async.py
+++ b/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta3_generated_cloud_tasks_list_queues_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta3_generated_cloud_tasks_list_queues_sync.py
+++ b/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta3_generated_cloud_tasks_list_queues_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta3_generated_cloud_tasks_list_tasks_async.py
+++ b/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta3_generated_cloud_tasks_list_tasks_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta3_generated_cloud_tasks_list_tasks_sync.py
+++ b/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta3_generated_cloud_tasks_list_tasks_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta3_generated_cloud_tasks_pause_queue_async.py
+++ b/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta3_generated_cloud_tasks_pause_queue_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta3_generated_cloud_tasks_pause_queue_sync.py
+++ b/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta3_generated_cloud_tasks_pause_queue_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta3_generated_cloud_tasks_purge_queue_async.py
+++ b/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta3_generated_cloud_tasks_purge_queue_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta3_generated_cloud_tasks_purge_queue_sync.py
+++ b/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta3_generated_cloud_tasks_purge_queue_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta3_generated_cloud_tasks_resume_queue_async.py
+++ b/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta3_generated_cloud_tasks_resume_queue_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta3_generated_cloud_tasks_resume_queue_sync.py
+++ b/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta3_generated_cloud_tasks_resume_queue_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta3_generated_cloud_tasks_run_task_async.py
+++ b/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta3_generated_cloud_tasks_run_task_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta3_generated_cloud_tasks_run_task_sync.py
+++ b/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta3_generated_cloud_tasks_run_task_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta3_generated_cloud_tasks_set_iam_policy_async.py
+++ b/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta3_generated_cloud_tasks_set_iam_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta3_generated_cloud_tasks_set_iam_policy_sync.py
+++ b/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta3_generated_cloud_tasks_set_iam_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta3_generated_cloud_tasks_test_iam_permissions_async.py
+++ b/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta3_generated_cloud_tasks_test_iam_permissions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta3_generated_cloud_tasks_test_iam_permissions_sync.py
+++ b/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta3_generated_cloud_tasks_test_iam_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta3_generated_cloud_tasks_update_queue_async.py
+++ b/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta3_generated_cloud_tasks_update_queue_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta3_generated_cloud_tasks_update_queue_sync.py
+++ b/packages/google-cloud-tasks/samples/generated_samples/cloudtasks_v2beta3_generated_cloud_tasks_update_queue_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/tests/__init__.py
+++ b/packages/google-cloud-tasks/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/tests/unit/__init__.py
+++ b/packages/google-cloud-tasks/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-tasks/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/tests/unit/gapic/tasks_v2/__init__.py
+++ b/packages/google-cloud-tasks/tests/unit/gapic/tasks_v2/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/tests/unit/gapic/tasks_v2beta2/__init__.py
+++ b/packages/google-cloud-tasks/tests/unit/gapic/tasks_v2beta2/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tasks/tests/unit/gapic/tasks_v2beta3/__init__.py
+++ b/packages/google-cloud-tasks/tests/unit/gapic/tasks_v2beta3/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/.flake8
+++ b/packages/google-cloud-telcoautomation/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/MANIFEST.in
+++ b/packages/google-cloud-telcoautomation/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/google/cloud/telcoautomation/__init__.py
+++ b/packages/google-cloud-telcoautomation/google/cloud/telcoautomation/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/google/cloud/telcoautomation/gapic_version.py
+++ b/packages/google-cloud-telcoautomation/google/cloud/telcoautomation/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/google/cloud/telcoautomation_v1/gapic_version.py
+++ b/packages/google-cloud-telcoautomation/google/cloud/telcoautomation_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/google/cloud/telcoautomation_v1/services/__init__.py
+++ b/packages/google-cloud-telcoautomation/google/cloud/telcoautomation_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/google/cloud/telcoautomation_v1/services/telco_automation/__init__.py
+++ b/packages/google-cloud-telcoautomation/google/cloud/telcoautomation_v1/services/telco_automation/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/google/cloud/telcoautomation_v1/services/telco_automation/client.py
+++ b/packages/google-cloud-telcoautomation/google/cloud/telcoautomation_v1/services/telco_automation/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/google/cloud/telcoautomation_v1/services/telco_automation/pagers.py
+++ b/packages/google-cloud-telcoautomation/google/cloud/telcoautomation_v1/services/telco_automation/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/google/cloud/telcoautomation_v1/services/telco_automation/transports/__init__.py
+++ b/packages/google-cloud-telcoautomation/google/cloud/telcoautomation_v1/services/telco_automation/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/google/cloud/telcoautomation_v1/services/telco_automation/transports/base.py
+++ b/packages/google-cloud-telcoautomation/google/cloud/telcoautomation_v1/services/telco_automation/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/google/cloud/telcoautomation_v1/services/telco_automation/transports/grpc.py
+++ b/packages/google-cloud-telcoautomation/google/cloud/telcoautomation_v1/services/telco_automation/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/google/cloud/telcoautomation_v1/services/telco_automation/transports/grpc_asyncio.py
+++ b/packages/google-cloud-telcoautomation/google/cloud/telcoautomation_v1/services/telco_automation/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/google/cloud/telcoautomation_v1/services/telco_automation/transports/rest.py
+++ b/packages/google-cloud-telcoautomation/google/cloud/telcoautomation_v1/services/telco_automation/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/google/cloud/telcoautomation_v1/services/telco_automation/transports/rest_base.py
+++ b/packages/google-cloud-telcoautomation/google/cloud/telcoautomation_v1/services/telco_automation/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/google/cloud/telcoautomation_v1/types/__init__.py
+++ b/packages/google-cloud-telcoautomation/google/cloud/telcoautomation_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/google/cloud/telcoautomation_v1/types/telcoautomation.py
+++ b/packages/google-cloud-telcoautomation/google/cloud/telcoautomation_v1/types/telcoautomation.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/google/cloud/telcoautomation_v1alpha1/gapic_version.py
+++ b/packages/google-cloud-telcoautomation/google/cloud/telcoautomation_v1alpha1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/google/cloud/telcoautomation_v1alpha1/services/__init__.py
+++ b/packages/google-cloud-telcoautomation/google/cloud/telcoautomation_v1alpha1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/google/cloud/telcoautomation_v1alpha1/services/telco_automation/__init__.py
+++ b/packages/google-cloud-telcoautomation/google/cloud/telcoautomation_v1alpha1/services/telco_automation/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/google/cloud/telcoautomation_v1alpha1/services/telco_automation/client.py
+++ b/packages/google-cloud-telcoautomation/google/cloud/telcoautomation_v1alpha1/services/telco_automation/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/google/cloud/telcoautomation_v1alpha1/services/telco_automation/pagers.py
+++ b/packages/google-cloud-telcoautomation/google/cloud/telcoautomation_v1alpha1/services/telco_automation/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/google/cloud/telcoautomation_v1alpha1/services/telco_automation/transports/__init__.py
+++ b/packages/google-cloud-telcoautomation/google/cloud/telcoautomation_v1alpha1/services/telco_automation/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/google/cloud/telcoautomation_v1alpha1/services/telco_automation/transports/base.py
+++ b/packages/google-cloud-telcoautomation/google/cloud/telcoautomation_v1alpha1/services/telco_automation/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/google/cloud/telcoautomation_v1alpha1/services/telco_automation/transports/grpc.py
+++ b/packages/google-cloud-telcoautomation/google/cloud/telcoautomation_v1alpha1/services/telco_automation/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/google/cloud/telcoautomation_v1alpha1/services/telco_automation/transports/grpc_asyncio.py
+++ b/packages/google-cloud-telcoautomation/google/cloud/telcoautomation_v1alpha1/services/telco_automation/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/google/cloud/telcoautomation_v1alpha1/services/telco_automation/transports/rest.py
+++ b/packages/google-cloud-telcoautomation/google/cloud/telcoautomation_v1alpha1/services/telco_automation/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/google/cloud/telcoautomation_v1alpha1/services/telco_automation/transports/rest_base.py
+++ b/packages/google-cloud-telcoautomation/google/cloud/telcoautomation_v1alpha1/services/telco_automation/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/google/cloud/telcoautomation_v1alpha1/types/__init__.py
+++ b/packages/google-cloud-telcoautomation/google/cloud/telcoautomation_v1alpha1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/google/cloud/telcoautomation_v1alpha1/types/telcoautomation.py
+++ b/packages/google-cloud-telcoautomation/google/cloud/telcoautomation_v1alpha1/types/telcoautomation.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_apply_deployment_async.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_apply_deployment_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_apply_deployment_sync.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_apply_deployment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_apply_hydrated_deployment_async.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_apply_hydrated_deployment_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_apply_hydrated_deployment_sync.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_apply_hydrated_deployment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_approve_blueprint_async.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_approve_blueprint_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_approve_blueprint_sync.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_approve_blueprint_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_compute_deployment_status_async.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_compute_deployment_status_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_compute_deployment_status_sync.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_compute_deployment_status_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_create_blueprint_async.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_create_blueprint_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_create_blueprint_sync.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_create_blueprint_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_create_deployment_async.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_create_deployment_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_create_deployment_sync.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_create_deployment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_create_edge_slm_sync.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_create_edge_slm_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_create_orchestration_cluster_sync.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_create_orchestration_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_delete_blueprint_async.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_delete_blueprint_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_delete_blueprint_sync.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_delete_blueprint_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_delete_edge_slm_sync.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_delete_edge_slm_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_delete_orchestration_cluster_sync.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_delete_orchestration_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_discard_blueprint_changes_async.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_discard_blueprint_changes_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_discard_blueprint_changes_sync.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_discard_blueprint_changes_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_discard_deployment_changes_async.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_discard_deployment_changes_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_discard_deployment_changes_sync.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_discard_deployment_changes_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_get_blueprint_async.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_get_blueprint_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_get_blueprint_sync.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_get_blueprint_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_get_deployment_async.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_get_deployment_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_get_deployment_sync.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_get_deployment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_get_edge_slm_async.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_get_edge_slm_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_get_edge_slm_sync.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_get_edge_slm_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_get_hydrated_deployment_async.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_get_hydrated_deployment_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_get_hydrated_deployment_sync.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_get_hydrated_deployment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_get_orchestration_cluster_async.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_get_orchestration_cluster_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_get_orchestration_cluster_sync.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_get_orchestration_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_get_public_blueprint_async.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_get_public_blueprint_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_get_public_blueprint_sync.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_get_public_blueprint_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_list_blueprint_revisions_async.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_list_blueprint_revisions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_list_blueprint_revisions_sync.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_list_blueprint_revisions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_list_blueprints_async.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_list_blueprints_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_list_blueprints_sync.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_list_blueprints_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_list_deployment_revisions_async.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_list_deployment_revisions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_list_deployment_revisions_sync.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_list_deployment_revisions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_list_deployments_async.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_list_deployments_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_list_deployments_sync.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_list_deployments_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_list_edge_slms_async.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_list_edge_slms_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_list_edge_slms_sync.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_list_edge_slms_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_list_hydrated_deployments_async.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_list_hydrated_deployments_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_list_hydrated_deployments_sync.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_list_hydrated_deployments_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_list_orchestration_clusters_async.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_list_orchestration_clusters_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_list_orchestration_clusters_sync.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_list_orchestration_clusters_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_list_public_blueprints_async.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_list_public_blueprints_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_list_public_blueprints_sync.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_list_public_blueprints_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_propose_blueprint_async.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_propose_blueprint_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_propose_blueprint_sync.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_propose_blueprint_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_reject_blueprint_async.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_reject_blueprint_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_reject_blueprint_sync.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_reject_blueprint_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_remove_deployment_async.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_remove_deployment_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_remove_deployment_sync.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_remove_deployment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_rollback_deployment_async.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_rollback_deployment_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_rollback_deployment_sync.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_rollback_deployment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_search_blueprint_revisions_async.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_search_blueprint_revisions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_search_blueprint_revisions_sync.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_search_blueprint_revisions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_search_deployment_revisions_async.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_search_deployment_revisions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_search_deployment_revisions_sync.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_search_deployment_revisions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_update_blueprint_async.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_update_blueprint_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_update_blueprint_sync.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_update_blueprint_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_update_deployment_async.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_update_deployment_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_update_deployment_sync.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_update_deployment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_update_hydrated_deployment_async.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_update_hydrated_deployment_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_update_hydrated_deployment_sync.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1_generated_telco_automation_update_hydrated_deployment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_apply_deployment_async.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_apply_deployment_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_apply_deployment_sync.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_apply_deployment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_apply_hydrated_deployment_async.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_apply_hydrated_deployment_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_apply_hydrated_deployment_sync.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_apply_hydrated_deployment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_approve_blueprint_async.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_approve_blueprint_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_approve_blueprint_sync.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_approve_blueprint_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_compute_deployment_status_async.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_compute_deployment_status_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_compute_deployment_status_sync.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_compute_deployment_status_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_create_blueprint_async.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_create_blueprint_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_create_blueprint_sync.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_create_blueprint_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_create_deployment_async.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_create_deployment_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_create_deployment_sync.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_create_deployment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_create_edge_slm_sync.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_create_edge_slm_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_create_orchestration_cluster_sync.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_create_orchestration_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_delete_blueprint_async.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_delete_blueprint_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_delete_blueprint_sync.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_delete_blueprint_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_delete_edge_slm_sync.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_delete_edge_slm_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_delete_orchestration_cluster_sync.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_delete_orchestration_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_discard_blueprint_changes_async.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_discard_blueprint_changes_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_discard_blueprint_changes_sync.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_discard_blueprint_changes_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_discard_deployment_changes_async.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_discard_deployment_changes_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_discard_deployment_changes_sync.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_discard_deployment_changes_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_get_blueprint_async.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_get_blueprint_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_get_blueprint_sync.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_get_blueprint_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_get_deployment_async.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_get_deployment_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_get_deployment_sync.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_get_deployment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_get_edge_slm_async.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_get_edge_slm_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_get_edge_slm_sync.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_get_edge_slm_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_get_hydrated_deployment_async.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_get_hydrated_deployment_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_get_hydrated_deployment_sync.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_get_hydrated_deployment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_get_orchestration_cluster_async.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_get_orchestration_cluster_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_get_orchestration_cluster_sync.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_get_orchestration_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_get_public_blueprint_async.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_get_public_blueprint_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_get_public_blueprint_sync.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_get_public_blueprint_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_list_blueprint_revisions_async.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_list_blueprint_revisions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_list_blueprint_revisions_sync.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_list_blueprint_revisions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_list_blueprints_async.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_list_blueprints_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_list_blueprints_sync.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_list_blueprints_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_list_deployment_revisions_async.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_list_deployment_revisions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_list_deployment_revisions_sync.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_list_deployment_revisions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_list_deployments_async.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_list_deployments_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_list_deployments_sync.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_list_deployments_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_list_edge_slms_async.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_list_edge_slms_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_list_edge_slms_sync.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_list_edge_slms_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_list_hydrated_deployments_async.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_list_hydrated_deployments_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_list_hydrated_deployments_sync.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_list_hydrated_deployments_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_list_orchestration_clusters_async.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_list_orchestration_clusters_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_list_orchestration_clusters_sync.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_list_orchestration_clusters_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_list_public_blueprints_async.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_list_public_blueprints_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_list_public_blueprints_sync.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_list_public_blueprints_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_propose_blueprint_async.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_propose_blueprint_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_propose_blueprint_sync.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_propose_blueprint_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_reject_blueprint_async.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_reject_blueprint_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_reject_blueprint_sync.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_reject_blueprint_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_remove_deployment_async.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_remove_deployment_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_remove_deployment_sync.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_remove_deployment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_rollback_deployment_async.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_rollback_deployment_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_rollback_deployment_sync.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_rollback_deployment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_search_blueprint_revisions_async.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_search_blueprint_revisions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_search_blueprint_revisions_sync.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_search_blueprint_revisions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_search_deployment_revisions_async.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_search_deployment_revisions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_search_deployment_revisions_sync.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_search_deployment_revisions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_update_blueprint_async.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_update_blueprint_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_update_blueprint_sync.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_update_blueprint_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_update_deployment_async.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_update_deployment_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_update_deployment_sync.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_update_deployment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_update_hydrated_deployment_async.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_update_hydrated_deployment_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_update_hydrated_deployment_sync.py
+++ b/packages/google-cloud-telcoautomation/samples/generated_samples/telcoautomation_v1alpha1_generated_telco_automation_update_hydrated_deployment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/tests/__init__.py
+++ b/packages/google-cloud-telcoautomation/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/tests/unit/__init__.py
+++ b/packages/google-cloud-telcoautomation/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-telcoautomation/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/tests/unit/gapic/telcoautomation_v1/__init__.py
+++ b/packages/google-cloud-telcoautomation/tests/unit/gapic/telcoautomation_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-telcoautomation/tests/unit/gapic/telcoautomation_v1alpha1/__init__.py
+++ b/packages/google-cloud-telcoautomation/tests/unit/gapic/telcoautomation_v1alpha1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-texttospeech/.flake8
+++ b/packages/google-cloud-texttospeech/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-texttospeech/MANIFEST.in
+++ b/packages/google-cloud-texttospeech/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-texttospeech/google/cloud/texttospeech/__init__.py
+++ b/packages/google-cloud-texttospeech/google/cloud/texttospeech/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-texttospeech/google/cloud/texttospeech/gapic_version.py
+++ b/packages/google-cloud-texttospeech/google/cloud/texttospeech/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-texttospeech/google/cloud/texttospeech_v1/gapic_version.py
+++ b/packages/google-cloud-texttospeech/google/cloud/texttospeech_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-texttospeech/google/cloud/texttospeech_v1/services/__init__.py
+++ b/packages/google-cloud-texttospeech/google/cloud/texttospeech_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-texttospeech/google/cloud/texttospeech_v1/services/text_to_speech/__init__.py
+++ b/packages/google-cloud-texttospeech/google/cloud/texttospeech_v1/services/text_to_speech/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-texttospeech/google/cloud/texttospeech_v1/services/text_to_speech/async_client.py
+++ b/packages/google-cloud-texttospeech/google/cloud/texttospeech_v1/services/text_to_speech/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-texttospeech/google/cloud/texttospeech_v1/services/text_to_speech/client.py
+++ b/packages/google-cloud-texttospeech/google/cloud/texttospeech_v1/services/text_to_speech/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-texttospeech/google/cloud/texttospeech_v1/services/text_to_speech/transports/__init__.py
+++ b/packages/google-cloud-texttospeech/google/cloud/texttospeech_v1/services/text_to_speech/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-texttospeech/google/cloud/texttospeech_v1/services/text_to_speech/transports/base.py
+++ b/packages/google-cloud-texttospeech/google/cloud/texttospeech_v1/services/text_to_speech/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-texttospeech/google/cloud/texttospeech_v1/services/text_to_speech/transports/grpc.py
+++ b/packages/google-cloud-texttospeech/google/cloud/texttospeech_v1/services/text_to_speech/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-texttospeech/google/cloud/texttospeech_v1/services/text_to_speech/transports/grpc_asyncio.py
+++ b/packages/google-cloud-texttospeech/google/cloud/texttospeech_v1/services/text_to_speech/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-texttospeech/google/cloud/texttospeech_v1/services/text_to_speech/transports/rest.py
+++ b/packages/google-cloud-texttospeech/google/cloud/texttospeech_v1/services/text_to_speech/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-texttospeech/google/cloud/texttospeech_v1/services/text_to_speech/transports/rest_base.py
+++ b/packages/google-cloud-texttospeech/google/cloud/texttospeech_v1/services/text_to_speech/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-texttospeech/google/cloud/texttospeech_v1/services/text_to_speech_long_audio_synthesize/__init__.py
+++ b/packages/google-cloud-texttospeech/google/cloud/texttospeech_v1/services/text_to_speech_long_audio_synthesize/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-texttospeech/google/cloud/texttospeech_v1/services/text_to_speech_long_audio_synthesize/client.py
+++ b/packages/google-cloud-texttospeech/google/cloud/texttospeech_v1/services/text_to_speech_long_audio_synthesize/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-texttospeech/google/cloud/texttospeech_v1/services/text_to_speech_long_audio_synthesize/transports/__init__.py
+++ b/packages/google-cloud-texttospeech/google/cloud/texttospeech_v1/services/text_to_speech_long_audio_synthesize/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-texttospeech/google/cloud/texttospeech_v1/services/text_to_speech_long_audio_synthesize/transports/base.py
+++ b/packages/google-cloud-texttospeech/google/cloud/texttospeech_v1/services/text_to_speech_long_audio_synthesize/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-texttospeech/google/cloud/texttospeech_v1/services/text_to_speech_long_audio_synthesize/transports/grpc.py
+++ b/packages/google-cloud-texttospeech/google/cloud/texttospeech_v1/services/text_to_speech_long_audio_synthesize/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-texttospeech/google/cloud/texttospeech_v1/services/text_to_speech_long_audio_synthesize/transports/grpc_asyncio.py
+++ b/packages/google-cloud-texttospeech/google/cloud/texttospeech_v1/services/text_to_speech_long_audio_synthesize/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-texttospeech/google/cloud/texttospeech_v1/services/text_to_speech_long_audio_synthesize/transports/rest.py
+++ b/packages/google-cloud-texttospeech/google/cloud/texttospeech_v1/services/text_to_speech_long_audio_synthesize/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-texttospeech/google/cloud/texttospeech_v1/services/text_to_speech_long_audio_synthesize/transports/rest_base.py
+++ b/packages/google-cloud-texttospeech/google/cloud/texttospeech_v1/services/text_to_speech_long_audio_synthesize/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-texttospeech/google/cloud/texttospeech_v1/types/__init__.py
+++ b/packages/google-cloud-texttospeech/google/cloud/texttospeech_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-texttospeech/google/cloud/texttospeech_v1/types/cloud_tts.py
+++ b/packages/google-cloud-texttospeech/google/cloud/texttospeech_v1/types/cloud_tts.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-texttospeech/google/cloud/texttospeech_v1/types/cloud_tts_lrs.py
+++ b/packages/google-cloud-texttospeech/google/cloud/texttospeech_v1/types/cloud_tts_lrs.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-texttospeech/google/cloud/texttospeech_v1beta1/gapic_version.py
+++ b/packages/google-cloud-texttospeech/google/cloud/texttospeech_v1beta1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-texttospeech/google/cloud/texttospeech_v1beta1/services/__init__.py
+++ b/packages/google-cloud-texttospeech/google/cloud/texttospeech_v1beta1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-texttospeech/google/cloud/texttospeech_v1beta1/services/text_to_speech/__init__.py
+++ b/packages/google-cloud-texttospeech/google/cloud/texttospeech_v1beta1/services/text_to_speech/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-texttospeech/google/cloud/texttospeech_v1beta1/services/text_to_speech/async_client.py
+++ b/packages/google-cloud-texttospeech/google/cloud/texttospeech_v1beta1/services/text_to_speech/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-texttospeech/google/cloud/texttospeech_v1beta1/services/text_to_speech/client.py
+++ b/packages/google-cloud-texttospeech/google/cloud/texttospeech_v1beta1/services/text_to_speech/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-texttospeech/google/cloud/texttospeech_v1beta1/services/text_to_speech/transports/__init__.py
+++ b/packages/google-cloud-texttospeech/google/cloud/texttospeech_v1beta1/services/text_to_speech/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-texttospeech/google/cloud/texttospeech_v1beta1/services/text_to_speech/transports/base.py
+++ b/packages/google-cloud-texttospeech/google/cloud/texttospeech_v1beta1/services/text_to_speech/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-texttospeech/google/cloud/texttospeech_v1beta1/services/text_to_speech/transports/grpc.py
+++ b/packages/google-cloud-texttospeech/google/cloud/texttospeech_v1beta1/services/text_to_speech/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-texttospeech/google/cloud/texttospeech_v1beta1/services/text_to_speech/transports/grpc_asyncio.py
+++ b/packages/google-cloud-texttospeech/google/cloud/texttospeech_v1beta1/services/text_to_speech/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-texttospeech/google/cloud/texttospeech_v1beta1/services/text_to_speech/transports/rest.py
+++ b/packages/google-cloud-texttospeech/google/cloud/texttospeech_v1beta1/services/text_to_speech/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-texttospeech/google/cloud/texttospeech_v1beta1/services/text_to_speech/transports/rest_base.py
+++ b/packages/google-cloud-texttospeech/google/cloud/texttospeech_v1beta1/services/text_to_speech/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-texttospeech/google/cloud/texttospeech_v1beta1/services/text_to_speech_long_audio_synthesize/__init__.py
+++ b/packages/google-cloud-texttospeech/google/cloud/texttospeech_v1beta1/services/text_to_speech_long_audio_synthesize/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-texttospeech/google/cloud/texttospeech_v1beta1/services/text_to_speech_long_audio_synthesize/client.py
+++ b/packages/google-cloud-texttospeech/google/cloud/texttospeech_v1beta1/services/text_to_speech_long_audio_synthesize/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-texttospeech/google/cloud/texttospeech_v1beta1/services/text_to_speech_long_audio_synthesize/transports/__init__.py
+++ b/packages/google-cloud-texttospeech/google/cloud/texttospeech_v1beta1/services/text_to_speech_long_audio_synthesize/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-texttospeech/google/cloud/texttospeech_v1beta1/services/text_to_speech_long_audio_synthesize/transports/base.py
+++ b/packages/google-cloud-texttospeech/google/cloud/texttospeech_v1beta1/services/text_to_speech_long_audio_synthesize/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-texttospeech/google/cloud/texttospeech_v1beta1/services/text_to_speech_long_audio_synthesize/transports/grpc.py
+++ b/packages/google-cloud-texttospeech/google/cloud/texttospeech_v1beta1/services/text_to_speech_long_audio_synthesize/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-texttospeech/google/cloud/texttospeech_v1beta1/services/text_to_speech_long_audio_synthesize/transports/grpc_asyncio.py
+++ b/packages/google-cloud-texttospeech/google/cloud/texttospeech_v1beta1/services/text_to_speech_long_audio_synthesize/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-texttospeech/google/cloud/texttospeech_v1beta1/services/text_to_speech_long_audio_synthesize/transports/rest.py
+++ b/packages/google-cloud-texttospeech/google/cloud/texttospeech_v1beta1/services/text_to_speech_long_audio_synthesize/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-texttospeech/google/cloud/texttospeech_v1beta1/services/text_to_speech_long_audio_synthesize/transports/rest_base.py
+++ b/packages/google-cloud-texttospeech/google/cloud/texttospeech_v1beta1/services/text_to_speech_long_audio_synthesize/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-texttospeech/google/cloud/texttospeech_v1beta1/types/__init__.py
+++ b/packages/google-cloud-texttospeech/google/cloud/texttospeech_v1beta1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-texttospeech/google/cloud/texttospeech_v1beta1/types/cloud_tts.py
+++ b/packages/google-cloud-texttospeech/google/cloud/texttospeech_v1beta1/types/cloud_tts.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-texttospeech/google/cloud/texttospeech_v1beta1/types/cloud_tts_lrs.py
+++ b/packages/google-cloud-texttospeech/google/cloud/texttospeech_v1beta1/types/cloud_tts_lrs.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-texttospeech/samples/generated_samples/texttospeech_v1_generated_text_to_speech_list_voices_async.py
+++ b/packages/google-cloud-texttospeech/samples/generated_samples/texttospeech_v1_generated_text_to_speech_list_voices_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-texttospeech/samples/generated_samples/texttospeech_v1_generated_text_to_speech_list_voices_sync.py
+++ b/packages/google-cloud-texttospeech/samples/generated_samples/texttospeech_v1_generated_text_to_speech_list_voices_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-texttospeech/samples/generated_samples/texttospeech_v1_generated_text_to_speech_long_audio_synthesize_synthesize_long_audio_sync.py
+++ b/packages/google-cloud-texttospeech/samples/generated_samples/texttospeech_v1_generated_text_to_speech_long_audio_synthesize_synthesize_long_audio_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-texttospeech/samples/generated_samples/texttospeech_v1_generated_text_to_speech_streaming_synthesize_async.py
+++ b/packages/google-cloud-texttospeech/samples/generated_samples/texttospeech_v1_generated_text_to_speech_streaming_synthesize_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-texttospeech/samples/generated_samples/texttospeech_v1_generated_text_to_speech_streaming_synthesize_sync.py
+++ b/packages/google-cloud-texttospeech/samples/generated_samples/texttospeech_v1_generated_text_to_speech_streaming_synthesize_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-texttospeech/samples/generated_samples/texttospeech_v1_generated_text_to_speech_synthesize_speech_async.py
+++ b/packages/google-cloud-texttospeech/samples/generated_samples/texttospeech_v1_generated_text_to_speech_synthesize_speech_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-texttospeech/samples/generated_samples/texttospeech_v1_generated_text_to_speech_synthesize_speech_sync.py
+++ b/packages/google-cloud-texttospeech/samples/generated_samples/texttospeech_v1_generated_text_to_speech_synthesize_speech_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-texttospeech/samples/generated_samples/texttospeech_v1beta1_generated_text_to_speech_list_voices_async.py
+++ b/packages/google-cloud-texttospeech/samples/generated_samples/texttospeech_v1beta1_generated_text_to_speech_list_voices_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-texttospeech/samples/generated_samples/texttospeech_v1beta1_generated_text_to_speech_list_voices_sync.py
+++ b/packages/google-cloud-texttospeech/samples/generated_samples/texttospeech_v1beta1_generated_text_to_speech_list_voices_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-texttospeech/samples/generated_samples/texttospeech_v1beta1_generated_text_to_speech_long_audio_synthesize_synthesize_long_audio_sync.py
+++ b/packages/google-cloud-texttospeech/samples/generated_samples/texttospeech_v1beta1_generated_text_to_speech_long_audio_synthesize_synthesize_long_audio_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-texttospeech/samples/generated_samples/texttospeech_v1beta1_generated_text_to_speech_streaming_synthesize_async.py
+++ b/packages/google-cloud-texttospeech/samples/generated_samples/texttospeech_v1beta1_generated_text_to_speech_streaming_synthesize_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-texttospeech/samples/generated_samples/texttospeech_v1beta1_generated_text_to_speech_streaming_synthesize_sync.py
+++ b/packages/google-cloud-texttospeech/samples/generated_samples/texttospeech_v1beta1_generated_text_to_speech_streaming_synthesize_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-texttospeech/samples/generated_samples/texttospeech_v1beta1_generated_text_to_speech_synthesize_speech_async.py
+++ b/packages/google-cloud-texttospeech/samples/generated_samples/texttospeech_v1beta1_generated_text_to_speech_synthesize_speech_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-texttospeech/samples/generated_samples/texttospeech_v1beta1_generated_text_to_speech_synthesize_speech_sync.py
+++ b/packages/google-cloud-texttospeech/samples/generated_samples/texttospeech_v1beta1_generated_text_to_speech_synthesize_speech_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-texttospeech/tests/__init__.py
+++ b/packages/google-cloud-texttospeech/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-texttospeech/tests/unit/__init__.py
+++ b/packages/google-cloud-texttospeech/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-texttospeech/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-texttospeech/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-texttospeech/tests/unit/gapic/texttospeech_v1/__init__.py
+++ b/packages/google-cloud-texttospeech/tests/unit/gapic/texttospeech_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-texttospeech/tests/unit/gapic/texttospeech_v1beta1/__init__.py
+++ b/packages/google-cloud-texttospeech/tests/unit/gapic/texttospeech_v1beta1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tpu/.flake8
+++ b/packages/google-cloud-tpu/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tpu/MANIFEST.in
+++ b/packages/google-cloud-tpu/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tpu/google/cloud/tpu/__init__.py
+++ b/packages/google-cloud-tpu/google/cloud/tpu/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tpu/google/cloud/tpu/gapic_version.py
+++ b/packages/google-cloud-tpu/google/cloud/tpu/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tpu/google/cloud/tpu_v1/gapic_version.py
+++ b/packages/google-cloud-tpu/google/cloud/tpu_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tpu/google/cloud/tpu_v1/services/__init__.py
+++ b/packages/google-cloud-tpu/google/cloud/tpu_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tpu/google/cloud/tpu_v1/services/tpu/__init__.py
+++ b/packages/google-cloud-tpu/google/cloud/tpu_v1/services/tpu/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tpu/google/cloud/tpu_v1/services/tpu/client.py
+++ b/packages/google-cloud-tpu/google/cloud/tpu_v1/services/tpu/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tpu/google/cloud/tpu_v1/services/tpu/pagers.py
+++ b/packages/google-cloud-tpu/google/cloud/tpu_v1/services/tpu/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tpu/google/cloud/tpu_v1/services/tpu/transports/__init__.py
+++ b/packages/google-cloud-tpu/google/cloud/tpu_v1/services/tpu/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tpu/google/cloud/tpu_v1/services/tpu/transports/base.py
+++ b/packages/google-cloud-tpu/google/cloud/tpu_v1/services/tpu/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tpu/google/cloud/tpu_v1/services/tpu/transports/grpc.py
+++ b/packages/google-cloud-tpu/google/cloud/tpu_v1/services/tpu/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tpu/google/cloud/tpu_v1/services/tpu/transports/grpc_asyncio.py
+++ b/packages/google-cloud-tpu/google/cloud/tpu_v1/services/tpu/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tpu/google/cloud/tpu_v1/types/__init__.py
+++ b/packages/google-cloud-tpu/google/cloud/tpu_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tpu/google/cloud/tpu_v1/types/cloud_tpu.py
+++ b/packages/google-cloud-tpu/google/cloud/tpu_v1/types/cloud_tpu.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tpu/google/cloud/tpu_v2/gapic_version.py
+++ b/packages/google-cloud-tpu/google/cloud/tpu_v2/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tpu/google/cloud/tpu_v2/services/__init__.py
+++ b/packages/google-cloud-tpu/google/cloud/tpu_v2/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tpu/google/cloud/tpu_v2/services/tpu/__init__.py
+++ b/packages/google-cloud-tpu/google/cloud/tpu_v2/services/tpu/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tpu/google/cloud/tpu_v2/services/tpu/client.py
+++ b/packages/google-cloud-tpu/google/cloud/tpu_v2/services/tpu/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tpu/google/cloud/tpu_v2/services/tpu/pagers.py
+++ b/packages/google-cloud-tpu/google/cloud/tpu_v2/services/tpu/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tpu/google/cloud/tpu_v2/services/tpu/transports/__init__.py
+++ b/packages/google-cloud-tpu/google/cloud/tpu_v2/services/tpu/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tpu/google/cloud/tpu_v2/services/tpu/transports/base.py
+++ b/packages/google-cloud-tpu/google/cloud/tpu_v2/services/tpu/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tpu/google/cloud/tpu_v2/services/tpu/transports/grpc.py
+++ b/packages/google-cloud-tpu/google/cloud/tpu_v2/services/tpu/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tpu/google/cloud/tpu_v2/services/tpu/transports/grpc_asyncio.py
+++ b/packages/google-cloud-tpu/google/cloud/tpu_v2/services/tpu/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tpu/google/cloud/tpu_v2/services/tpu/transports/rest.py
+++ b/packages/google-cloud-tpu/google/cloud/tpu_v2/services/tpu/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tpu/google/cloud/tpu_v2/services/tpu/transports/rest_base.py
+++ b/packages/google-cloud-tpu/google/cloud/tpu_v2/services/tpu/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tpu/google/cloud/tpu_v2/types/__init__.py
+++ b/packages/google-cloud-tpu/google/cloud/tpu_v2/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tpu/google/cloud/tpu_v2/types/cloud_tpu.py
+++ b/packages/google-cloud-tpu/google/cloud/tpu_v2/types/cloud_tpu.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tpu/google/cloud/tpu_v2alpha1/gapic_version.py
+++ b/packages/google-cloud-tpu/google/cloud/tpu_v2alpha1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tpu/google/cloud/tpu_v2alpha1/services/__init__.py
+++ b/packages/google-cloud-tpu/google/cloud/tpu_v2alpha1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tpu/google/cloud/tpu_v2alpha1/services/tpu/__init__.py
+++ b/packages/google-cloud-tpu/google/cloud/tpu_v2alpha1/services/tpu/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tpu/google/cloud/tpu_v2alpha1/services/tpu/client.py
+++ b/packages/google-cloud-tpu/google/cloud/tpu_v2alpha1/services/tpu/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tpu/google/cloud/tpu_v2alpha1/services/tpu/pagers.py
+++ b/packages/google-cloud-tpu/google/cloud/tpu_v2alpha1/services/tpu/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tpu/google/cloud/tpu_v2alpha1/services/tpu/transports/__init__.py
+++ b/packages/google-cloud-tpu/google/cloud/tpu_v2alpha1/services/tpu/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tpu/google/cloud/tpu_v2alpha1/services/tpu/transports/base.py
+++ b/packages/google-cloud-tpu/google/cloud/tpu_v2alpha1/services/tpu/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tpu/google/cloud/tpu_v2alpha1/services/tpu/transports/grpc.py
+++ b/packages/google-cloud-tpu/google/cloud/tpu_v2alpha1/services/tpu/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tpu/google/cloud/tpu_v2alpha1/services/tpu/transports/grpc_asyncio.py
+++ b/packages/google-cloud-tpu/google/cloud/tpu_v2alpha1/services/tpu/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tpu/google/cloud/tpu_v2alpha1/types/__init__.py
+++ b/packages/google-cloud-tpu/google/cloud/tpu_v2alpha1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tpu/google/cloud/tpu_v2alpha1/types/cloud_tpu.py
+++ b/packages/google-cloud-tpu/google/cloud/tpu_v2alpha1/types/cloud_tpu.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tpu/samples/generated_samples/tpu_v1_generated_tpu_create_node_sync.py
+++ b/packages/google-cloud-tpu/samples/generated_samples/tpu_v1_generated_tpu_create_node_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tpu/samples/generated_samples/tpu_v1_generated_tpu_delete_node_sync.py
+++ b/packages/google-cloud-tpu/samples/generated_samples/tpu_v1_generated_tpu_delete_node_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tpu/samples/generated_samples/tpu_v1_generated_tpu_get_accelerator_type_async.py
+++ b/packages/google-cloud-tpu/samples/generated_samples/tpu_v1_generated_tpu_get_accelerator_type_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tpu/samples/generated_samples/tpu_v1_generated_tpu_get_accelerator_type_sync.py
+++ b/packages/google-cloud-tpu/samples/generated_samples/tpu_v1_generated_tpu_get_accelerator_type_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tpu/samples/generated_samples/tpu_v1_generated_tpu_get_node_async.py
+++ b/packages/google-cloud-tpu/samples/generated_samples/tpu_v1_generated_tpu_get_node_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tpu/samples/generated_samples/tpu_v1_generated_tpu_get_node_sync.py
+++ b/packages/google-cloud-tpu/samples/generated_samples/tpu_v1_generated_tpu_get_node_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tpu/samples/generated_samples/tpu_v1_generated_tpu_get_tensor_flow_version_async.py
+++ b/packages/google-cloud-tpu/samples/generated_samples/tpu_v1_generated_tpu_get_tensor_flow_version_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tpu/samples/generated_samples/tpu_v1_generated_tpu_get_tensor_flow_version_sync.py
+++ b/packages/google-cloud-tpu/samples/generated_samples/tpu_v1_generated_tpu_get_tensor_flow_version_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tpu/samples/generated_samples/tpu_v1_generated_tpu_list_accelerator_types_async.py
+++ b/packages/google-cloud-tpu/samples/generated_samples/tpu_v1_generated_tpu_list_accelerator_types_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tpu/samples/generated_samples/tpu_v1_generated_tpu_list_accelerator_types_sync.py
+++ b/packages/google-cloud-tpu/samples/generated_samples/tpu_v1_generated_tpu_list_accelerator_types_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tpu/samples/generated_samples/tpu_v1_generated_tpu_list_nodes_async.py
+++ b/packages/google-cloud-tpu/samples/generated_samples/tpu_v1_generated_tpu_list_nodes_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tpu/samples/generated_samples/tpu_v1_generated_tpu_list_nodes_sync.py
+++ b/packages/google-cloud-tpu/samples/generated_samples/tpu_v1_generated_tpu_list_nodes_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tpu/samples/generated_samples/tpu_v1_generated_tpu_list_tensor_flow_versions_async.py
+++ b/packages/google-cloud-tpu/samples/generated_samples/tpu_v1_generated_tpu_list_tensor_flow_versions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tpu/samples/generated_samples/tpu_v1_generated_tpu_list_tensor_flow_versions_sync.py
+++ b/packages/google-cloud-tpu/samples/generated_samples/tpu_v1_generated_tpu_list_tensor_flow_versions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tpu/samples/generated_samples/tpu_v1_generated_tpu_reimage_node_sync.py
+++ b/packages/google-cloud-tpu/samples/generated_samples/tpu_v1_generated_tpu_reimage_node_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tpu/samples/generated_samples/tpu_v1_generated_tpu_start_node_sync.py
+++ b/packages/google-cloud-tpu/samples/generated_samples/tpu_v1_generated_tpu_start_node_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tpu/samples/generated_samples/tpu_v1_generated_tpu_stop_node_sync.py
+++ b/packages/google-cloud-tpu/samples/generated_samples/tpu_v1_generated_tpu_stop_node_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tpu/samples/generated_samples/tpu_v2_generated_tpu_create_node_sync.py
+++ b/packages/google-cloud-tpu/samples/generated_samples/tpu_v2_generated_tpu_create_node_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tpu/samples/generated_samples/tpu_v2_generated_tpu_create_queued_resource_sync.py
+++ b/packages/google-cloud-tpu/samples/generated_samples/tpu_v2_generated_tpu_create_queued_resource_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tpu/samples/generated_samples/tpu_v2_generated_tpu_delete_node_sync.py
+++ b/packages/google-cloud-tpu/samples/generated_samples/tpu_v2_generated_tpu_delete_node_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tpu/samples/generated_samples/tpu_v2_generated_tpu_delete_queued_resource_sync.py
+++ b/packages/google-cloud-tpu/samples/generated_samples/tpu_v2_generated_tpu_delete_queued_resource_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tpu/samples/generated_samples/tpu_v2_generated_tpu_generate_service_identity_async.py
+++ b/packages/google-cloud-tpu/samples/generated_samples/tpu_v2_generated_tpu_generate_service_identity_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tpu/samples/generated_samples/tpu_v2_generated_tpu_generate_service_identity_sync.py
+++ b/packages/google-cloud-tpu/samples/generated_samples/tpu_v2_generated_tpu_generate_service_identity_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tpu/samples/generated_samples/tpu_v2_generated_tpu_get_accelerator_type_async.py
+++ b/packages/google-cloud-tpu/samples/generated_samples/tpu_v2_generated_tpu_get_accelerator_type_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tpu/samples/generated_samples/tpu_v2_generated_tpu_get_accelerator_type_sync.py
+++ b/packages/google-cloud-tpu/samples/generated_samples/tpu_v2_generated_tpu_get_accelerator_type_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tpu/samples/generated_samples/tpu_v2_generated_tpu_get_guest_attributes_async.py
+++ b/packages/google-cloud-tpu/samples/generated_samples/tpu_v2_generated_tpu_get_guest_attributes_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tpu/samples/generated_samples/tpu_v2_generated_tpu_get_guest_attributes_sync.py
+++ b/packages/google-cloud-tpu/samples/generated_samples/tpu_v2_generated_tpu_get_guest_attributes_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tpu/samples/generated_samples/tpu_v2_generated_tpu_get_node_async.py
+++ b/packages/google-cloud-tpu/samples/generated_samples/tpu_v2_generated_tpu_get_node_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tpu/samples/generated_samples/tpu_v2_generated_tpu_get_node_sync.py
+++ b/packages/google-cloud-tpu/samples/generated_samples/tpu_v2_generated_tpu_get_node_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tpu/samples/generated_samples/tpu_v2_generated_tpu_get_queued_resource_async.py
+++ b/packages/google-cloud-tpu/samples/generated_samples/tpu_v2_generated_tpu_get_queued_resource_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tpu/samples/generated_samples/tpu_v2_generated_tpu_get_queued_resource_sync.py
+++ b/packages/google-cloud-tpu/samples/generated_samples/tpu_v2_generated_tpu_get_queued_resource_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tpu/samples/generated_samples/tpu_v2_generated_tpu_get_runtime_version_async.py
+++ b/packages/google-cloud-tpu/samples/generated_samples/tpu_v2_generated_tpu_get_runtime_version_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tpu/samples/generated_samples/tpu_v2_generated_tpu_get_runtime_version_sync.py
+++ b/packages/google-cloud-tpu/samples/generated_samples/tpu_v2_generated_tpu_get_runtime_version_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tpu/samples/generated_samples/tpu_v2_generated_tpu_list_accelerator_types_async.py
+++ b/packages/google-cloud-tpu/samples/generated_samples/tpu_v2_generated_tpu_list_accelerator_types_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tpu/samples/generated_samples/tpu_v2_generated_tpu_list_accelerator_types_sync.py
+++ b/packages/google-cloud-tpu/samples/generated_samples/tpu_v2_generated_tpu_list_accelerator_types_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tpu/samples/generated_samples/tpu_v2_generated_tpu_list_nodes_async.py
+++ b/packages/google-cloud-tpu/samples/generated_samples/tpu_v2_generated_tpu_list_nodes_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tpu/samples/generated_samples/tpu_v2_generated_tpu_list_nodes_sync.py
+++ b/packages/google-cloud-tpu/samples/generated_samples/tpu_v2_generated_tpu_list_nodes_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tpu/samples/generated_samples/tpu_v2_generated_tpu_list_queued_resources_async.py
+++ b/packages/google-cloud-tpu/samples/generated_samples/tpu_v2_generated_tpu_list_queued_resources_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tpu/samples/generated_samples/tpu_v2_generated_tpu_list_queued_resources_sync.py
+++ b/packages/google-cloud-tpu/samples/generated_samples/tpu_v2_generated_tpu_list_queued_resources_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tpu/samples/generated_samples/tpu_v2_generated_tpu_list_runtime_versions_async.py
+++ b/packages/google-cloud-tpu/samples/generated_samples/tpu_v2_generated_tpu_list_runtime_versions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tpu/samples/generated_samples/tpu_v2_generated_tpu_list_runtime_versions_sync.py
+++ b/packages/google-cloud-tpu/samples/generated_samples/tpu_v2_generated_tpu_list_runtime_versions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tpu/samples/generated_samples/tpu_v2_generated_tpu_reset_queued_resource_sync.py
+++ b/packages/google-cloud-tpu/samples/generated_samples/tpu_v2_generated_tpu_reset_queued_resource_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tpu/samples/generated_samples/tpu_v2_generated_tpu_start_node_sync.py
+++ b/packages/google-cloud-tpu/samples/generated_samples/tpu_v2_generated_tpu_start_node_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tpu/samples/generated_samples/tpu_v2_generated_tpu_stop_node_sync.py
+++ b/packages/google-cloud-tpu/samples/generated_samples/tpu_v2_generated_tpu_stop_node_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tpu/samples/generated_samples/tpu_v2_generated_tpu_update_node_sync.py
+++ b/packages/google-cloud-tpu/samples/generated_samples/tpu_v2_generated_tpu_update_node_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tpu/samples/generated_samples/tpu_v2alpha1_generated_tpu_create_node_sync.py
+++ b/packages/google-cloud-tpu/samples/generated_samples/tpu_v2alpha1_generated_tpu_create_node_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tpu/samples/generated_samples/tpu_v2alpha1_generated_tpu_create_queued_resource_sync.py
+++ b/packages/google-cloud-tpu/samples/generated_samples/tpu_v2alpha1_generated_tpu_create_queued_resource_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tpu/samples/generated_samples/tpu_v2alpha1_generated_tpu_delete_node_sync.py
+++ b/packages/google-cloud-tpu/samples/generated_samples/tpu_v2alpha1_generated_tpu_delete_node_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tpu/samples/generated_samples/tpu_v2alpha1_generated_tpu_delete_queued_resource_sync.py
+++ b/packages/google-cloud-tpu/samples/generated_samples/tpu_v2alpha1_generated_tpu_delete_queued_resource_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tpu/samples/generated_samples/tpu_v2alpha1_generated_tpu_generate_service_identity_async.py
+++ b/packages/google-cloud-tpu/samples/generated_samples/tpu_v2alpha1_generated_tpu_generate_service_identity_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tpu/samples/generated_samples/tpu_v2alpha1_generated_tpu_generate_service_identity_sync.py
+++ b/packages/google-cloud-tpu/samples/generated_samples/tpu_v2alpha1_generated_tpu_generate_service_identity_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tpu/samples/generated_samples/tpu_v2alpha1_generated_tpu_get_accelerator_type_async.py
+++ b/packages/google-cloud-tpu/samples/generated_samples/tpu_v2alpha1_generated_tpu_get_accelerator_type_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tpu/samples/generated_samples/tpu_v2alpha1_generated_tpu_get_accelerator_type_sync.py
+++ b/packages/google-cloud-tpu/samples/generated_samples/tpu_v2alpha1_generated_tpu_get_accelerator_type_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tpu/samples/generated_samples/tpu_v2alpha1_generated_tpu_get_guest_attributes_async.py
+++ b/packages/google-cloud-tpu/samples/generated_samples/tpu_v2alpha1_generated_tpu_get_guest_attributes_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tpu/samples/generated_samples/tpu_v2alpha1_generated_tpu_get_guest_attributes_sync.py
+++ b/packages/google-cloud-tpu/samples/generated_samples/tpu_v2alpha1_generated_tpu_get_guest_attributes_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tpu/samples/generated_samples/tpu_v2alpha1_generated_tpu_get_node_async.py
+++ b/packages/google-cloud-tpu/samples/generated_samples/tpu_v2alpha1_generated_tpu_get_node_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tpu/samples/generated_samples/tpu_v2alpha1_generated_tpu_get_node_sync.py
+++ b/packages/google-cloud-tpu/samples/generated_samples/tpu_v2alpha1_generated_tpu_get_node_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tpu/samples/generated_samples/tpu_v2alpha1_generated_tpu_get_queued_resource_async.py
+++ b/packages/google-cloud-tpu/samples/generated_samples/tpu_v2alpha1_generated_tpu_get_queued_resource_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tpu/samples/generated_samples/tpu_v2alpha1_generated_tpu_get_queued_resource_sync.py
+++ b/packages/google-cloud-tpu/samples/generated_samples/tpu_v2alpha1_generated_tpu_get_queued_resource_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tpu/samples/generated_samples/tpu_v2alpha1_generated_tpu_get_runtime_version_async.py
+++ b/packages/google-cloud-tpu/samples/generated_samples/tpu_v2alpha1_generated_tpu_get_runtime_version_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tpu/samples/generated_samples/tpu_v2alpha1_generated_tpu_get_runtime_version_sync.py
+++ b/packages/google-cloud-tpu/samples/generated_samples/tpu_v2alpha1_generated_tpu_get_runtime_version_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tpu/samples/generated_samples/tpu_v2alpha1_generated_tpu_list_accelerator_types_async.py
+++ b/packages/google-cloud-tpu/samples/generated_samples/tpu_v2alpha1_generated_tpu_list_accelerator_types_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tpu/samples/generated_samples/tpu_v2alpha1_generated_tpu_list_accelerator_types_sync.py
+++ b/packages/google-cloud-tpu/samples/generated_samples/tpu_v2alpha1_generated_tpu_list_accelerator_types_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tpu/samples/generated_samples/tpu_v2alpha1_generated_tpu_list_nodes_async.py
+++ b/packages/google-cloud-tpu/samples/generated_samples/tpu_v2alpha1_generated_tpu_list_nodes_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tpu/samples/generated_samples/tpu_v2alpha1_generated_tpu_list_nodes_sync.py
+++ b/packages/google-cloud-tpu/samples/generated_samples/tpu_v2alpha1_generated_tpu_list_nodes_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tpu/samples/generated_samples/tpu_v2alpha1_generated_tpu_list_queued_resources_async.py
+++ b/packages/google-cloud-tpu/samples/generated_samples/tpu_v2alpha1_generated_tpu_list_queued_resources_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tpu/samples/generated_samples/tpu_v2alpha1_generated_tpu_list_queued_resources_sync.py
+++ b/packages/google-cloud-tpu/samples/generated_samples/tpu_v2alpha1_generated_tpu_list_queued_resources_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tpu/samples/generated_samples/tpu_v2alpha1_generated_tpu_list_reservations_async.py
+++ b/packages/google-cloud-tpu/samples/generated_samples/tpu_v2alpha1_generated_tpu_list_reservations_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tpu/samples/generated_samples/tpu_v2alpha1_generated_tpu_list_reservations_sync.py
+++ b/packages/google-cloud-tpu/samples/generated_samples/tpu_v2alpha1_generated_tpu_list_reservations_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tpu/samples/generated_samples/tpu_v2alpha1_generated_tpu_list_runtime_versions_async.py
+++ b/packages/google-cloud-tpu/samples/generated_samples/tpu_v2alpha1_generated_tpu_list_runtime_versions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tpu/samples/generated_samples/tpu_v2alpha1_generated_tpu_list_runtime_versions_sync.py
+++ b/packages/google-cloud-tpu/samples/generated_samples/tpu_v2alpha1_generated_tpu_list_runtime_versions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tpu/samples/generated_samples/tpu_v2alpha1_generated_tpu_perform_maintenance_queued_resource_sync.py
+++ b/packages/google-cloud-tpu/samples/generated_samples/tpu_v2alpha1_generated_tpu_perform_maintenance_queued_resource_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tpu/samples/generated_samples/tpu_v2alpha1_generated_tpu_perform_maintenance_sync.py
+++ b/packages/google-cloud-tpu/samples/generated_samples/tpu_v2alpha1_generated_tpu_perform_maintenance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tpu/samples/generated_samples/tpu_v2alpha1_generated_tpu_reset_queued_resource_sync.py
+++ b/packages/google-cloud-tpu/samples/generated_samples/tpu_v2alpha1_generated_tpu_reset_queued_resource_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tpu/samples/generated_samples/tpu_v2alpha1_generated_tpu_simulate_maintenance_event_sync.py
+++ b/packages/google-cloud-tpu/samples/generated_samples/tpu_v2alpha1_generated_tpu_simulate_maintenance_event_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tpu/samples/generated_samples/tpu_v2alpha1_generated_tpu_start_node_sync.py
+++ b/packages/google-cloud-tpu/samples/generated_samples/tpu_v2alpha1_generated_tpu_start_node_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tpu/samples/generated_samples/tpu_v2alpha1_generated_tpu_stop_node_sync.py
+++ b/packages/google-cloud-tpu/samples/generated_samples/tpu_v2alpha1_generated_tpu_stop_node_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tpu/samples/generated_samples/tpu_v2alpha1_generated_tpu_update_node_sync.py
+++ b/packages/google-cloud-tpu/samples/generated_samples/tpu_v2alpha1_generated_tpu_update_node_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tpu/tests/__init__.py
+++ b/packages/google-cloud-tpu/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tpu/tests/unit/__init__.py
+++ b/packages/google-cloud-tpu/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tpu/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-tpu/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tpu/tests/unit/gapic/tpu_v1/__init__.py
+++ b/packages/google-cloud-tpu/tests/unit/gapic/tpu_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tpu/tests/unit/gapic/tpu_v2/__init__.py
+++ b/packages/google-cloud-tpu/tests/unit/gapic/tpu_v2/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-tpu/tests/unit/gapic/tpu_v2alpha1/__init__.py
+++ b/packages/google-cloud-tpu/tests/unit/gapic/tpu_v2alpha1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-trace/.flake8
+++ b/packages/google-cloud-trace/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-trace/MANIFEST.in
+++ b/packages/google-cloud-trace/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-trace/google/cloud/trace/__init__.py
+++ b/packages/google-cloud-trace/google/cloud/trace/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-trace/google/cloud/trace/gapic_version.py
+++ b/packages/google-cloud-trace/google/cloud/trace/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-trace/google/cloud/trace_v1/gapic_version.py
+++ b/packages/google-cloud-trace/google/cloud/trace_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-trace/google/cloud/trace_v1/services/__init__.py
+++ b/packages/google-cloud-trace/google/cloud/trace_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-trace/google/cloud/trace_v1/services/trace_service/__init__.py
+++ b/packages/google-cloud-trace/google/cloud/trace_v1/services/trace_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-trace/google/cloud/trace_v1/services/trace_service/async_client.py
+++ b/packages/google-cloud-trace/google/cloud/trace_v1/services/trace_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-trace/google/cloud/trace_v1/services/trace_service/client.py
+++ b/packages/google-cloud-trace/google/cloud/trace_v1/services/trace_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-trace/google/cloud/trace_v1/services/trace_service/pagers.py
+++ b/packages/google-cloud-trace/google/cloud/trace_v1/services/trace_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-trace/google/cloud/trace_v1/services/trace_service/transports/__init__.py
+++ b/packages/google-cloud-trace/google/cloud/trace_v1/services/trace_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-trace/google/cloud/trace_v1/services/trace_service/transports/base.py
+++ b/packages/google-cloud-trace/google/cloud/trace_v1/services/trace_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-trace/google/cloud/trace_v1/services/trace_service/transports/grpc.py
+++ b/packages/google-cloud-trace/google/cloud/trace_v1/services/trace_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-trace/google/cloud/trace_v1/services/trace_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-trace/google/cloud/trace_v1/services/trace_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-trace/google/cloud/trace_v1/services/trace_service/transports/rest.py
+++ b/packages/google-cloud-trace/google/cloud/trace_v1/services/trace_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-trace/google/cloud/trace_v1/services/trace_service/transports/rest_base.py
+++ b/packages/google-cloud-trace/google/cloud/trace_v1/services/trace_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-trace/google/cloud/trace_v1/types/__init__.py
+++ b/packages/google-cloud-trace/google/cloud/trace_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-trace/google/cloud/trace_v1/types/trace.py
+++ b/packages/google-cloud-trace/google/cloud/trace_v1/types/trace.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-trace/google/cloud/trace_v2/gapic_version.py
+++ b/packages/google-cloud-trace/google/cloud/trace_v2/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-trace/google/cloud/trace_v2/services/__init__.py
+++ b/packages/google-cloud-trace/google/cloud/trace_v2/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-trace/google/cloud/trace_v2/services/trace_service/__init__.py
+++ b/packages/google-cloud-trace/google/cloud/trace_v2/services/trace_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-trace/google/cloud/trace_v2/services/trace_service/async_client.py
+++ b/packages/google-cloud-trace/google/cloud/trace_v2/services/trace_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-trace/google/cloud/trace_v2/services/trace_service/client.py
+++ b/packages/google-cloud-trace/google/cloud/trace_v2/services/trace_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-trace/google/cloud/trace_v2/services/trace_service/transports/__init__.py
+++ b/packages/google-cloud-trace/google/cloud/trace_v2/services/trace_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-trace/google/cloud/trace_v2/services/trace_service/transports/base.py
+++ b/packages/google-cloud-trace/google/cloud/trace_v2/services/trace_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-trace/google/cloud/trace_v2/services/trace_service/transports/grpc.py
+++ b/packages/google-cloud-trace/google/cloud/trace_v2/services/trace_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-trace/google/cloud/trace_v2/services/trace_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-trace/google/cloud/trace_v2/services/trace_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-trace/google/cloud/trace_v2/services/trace_service/transports/rest.py
+++ b/packages/google-cloud-trace/google/cloud/trace_v2/services/trace_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-trace/google/cloud/trace_v2/services/trace_service/transports/rest_base.py
+++ b/packages/google-cloud-trace/google/cloud/trace_v2/services/trace_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-trace/google/cloud/trace_v2/types/__init__.py
+++ b/packages/google-cloud-trace/google/cloud/trace_v2/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-trace/google/cloud/trace_v2/types/trace.py
+++ b/packages/google-cloud-trace/google/cloud/trace_v2/types/trace.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-trace/google/cloud/trace_v2/types/tracing.py
+++ b/packages/google-cloud-trace/google/cloud/trace_v2/types/tracing.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-trace/samples/generated_samples/cloudtrace_v1_generated_trace_service_get_trace_async.py
+++ b/packages/google-cloud-trace/samples/generated_samples/cloudtrace_v1_generated_trace_service_get_trace_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-trace/samples/generated_samples/cloudtrace_v1_generated_trace_service_get_trace_sync.py
+++ b/packages/google-cloud-trace/samples/generated_samples/cloudtrace_v1_generated_trace_service_get_trace_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-trace/samples/generated_samples/cloudtrace_v1_generated_trace_service_list_traces_async.py
+++ b/packages/google-cloud-trace/samples/generated_samples/cloudtrace_v1_generated_trace_service_list_traces_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-trace/samples/generated_samples/cloudtrace_v1_generated_trace_service_list_traces_sync.py
+++ b/packages/google-cloud-trace/samples/generated_samples/cloudtrace_v1_generated_trace_service_list_traces_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-trace/samples/generated_samples/cloudtrace_v1_generated_trace_service_patch_traces_async.py
+++ b/packages/google-cloud-trace/samples/generated_samples/cloudtrace_v1_generated_trace_service_patch_traces_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-trace/samples/generated_samples/cloudtrace_v1_generated_trace_service_patch_traces_sync.py
+++ b/packages/google-cloud-trace/samples/generated_samples/cloudtrace_v1_generated_trace_service_patch_traces_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-trace/samples/generated_samples/cloudtrace_v2_generated_trace_service_batch_write_spans_async.py
+++ b/packages/google-cloud-trace/samples/generated_samples/cloudtrace_v2_generated_trace_service_batch_write_spans_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-trace/samples/generated_samples/cloudtrace_v2_generated_trace_service_batch_write_spans_sync.py
+++ b/packages/google-cloud-trace/samples/generated_samples/cloudtrace_v2_generated_trace_service_batch_write_spans_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-trace/samples/generated_samples/cloudtrace_v2_generated_trace_service_create_span_async.py
+++ b/packages/google-cloud-trace/samples/generated_samples/cloudtrace_v2_generated_trace_service_create_span_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-trace/samples/generated_samples/cloudtrace_v2_generated_trace_service_create_span_sync.py
+++ b/packages/google-cloud-trace/samples/generated_samples/cloudtrace_v2_generated_trace_service_create_span_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-trace/tests/__init__.py
+++ b/packages/google-cloud-trace/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-trace/tests/unit/__init__.py
+++ b/packages/google-cloud-trace/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-trace/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-trace/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-trace/tests/unit/gapic/trace_v1/__init__.py
+++ b/packages/google-cloud-trace/tests/unit/gapic/trace_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-trace/tests/unit/gapic/trace_v2/__init__.py
+++ b/packages/google-cloud-trace/tests/unit/gapic/trace_v2/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-translate/.flake8
+++ b/packages/google-cloud-translate/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-translate/MANIFEST.in
+++ b/packages/google-cloud-translate/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-translate/google/cloud/translate/__init__.py
+++ b/packages/google-cloud-translate/google/cloud/translate/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-translate/google/cloud/translate/gapic_version.py
+++ b/packages/google-cloud-translate/google/cloud/translate/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-translate/google/cloud/translate_v3/gapic_version.py
+++ b/packages/google-cloud-translate/google/cloud/translate_v3/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-translate/google/cloud/translate_v3/services/__init__.py
+++ b/packages/google-cloud-translate/google/cloud/translate_v3/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-translate/google/cloud/translate_v3/services/translation_service/__init__.py
+++ b/packages/google-cloud-translate/google/cloud/translate_v3/services/translation_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-translate/google/cloud/translate_v3/services/translation_service/client.py
+++ b/packages/google-cloud-translate/google/cloud/translate_v3/services/translation_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-translate/google/cloud/translate_v3/services/translation_service/pagers.py
+++ b/packages/google-cloud-translate/google/cloud/translate_v3/services/translation_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-translate/google/cloud/translate_v3/services/translation_service/transports/__init__.py
+++ b/packages/google-cloud-translate/google/cloud/translate_v3/services/translation_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-translate/google/cloud/translate_v3/services/translation_service/transports/base.py
+++ b/packages/google-cloud-translate/google/cloud/translate_v3/services/translation_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-translate/google/cloud/translate_v3/services/translation_service/transports/grpc.py
+++ b/packages/google-cloud-translate/google/cloud/translate_v3/services/translation_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-translate/google/cloud/translate_v3/services/translation_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-translate/google/cloud/translate_v3/services/translation_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-translate/google/cloud/translate_v3/services/translation_service/transports/rest.py
+++ b/packages/google-cloud-translate/google/cloud/translate_v3/services/translation_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-translate/google/cloud/translate_v3/services/translation_service/transports/rest_base.py
+++ b/packages/google-cloud-translate/google/cloud/translate_v3/services/translation_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-translate/google/cloud/translate_v3/types/__init__.py
+++ b/packages/google-cloud-translate/google/cloud/translate_v3/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-translate/google/cloud/translate_v3/types/adaptive_mt.py
+++ b/packages/google-cloud-translate/google/cloud/translate_v3/types/adaptive_mt.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-translate/google/cloud/translate_v3/types/automl_translation.py
+++ b/packages/google-cloud-translate/google/cloud/translate_v3/types/automl_translation.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-translate/google/cloud/translate_v3/types/common.py
+++ b/packages/google-cloud-translate/google/cloud/translate_v3/types/common.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-translate/google/cloud/translate_v3/types/translation_service.py
+++ b/packages/google-cloud-translate/google/cloud/translate_v3/types/translation_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-translate/google/cloud/translate_v3beta1/gapic_version.py
+++ b/packages/google-cloud-translate/google/cloud/translate_v3beta1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-translate/google/cloud/translate_v3beta1/services/__init__.py
+++ b/packages/google-cloud-translate/google/cloud/translate_v3beta1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-translate/google/cloud/translate_v3beta1/services/translation_service/__init__.py
+++ b/packages/google-cloud-translate/google/cloud/translate_v3beta1/services/translation_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-translate/google/cloud/translate_v3beta1/services/translation_service/client.py
+++ b/packages/google-cloud-translate/google/cloud/translate_v3beta1/services/translation_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-translate/google/cloud/translate_v3beta1/services/translation_service/pagers.py
+++ b/packages/google-cloud-translate/google/cloud/translate_v3beta1/services/translation_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-translate/google/cloud/translate_v3beta1/services/translation_service/transports/__init__.py
+++ b/packages/google-cloud-translate/google/cloud/translate_v3beta1/services/translation_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-translate/google/cloud/translate_v3beta1/services/translation_service/transports/base.py
+++ b/packages/google-cloud-translate/google/cloud/translate_v3beta1/services/translation_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-translate/google/cloud/translate_v3beta1/services/translation_service/transports/grpc.py
+++ b/packages/google-cloud-translate/google/cloud/translate_v3beta1/services/translation_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-translate/google/cloud/translate_v3beta1/services/translation_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-translate/google/cloud/translate_v3beta1/services/translation_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-translate/google/cloud/translate_v3beta1/services/translation_service/transports/rest.py
+++ b/packages/google-cloud-translate/google/cloud/translate_v3beta1/services/translation_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-translate/google/cloud/translate_v3beta1/services/translation_service/transports/rest_base.py
+++ b/packages/google-cloud-translate/google/cloud/translate_v3beta1/services/translation_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-translate/google/cloud/translate_v3beta1/types/__init__.py
+++ b/packages/google-cloud-translate/google/cloud/translate_v3beta1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-translate/google/cloud/translate_v3beta1/types/translation_service.py
+++ b/packages/google-cloud-translate/google/cloud/translate_v3beta1/types/translation_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_adaptive_mt_translate_async.py
+++ b/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_adaptive_mt_translate_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_adaptive_mt_translate_sync.py
+++ b/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_adaptive_mt_translate_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_batch_translate_document_sync.py
+++ b/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_batch_translate_document_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_batch_translate_text_sync.py
+++ b/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_batch_translate_text_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_create_adaptive_mt_dataset_async.py
+++ b/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_create_adaptive_mt_dataset_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_create_adaptive_mt_dataset_sync.py
+++ b/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_create_adaptive_mt_dataset_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_create_dataset_sync.py
+++ b/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_create_dataset_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_create_glossary_entry_async.py
+++ b/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_create_glossary_entry_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_create_glossary_entry_sync.py
+++ b/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_create_glossary_entry_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_create_glossary_sync.py
+++ b/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_create_glossary_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_create_model_sync.py
+++ b/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_create_model_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_delete_adaptive_mt_dataset_async.py
+++ b/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_delete_adaptive_mt_dataset_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_delete_adaptive_mt_dataset_sync.py
+++ b/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_delete_adaptive_mt_dataset_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_delete_adaptive_mt_file_async.py
+++ b/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_delete_adaptive_mt_file_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_delete_adaptive_mt_file_sync.py
+++ b/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_delete_adaptive_mt_file_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_delete_dataset_sync.py
+++ b/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_delete_dataset_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_delete_glossary_entry_async.py
+++ b/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_delete_glossary_entry_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_delete_glossary_entry_sync.py
+++ b/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_delete_glossary_entry_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_delete_glossary_sync.py
+++ b/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_delete_glossary_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_delete_model_sync.py
+++ b/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_delete_model_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_detect_language_async.py
+++ b/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_detect_language_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_detect_language_sync.py
+++ b/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_detect_language_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_export_data_sync.py
+++ b/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_export_data_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_get_adaptive_mt_dataset_async.py
+++ b/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_get_adaptive_mt_dataset_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_get_adaptive_mt_dataset_sync.py
+++ b/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_get_adaptive_mt_dataset_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_get_adaptive_mt_file_async.py
+++ b/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_get_adaptive_mt_file_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_get_adaptive_mt_file_sync.py
+++ b/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_get_adaptive_mt_file_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_get_dataset_async.py
+++ b/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_get_dataset_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_get_dataset_sync.py
+++ b/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_get_dataset_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_get_glossary_async.py
+++ b/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_get_glossary_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_get_glossary_entry_async.py
+++ b/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_get_glossary_entry_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_get_glossary_entry_sync.py
+++ b/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_get_glossary_entry_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_get_glossary_sync.py
+++ b/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_get_glossary_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_get_model_async.py
+++ b/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_get_model_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_get_model_sync.py
+++ b/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_get_model_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_get_supported_languages_async.py
+++ b/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_get_supported_languages_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_get_supported_languages_sync.py
+++ b/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_get_supported_languages_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_import_adaptive_mt_file_async.py
+++ b/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_import_adaptive_mt_file_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_import_adaptive_mt_file_sync.py
+++ b/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_import_adaptive_mt_file_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_import_data_sync.py
+++ b/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_import_data_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_list_adaptive_mt_datasets_async.py
+++ b/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_list_adaptive_mt_datasets_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_list_adaptive_mt_datasets_sync.py
+++ b/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_list_adaptive_mt_datasets_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_list_adaptive_mt_files_async.py
+++ b/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_list_adaptive_mt_files_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_list_adaptive_mt_files_sync.py
+++ b/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_list_adaptive_mt_files_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_list_adaptive_mt_sentences_async.py
+++ b/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_list_adaptive_mt_sentences_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_list_adaptive_mt_sentences_sync.py
+++ b/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_list_adaptive_mt_sentences_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_list_datasets_async.py
+++ b/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_list_datasets_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_list_datasets_sync.py
+++ b/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_list_datasets_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_list_examples_async.py
+++ b/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_list_examples_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_list_examples_sync.py
+++ b/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_list_examples_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_list_glossaries_async.py
+++ b/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_list_glossaries_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_list_glossaries_sync.py
+++ b/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_list_glossaries_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_list_glossary_entries_async.py
+++ b/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_list_glossary_entries_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_list_glossary_entries_sync.py
+++ b/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_list_glossary_entries_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_list_models_async.py
+++ b/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_list_models_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_list_models_sync.py
+++ b/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_list_models_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_romanize_text_async.py
+++ b/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_romanize_text_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_romanize_text_sync.py
+++ b/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_romanize_text_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_translate_document_async.py
+++ b/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_translate_document_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_translate_document_sync.py
+++ b/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_translate_document_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_translate_text_async.py
+++ b/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_translate_text_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_translate_text_sync.py
+++ b/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_translate_text_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_update_glossary_entry_async.py
+++ b/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_update_glossary_entry_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_update_glossary_entry_sync.py
+++ b/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_update_glossary_entry_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_update_glossary_sync.py
+++ b/packages/google-cloud-translate/samples/generated_samples/translate_v3_generated_translation_service_update_glossary_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-translate/samples/generated_samples/translate_v3beta1_generated_translation_service_batch_translate_document_sync.py
+++ b/packages/google-cloud-translate/samples/generated_samples/translate_v3beta1_generated_translation_service_batch_translate_document_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-translate/samples/generated_samples/translate_v3beta1_generated_translation_service_batch_translate_text_sync.py
+++ b/packages/google-cloud-translate/samples/generated_samples/translate_v3beta1_generated_translation_service_batch_translate_text_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-translate/samples/generated_samples/translate_v3beta1_generated_translation_service_create_glossary_sync.py
+++ b/packages/google-cloud-translate/samples/generated_samples/translate_v3beta1_generated_translation_service_create_glossary_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-translate/samples/generated_samples/translate_v3beta1_generated_translation_service_delete_glossary_sync.py
+++ b/packages/google-cloud-translate/samples/generated_samples/translate_v3beta1_generated_translation_service_delete_glossary_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-translate/samples/generated_samples/translate_v3beta1_generated_translation_service_detect_language_async.py
+++ b/packages/google-cloud-translate/samples/generated_samples/translate_v3beta1_generated_translation_service_detect_language_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-translate/samples/generated_samples/translate_v3beta1_generated_translation_service_detect_language_sync.py
+++ b/packages/google-cloud-translate/samples/generated_samples/translate_v3beta1_generated_translation_service_detect_language_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-translate/samples/generated_samples/translate_v3beta1_generated_translation_service_get_glossary_async.py
+++ b/packages/google-cloud-translate/samples/generated_samples/translate_v3beta1_generated_translation_service_get_glossary_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-translate/samples/generated_samples/translate_v3beta1_generated_translation_service_get_glossary_sync.py
+++ b/packages/google-cloud-translate/samples/generated_samples/translate_v3beta1_generated_translation_service_get_glossary_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-translate/samples/generated_samples/translate_v3beta1_generated_translation_service_get_supported_languages_async.py
+++ b/packages/google-cloud-translate/samples/generated_samples/translate_v3beta1_generated_translation_service_get_supported_languages_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-translate/samples/generated_samples/translate_v3beta1_generated_translation_service_get_supported_languages_sync.py
+++ b/packages/google-cloud-translate/samples/generated_samples/translate_v3beta1_generated_translation_service_get_supported_languages_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-translate/samples/generated_samples/translate_v3beta1_generated_translation_service_list_glossaries_async.py
+++ b/packages/google-cloud-translate/samples/generated_samples/translate_v3beta1_generated_translation_service_list_glossaries_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-translate/samples/generated_samples/translate_v3beta1_generated_translation_service_list_glossaries_sync.py
+++ b/packages/google-cloud-translate/samples/generated_samples/translate_v3beta1_generated_translation_service_list_glossaries_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-translate/samples/generated_samples/translate_v3beta1_generated_translation_service_refine_text_async.py
+++ b/packages/google-cloud-translate/samples/generated_samples/translate_v3beta1_generated_translation_service_refine_text_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-translate/samples/generated_samples/translate_v3beta1_generated_translation_service_refine_text_sync.py
+++ b/packages/google-cloud-translate/samples/generated_samples/translate_v3beta1_generated_translation_service_refine_text_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-translate/samples/generated_samples/translate_v3beta1_generated_translation_service_translate_document_async.py
+++ b/packages/google-cloud-translate/samples/generated_samples/translate_v3beta1_generated_translation_service_translate_document_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-translate/samples/generated_samples/translate_v3beta1_generated_translation_service_translate_document_sync.py
+++ b/packages/google-cloud-translate/samples/generated_samples/translate_v3beta1_generated_translation_service_translate_document_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-translate/samples/generated_samples/translate_v3beta1_generated_translation_service_translate_text_async.py
+++ b/packages/google-cloud-translate/samples/generated_samples/translate_v3beta1_generated_translation_service_translate_text_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-translate/samples/generated_samples/translate_v3beta1_generated_translation_service_translate_text_sync.py
+++ b/packages/google-cloud-translate/samples/generated_samples/translate_v3beta1_generated_translation_service_translate_text_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-translate/tests/__init__.py
+++ b/packages/google-cloud-translate/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-translate/tests/unit/__init__.py
+++ b/packages/google-cloud-translate/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-translate/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-translate/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-translate/tests/unit/gapic/translate_v3/__init__.py
+++ b/packages/google-cloud-translate/tests/unit/gapic/translate_v3/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-translate/tests/unit/gapic/translate_v3beta1/__init__.py
+++ b/packages/google-cloud-translate/tests/unit/gapic/translate_v3beta1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/.flake8
+++ b/packages/google-cloud-vectorsearch/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/MANIFEST.in
+++ b/packages/google-cloud-vectorsearch/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/google/cloud/vectorsearch/__init__.py
+++ b/packages/google-cloud-vectorsearch/google/cloud/vectorsearch/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/google/cloud/vectorsearch/gapic_version.py
+++ b/packages/google-cloud-vectorsearch/google/cloud/vectorsearch/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1/gapic_version.py
+++ b/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1/services/__init__.py
+++ b/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1/services/data_object_search_service/__init__.py
+++ b/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1/services/data_object_search_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1/services/data_object_search_service/async_client.py
+++ b/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1/services/data_object_search_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1/services/data_object_search_service/client.py
+++ b/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1/services/data_object_search_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1/services/data_object_search_service/pagers.py
+++ b/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1/services/data_object_search_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1/services/data_object_search_service/transports/__init__.py
+++ b/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1/services/data_object_search_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1/services/data_object_search_service/transports/base.py
+++ b/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1/services/data_object_search_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1/services/data_object_search_service/transports/grpc.py
+++ b/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1/services/data_object_search_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1/services/data_object_search_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1/services/data_object_search_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1/services/data_object_search_service/transports/rest.py
+++ b/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1/services/data_object_search_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1/services/data_object_search_service/transports/rest_base.py
+++ b/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1/services/data_object_search_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1/services/data_object_service/__init__.py
+++ b/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1/services/data_object_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1/services/data_object_service/async_client.py
+++ b/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1/services/data_object_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1/services/data_object_service/client.py
+++ b/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1/services/data_object_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1/services/data_object_service/transports/__init__.py
+++ b/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1/services/data_object_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1/services/data_object_service/transports/base.py
+++ b/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1/services/data_object_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1/services/data_object_service/transports/grpc.py
+++ b/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1/services/data_object_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1/services/data_object_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1/services/data_object_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1/services/data_object_service/transports/rest.py
+++ b/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1/services/data_object_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1/services/data_object_service/transports/rest_base.py
+++ b/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1/services/data_object_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1/services/vector_search_service/__init__.py
+++ b/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1/services/vector_search_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1/services/vector_search_service/client.py
+++ b/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1/services/vector_search_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1/services/vector_search_service/pagers.py
+++ b/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1/services/vector_search_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1/services/vector_search_service/transports/__init__.py
+++ b/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1/services/vector_search_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1/services/vector_search_service/transports/base.py
+++ b/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1/services/vector_search_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1/services/vector_search_service/transports/grpc.py
+++ b/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1/services/vector_search_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1/services/vector_search_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1/services/vector_search_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1/services/vector_search_service/transports/rest.py
+++ b/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1/services/vector_search_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1/services/vector_search_service/transports/rest_base.py
+++ b/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1/services/vector_search_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1/types/__init__.py
+++ b/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1/types/common.py
+++ b/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1/types/common.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1/types/data_object.py
+++ b/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1/types/data_object.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1/types/data_object_search_service.py
+++ b/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1/types/data_object_search_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1/types/data_object_service.py
+++ b/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1/types/data_object_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1/types/embedding_config.py
+++ b/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1/types/embedding_config.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1/types/encryption_spec.py
+++ b/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1/types/encryption_spec.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1/types/vectorsearch_service.py
+++ b/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1/types/vectorsearch_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1beta/gapic_version.py
+++ b/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1beta/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1beta/services/__init__.py
+++ b/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1beta/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1beta/services/data_object_search_service/__init__.py
+++ b/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1beta/services/data_object_search_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1beta/services/data_object_search_service/async_client.py
+++ b/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1beta/services/data_object_search_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1beta/services/data_object_search_service/client.py
+++ b/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1beta/services/data_object_search_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1beta/services/data_object_search_service/pagers.py
+++ b/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1beta/services/data_object_search_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1beta/services/data_object_search_service/transports/__init__.py
+++ b/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1beta/services/data_object_search_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1beta/services/data_object_search_service/transports/base.py
+++ b/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1beta/services/data_object_search_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1beta/services/data_object_search_service/transports/grpc.py
+++ b/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1beta/services/data_object_search_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1beta/services/data_object_search_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1beta/services/data_object_search_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1beta/services/data_object_search_service/transports/rest.py
+++ b/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1beta/services/data_object_search_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1beta/services/data_object_search_service/transports/rest_base.py
+++ b/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1beta/services/data_object_search_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1beta/services/data_object_service/__init__.py
+++ b/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1beta/services/data_object_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1beta/services/data_object_service/async_client.py
+++ b/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1beta/services/data_object_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1beta/services/data_object_service/client.py
+++ b/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1beta/services/data_object_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1beta/services/data_object_service/transports/__init__.py
+++ b/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1beta/services/data_object_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1beta/services/data_object_service/transports/base.py
+++ b/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1beta/services/data_object_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1beta/services/data_object_service/transports/grpc.py
+++ b/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1beta/services/data_object_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1beta/services/data_object_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1beta/services/data_object_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1beta/services/data_object_service/transports/rest.py
+++ b/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1beta/services/data_object_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1beta/services/data_object_service/transports/rest_base.py
+++ b/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1beta/services/data_object_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1beta/services/vector_search_service/__init__.py
+++ b/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1beta/services/vector_search_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1beta/services/vector_search_service/client.py
+++ b/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1beta/services/vector_search_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1beta/services/vector_search_service/pagers.py
+++ b/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1beta/services/vector_search_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1beta/services/vector_search_service/transports/__init__.py
+++ b/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1beta/services/vector_search_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1beta/services/vector_search_service/transports/base.py
+++ b/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1beta/services/vector_search_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1beta/services/vector_search_service/transports/grpc.py
+++ b/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1beta/services/vector_search_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1beta/services/vector_search_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1beta/services/vector_search_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1beta/services/vector_search_service/transports/rest.py
+++ b/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1beta/services/vector_search_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1beta/services/vector_search_service/transports/rest_base.py
+++ b/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1beta/services/vector_search_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1beta/types/__init__.py
+++ b/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1beta/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1beta/types/common.py
+++ b/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1beta/types/common.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1beta/types/data_object.py
+++ b/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1beta/types/data_object.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1beta/types/data_object_search_service.py
+++ b/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1beta/types/data_object_search_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1beta/types/data_object_service.py
+++ b/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1beta/types/data_object_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1beta/types/embedding_config.py
+++ b/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1beta/types/embedding_config.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1beta/types/encryption_spec.py
+++ b/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1beta/types/encryption_spec.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1beta/types/vectorsearch_service.py
+++ b/packages/google-cloud-vectorsearch/google/cloud/vectorsearch_v1beta/types/vectorsearch_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1_generated_data_object_search_service_aggregate_data_objects_async.py
+++ b/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1_generated_data_object_search_service_aggregate_data_objects_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1_generated_data_object_search_service_aggregate_data_objects_sync.py
+++ b/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1_generated_data_object_search_service_aggregate_data_objects_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1_generated_data_object_search_service_batch_search_data_objects_async.py
+++ b/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1_generated_data_object_search_service_batch_search_data_objects_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1_generated_data_object_search_service_batch_search_data_objects_sync.py
+++ b/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1_generated_data_object_search_service_batch_search_data_objects_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1_generated_data_object_search_service_query_data_objects_async.py
+++ b/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1_generated_data_object_search_service_query_data_objects_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1_generated_data_object_search_service_query_data_objects_sync.py
+++ b/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1_generated_data_object_search_service_query_data_objects_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1_generated_data_object_search_service_search_data_objects_async.py
+++ b/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1_generated_data_object_search_service_search_data_objects_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1_generated_data_object_search_service_search_data_objects_sync.py
+++ b/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1_generated_data_object_search_service_search_data_objects_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1_generated_data_object_service_batch_create_data_objects_async.py
+++ b/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1_generated_data_object_service_batch_create_data_objects_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1_generated_data_object_service_batch_create_data_objects_sync.py
+++ b/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1_generated_data_object_service_batch_create_data_objects_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1_generated_data_object_service_batch_delete_data_objects_async.py
+++ b/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1_generated_data_object_service_batch_delete_data_objects_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1_generated_data_object_service_batch_delete_data_objects_sync.py
+++ b/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1_generated_data_object_service_batch_delete_data_objects_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1_generated_data_object_service_batch_update_data_objects_async.py
+++ b/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1_generated_data_object_service_batch_update_data_objects_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1_generated_data_object_service_batch_update_data_objects_sync.py
+++ b/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1_generated_data_object_service_batch_update_data_objects_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1_generated_data_object_service_create_data_object_async.py
+++ b/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1_generated_data_object_service_create_data_object_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1_generated_data_object_service_create_data_object_sync.py
+++ b/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1_generated_data_object_service_create_data_object_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1_generated_data_object_service_delete_data_object_async.py
+++ b/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1_generated_data_object_service_delete_data_object_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1_generated_data_object_service_delete_data_object_sync.py
+++ b/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1_generated_data_object_service_delete_data_object_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1_generated_data_object_service_get_data_object_async.py
+++ b/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1_generated_data_object_service_get_data_object_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1_generated_data_object_service_get_data_object_sync.py
+++ b/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1_generated_data_object_service_get_data_object_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1_generated_data_object_service_update_data_object_async.py
+++ b/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1_generated_data_object_service_update_data_object_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1_generated_data_object_service_update_data_object_sync.py
+++ b/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1_generated_data_object_service_update_data_object_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1_generated_vector_search_service_create_collection_sync.py
+++ b/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1_generated_vector_search_service_create_collection_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1_generated_vector_search_service_create_index_sync.py
+++ b/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1_generated_vector_search_service_create_index_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1_generated_vector_search_service_delete_collection_sync.py
+++ b/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1_generated_vector_search_service_delete_collection_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1_generated_vector_search_service_delete_index_sync.py
+++ b/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1_generated_vector_search_service_delete_index_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1_generated_vector_search_service_export_data_objects_sync.py
+++ b/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1_generated_vector_search_service_export_data_objects_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1_generated_vector_search_service_get_collection_async.py
+++ b/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1_generated_vector_search_service_get_collection_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1_generated_vector_search_service_get_collection_sync.py
+++ b/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1_generated_vector_search_service_get_collection_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1_generated_vector_search_service_get_index_async.py
+++ b/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1_generated_vector_search_service_get_index_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1_generated_vector_search_service_get_index_sync.py
+++ b/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1_generated_vector_search_service_get_index_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1_generated_vector_search_service_import_data_objects_sync.py
+++ b/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1_generated_vector_search_service_import_data_objects_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1_generated_vector_search_service_list_collections_async.py
+++ b/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1_generated_vector_search_service_list_collections_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1_generated_vector_search_service_list_collections_sync.py
+++ b/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1_generated_vector_search_service_list_collections_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1_generated_vector_search_service_list_indexes_async.py
+++ b/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1_generated_vector_search_service_list_indexes_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1_generated_vector_search_service_list_indexes_sync.py
+++ b/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1_generated_vector_search_service_list_indexes_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1_generated_vector_search_service_update_collection_sync.py
+++ b/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1_generated_vector_search_service_update_collection_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1_generated_vector_search_service_update_index_sync.py
+++ b/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1_generated_vector_search_service_update_index_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1beta_generated_data_object_search_service_aggregate_data_objects_async.py
+++ b/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1beta_generated_data_object_search_service_aggregate_data_objects_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1beta_generated_data_object_search_service_aggregate_data_objects_sync.py
+++ b/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1beta_generated_data_object_search_service_aggregate_data_objects_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1beta_generated_data_object_search_service_batch_search_data_objects_async.py
+++ b/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1beta_generated_data_object_search_service_batch_search_data_objects_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1beta_generated_data_object_search_service_batch_search_data_objects_sync.py
+++ b/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1beta_generated_data_object_search_service_batch_search_data_objects_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1beta_generated_data_object_search_service_query_data_objects_async.py
+++ b/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1beta_generated_data_object_search_service_query_data_objects_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1beta_generated_data_object_search_service_query_data_objects_sync.py
+++ b/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1beta_generated_data_object_search_service_query_data_objects_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1beta_generated_data_object_search_service_search_data_objects_async.py
+++ b/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1beta_generated_data_object_search_service_search_data_objects_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1beta_generated_data_object_search_service_search_data_objects_sync.py
+++ b/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1beta_generated_data_object_search_service_search_data_objects_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1beta_generated_data_object_service_batch_create_data_objects_async.py
+++ b/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1beta_generated_data_object_service_batch_create_data_objects_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1beta_generated_data_object_service_batch_create_data_objects_sync.py
+++ b/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1beta_generated_data_object_service_batch_create_data_objects_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1beta_generated_data_object_service_batch_delete_data_objects_async.py
+++ b/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1beta_generated_data_object_service_batch_delete_data_objects_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1beta_generated_data_object_service_batch_delete_data_objects_sync.py
+++ b/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1beta_generated_data_object_service_batch_delete_data_objects_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1beta_generated_data_object_service_batch_update_data_objects_async.py
+++ b/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1beta_generated_data_object_service_batch_update_data_objects_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1beta_generated_data_object_service_batch_update_data_objects_sync.py
+++ b/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1beta_generated_data_object_service_batch_update_data_objects_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1beta_generated_data_object_service_create_data_object_async.py
+++ b/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1beta_generated_data_object_service_create_data_object_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1beta_generated_data_object_service_create_data_object_sync.py
+++ b/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1beta_generated_data_object_service_create_data_object_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1beta_generated_data_object_service_delete_data_object_async.py
+++ b/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1beta_generated_data_object_service_delete_data_object_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1beta_generated_data_object_service_delete_data_object_sync.py
+++ b/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1beta_generated_data_object_service_delete_data_object_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1beta_generated_data_object_service_get_data_object_async.py
+++ b/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1beta_generated_data_object_service_get_data_object_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1beta_generated_data_object_service_get_data_object_sync.py
+++ b/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1beta_generated_data_object_service_get_data_object_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1beta_generated_data_object_service_update_data_object_async.py
+++ b/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1beta_generated_data_object_service_update_data_object_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1beta_generated_data_object_service_update_data_object_sync.py
+++ b/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1beta_generated_data_object_service_update_data_object_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1beta_generated_vector_search_service_create_collection_sync.py
+++ b/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1beta_generated_vector_search_service_create_collection_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1beta_generated_vector_search_service_create_index_sync.py
+++ b/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1beta_generated_vector_search_service_create_index_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1beta_generated_vector_search_service_delete_collection_sync.py
+++ b/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1beta_generated_vector_search_service_delete_collection_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1beta_generated_vector_search_service_delete_index_sync.py
+++ b/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1beta_generated_vector_search_service_delete_index_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1beta_generated_vector_search_service_export_data_objects_sync.py
+++ b/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1beta_generated_vector_search_service_export_data_objects_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1beta_generated_vector_search_service_get_collection_async.py
+++ b/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1beta_generated_vector_search_service_get_collection_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1beta_generated_vector_search_service_get_collection_sync.py
+++ b/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1beta_generated_vector_search_service_get_collection_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1beta_generated_vector_search_service_get_index_async.py
+++ b/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1beta_generated_vector_search_service_get_index_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1beta_generated_vector_search_service_get_index_sync.py
+++ b/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1beta_generated_vector_search_service_get_index_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1beta_generated_vector_search_service_import_data_objects_sync.py
+++ b/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1beta_generated_vector_search_service_import_data_objects_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1beta_generated_vector_search_service_list_collections_async.py
+++ b/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1beta_generated_vector_search_service_list_collections_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1beta_generated_vector_search_service_list_collections_sync.py
+++ b/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1beta_generated_vector_search_service_list_collections_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1beta_generated_vector_search_service_list_indexes_async.py
+++ b/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1beta_generated_vector_search_service_list_indexes_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1beta_generated_vector_search_service_list_indexes_sync.py
+++ b/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1beta_generated_vector_search_service_list_indexes_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1beta_generated_vector_search_service_update_collection_sync.py
+++ b/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1beta_generated_vector_search_service_update_collection_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1beta_generated_vector_search_service_update_index_sync.py
+++ b/packages/google-cloud-vectorsearch/samples/generated_samples/vectorsearch_v1beta_generated_vector_search_service_update_index_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/tests/__init__.py
+++ b/packages/google-cloud-vectorsearch/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/tests/unit/__init__.py
+++ b/packages/google-cloud-vectorsearch/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-vectorsearch/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/tests/unit/gapic/vectorsearch_v1/__init__.py
+++ b/packages/google-cloud-vectorsearch/tests/unit/gapic/vectorsearch_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vectorsearch/tests/unit/gapic/vectorsearch_v1beta/__init__.py
+++ b/packages/google-cloud-vectorsearch/tests/unit/gapic/vectorsearch_v1beta/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-live-stream/.flake8
+++ b/packages/google-cloud-video-live-stream/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-live-stream/MANIFEST.in
+++ b/packages/google-cloud-video-live-stream/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-live-stream/google/cloud/video/live_stream/__init__.py
+++ b/packages/google-cloud-video-live-stream/google/cloud/video/live_stream/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-live-stream/google/cloud/video/live_stream/gapic_version.py
+++ b/packages/google-cloud-video-live-stream/google/cloud/video/live_stream/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-live-stream/google/cloud/video/live_stream_v1/gapic_version.py
+++ b/packages/google-cloud-video-live-stream/google/cloud/video/live_stream_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-live-stream/google/cloud/video/live_stream_v1/services/__init__.py
+++ b/packages/google-cloud-video-live-stream/google/cloud/video/live_stream_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-live-stream/google/cloud/video/live_stream_v1/services/livestream_service/__init__.py
+++ b/packages/google-cloud-video-live-stream/google/cloud/video/live_stream_v1/services/livestream_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-live-stream/google/cloud/video/live_stream_v1/services/livestream_service/client.py
+++ b/packages/google-cloud-video-live-stream/google/cloud/video/live_stream_v1/services/livestream_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-live-stream/google/cloud/video/live_stream_v1/services/livestream_service/pagers.py
+++ b/packages/google-cloud-video-live-stream/google/cloud/video/live_stream_v1/services/livestream_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-live-stream/google/cloud/video/live_stream_v1/services/livestream_service/transports/__init__.py
+++ b/packages/google-cloud-video-live-stream/google/cloud/video/live_stream_v1/services/livestream_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-live-stream/google/cloud/video/live_stream_v1/services/livestream_service/transports/base.py
+++ b/packages/google-cloud-video-live-stream/google/cloud/video/live_stream_v1/services/livestream_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-live-stream/google/cloud/video/live_stream_v1/services/livestream_service/transports/grpc.py
+++ b/packages/google-cloud-video-live-stream/google/cloud/video/live_stream_v1/services/livestream_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-live-stream/google/cloud/video/live_stream_v1/services/livestream_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-video-live-stream/google/cloud/video/live_stream_v1/services/livestream_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-live-stream/google/cloud/video/live_stream_v1/services/livestream_service/transports/rest.py
+++ b/packages/google-cloud-video-live-stream/google/cloud/video/live_stream_v1/services/livestream_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-live-stream/google/cloud/video/live_stream_v1/services/livestream_service/transports/rest_base.py
+++ b/packages/google-cloud-video-live-stream/google/cloud/video/live_stream_v1/services/livestream_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-live-stream/google/cloud/video/live_stream_v1/types/__init__.py
+++ b/packages/google-cloud-video-live-stream/google/cloud/video/live_stream_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-live-stream/google/cloud/video/live_stream_v1/types/outputs.py
+++ b/packages/google-cloud-video-live-stream/google/cloud/video/live_stream_v1/types/outputs.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-live-stream/google/cloud/video/live_stream_v1/types/resources.py
+++ b/packages/google-cloud-video-live-stream/google/cloud/video/live_stream_v1/types/resources.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-live-stream/google/cloud/video/live_stream_v1/types/service.py
+++ b/packages/google-cloud-video-live-stream/google/cloud/video/live_stream_v1/types/service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-live-stream/samples/generated_samples/livestream_v1_generated_livestream_service_create_asset_sync.py
+++ b/packages/google-cloud-video-live-stream/samples/generated_samples/livestream_v1_generated_livestream_service_create_asset_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-live-stream/samples/generated_samples/livestream_v1_generated_livestream_service_create_channel_sync.py
+++ b/packages/google-cloud-video-live-stream/samples/generated_samples/livestream_v1_generated_livestream_service_create_channel_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-live-stream/samples/generated_samples/livestream_v1_generated_livestream_service_create_clip_sync.py
+++ b/packages/google-cloud-video-live-stream/samples/generated_samples/livestream_v1_generated_livestream_service_create_clip_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-live-stream/samples/generated_samples/livestream_v1_generated_livestream_service_create_dvr_session_sync.py
+++ b/packages/google-cloud-video-live-stream/samples/generated_samples/livestream_v1_generated_livestream_service_create_dvr_session_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-live-stream/samples/generated_samples/livestream_v1_generated_livestream_service_create_event_async.py
+++ b/packages/google-cloud-video-live-stream/samples/generated_samples/livestream_v1_generated_livestream_service_create_event_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-live-stream/samples/generated_samples/livestream_v1_generated_livestream_service_create_event_sync.py
+++ b/packages/google-cloud-video-live-stream/samples/generated_samples/livestream_v1_generated_livestream_service_create_event_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-live-stream/samples/generated_samples/livestream_v1_generated_livestream_service_create_input_sync.py
+++ b/packages/google-cloud-video-live-stream/samples/generated_samples/livestream_v1_generated_livestream_service_create_input_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-live-stream/samples/generated_samples/livestream_v1_generated_livestream_service_delete_asset_sync.py
+++ b/packages/google-cloud-video-live-stream/samples/generated_samples/livestream_v1_generated_livestream_service_delete_asset_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-live-stream/samples/generated_samples/livestream_v1_generated_livestream_service_delete_channel_sync.py
+++ b/packages/google-cloud-video-live-stream/samples/generated_samples/livestream_v1_generated_livestream_service_delete_channel_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-live-stream/samples/generated_samples/livestream_v1_generated_livestream_service_delete_clip_sync.py
+++ b/packages/google-cloud-video-live-stream/samples/generated_samples/livestream_v1_generated_livestream_service_delete_clip_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-live-stream/samples/generated_samples/livestream_v1_generated_livestream_service_delete_dvr_session_sync.py
+++ b/packages/google-cloud-video-live-stream/samples/generated_samples/livestream_v1_generated_livestream_service_delete_dvr_session_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-live-stream/samples/generated_samples/livestream_v1_generated_livestream_service_delete_event_async.py
+++ b/packages/google-cloud-video-live-stream/samples/generated_samples/livestream_v1_generated_livestream_service_delete_event_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-live-stream/samples/generated_samples/livestream_v1_generated_livestream_service_delete_event_sync.py
+++ b/packages/google-cloud-video-live-stream/samples/generated_samples/livestream_v1_generated_livestream_service_delete_event_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-live-stream/samples/generated_samples/livestream_v1_generated_livestream_service_delete_input_sync.py
+++ b/packages/google-cloud-video-live-stream/samples/generated_samples/livestream_v1_generated_livestream_service_delete_input_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-live-stream/samples/generated_samples/livestream_v1_generated_livestream_service_get_asset_async.py
+++ b/packages/google-cloud-video-live-stream/samples/generated_samples/livestream_v1_generated_livestream_service_get_asset_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-live-stream/samples/generated_samples/livestream_v1_generated_livestream_service_get_asset_sync.py
+++ b/packages/google-cloud-video-live-stream/samples/generated_samples/livestream_v1_generated_livestream_service_get_asset_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-live-stream/samples/generated_samples/livestream_v1_generated_livestream_service_get_channel_async.py
+++ b/packages/google-cloud-video-live-stream/samples/generated_samples/livestream_v1_generated_livestream_service_get_channel_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-live-stream/samples/generated_samples/livestream_v1_generated_livestream_service_get_channel_sync.py
+++ b/packages/google-cloud-video-live-stream/samples/generated_samples/livestream_v1_generated_livestream_service_get_channel_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-live-stream/samples/generated_samples/livestream_v1_generated_livestream_service_get_clip_async.py
+++ b/packages/google-cloud-video-live-stream/samples/generated_samples/livestream_v1_generated_livestream_service_get_clip_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-live-stream/samples/generated_samples/livestream_v1_generated_livestream_service_get_clip_sync.py
+++ b/packages/google-cloud-video-live-stream/samples/generated_samples/livestream_v1_generated_livestream_service_get_clip_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-live-stream/samples/generated_samples/livestream_v1_generated_livestream_service_get_dvr_session_async.py
+++ b/packages/google-cloud-video-live-stream/samples/generated_samples/livestream_v1_generated_livestream_service_get_dvr_session_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-live-stream/samples/generated_samples/livestream_v1_generated_livestream_service_get_dvr_session_sync.py
+++ b/packages/google-cloud-video-live-stream/samples/generated_samples/livestream_v1_generated_livestream_service_get_dvr_session_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-live-stream/samples/generated_samples/livestream_v1_generated_livestream_service_get_event_async.py
+++ b/packages/google-cloud-video-live-stream/samples/generated_samples/livestream_v1_generated_livestream_service_get_event_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-live-stream/samples/generated_samples/livestream_v1_generated_livestream_service_get_event_sync.py
+++ b/packages/google-cloud-video-live-stream/samples/generated_samples/livestream_v1_generated_livestream_service_get_event_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-live-stream/samples/generated_samples/livestream_v1_generated_livestream_service_get_input_async.py
+++ b/packages/google-cloud-video-live-stream/samples/generated_samples/livestream_v1_generated_livestream_service_get_input_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-live-stream/samples/generated_samples/livestream_v1_generated_livestream_service_get_input_sync.py
+++ b/packages/google-cloud-video-live-stream/samples/generated_samples/livestream_v1_generated_livestream_service_get_input_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-live-stream/samples/generated_samples/livestream_v1_generated_livestream_service_get_pool_async.py
+++ b/packages/google-cloud-video-live-stream/samples/generated_samples/livestream_v1_generated_livestream_service_get_pool_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-live-stream/samples/generated_samples/livestream_v1_generated_livestream_service_get_pool_sync.py
+++ b/packages/google-cloud-video-live-stream/samples/generated_samples/livestream_v1_generated_livestream_service_get_pool_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-live-stream/samples/generated_samples/livestream_v1_generated_livestream_service_list_assets_async.py
+++ b/packages/google-cloud-video-live-stream/samples/generated_samples/livestream_v1_generated_livestream_service_list_assets_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-live-stream/samples/generated_samples/livestream_v1_generated_livestream_service_list_assets_sync.py
+++ b/packages/google-cloud-video-live-stream/samples/generated_samples/livestream_v1_generated_livestream_service_list_assets_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-live-stream/samples/generated_samples/livestream_v1_generated_livestream_service_list_channels_async.py
+++ b/packages/google-cloud-video-live-stream/samples/generated_samples/livestream_v1_generated_livestream_service_list_channels_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-live-stream/samples/generated_samples/livestream_v1_generated_livestream_service_list_channels_sync.py
+++ b/packages/google-cloud-video-live-stream/samples/generated_samples/livestream_v1_generated_livestream_service_list_channels_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-live-stream/samples/generated_samples/livestream_v1_generated_livestream_service_list_clips_async.py
+++ b/packages/google-cloud-video-live-stream/samples/generated_samples/livestream_v1_generated_livestream_service_list_clips_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-live-stream/samples/generated_samples/livestream_v1_generated_livestream_service_list_clips_sync.py
+++ b/packages/google-cloud-video-live-stream/samples/generated_samples/livestream_v1_generated_livestream_service_list_clips_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-live-stream/samples/generated_samples/livestream_v1_generated_livestream_service_list_dvr_sessions_async.py
+++ b/packages/google-cloud-video-live-stream/samples/generated_samples/livestream_v1_generated_livestream_service_list_dvr_sessions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-live-stream/samples/generated_samples/livestream_v1_generated_livestream_service_list_dvr_sessions_sync.py
+++ b/packages/google-cloud-video-live-stream/samples/generated_samples/livestream_v1_generated_livestream_service_list_dvr_sessions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-live-stream/samples/generated_samples/livestream_v1_generated_livestream_service_list_events_async.py
+++ b/packages/google-cloud-video-live-stream/samples/generated_samples/livestream_v1_generated_livestream_service_list_events_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-live-stream/samples/generated_samples/livestream_v1_generated_livestream_service_list_events_sync.py
+++ b/packages/google-cloud-video-live-stream/samples/generated_samples/livestream_v1_generated_livestream_service_list_events_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-live-stream/samples/generated_samples/livestream_v1_generated_livestream_service_list_inputs_async.py
+++ b/packages/google-cloud-video-live-stream/samples/generated_samples/livestream_v1_generated_livestream_service_list_inputs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-live-stream/samples/generated_samples/livestream_v1_generated_livestream_service_list_inputs_sync.py
+++ b/packages/google-cloud-video-live-stream/samples/generated_samples/livestream_v1_generated_livestream_service_list_inputs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-live-stream/samples/generated_samples/livestream_v1_generated_livestream_service_preview_input_async.py
+++ b/packages/google-cloud-video-live-stream/samples/generated_samples/livestream_v1_generated_livestream_service_preview_input_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-live-stream/samples/generated_samples/livestream_v1_generated_livestream_service_preview_input_sync.py
+++ b/packages/google-cloud-video-live-stream/samples/generated_samples/livestream_v1_generated_livestream_service_preview_input_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-live-stream/samples/generated_samples/livestream_v1_generated_livestream_service_start_channel_sync.py
+++ b/packages/google-cloud-video-live-stream/samples/generated_samples/livestream_v1_generated_livestream_service_start_channel_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-live-stream/samples/generated_samples/livestream_v1_generated_livestream_service_start_distribution_sync.py
+++ b/packages/google-cloud-video-live-stream/samples/generated_samples/livestream_v1_generated_livestream_service_start_distribution_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-live-stream/samples/generated_samples/livestream_v1_generated_livestream_service_stop_channel_sync.py
+++ b/packages/google-cloud-video-live-stream/samples/generated_samples/livestream_v1_generated_livestream_service_stop_channel_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-live-stream/samples/generated_samples/livestream_v1_generated_livestream_service_stop_distribution_sync.py
+++ b/packages/google-cloud-video-live-stream/samples/generated_samples/livestream_v1_generated_livestream_service_stop_distribution_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-live-stream/samples/generated_samples/livestream_v1_generated_livestream_service_update_channel_sync.py
+++ b/packages/google-cloud-video-live-stream/samples/generated_samples/livestream_v1_generated_livestream_service_update_channel_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-live-stream/samples/generated_samples/livestream_v1_generated_livestream_service_update_dvr_session_sync.py
+++ b/packages/google-cloud-video-live-stream/samples/generated_samples/livestream_v1_generated_livestream_service_update_dvr_session_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-live-stream/samples/generated_samples/livestream_v1_generated_livestream_service_update_input_sync.py
+++ b/packages/google-cloud-video-live-stream/samples/generated_samples/livestream_v1_generated_livestream_service_update_input_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-live-stream/samples/generated_samples/livestream_v1_generated_livestream_service_update_pool_sync.py
+++ b/packages/google-cloud-video-live-stream/samples/generated_samples/livestream_v1_generated_livestream_service_update_pool_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-live-stream/tests/__init__.py
+++ b/packages/google-cloud-video-live-stream/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-live-stream/tests/unit/__init__.py
+++ b/packages/google-cloud-video-live-stream/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-live-stream/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-video-live-stream/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-live-stream/tests/unit/gapic/live_stream_v1/__init__.py
+++ b/packages/google-cloud-video-live-stream/tests/unit/gapic/live_stream_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-stitcher/.flake8
+++ b/packages/google-cloud-video-stitcher/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-stitcher/MANIFEST.in
+++ b/packages/google-cloud-video-stitcher/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-stitcher/google/cloud/video/stitcher/__init__.py
+++ b/packages/google-cloud-video-stitcher/google/cloud/video/stitcher/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-stitcher/google/cloud/video/stitcher/gapic_version.py
+++ b/packages/google-cloud-video-stitcher/google/cloud/video/stitcher/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-stitcher/google/cloud/video/stitcher_v1/gapic_version.py
+++ b/packages/google-cloud-video-stitcher/google/cloud/video/stitcher_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-stitcher/google/cloud/video/stitcher_v1/services/__init__.py
+++ b/packages/google-cloud-video-stitcher/google/cloud/video/stitcher_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-stitcher/google/cloud/video/stitcher_v1/services/video_stitcher_service/__init__.py
+++ b/packages/google-cloud-video-stitcher/google/cloud/video/stitcher_v1/services/video_stitcher_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-stitcher/google/cloud/video/stitcher_v1/services/video_stitcher_service/client.py
+++ b/packages/google-cloud-video-stitcher/google/cloud/video/stitcher_v1/services/video_stitcher_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-stitcher/google/cloud/video/stitcher_v1/services/video_stitcher_service/pagers.py
+++ b/packages/google-cloud-video-stitcher/google/cloud/video/stitcher_v1/services/video_stitcher_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-stitcher/google/cloud/video/stitcher_v1/services/video_stitcher_service/transports/__init__.py
+++ b/packages/google-cloud-video-stitcher/google/cloud/video/stitcher_v1/services/video_stitcher_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-stitcher/google/cloud/video/stitcher_v1/services/video_stitcher_service/transports/base.py
+++ b/packages/google-cloud-video-stitcher/google/cloud/video/stitcher_v1/services/video_stitcher_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-stitcher/google/cloud/video/stitcher_v1/services/video_stitcher_service/transports/grpc.py
+++ b/packages/google-cloud-video-stitcher/google/cloud/video/stitcher_v1/services/video_stitcher_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-stitcher/google/cloud/video/stitcher_v1/services/video_stitcher_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-video-stitcher/google/cloud/video/stitcher_v1/services/video_stitcher_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-stitcher/google/cloud/video/stitcher_v1/services/video_stitcher_service/transports/rest.py
+++ b/packages/google-cloud-video-stitcher/google/cloud/video/stitcher_v1/services/video_stitcher_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-stitcher/google/cloud/video/stitcher_v1/services/video_stitcher_service/transports/rest_base.py
+++ b/packages/google-cloud-video-stitcher/google/cloud/video/stitcher_v1/services/video_stitcher_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-stitcher/google/cloud/video/stitcher_v1/types/__init__.py
+++ b/packages/google-cloud-video-stitcher/google/cloud/video/stitcher_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-stitcher/google/cloud/video/stitcher_v1/types/ad_tag_details.py
+++ b/packages/google-cloud-video-stitcher/google/cloud/video/stitcher_v1/types/ad_tag_details.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-stitcher/google/cloud/video/stitcher_v1/types/cdn_keys.py
+++ b/packages/google-cloud-video-stitcher/google/cloud/video/stitcher_v1/types/cdn_keys.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-stitcher/google/cloud/video/stitcher_v1/types/companions.py
+++ b/packages/google-cloud-video-stitcher/google/cloud/video/stitcher_v1/types/companions.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-stitcher/google/cloud/video/stitcher_v1/types/events.py
+++ b/packages/google-cloud-video-stitcher/google/cloud/video/stitcher_v1/types/events.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-stitcher/google/cloud/video/stitcher_v1/types/fetch_options.py
+++ b/packages/google-cloud-video-stitcher/google/cloud/video/stitcher_v1/types/fetch_options.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-stitcher/google/cloud/video/stitcher_v1/types/live_configs.py
+++ b/packages/google-cloud-video-stitcher/google/cloud/video/stitcher_v1/types/live_configs.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-stitcher/google/cloud/video/stitcher_v1/types/sessions.py
+++ b/packages/google-cloud-video-stitcher/google/cloud/video/stitcher_v1/types/sessions.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-stitcher/google/cloud/video/stitcher_v1/types/slates.py
+++ b/packages/google-cloud-video-stitcher/google/cloud/video/stitcher_v1/types/slates.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-stitcher/google/cloud/video/stitcher_v1/types/stitch_details.py
+++ b/packages/google-cloud-video-stitcher/google/cloud/video/stitcher_v1/types/stitch_details.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-stitcher/google/cloud/video/stitcher_v1/types/video_stitcher_service.py
+++ b/packages/google-cloud-video-stitcher/google/cloud/video/stitcher_v1/types/video_stitcher_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-stitcher/google/cloud/video/stitcher_v1/types/vod_configs.py
+++ b/packages/google-cloud-video-stitcher/google/cloud/video/stitcher_v1/types/vod_configs.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-stitcher/samples/generated_samples/videostitcher_v1_generated_video_stitcher_service_create_cdn_key_sync.py
+++ b/packages/google-cloud-video-stitcher/samples/generated_samples/videostitcher_v1_generated_video_stitcher_service_create_cdn_key_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-stitcher/samples/generated_samples/videostitcher_v1_generated_video_stitcher_service_create_live_config_sync.py
+++ b/packages/google-cloud-video-stitcher/samples/generated_samples/videostitcher_v1_generated_video_stitcher_service_create_live_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-stitcher/samples/generated_samples/videostitcher_v1_generated_video_stitcher_service_create_live_session_async.py
+++ b/packages/google-cloud-video-stitcher/samples/generated_samples/videostitcher_v1_generated_video_stitcher_service_create_live_session_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-stitcher/samples/generated_samples/videostitcher_v1_generated_video_stitcher_service_create_live_session_sync.py
+++ b/packages/google-cloud-video-stitcher/samples/generated_samples/videostitcher_v1_generated_video_stitcher_service_create_live_session_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-stitcher/samples/generated_samples/videostitcher_v1_generated_video_stitcher_service_create_slate_sync.py
+++ b/packages/google-cloud-video-stitcher/samples/generated_samples/videostitcher_v1_generated_video_stitcher_service_create_slate_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-stitcher/samples/generated_samples/videostitcher_v1_generated_video_stitcher_service_create_vod_config_sync.py
+++ b/packages/google-cloud-video-stitcher/samples/generated_samples/videostitcher_v1_generated_video_stitcher_service_create_vod_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-stitcher/samples/generated_samples/videostitcher_v1_generated_video_stitcher_service_create_vod_session_async.py
+++ b/packages/google-cloud-video-stitcher/samples/generated_samples/videostitcher_v1_generated_video_stitcher_service_create_vod_session_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-stitcher/samples/generated_samples/videostitcher_v1_generated_video_stitcher_service_create_vod_session_sync.py
+++ b/packages/google-cloud-video-stitcher/samples/generated_samples/videostitcher_v1_generated_video_stitcher_service_create_vod_session_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-stitcher/samples/generated_samples/videostitcher_v1_generated_video_stitcher_service_delete_cdn_key_sync.py
+++ b/packages/google-cloud-video-stitcher/samples/generated_samples/videostitcher_v1_generated_video_stitcher_service_delete_cdn_key_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-stitcher/samples/generated_samples/videostitcher_v1_generated_video_stitcher_service_delete_live_config_sync.py
+++ b/packages/google-cloud-video-stitcher/samples/generated_samples/videostitcher_v1_generated_video_stitcher_service_delete_live_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-stitcher/samples/generated_samples/videostitcher_v1_generated_video_stitcher_service_delete_slate_sync.py
+++ b/packages/google-cloud-video-stitcher/samples/generated_samples/videostitcher_v1_generated_video_stitcher_service_delete_slate_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-stitcher/samples/generated_samples/videostitcher_v1_generated_video_stitcher_service_delete_vod_config_sync.py
+++ b/packages/google-cloud-video-stitcher/samples/generated_samples/videostitcher_v1_generated_video_stitcher_service_delete_vod_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-stitcher/samples/generated_samples/videostitcher_v1_generated_video_stitcher_service_get_cdn_key_async.py
+++ b/packages/google-cloud-video-stitcher/samples/generated_samples/videostitcher_v1_generated_video_stitcher_service_get_cdn_key_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-stitcher/samples/generated_samples/videostitcher_v1_generated_video_stitcher_service_get_cdn_key_sync.py
+++ b/packages/google-cloud-video-stitcher/samples/generated_samples/videostitcher_v1_generated_video_stitcher_service_get_cdn_key_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-stitcher/samples/generated_samples/videostitcher_v1_generated_video_stitcher_service_get_live_ad_tag_detail_async.py
+++ b/packages/google-cloud-video-stitcher/samples/generated_samples/videostitcher_v1_generated_video_stitcher_service_get_live_ad_tag_detail_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-stitcher/samples/generated_samples/videostitcher_v1_generated_video_stitcher_service_get_live_ad_tag_detail_sync.py
+++ b/packages/google-cloud-video-stitcher/samples/generated_samples/videostitcher_v1_generated_video_stitcher_service_get_live_ad_tag_detail_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-stitcher/samples/generated_samples/videostitcher_v1_generated_video_stitcher_service_get_live_config_async.py
+++ b/packages/google-cloud-video-stitcher/samples/generated_samples/videostitcher_v1_generated_video_stitcher_service_get_live_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-stitcher/samples/generated_samples/videostitcher_v1_generated_video_stitcher_service_get_live_config_sync.py
+++ b/packages/google-cloud-video-stitcher/samples/generated_samples/videostitcher_v1_generated_video_stitcher_service_get_live_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-stitcher/samples/generated_samples/videostitcher_v1_generated_video_stitcher_service_get_live_session_async.py
+++ b/packages/google-cloud-video-stitcher/samples/generated_samples/videostitcher_v1_generated_video_stitcher_service_get_live_session_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-stitcher/samples/generated_samples/videostitcher_v1_generated_video_stitcher_service_get_live_session_sync.py
+++ b/packages/google-cloud-video-stitcher/samples/generated_samples/videostitcher_v1_generated_video_stitcher_service_get_live_session_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-stitcher/samples/generated_samples/videostitcher_v1_generated_video_stitcher_service_get_slate_async.py
+++ b/packages/google-cloud-video-stitcher/samples/generated_samples/videostitcher_v1_generated_video_stitcher_service_get_slate_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-stitcher/samples/generated_samples/videostitcher_v1_generated_video_stitcher_service_get_slate_sync.py
+++ b/packages/google-cloud-video-stitcher/samples/generated_samples/videostitcher_v1_generated_video_stitcher_service_get_slate_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-stitcher/samples/generated_samples/videostitcher_v1_generated_video_stitcher_service_get_vod_ad_tag_detail_async.py
+++ b/packages/google-cloud-video-stitcher/samples/generated_samples/videostitcher_v1_generated_video_stitcher_service_get_vod_ad_tag_detail_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-stitcher/samples/generated_samples/videostitcher_v1_generated_video_stitcher_service_get_vod_ad_tag_detail_sync.py
+++ b/packages/google-cloud-video-stitcher/samples/generated_samples/videostitcher_v1_generated_video_stitcher_service_get_vod_ad_tag_detail_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-stitcher/samples/generated_samples/videostitcher_v1_generated_video_stitcher_service_get_vod_config_async.py
+++ b/packages/google-cloud-video-stitcher/samples/generated_samples/videostitcher_v1_generated_video_stitcher_service_get_vod_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-stitcher/samples/generated_samples/videostitcher_v1_generated_video_stitcher_service_get_vod_config_sync.py
+++ b/packages/google-cloud-video-stitcher/samples/generated_samples/videostitcher_v1_generated_video_stitcher_service_get_vod_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-stitcher/samples/generated_samples/videostitcher_v1_generated_video_stitcher_service_get_vod_session_async.py
+++ b/packages/google-cloud-video-stitcher/samples/generated_samples/videostitcher_v1_generated_video_stitcher_service_get_vod_session_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-stitcher/samples/generated_samples/videostitcher_v1_generated_video_stitcher_service_get_vod_session_sync.py
+++ b/packages/google-cloud-video-stitcher/samples/generated_samples/videostitcher_v1_generated_video_stitcher_service_get_vod_session_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-stitcher/samples/generated_samples/videostitcher_v1_generated_video_stitcher_service_get_vod_stitch_detail_async.py
+++ b/packages/google-cloud-video-stitcher/samples/generated_samples/videostitcher_v1_generated_video_stitcher_service_get_vod_stitch_detail_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-stitcher/samples/generated_samples/videostitcher_v1_generated_video_stitcher_service_get_vod_stitch_detail_sync.py
+++ b/packages/google-cloud-video-stitcher/samples/generated_samples/videostitcher_v1_generated_video_stitcher_service_get_vod_stitch_detail_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-stitcher/samples/generated_samples/videostitcher_v1_generated_video_stitcher_service_list_cdn_keys_async.py
+++ b/packages/google-cloud-video-stitcher/samples/generated_samples/videostitcher_v1_generated_video_stitcher_service_list_cdn_keys_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-stitcher/samples/generated_samples/videostitcher_v1_generated_video_stitcher_service_list_cdn_keys_sync.py
+++ b/packages/google-cloud-video-stitcher/samples/generated_samples/videostitcher_v1_generated_video_stitcher_service_list_cdn_keys_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-stitcher/samples/generated_samples/videostitcher_v1_generated_video_stitcher_service_list_live_ad_tag_details_async.py
+++ b/packages/google-cloud-video-stitcher/samples/generated_samples/videostitcher_v1_generated_video_stitcher_service_list_live_ad_tag_details_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-stitcher/samples/generated_samples/videostitcher_v1_generated_video_stitcher_service_list_live_ad_tag_details_sync.py
+++ b/packages/google-cloud-video-stitcher/samples/generated_samples/videostitcher_v1_generated_video_stitcher_service_list_live_ad_tag_details_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-stitcher/samples/generated_samples/videostitcher_v1_generated_video_stitcher_service_list_live_configs_async.py
+++ b/packages/google-cloud-video-stitcher/samples/generated_samples/videostitcher_v1_generated_video_stitcher_service_list_live_configs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-stitcher/samples/generated_samples/videostitcher_v1_generated_video_stitcher_service_list_live_configs_sync.py
+++ b/packages/google-cloud-video-stitcher/samples/generated_samples/videostitcher_v1_generated_video_stitcher_service_list_live_configs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-stitcher/samples/generated_samples/videostitcher_v1_generated_video_stitcher_service_list_slates_async.py
+++ b/packages/google-cloud-video-stitcher/samples/generated_samples/videostitcher_v1_generated_video_stitcher_service_list_slates_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-stitcher/samples/generated_samples/videostitcher_v1_generated_video_stitcher_service_list_slates_sync.py
+++ b/packages/google-cloud-video-stitcher/samples/generated_samples/videostitcher_v1_generated_video_stitcher_service_list_slates_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-stitcher/samples/generated_samples/videostitcher_v1_generated_video_stitcher_service_list_vod_ad_tag_details_async.py
+++ b/packages/google-cloud-video-stitcher/samples/generated_samples/videostitcher_v1_generated_video_stitcher_service_list_vod_ad_tag_details_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-stitcher/samples/generated_samples/videostitcher_v1_generated_video_stitcher_service_list_vod_ad_tag_details_sync.py
+++ b/packages/google-cloud-video-stitcher/samples/generated_samples/videostitcher_v1_generated_video_stitcher_service_list_vod_ad_tag_details_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-stitcher/samples/generated_samples/videostitcher_v1_generated_video_stitcher_service_list_vod_configs_async.py
+++ b/packages/google-cloud-video-stitcher/samples/generated_samples/videostitcher_v1_generated_video_stitcher_service_list_vod_configs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-stitcher/samples/generated_samples/videostitcher_v1_generated_video_stitcher_service_list_vod_configs_sync.py
+++ b/packages/google-cloud-video-stitcher/samples/generated_samples/videostitcher_v1_generated_video_stitcher_service_list_vod_configs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-stitcher/samples/generated_samples/videostitcher_v1_generated_video_stitcher_service_list_vod_stitch_details_async.py
+++ b/packages/google-cloud-video-stitcher/samples/generated_samples/videostitcher_v1_generated_video_stitcher_service_list_vod_stitch_details_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-stitcher/samples/generated_samples/videostitcher_v1_generated_video_stitcher_service_list_vod_stitch_details_sync.py
+++ b/packages/google-cloud-video-stitcher/samples/generated_samples/videostitcher_v1_generated_video_stitcher_service_list_vod_stitch_details_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-stitcher/samples/generated_samples/videostitcher_v1_generated_video_stitcher_service_update_cdn_key_sync.py
+++ b/packages/google-cloud-video-stitcher/samples/generated_samples/videostitcher_v1_generated_video_stitcher_service_update_cdn_key_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-stitcher/samples/generated_samples/videostitcher_v1_generated_video_stitcher_service_update_live_config_sync.py
+++ b/packages/google-cloud-video-stitcher/samples/generated_samples/videostitcher_v1_generated_video_stitcher_service_update_live_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-stitcher/samples/generated_samples/videostitcher_v1_generated_video_stitcher_service_update_slate_sync.py
+++ b/packages/google-cloud-video-stitcher/samples/generated_samples/videostitcher_v1_generated_video_stitcher_service_update_slate_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-stitcher/samples/generated_samples/videostitcher_v1_generated_video_stitcher_service_update_vod_config_sync.py
+++ b/packages/google-cloud-video-stitcher/samples/generated_samples/videostitcher_v1_generated_video_stitcher_service_update_vod_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-stitcher/tests/__init__.py
+++ b/packages/google-cloud-video-stitcher/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-stitcher/tests/unit/__init__.py
+++ b/packages/google-cloud-video-stitcher/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-stitcher/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-video-stitcher/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-stitcher/tests/unit/gapic/stitcher_v1/__init__.py
+++ b/packages/google-cloud-video-stitcher/tests/unit/gapic/stitcher_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-transcoder/.flake8
+++ b/packages/google-cloud-video-transcoder/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-transcoder/MANIFEST.in
+++ b/packages/google-cloud-video-transcoder/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-transcoder/google/cloud/video/transcoder/__init__.py
+++ b/packages/google-cloud-video-transcoder/google/cloud/video/transcoder/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-transcoder/google/cloud/video/transcoder/gapic_version.py
+++ b/packages/google-cloud-video-transcoder/google/cloud/video/transcoder/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-transcoder/google/cloud/video/transcoder_v1/gapic_version.py
+++ b/packages/google-cloud-video-transcoder/google/cloud/video/transcoder_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-transcoder/google/cloud/video/transcoder_v1/services/__init__.py
+++ b/packages/google-cloud-video-transcoder/google/cloud/video/transcoder_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-transcoder/google/cloud/video/transcoder_v1/services/transcoder_service/__init__.py
+++ b/packages/google-cloud-video-transcoder/google/cloud/video/transcoder_v1/services/transcoder_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-transcoder/google/cloud/video/transcoder_v1/services/transcoder_service/async_client.py
+++ b/packages/google-cloud-video-transcoder/google/cloud/video/transcoder_v1/services/transcoder_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-transcoder/google/cloud/video/transcoder_v1/services/transcoder_service/client.py
+++ b/packages/google-cloud-video-transcoder/google/cloud/video/transcoder_v1/services/transcoder_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-transcoder/google/cloud/video/transcoder_v1/services/transcoder_service/pagers.py
+++ b/packages/google-cloud-video-transcoder/google/cloud/video/transcoder_v1/services/transcoder_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-transcoder/google/cloud/video/transcoder_v1/services/transcoder_service/transports/__init__.py
+++ b/packages/google-cloud-video-transcoder/google/cloud/video/transcoder_v1/services/transcoder_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-transcoder/google/cloud/video/transcoder_v1/services/transcoder_service/transports/base.py
+++ b/packages/google-cloud-video-transcoder/google/cloud/video/transcoder_v1/services/transcoder_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-transcoder/google/cloud/video/transcoder_v1/services/transcoder_service/transports/grpc.py
+++ b/packages/google-cloud-video-transcoder/google/cloud/video/transcoder_v1/services/transcoder_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-transcoder/google/cloud/video/transcoder_v1/services/transcoder_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-video-transcoder/google/cloud/video/transcoder_v1/services/transcoder_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-transcoder/google/cloud/video/transcoder_v1/services/transcoder_service/transports/rest.py
+++ b/packages/google-cloud-video-transcoder/google/cloud/video/transcoder_v1/services/transcoder_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-transcoder/google/cloud/video/transcoder_v1/services/transcoder_service/transports/rest_base.py
+++ b/packages/google-cloud-video-transcoder/google/cloud/video/transcoder_v1/services/transcoder_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-transcoder/google/cloud/video/transcoder_v1/types/__init__.py
+++ b/packages/google-cloud-video-transcoder/google/cloud/video/transcoder_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-transcoder/google/cloud/video/transcoder_v1/types/resources.py
+++ b/packages/google-cloud-video-transcoder/google/cloud/video/transcoder_v1/types/resources.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-transcoder/google/cloud/video/transcoder_v1/types/services.py
+++ b/packages/google-cloud-video-transcoder/google/cloud/video/transcoder_v1/types/services.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-transcoder/samples/generated_samples/transcoder_v1_generated_transcoder_service_create_job_async.py
+++ b/packages/google-cloud-video-transcoder/samples/generated_samples/transcoder_v1_generated_transcoder_service_create_job_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-transcoder/samples/generated_samples/transcoder_v1_generated_transcoder_service_create_job_sync.py
+++ b/packages/google-cloud-video-transcoder/samples/generated_samples/transcoder_v1_generated_transcoder_service_create_job_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-transcoder/samples/generated_samples/transcoder_v1_generated_transcoder_service_create_job_template_async.py
+++ b/packages/google-cloud-video-transcoder/samples/generated_samples/transcoder_v1_generated_transcoder_service_create_job_template_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-transcoder/samples/generated_samples/transcoder_v1_generated_transcoder_service_create_job_template_sync.py
+++ b/packages/google-cloud-video-transcoder/samples/generated_samples/transcoder_v1_generated_transcoder_service_create_job_template_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-transcoder/samples/generated_samples/transcoder_v1_generated_transcoder_service_delete_job_async.py
+++ b/packages/google-cloud-video-transcoder/samples/generated_samples/transcoder_v1_generated_transcoder_service_delete_job_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-transcoder/samples/generated_samples/transcoder_v1_generated_transcoder_service_delete_job_sync.py
+++ b/packages/google-cloud-video-transcoder/samples/generated_samples/transcoder_v1_generated_transcoder_service_delete_job_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-transcoder/samples/generated_samples/transcoder_v1_generated_transcoder_service_delete_job_template_async.py
+++ b/packages/google-cloud-video-transcoder/samples/generated_samples/transcoder_v1_generated_transcoder_service_delete_job_template_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-transcoder/samples/generated_samples/transcoder_v1_generated_transcoder_service_delete_job_template_sync.py
+++ b/packages/google-cloud-video-transcoder/samples/generated_samples/transcoder_v1_generated_transcoder_service_delete_job_template_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-transcoder/samples/generated_samples/transcoder_v1_generated_transcoder_service_get_job_async.py
+++ b/packages/google-cloud-video-transcoder/samples/generated_samples/transcoder_v1_generated_transcoder_service_get_job_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-transcoder/samples/generated_samples/transcoder_v1_generated_transcoder_service_get_job_sync.py
+++ b/packages/google-cloud-video-transcoder/samples/generated_samples/transcoder_v1_generated_transcoder_service_get_job_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-transcoder/samples/generated_samples/transcoder_v1_generated_transcoder_service_get_job_template_async.py
+++ b/packages/google-cloud-video-transcoder/samples/generated_samples/transcoder_v1_generated_transcoder_service_get_job_template_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-transcoder/samples/generated_samples/transcoder_v1_generated_transcoder_service_get_job_template_sync.py
+++ b/packages/google-cloud-video-transcoder/samples/generated_samples/transcoder_v1_generated_transcoder_service_get_job_template_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-transcoder/samples/generated_samples/transcoder_v1_generated_transcoder_service_list_job_templates_async.py
+++ b/packages/google-cloud-video-transcoder/samples/generated_samples/transcoder_v1_generated_transcoder_service_list_job_templates_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-transcoder/samples/generated_samples/transcoder_v1_generated_transcoder_service_list_job_templates_sync.py
+++ b/packages/google-cloud-video-transcoder/samples/generated_samples/transcoder_v1_generated_transcoder_service_list_job_templates_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-transcoder/samples/generated_samples/transcoder_v1_generated_transcoder_service_list_jobs_async.py
+++ b/packages/google-cloud-video-transcoder/samples/generated_samples/transcoder_v1_generated_transcoder_service_list_jobs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-transcoder/samples/generated_samples/transcoder_v1_generated_transcoder_service_list_jobs_sync.py
+++ b/packages/google-cloud-video-transcoder/samples/generated_samples/transcoder_v1_generated_transcoder_service_list_jobs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-transcoder/tests/__init__.py
+++ b/packages/google-cloud-video-transcoder/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-transcoder/tests/unit/__init__.py
+++ b/packages/google-cloud-video-transcoder/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-transcoder/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-video-transcoder/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-video-transcoder/tests/unit/gapic/transcoder_v1/__init__.py
+++ b/packages/google-cloud-video-transcoder/tests/unit/gapic/transcoder_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-videointelligence/.flake8
+++ b/packages/google-cloud-videointelligence/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-videointelligence/MANIFEST.in
+++ b/packages/google-cloud-videointelligence/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-videointelligence/google/cloud/videointelligence/__init__.py
+++ b/packages/google-cloud-videointelligence/google/cloud/videointelligence/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-videointelligence/google/cloud/videointelligence/gapic_version.py
+++ b/packages/google-cloud-videointelligence/google/cloud/videointelligence/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1/gapic_version.py
+++ b/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1/services/__init__.py
+++ b/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1/services/video_intelligence_service/__init__.py
+++ b/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1/services/video_intelligence_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1/services/video_intelligence_service/client.py
+++ b/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1/services/video_intelligence_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1/services/video_intelligence_service/transports/__init__.py
+++ b/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1/services/video_intelligence_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1/services/video_intelligence_service/transports/base.py
+++ b/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1/services/video_intelligence_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1/services/video_intelligence_service/transports/grpc.py
+++ b/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1/services/video_intelligence_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1/services/video_intelligence_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1/services/video_intelligence_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1/services/video_intelligence_service/transports/rest.py
+++ b/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1/services/video_intelligence_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1/services/video_intelligence_service/transports/rest_base.py
+++ b/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1/services/video_intelligence_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1/types/__init__.py
+++ b/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1/types/video_intelligence.py
+++ b/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1/types/video_intelligence.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1beta2/gapic_version.py
+++ b/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1beta2/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1beta2/services/__init__.py
+++ b/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1beta2/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1beta2/services/video_intelligence_service/__init__.py
+++ b/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1beta2/services/video_intelligence_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1beta2/services/video_intelligence_service/client.py
+++ b/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1beta2/services/video_intelligence_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1beta2/services/video_intelligence_service/transports/__init__.py
+++ b/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1beta2/services/video_intelligence_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1beta2/services/video_intelligence_service/transports/base.py
+++ b/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1beta2/services/video_intelligence_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1beta2/services/video_intelligence_service/transports/grpc.py
+++ b/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1beta2/services/video_intelligence_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1beta2/services/video_intelligence_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1beta2/services/video_intelligence_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1beta2/services/video_intelligence_service/transports/rest.py
+++ b/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1beta2/services/video_intelligence_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1beta2/services/video_intelligence_service/transports/rest_base.py
+++ b/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1beta2/services/video_intelligence_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1beta2/types/__init__.py
+++ b/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1beta2/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1beta2/types/video_intelligence.py
+++ b/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1beta2/types/video_intelligence.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1p1beta1/gapic_version.py
+++ b/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1p1beta1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1p1beta1/services/__init__.py
+++ b/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1p1beta1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1p1beta1/services/video_intelligence_service/__init__.py
+++ b/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1p1beta1/services/video_intelligence_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1p1beta1/services/video_intelligence_service/client.py
+++ b/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1p1beta1/services/video_intelligence_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1p1beta1/services/video_intelligence_service/transports/__init__.py
+++ b/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1p1beta1/services/video_intelligence_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1p1beta1/services/video_intelligence_service/transports/base.py
+++ b/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1p1beta1/services/video_intelligence_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1p1beta1/services/video_intelligence_service/transports/grpc.py
+++ b/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1p1beta1/services/video_intelligence_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1p1beta1/services/video_intelligence_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1p1beta1/services/video_intelligence_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1p1beta1/services/video_intelligence_service/transports/rest.py
+++ b/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1p1beta1/services/video_intelligence_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1p1beta1/services/video_intelligence_service/transports/rest_base.py
+++ b/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1p1beta1/services/video_intelligence_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1p1beta1/types/__init__.py
+++ b/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1p1beta1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1p1beta1/types/video_intelligence.py
+++ b/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1p1beta1/types/video_intelligence.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1p2beta1/gapic_version.py
+++ b/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1p2beta1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1p2beta1/services/__init__.py
+++ b/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1p2beta1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1p2beta1/services/video_intelligence_service/__init__.py
+++ b/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1p2beta1/services/video_intelligence_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1p2beta1/services/video_intelligence_service/client.py
+++ b/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1p2beta1/services/video_intelligence_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1p2beta1/services/video_intelligence_service/transports/__init__.py
+++ b/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1p2beta1/services/video_intelligence_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1p2beta1/services/video_intelligence_service/transports/base.py
+++ b/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1p2beta1/services/video_intelligence_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1p2beta1/services/video_intelligence_service/transports/grpc.py
+++ b/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1p2beta1/services/video_intelligence_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1p2beta1/services/video_intelligence_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1p2beta1/services/video_intelligence_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1p2beta1/services/video_intelligence_service/transports/rest.py
+++ b/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1p2beta1/services/video_intelligence_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1p2beta1/services/video_intelligence_service/transports/rest_base.py
+++ b/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1p2beta1/services/video_intelligence_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1p2beta1/types/__init__.py
+++ b/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1p2beta1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1p2beta1/types/video_intelligence.py
+++ b/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1p2beta1/types/video_intelligence.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1p3beta1/gapic_version.py
+++ b/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1p3beta1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1p3beta1/services/__init__.py
+++ b/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1p3beta1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1p3beta1/services/streaming_video_intelligence_service/__init__.py
+++ b/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1p3beta1/services/streaming_video_intelligence_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1p3beta1/services/streaming_video_intelligence_service/async_client.py
+++ b/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1p3beta1/services/streaming_video_intelligence_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1p3beta1/services/streaming_video_intelligence_service/client.py
+++ b/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1p3beta1/services/streaming_video_intelligence_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1p3beta1/services/streaming_video_intelligence_service/transports/__init__.py
+++ b/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1p3beta1/services/streaming_video_intelligence_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1p3beta1/services/streaming_video_intelligence_service/transports/base.py
+++ b/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1p3beta1/services/streaming_video_intelligence_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1p3beta1/services/streaming_video_intelligence_service/transports/grpc.py
+++ b/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1p3beta1/services/streaming_video_intelligence_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1p3beta1/services/streaming_video_intelligence_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1p3beta1/services/streaming_video_intelligence_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1p3beta1/services/video_intelligence_service/__init__.py
+++ b/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1p3beta1/services/video_intelligence_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1p3beta1/services/video_intelligence_service/client.py
+++ b/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1p3beta1/services/video_intelligence_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1p3beta1/services/video_intelligence_service/transports/__init__.py
+++ b/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1p3beta1/services/video_intelligence_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1p3beta1/services/video_intelligence_service/transports/base.py
+++ b/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1p3beta1/services/video_intelligence_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1p3beta1/services/video_intelligence_service/transports/grpc.py
+++ b/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1p3beta1/services/video_intelligence_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1p3beta1/services/video_intelligence_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1p3beta1/services/video_intelligence_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1p3beta1/types/__init__.py
+++ b/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1p3beta1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1p3beta1/types/video_intelligence.py
+++ b/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1p3beta1/types/video_intelligence.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-videointelligence/samples/generated_samples/videointelligence_v1_generated_video_intelligence_service_annotate_video_sync.py
+++ b/packages/google-cloud-videointelligence/samples/generated_samples/videointelligence_v1_generated_video_intelligence_service_annotate_video_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-videointelligence/samples/generated_samples/videointelligence_v1beta2_generated_video_intelligence_service_annotate_video_sync.py
+++ b/packages/google-cloud-videointelligence/samples/generated_samples/videointelligence_v1beta2_generated_video_intelligence_service_annotate_video_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-videointelligence/samples/generated_samples/videointelligence_v1p1beta1_generated_video_intelligence_service_annotate_video_sync.py
+++ b/packages/google-cloud-videointelligence/samples/generated_samples/videointelligence_v1p1beta1_generated_video_intelligence_service_annotate_video_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-videointelligence/samples/generated_samples/videointelligence_v1p2beta1_generated_video_intelligence_service_annotate_video_sync.py
+++ b/packages/google-cloud-videointelligence/samples/generated_samples/videointelligence_v1p2beta1_generated_video_intelligence_service_annotate_video_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-videointelligence/samples/generated_samples/videointelligence_v1p3beta1_generated_streaming_video_intelligence_service_streaming_annotate_video_async.py
+++ b/packages/google-cloud-videointelligence/samples/generated_samples/videointelligence_v1p3beta1_generated_streaming_video_intelligence_service_streaming_annotate_video_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-videointelligence/samples/generated_samples/videointelligence_v1p3beta1_generated_streaming_video_intelligence_service_streaming_annotate_video_sync.py
+++ b/packages/google-cloud-videointelligence/samples/generated_samples/videointelligence_v1p3beta1_generated_streaming_video_intelligence_service_streaming_annotate_video_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-videointelligence/samples/generated_samples/videointelligence_v1p3beta1_generated_video_intelligence_service_annotate_video_sync.py
+++ b/packages/google-cloud-videointelligence/samples/generated_samples/videointelligence_v1p3beta1_generated_video_intelligence_service_annotate_video_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-videointelligence/tests/__init__.py
+++ b/packages/google-cloud-videointelligence/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-videointelligence/tests/unit/__init__.py
+++ b/packages/google-cloud-videointelligence/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-videointelligence/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-videointelligence/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-videointelligence/tests/unit/gapic/videointelligence_v1/__init__.py
+++ b/packages/google-cloud-videointelligence/tests/unit/gapic/videointelligence_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-videointelligence/tests/unit/gapic/videointelligence_v1beta2/__init__.py
+++ b/packages/google-cloud-videointelligence/tests/unit/gapic/videointelligence_v1beta2/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-videointelligence/tests/unit/gapic/videointelligence_v1p1beta1/__init__.py
+++ b/packages/google-cloud-videointelligence/tests/unit/gapic/videointelligence_v1p1beta1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-videointelligence/tests/unit/gapic/videointelligence_v1p2beta1/__init__.py
+++ b/packages/google-cloud-videointelligence/tests/unit/gapic/videointelligence_v1p2beta1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-videointelligence/tests/unit/gapic/videointelligence_v1p3beta1/__init__.py
+++ b/packages/google-cloud-videointelligence/tests/unit/gapic/videointelligence_v1p3beta1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/.flake8
+++ b/packages/google-cloud-vision/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/MANIFEST.in
+++ b/packages/google-cloud-vision/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/google/cloud/vision/__init__.py
+++ b/packages/google-cloud-vision/google/cloud/vision/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/google/cloud/vision/gapic_version.py
+++ b/packages/google-cloud-vision/google/cloud/vision/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/google/cloud/vision_v1/gapic_version.py
+++ b/packages/google-cloud-vision/google/cloud/vision_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/google/cloud/vision_v1/services/__init__.py
+++ b/packages/google-cloud-vision/google/cloud/vision_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/google/cloud/vision_v1/services/image_annotator/__init__.py
+++ b/packages/google-cloud-vision/google/cloud/vision_v1/services/image_annotator/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/google/cloud/vision_v1/services/image_annotator/client.py
+++ b/packages/google-cloud-vision/google/cloud/vision_v1/services/image_annotator/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/google/cloud/vision_v1/services/image_annotator/transports/__init__.py
+++ b/packages/google-cloud-vision/google/cloud/vision_v1/services/image_annotator/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/google/cloud/vision_v1/services/image_annotator/transports/base.py
+++ b/packages/google-cloud-vision/google/cloud/vision_v1/services/image_annotator/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/google/cloud/vision_v1/services/image_annotator/transports/grpc.py
+++ b/packages/google-cloud-vision/google/cloud/vision_v1/services/image_annotator/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/google/cloud/vision_v1/services/image_annotator/transports/grpc_asyncio.py
+++ b/packages/google-cloud-vision/google/cloud/vision_v1/services/image_annotator/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/google/cloud/vision_v1/services/image_annotator/transports/rest.py
+++ b/packages/google-cloud-vision/google/cloud/vision_v1/services/image_annotator/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/google/cloud/vision_v1/services/image_annotator/transports/rest_base.py
+++ b/packages/google-cloud-vision/google/cloud/vision_v1/services/image_annotator/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/google/cloud/vision_v1/services/product_search/__init__.py
+++ b/packages/google-cloud-vision/google/cloud/vision_v1/services/product_search/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/google/cloud/vision_v1/services/product_search/client.py
+++ b/packages/google-cloud-vision/google/cloud/vision_v1/services/product_search/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/google/cloud/vision_v1/services/product_search/pagers.py
+++ b/packages/google-cloud-vision/google/cloud/vision_v1/services/product_search/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/google/cloud/vision_v1/services/product_search/transports/__init__.py
+++ b/packages/google-cloud-vision/google/cloud/vision_v1/services/product_search/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/google/cloud/vision_v1/services/product_search/transports/base.py
+++ b/packages/google-cloud-vision/google/cloud/vision_v1/services/product_search/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/google/cloud/vision_v1/services/product_search/transports/grpc.py
+++ b/packages/google-cloud-vision/google/cloud/vision_v1/services/product_search/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/google/cloud/vision_v1/services/product_search/transports/grpc_asyncio.py
+++ b/packages/google-cloud-vision/google/cloud/vision_v1/services/product_search/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/google/cloud/vision_v1/services/product_search/transports/rest.py
+++ b/packages/google-cloud-vision/google/cloud/vision_v1/services/product_search/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/google/cloud/vision_v1/services/product_search/transports/rest_base.py
+++ b/packages/google-cloud-vision/google/cloud/vision_v1/services/product_search/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/google/cloud/vision_v1/types/__init__.py
+++ b/packages/google-cloud-vision/google/cloud/vision_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/google/cloud/vision_v1/types/geometry.py
+++ b/packages/google-cloud-vision/google/cloud/vision_v1/types/geometry.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/google/cloud/vision_v1/types/image_annotator.py
+++ b/packages/google-cloud-vision/google/cloud/vision_v1/types/image_annotator.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/google/cloud/vision_v1/types/product_search.py
+++ b/packages/google-cloud-vision/google/cloud/vision_v1/types/product_search.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/google/cloud/vision_v1/types/product_search_service.py
+++ b/packages/google-cloud-vision/google/cloud/vision_v1/types/product_search_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/google/cloud/vision_v1/types/text_annotation.py
+++ b/packages/google-cloud-vision/google/cloud/vision_v1/types/text_annotation.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/google/cloud/vision_v1/types/web_detection.py
+++ b/packages/google-cloud-vision/google/cloud/vision_v1/types/web_detection.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/google/cloud/vision_v1p1beta1/gapic_version.py
+++ b/packages/google-cloud-vision/google/cloud/vision_v1p1beta1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/google/cloud/vision_v1p1beta1/services/__init__.py
+++ b/packages/google-cloud-vision/google/cloud/vision_v1p1beta1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/google/cloud/vision_v1p1beta1/services/image_annotator/__init__.py
+++ b/packages/google-cloud-vision/google/cloud/vision_v1p1beta1/services/image_annotator/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/google/cloud/vision_v1p1beta1/services/image_annotator/async_client.py
+++ b/packages/google-cloud-vision/google/cloud/vision_v1p1beta1/services/image_annotator/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/google/cloud/vision_v1p1beta1/services/image_annotator/client.py
+++ b/packages/google-cloud-vision/google/cloud/vision_v1p1beta1/services/image_annotator/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/google/cloud/vision_v1p1beta1/services/image_annotator/transports/__init__.py
+++ b/packages/google-cloud-vision/google/cloud/vision_v1p1beta1/services/image_annotator/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/google/cloud/vision_v1p1beta1/services/image_annotator/transports/base.py
+++ b/packages/google-cloud-vision/google/cloud/vision_v1p1beta1/services/image_annotator/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/google/cloud/vision_v1p1beta1/services/image_annotator/transports/grpc.py
+++ b/packages/google-cloud-vision/google/cloud/vision_v1p1beta1/services/image_annotator/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/google/cloud/vision_v1p1beta1/services/image_annotator/transports/grpc_asyncio.py
+++ b/packages/google-cloud-vision/google/cloud/vision_v1p1beta1/services/image_annotator/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/google/cloud/vision_v1p1beta1/services/image_annotator/transports/rest.py
+++ b/packages/google-cloud-vision/google/cloud/vision_v1p1beta1/services/image_annotator/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/google/cloud/vision_v1p1beta1/services/image_annotator/transports/rest_base.py
+++ b/packages/google-cloud-vision/google/cloud/vision_v1p1beta1/services/image_annotator/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/google/cloud/vision_v1p1beta1/types/__init__.py
+++ b/packages/google-cloud-vision/google/cloud/vision_v1p1beta1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/google/cloud/vision_v1p1beta1/types/geometry.py
+++ b/packages/google-cloud-vision/google/cloud/vision_v1p1beta1/types/geometry.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/google/cloud/vision_v1p1beta1/types/image_annotator.py
+++ b/packages/google-cloud-vision/google/cloud/vision_v1p1beta1/types/image_annotator.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/google/cloud/vision_v1p1beta1/types/text_annotation.py
+++ b/packages/google-cloud-vision/google/cloud/vision_v1p1beta1/types/text_annotation.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/google/cloud/vision_v1p1beta1/types/web_detection.py
+++ b/packages/google-cloud-vision/google/cloud/vision_v1p1beta1/types/web_detection.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/google/cloud/vision_v1p2beta1/gapic_version.py
+++ b/packages/google-cloud-vision/google/cloud/vision_v1p2beta1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/google/cloud/vision_v1p2beta1/services/__init__.py
+++ b/packages/google-cloud-vision/google/cloud/vision_v1p2beta1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/google/cloud/vision_v1p2beta1/services/image_annotator/__init__.py
+++ b/packages/google-cloud-vision/google/cloud/vision_v1p2beta1/services/image_annotator/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/google/cloud/vision_v1p2beta1/services/image_annotator/client.py
+++ b/packages/google-cloud-vision/google/cloud/vision_v1p2beta1/services/image_annotator/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/google/cloud/vision_v1p2beta1/services/image_annotator/transports/__init__.py
+++ b/packages/google-cloud-vision/google/cloud/vision_v1p2beta1/services/image_annotator/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/google/cloud/vision_v1p2beta1/services/image_annotator/transports/base.py
+++ b/packages/google-cloud-vision/google/cloud/vision_v1p2beta1/services/image_annotator/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/google/cloud/vision_v1p2beta1/services/image_annotator/transports/grpc.py
+++ b/packages/google-cloud-vision/google/cloud/vision_v1p2beta1/services/image_annotator/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/google/cloud/vision_v1p2beta1/services/image_annotator/transports/grpc_asyncio.py
+++ b/packages/google-cloud-vision/google/cloud/vision_v1p2beta1/services/image_annotator/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/google/cloud/vision_v1p2beta1/services/image_annotator/transports/rest.py
+++ b/packages/google-cloud-vision/google/cloud/vision_v1p2beta1/services/image_annotator/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/google/cloud/vision_v1p2beta1/services/image_annotator/transports/rest_base.py
+++ b/packages/google-cloud-vision/google/cloud/vision_v1p2beta1/services/image_annotator/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/google/cloud/vision_v1p2beta1/types/__init__.py
+++ b/packages/google-cloud-vision/google/cloud/vision_v1p2beta1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/google/cloud/vision_v1p2beta1/types/geometry.py
+++ b/packages/google-cloud-vision/google/cloud/vision_v1p2beta1/types/geometry.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/google/cloud/vision_v1p2beta1/types/image_annotator.py
+++ b/packages/google-cloud-vision/google/cloud/vision_v1p2beta1/types/image_annotator.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/google/cloud/vision_v1p2beta1/types/text_annotation.py
+++ b/packages/google-cloud-vision/google/cloud/vision_v1p2beta1/types/text_annotation.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/google/cloud/vision_v1p2beta1/types/web_detection.py
+++ b/packages/google-cloud-vision/google/cloud/vision_v1p2beta1/types/web_detection.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/google/cloud/vision_v1p3beta1/gapic_version.py
+++ b/packages/google-cloud-vision/google/cloud/vision_v1p3beta1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/google/cloud/vision_v1p3beta1/services/__init__.py
+++ b/packages/google-cloud-vision/google/cloud/vision_v1p3beta1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/google/cloud/vision_v1p3beta1/services/image_annotator/__init__.py
+++ b/packages/google-cloud-vision/google/cloud/vision_v1p3beta1/services/image_annotator/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/google/cloud/vision_v1p3beta1/services/image_annotator/client.py
+++ b/packages/google-cloud-vision/google/cloud/vision_v1p3beta1/services/image_annotator/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/google/cloud/vision_v1p3beta1/services/image_annotator/transports/__init__.py
+++ b/packages/google-cloud-vision/google/cloud/vision_v1p3beta1/services/image_annotator/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/google/cloud/vision_v1p3beta1/services/image_annotator/transports/base.py
+++ b/packages/google-cloud-vision/google/cloud/vision_v1p3beta1/services/image_annotator/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/google/cloud/vision_v1p3beta1/services/image_annotator/transports/grpc.py
+++ b/packages/google-cloud-vision/google/cloud/vision_v1p3beta1/services/image_annotator/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/google/cloud/vision_v1p3beta1/services/image_annotator/transports/grpc_asyncio.py
+++ b/packages/google-cloud-vision/google/cloud/vision_v1p3beta1/services/image_annotator/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/google/cloud/vision_v1p3beta1/services/image_annotator/transports/rest.py
+++ b/packages/google-cloud-vision/google/cloud/vision_v1p3beta1/services/image_annotator/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/google/cloud/vision_v1p3beta1/services/image_annotator/transports/rest_base.py
+++ b/packages/google-cloud-vision/google/cloud/vision_v1p3beta1/services/image_annotator/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/google/cloud/vision_v1p3beta1/services/product_search/__init__.py
+++ b/packages/google-cloud-vision/google/cloud/vision_v1p3beta1/services/product_search/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/google/cloud/vision_v1p3beta1/services/product_search/client.py
+++ b/packages/google-cloud-vision/google/cloud/vision_v1p3beta1/services/product_search/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/google/cloud/vision_v1p3beta1/services/product_search/pagers.py
+++ b/packages/google-cloud-vision/google/cloud/vision_v1p3beta1/services/product_search/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/google/cloud/vision_v1p3beta1/services/product_search/transports/__init__.py
+++ b/packages/google-cloud-vision/google/cloud/vision_v1p3beta1/services/product_search/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/google/cloud/vision_v1p3beta1/services/product_search/transports/base.py
+++ b/packages/google-cloud-vision/google/cloud/vision_v1p3beta1/services/product_search/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/google/cloud/vision_v1p3beta1/services/product_search/transports/grpc.py
+++ b/packages/google-cloud-vision/google/cloud/vision_v1p3beta1/services/product_search/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/google/cloud/vision_v1p3beta1/services/product_search/transports/grpc_asyncio.py
+++ b/packages/google-cloud-vision/google/cloud/vision_v1p3beta1/services/product_search/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/google/cloud/vision_v1p3beta1/services/product_search/transports/rest.py
+++ b/packages/google-cloud-vision/google/cloud/vision_v1p3beta1/services/product_search/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/google/cloud/vision_v1p3beta1/services/product_search/transports/rest_base.py
+++ b/packages/google-cloud-vision/google/cloud/vision_v1p3beta1/services/product_search/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/google/cloud/vision_v1p3beta1/types/__init__.py
+++ b/packages/google-cloud-vision/google/cloud/vision_v1p3beta1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/google/cloud/vision_v1p3beta1/types/geometry.py
+++ b/packages/google-cloud-vision/google/cloud/vision_v1p3beta1/types/geometry.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/google/cloud/vision_v1p3beta1/types/image_annotator.py
+++ b/packages/google-cloud-vision/google/cloud/vision_v1p3beta1/types/image_annotator.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/google/cloud/vision_v1p3beta1/types/product_search.py
+++ b/packages/google-cloud-vision/google/cloud/vision_v1p3beta1/types/product_search.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/google/cloud/vision_v1p3beta1/types/product_search_service.py
+++ b/packages/google-cloud-vision/google/cloud/vision_v1p3beta1/types/product_search_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/google/cloud/vision_v1p3beta1/types/text_annotation.py
+++ b/packages/google-cloud-vision/google/cloud/vision_v1p3beta1/types/text_annotation.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/google/cloud/vision_v1p3beta1/types/web_detection.py
+++ b/packages/google-cloud-vision/google/cloud/vision_v1p3beta1/types/web_detection.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/google/cloud/vision_v1p4beta1/gapic_version.py
+++ b/packages/google-cloud-vision/google/cloud/vision_v1p4beta1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/google/cloud/vision_v1p4beta1/services/__init__.py
+++ b/packages/google-cloud-vision/google/cloud/vision_v1p4beta1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/google/cloud/vision_v1p4beta1/services/image_annotator/__init__.py
+++ b/packages/google-cloud-vision/google/cloud/vision_v1p4beta1/services/image_annotator/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/google/cloud/vision_v1p4beta1/services/image_annotator/client.py
+++ b/packages/google-cloud-vision/google/cloud/vision_v1p4beta1/services/image_annotator/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/google/cloud/vision_v1p4beta1/services/image_annotator/transports/__init__.py
+++ b/packages/google-cloud-vision/google/cloud/vision_v1p4beta1/services/image_annotator/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/google/cloud/vision_v1p4beta1/services/image_annotator/transports/base.py
+++ b/packages/google-cloud-vision/google/cloud/vision_v1p4beta1/services/image_annotator/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/google/cloud/vision_v1p4beta1/services/image_annotator/transports/grpc.py
+++ b/packages/google-cloud-vision/google/cloud/vision_v1p4beta1/services/image_annotator/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/google/cloud/vision_v1p4beta1/services/image_annotator/transports/grpc_asyncio.py
+++ b/packages/google-cloud-vision/google/cloud/vision_v1p4beta1/services/image_annotator/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/google/cloud/vision_v1p4beta1/services/image_annotator/transports/rest.py
+++ b/packages/google-cloud-vision/google/cloud/vision_v1p4beta1/services/image_annotator/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/google/cloud/vision_v1p4beta1/services/image_annotator/transports/rest_base.py
+++ b/packages/google-cloud-vision/google/cloud/vision_v1p4beta1/services/image_annotator/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/google/cloud/vision_v1p4beta1/services/product_search/__init__.py
+++ b/packages/google-cloud-vision/google/cloud/vision_v1p4beta1/services/product_search/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/google/cloud/vision_v1p4beta1/services/product_search/client.py
+++ b/packages/google-cloud-vision/google/cloud/vision_v1p4beta1/services/product_search/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/google/cloud/vision_v1p4beta1/services/product_search/pagers.py
+++ b/packages/google-cloud-vision/google/cloud/vision_v1p4beta1/services/product_search/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/google/cloud/vision_v1p4beta1/services/product_search/transports/__init__.py
+++ b/packages/google-cloud-vision/google/cloud/vision_v1p4beta1/services/product_search/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/google/cloud/vision_v1p4beta1/services/product_search/transports/base.py
+++ b/packages/google-cloud-vision/google/cloud/vision_v1p4beta1/services/product_search/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/google/cloud/vision_v1p4beta1/services/product_search/transports/grpc.py
+++ b/packages/google-cloud-vision/google/cloud/vision_v1p4beta1/services/product_search/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/google/cloud/vision_v1p4beta1/services/product_search/transports/grpc_asyncio.py
+++ b/packages/google-cloud-vision/google/cloud/vision_v1p4beta1/services/product_search/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/google/cloud/vision_v1p4beta1/services/product_search/transports/rest.py
+++ b/packages/google-cloud-vision/google/cloud/vision_v1p4beta1/services/product_search/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/google/cloud/vision_v1p4beta1/services/product_search/transports/rest_base.py
+++ b/packages/google-cloud-vision/google/cloud/vision_v1p4beta1/services/product_search/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/google/cloud/vision_v1p4beta1/types/__init__.py
+++ b/packages/google-cloud-vision/google/cloud/vision_v1p4beta1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/google/cloud/vision_v1p4beta1/types/face.py
+++ b/packages/google-cloud-vision/google/cloud/vision_v1p4beta1/types/face.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/google/cloud/vision_v1p4beta1/types/geometry.py
+++ b/packages/google-cloud-vision/google/cloud/vision_v1p4beta1/types/geometry.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/google/cloud/vision_v1p4beta1/types/image_annotator.py
+++ b/packages/google-cloud-vision/google/cloud/vision_v1p4beta1/types/image_annotator.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/google/cloud/vision_v1p4beta1/types/product_search.py
+++ b/packages/google-cloud-vision/google/cloud/vision_v1p4beta1/types/product_search.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/google/cloud/vision_v1p4beta1/types/product_search_service.py
+++ b/packages/google-cloud-vision/google/cloud/vision_v1p4beta1/types/product_search_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/google/cloud/vision_v1p4beta1/types/text_annotation.py
+++ b/packages/google-cloud-vision/google/cloud/vision_v1p4beta1/types/text_annotation.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/google/cloud/vision_v1p4beta1/types/web_detection.py
+++ b/packages/google-cloud-vision/google/cloud/vision_v1p4beta1/types/web_detection.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1_generated_image_annotator_async_batch_annotate_files_sync.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1_generated_image_annotator_async_batch_annotate_files_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1_generated_image_annotator_async_batch_annotate_images_sync.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1_generated_image_annotator_async_batch_annotate_images_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1_generated_image_annotator_batch_annotate_files_async.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1_generated_image_annotator_batch_annotate_files_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1_generated_image_annotator_batch_annotate_files_sync.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1_generated_image_annotator_batch_annotate_files_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1_generated_image_annotator_batch_annotate_images_async.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1_generated_image_annotator_batch_annotate_images_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1_generated_image_annotator_batch_annotate_images_sync.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1_generated_image_annotator_batch_annotate_images_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1_generated_product_search_add_product_to_product_set_async.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1_generated_product_search_add_product_to_product_set_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1_generated_product_search_add_product_to_product_set_sync.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1_generated_product_search_add_product_to_product_set_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1_generated_product_search_create_product_async.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1_generated_product_search_create_product_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1_generated_product_search_create_product_set_async.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1_generated_product_search_create_product_set_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1_generated_product_search_create_product_set_sync.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1_generated_product_search_create_product_set_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1_generated_product_search_create_product_sync.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1_generated_product_search_create_product_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1_generated_product_search_create_reference_image_async.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1_generated_product_search_create_reference_image_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1_generated_product_search_create_reference_image_sync.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1_generated_product_search_create_reference_image_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1_generated_product_search_delete_product_async.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1_generated_product_search_delete_product_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1_generated_product_search_delete_product_set_async.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1_generated_product_search_delete_product_set_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1_generated_product_search_delete_product_set_sync.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1_generated_product_search_delete_product_set_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1_generated_product_search_delete_product_sync.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1_generated_product_search_delete_product_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1_generated_product_search_delete_reference_image_async.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1_generated_product_search_delete_reference_image_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1_generated_product_search_delete_reference_image_sync.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1_generated_product_search_delete_reference_image_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1_generated_product_search_get_product_async.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1_generated_product_search_get_product_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1_generated_product_search_get_product_set_async.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1_generated_product_search_get_product_set_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1_generated_product_search_get_product_set_sync.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1_generated_product_search_get_product_set_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1_generated_product_search_get_product_sync.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1_generated_product_search_get_product_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1_generated_product_search_get_reference_image_async.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1_generated_product_search_get_reference_image_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1_generated_product_search_get_reference_image_sync.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1_generated_product_search_get_reference_image_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1_generated_product_search_import_product_sets_sync.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1_generated_product_search_import_product_sets_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1_generated_product_search_list_product_sets_async.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1_generated_product_search_list_product_sets_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1_generated_product_search_list_product_sets_sync.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1_generated_product_search_list_product_sets_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1_generated_product_search_list_products_async.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1_generated_product_search_list_products_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1_generated_product_search_list_products_in_product_set_async.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1_generated_product_search_list_products_in_product_set_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1_generated_product_search_list_products_in_product_set_sync.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1_generated_product_search_list_products_in_product_set_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1_generated_product_search_list_products_sync.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1_generated_product_search_list_products_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1_generated_product_search_list_reference_images_async.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1_generated_product_search_list_reference_images_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1_generated_product_search_list_reference_images_sync.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1_generated_product_search_list_reference_images_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1_generated_product_search_purge_products_sync.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1_generated_product_search_purge_products_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1_generated_product_search_remove_product_from_product_set_async.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1_generated_product_search_remove_product_from_product_set_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1_generated_product_search_remove_product_from_product_set_sync.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1_generated_product_search_remove_product_from_product_set_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1_generated_product_search_update_product_async.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1_generated_product_search_update_product_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1_generated_product_search_update_product_set_async.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1_generated_product_search_update_product_set_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1_generated_product_search_update_product_set_sync.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1_generated_product_search_update_product_set_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1_generated_product_search_update_product_sync.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1_generated_product_search_update_product_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1p1beta1_generated_image_annotator_batch_annotate_images_async.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1p1beta1_generated_image_annotator_batch_annotate_images_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1p1beta1_generated_image_annotator_batch_annotate_images_sync.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1p1beta1_generated_image_annotator_batch_annotate_images_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1p2beta1_generated_image_annotator_async_batch_annotate_files_sync.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1p2beta1_generated_image_annotator_async_batch_annotate_files_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1p2beta1_generated_image_annotator_batch_annotate_images_async.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1p2beta1_generated_image_annotator_batch_annotate_images_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1p2beta1_generated_image_annotator_batch_annotate_images_sync.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1p2beta1_generated_image_annotator_batch_annotate_images_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1p3beta1_generated_image_annotator_async_batch_annotate_files_sync.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1p3beta1_generated_image_annotator_async_batch_annotate_files_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1p3beta1_generated_image_annotator_batch_annotate_images_async.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1p3beta1_generated_image_annotator_batch_annotate_images_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1p3beta1_generated_image_annotator_batch_annotate_images_sync.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1p3beta1_generated_image_annotator_batch_annotate_images_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1p3beta1_generated_product_search_add_product_to_product_set_async.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1p3beta1_generated_product_search_add_product_to_product_set_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1p3beta1_generated_product_search_add_product_to_product_set_sync.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1p3beta1_generated_product_search_add_product_to_product_set_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1p3beta1_generated_product_search_create_product_async.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1p3beta1_generated_product_search_create_product_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1p3beta1_generated_product_search_create_product_set_async.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1p3beta1_generated_product_search_create_product_set_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1p3beta1_generated_product_search_create_product_set_sync.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1p3beta1_generated_product_search_create_product_set_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1p3beta1_generated_product_search_create_product_sync.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1p3beta1_generated_product_search_create_product_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1p3beta1_generated_product_search_create_reference_image_async.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1p3beta1_generated_product_search_create_reference_image_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1p3beta1_generated_product_search_create_reference_image_sync.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1p3beta1_generated_product_search_create_reference_image_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1p3beta1_generated_product_search_delete_product_async.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1p3beta1_generated_product_search_delete_product_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1p3beta1_generated_product_search_delete_product_set_async.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1p3beta1_generated_product_search_delete_product_set_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1p3beta1_generated_product_search_delete_product_set_sync.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1p3beta1_generated_product_search_delete_product_set_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1p3beta1_generated_product_search_delete_product_sync.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1p3beta1_generated_product_search_delete_product_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1p3beta1_generated_product_search_delete_reference_image_async.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1p3beta1_generated_product_search_delete_reference_image_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1p3beta1_generated_product_search_delete_reference_image_sync.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1p3beta1_generated_product_search_delete_reference_image_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1p3beta1_generated_product_search_get_product_async.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1p3beta1_generated_product_search_get_product_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1p3beta1_generated_product_search_get_product_set_async.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1p3beta1_generated_product_search_get_product_set_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1p3beta1_generated_product_search_get_product_set_sync.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1p3beta1_generated_product_search_get_product_set_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1p3beta1_generated_product_search_get_product_sync.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1p3beta1_generated_product_search_get_product_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1p3beta1_generated_product_search_get_reference_image_async.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1p3beta1_generated_product_search_get_reference_image_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1p3beta1_generated_product_search_get_reference_image_sync.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1p3beta1_generated_product_search_get_reference_image_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1p3beta1_generated_product_search_import_product_sets_sync.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1p3beta1_generated_product_search_import_product_sets_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1p3beta1_generated_product_search_list_product_sets_async.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1p3beta1_generated_product_search_list_product_sets_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1p3beta1_generated_product_search_list_product_sets_sync.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1p3beta1_generated_product_search_list_product_sets_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1p3beta1_generated_product_search_list_products_async.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1p3beta1_generated_product_search_list_products_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1p3beta1_generated_product_search_list_products_in_product_set_async.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1p3beta1_generated_product_search_list_products_in_product_set_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1p3beta1_generated_product_search_list_products_in_product_set_sync.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1p3beta1_generated_product_search_list_products_in_product_set_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1p3beta1_generated_product_search_list_products_sync.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1p3beta1_generated_product_search_list_products_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1p3beta1_generated_product_search_list_reference_images_async.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1p3beta1_generated_product_search_list_reference_images_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1p3beta1_generated_product_search_list_reference_images_sync.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1p3beta1_generated_product_search_list_reference_images_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1p3beta1_generated_product_search_remove_product_from_product_set_async.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1p3beta1_generated_product_search_remove_product_from_product_set_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1p3beta1_generated_product_search_remove_product_from_product_set_sync.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1p3beta1_generated_product_search_remove_product_from_product_set_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1p3beta1_generated_product_search_update_product_async.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1p3beta1_generated_product_search_update_product_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1p3beta1_generated_product_search_update_product_set_async.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1p3beta1_generated_product_search_update_product_set_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1p3beta1_generated_product_search_update_product_set_sync.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1p3beta1_generated_product_search_update_product_set_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1p3beta1_generated_product_search_update_product_sync.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1p3beta1_generated_product_search_update_product_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1p4beta1_generated_image_annotator_async_batch_annotate_files_sync.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1p4beta1_generated_image_annotator_async_batch_annotate_files_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1p4beta1_generated_image_annotator_async_batch_annotate_images_sync.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1p4beta1_generated_image_annotator_async_batch_annotate_images_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1p4beta1_generated_image_annotator_batch_annotate_files_async.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1p4beta1_generated_image_annotator_batch_annotate_files_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1p4beta1_generated_image_annotator_batch_annotate_files_sync.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1p4beta1_generated_image_annotator_batch_annotate_files_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1p4beta1_generated_image_annotator_batch_annotate_images_async.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1p4beta1_generated_image_annotator_batch_annotate_images_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1p4beta1_generated_image_annotator_batch_annotate_images_sync.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1p4beta1_generated_image_annotator_batch_annotate_images_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1p4beta1_generated_product_search_add_product_to_product_set_async.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1p4beta1_generated_product_search_add_product_to_product_set_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1p4beta1_generated_product_search_add_product_to_product_set_sync.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1p4beta1_generated_product_search_add_product_to_product_set_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1p4beta1_generated_product_search_create_product_async.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1p4beta1_generated_product_search_create_product_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1p4beta1_generated_product_search_create_product_set_async.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1p4beta1_generated_product_search_create_product_set_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1p4beta1_generated_product_search_create_product_set_sync.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1p4beta1_generated_product_search_create_product_set_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1p4beta1_generated_product_search_create_product_sync.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1p4beta1_generated_product_search_create_product_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1p4beta1_generated_product_search_create_reference_image_async.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1p4beta1_generated_product_search_create_reference_image_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1p4beta1_generated_product_search_create_reference_image_sync.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1p4beta1_generated_product_search_create_reference_image_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1p4beta1_generated_product_search_delete_product_async.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1p4beta1_generated_product_search_delete_product_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1p4beta1_generated_product_search_delete_product_set_async.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1p4beta1_generated_product_search_delete_product_set_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1p4beta1_generated_product_search_delete_product_set_sync.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1p4beta1_generated_product_search_delete_product_set_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1p4beta1_generated_product_search_delete_product_sync.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1p4beta1_generated_product_search_delete_product_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1p4beta1_generated_product_search_delete_reference_image_async.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1p4beta1_generated_product_search_delete_reference_image_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1p4beta1_generated_product_search_delete_reference_image_sync.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1p4beta1_generated_product_search_delete_reference_image_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1p4beta1_generated_product_search_get_product_async.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1p4beta1_generated_product_search_get_product_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1p4beta1_generated_product_search_get_product_set_async.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1p4beta1_generated_product_search_get_product_set_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1p4beta1_generated_product_search_get_product_set_sync.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1p4beta1_generated_product_search_get_product_set_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1p4beta1_generated_product_search_get_product_sync.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1p4beta1_generated_product_search_get_product_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1p4beta1_generated_product_search_get_reference_image_async.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1p4beta1_generated_product_search_get_reference_image_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1p4beta1_generated_product_search_get_reference_image_sync.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1p4beta1_generated_product_search_get_reference_image_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1p4beta1_generated_product_search_import_product_sets_sync.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1p4beta1_generated_product_search_import_product_sets_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1p4beta1_generated_product_search_list_product_sets_async.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1p4beta1_generated_product_search_list_product_sets_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1p4beta1_generated_product_search_list_product_sets_sync.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1p4beta1_generated_product_search_list_product_sets_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1p4beta1_generated_product_search_list_products_async.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1p4beta1_generated_product_search_list_products_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1p4beta1_generated_product_search_list_products_in_product_set_async.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1p4beta1_generated_product_search_list_products_in_product_set_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1p4beta1_generated_product_search_list_products_in_product_set_sync.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1p4beta1_generated_product_search_list_products_in_product_set_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1p4beta1_generated_product_search_list_products_sync.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1p4beta1_generated_product_search_list_products_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1p4beta1_generated_product_search_list_reference_images_async.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1p4beta1_generated_product_search_list_reference_images_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1p4beta1_generated_product_search_list_reference_images_sync.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1p4beta1_generated_product_search_list_reference_images_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1p4beta1_generated_product_search_purge_products_sync.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1p4beta1_generated_product_search_purge_products_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1p4beta1_generated_product_search_remove_product_from_product_set_async.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1p4beta1_generated_product_search_remove_product_from_product_set_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1p4beta1_generated_product_search_remove_product_from_product_set_sync.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1p4beta1_generated_product_search_remove_product_from_product_set_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1p4beta1_generated_product_search_update_product_async.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1p4beta1_generated_product_search_update_product_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1p4beta1_generated_product_search_update_product_set_async.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1p4beta1_generated_product_search_update_product_set_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1p4beta1_generated_product_search_update_product_set_sync.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1p4beta1_generated_product_search_update_product_set_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/samples/generated_samples/vision_v1p4beta1_generated_product_search_update_product_sync.py
+++ b/packages/google-cloud-vision/samples/generated_samples/vision_v1p4beta1_generated_product_search_update_product_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/tests/__init__.py
+++ b/packages/google-cloud-vision/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/tests/unit/__init__.py
+++ b/packages/google-cloud-vision/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-vision/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/tests/unit/gapic/vision_v1/__init__.py
+++ b/packages/google-cloud-vision/tests/unit/gapic/vision_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/tests/unit/gapic/vision_v1p1beta1/__init__.py
+++ b/packages/google-cloud-vision/tests/unit/gapic/vision_v1p1beta1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/tests/unit/gapic/vision_v1p2beta1/__init__.py
+++ b/packages/google-cloud-vision/tests/unit/gapic/vision_v1p2beta1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/tests/unit/gapic/vision_v1p3beta1/__init__.py
+++ b/packages/google-cloud-vision/tests/unit/gapic/vision_v1p3beta1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vision/tests/unit/gapic/vision_v1p4beta1/__init__.py
+++ b/packages/google-cloud-vision/tests/unit/gapic/vision_v1p4beta1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/.flake8
+++ b/packages/google-cloud-visionai/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/MANIFEST.in
+++ b/packages/google-cloud-visionai/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai/__init__.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai/gapic_version.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1/gapic_version.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1/services/__init__.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1/services/app_platform/__init__.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1/services/app_platform/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1/services/app_platform/client.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1/services/app_platform/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1/services/app_platform/pagers.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1/services/app_platform/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1/services/app_platform/transports/__init__.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1/services/app_platform/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1/services/app_platform/transports/base.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1/services/app_platform/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1/services/app_platform/transports/grpc.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1/services/app_platform/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1/services/app_platform/transports/grpc_asyncio.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1/services/app_platform/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1/services/app_platform/transports/rest.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1/services/app_platform/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1/services/app_platform/transports/rest_base.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1/services/app_platform/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1/services/health_check_service/__init__.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1/services/health_check_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1/services/health_check_service/async_client.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1/services/health_check_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1/services/health_check_service/client.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1/services/health_check_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1/services/health_check_service/transports/__init__.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1/services/health_check_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1/services/health_check_service/transports/base.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1/services/health_check_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1/services/health_check_service/transports/grpc.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1/services/health_check_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1/services/health_check_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1/services/health_check_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1/services/health_check_service/transports/rest.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1/services/health_check_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1/services/health_check_service/transports/rest_base.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1/services/health_check_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1/services/live_video_analytics/__init__.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1/services/live_video_analytics/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1/services/live_video_analytics/client.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1/services/live_video_analytics/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1/services/live_video_analytics/pagers.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1/services/live_video_analytics/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1/services/live_video_analytics/transports/__init__.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1/services/live_video_analytics/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1/services/live_video_analytics/transports/base.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1/services/live_video_analytics/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1/services/live_video_analytics/transports/grpc.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1/services/live_video_analytics/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1/services/live_video_analytics/transports/grpc_asyncio.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1/services/live_video_analytics/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1/services/live_video_analytics/transports/rest.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1/services/live_video_analytics/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1/services/live_video_analytics/transports/rest_base.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1/services/live_video_analytics/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1/services/streaming_service/__init__.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1/services/streaming_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1/services/streaming_service/async_client.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1/services/streaming_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1/services/streaming_service/client.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1/services/streaming_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1/services/streaming_service/transports/__init__.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1/services/streaming_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1/services/streaming_service/transports/base.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1/services/streaming_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1/services/streaming_service/transports/grpc.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1/services/streaming_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1/services/streaming_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1/services/streaming_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1/services/streaming_service/transports/rest.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1/services/streaming_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1/services/streaming_service/transports/rest_base.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1/services/streaming_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1/services/streams_service/__init__.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1/services/streams_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1/services/streams_service/client.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1/services/streams_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1/services/streams_service/pagers.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1/services/streams_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1/services/streams_service/transports/__init__.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1/services/streams_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1/services/streams_service/transports/base.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1/services/streams_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1/services/streams_service/transports/grpc.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1/services/streams_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1/services/streams_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1/services/streams_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1/services/streams_service/transports/rest.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1/services/streams_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1/services/streams_service/transports/rest_base.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1/services/streams_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1/services/warehouse/__init__.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1/services/warehouse/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1/services/warehouse/client.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1/services/warehouse/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1/services/warehouse/pagers.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1/services/warehouse/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1/services/warehouse/transports/__init__.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1/services/warehouse/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1/services/warehouse/transports/base.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1/services/warehouse/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1/services/warehouse/transports/grpc.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1/services/warehouse/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1/services/warehouse/transports/grpc_asyncio.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1/services/warehouse/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1/services/warehouse/transports/rest.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1/services/warehouse/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1/services/warehouse/transports/rest_base.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1/services/warehouse/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1/types/__init__.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1/types/annotations.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1/types/annotations.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1/types/common.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1/types/common.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1/types/health_service.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1/types/health_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1/types/lva.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1/types/lva.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1/types/lva_resources.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1/types/lva_resources.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1/types/lva_service.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1/types/lva_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1/types/streaming_resources.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1/types/streaming_resources.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1/types/streaming_service.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1/types/streaming_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1/types/streams_resources.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1/types/streams_resources.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1/types/streams_service.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1/types/streams_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1/types/warehouse.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1/types/warehouse.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1alpha1/gapic_version.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1alpha1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1alpha1/services/__init__.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1alpha1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1alpha1/services/app_platform/__init__.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1alpha1/services/app_platform/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1alpha1/services/app_platform/client.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1alpha1/services/app_platform/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1alpha1/services/app_platform/pagers.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1alpha1/services/app_platform/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1alpha1/services/app_platform/transports/__init__.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1alpha1/services/app_platform/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1alpha1/services/app_platform/transports/base.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1alpha1/services/app_platform/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1alpha1/services/app_platform/transports/grpc.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1alpha1/services/app_platform/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1alpha1/services/app_platform/transports/grpc_asyncio.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1alpha1/services/app_platform/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1alpha1/services/app_platform/transports/rest.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1alpha1/services/app_platform/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1alpha1/services/app_platform/transports/rest_base.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1alpha1/services/app_platform/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1alpha1/services/live_video_analytics/__init__.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1alpha1/services/live_video_analytics/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1alpha1/services/live_video_analytics/client.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1alpha1/services/live_video_analytics/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1alpha1/services/live_video_analytics/pagers.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1alpha1/services/live_video_analytics/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1alpha1/services/live_video_analytics/transports/__init__.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1alpha1/services/live_video_analytics/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1alpha1/services/live_video_analytics/transports/base.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1alpha1/services/live_video_analytics/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1alpha1/services/live_video_analytics/transports/grpc.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1alpha1/services/live_video_analytics/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1alpha1/services/live_video_analytics/transports/grpc_asyncio.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1alpha1/services/live_video_analytics/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1alpha1/services/live_video_analytics/transports/rest.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1alpha1/services/live_video_analytics/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1alpha1/services/live_video_analytics/transports/rest_base.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1alpha1/services/live_video_analytics/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1alpha1/services/streaming_service/__init__.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1alpha1/services/streaming_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1alpha1/services/streaming_service/async_client.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1alpha1/services/streaming_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1alpha1/services/streaming_service/client.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1alpha1/services/streaming_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1alpha1/services/streaming_service/transports/__init__.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1alpha1/services/streaming_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1alpha1/services/streaming_service/transports/base.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1alpha1/services/streaming_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1alpha1/services/streaming_service/transports/grpc.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1alpha1/services/streaming_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1alpha1/services/streaming_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1alpha1/services/streaming_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1alpha1/services/streaming_service/transports/rest.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1alpha1/services/streaming_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1alpha1/services/streaming_service/transports/rest_base.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1alpha1/services/streaming_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1alpha1/services/streams_service/__init__.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1alpha1/services/streams_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1alpha1/services/streams_service/client.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1alpha1/services/streams_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1alpha1/services/streams_service/pagers.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1alpha1/services/streams_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1alpha1/services/streams_service/transports/__init__.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1alpha1/services/streams_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1alpha1/services/streams_service/transports/base.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1alpha1/services/streams_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1alpha1/services/streams_service/transports/grpc.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1alpha1/services/streams_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1alpha1/services/streams_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1alpha1/services/streams_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1alpha1/services/streams_service/transports/rest.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1alpha1/services/streams_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1alpha1/services/streams_service/transports/rest_base.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1alpha1/services/streams_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1alpha1/services/warehouse/__init__.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1alpha1/services/warehouse/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1alpha1/services/warehouse/client.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1alpha1/services/warehouse/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1alpha1/services/warehouse/pagers.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1alpha1/services/warehouse/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1alpha1/services/warehouse/transports/__init__.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1alpha1/services/warehouse/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1alpha1/services/warehouse/transports/base.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1alpha1/services/warehouse/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1alpha1/services/warehouse/transports/grpc.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1alpha1/services/warehouse/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1alpha1/services/warehouse/transports/grpc_asyncio.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1alpha1/services/warehouse/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1alpha1/services/warehouse/transports/rest.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1alpha1/services/warehouse/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1alpha1/services/warehouse/transports/rest_base.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1alpha1/services/warehouse/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1alpha1/types/__init__.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1alpha1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1alpha1/types/annotations.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1alpha1/types/annotations.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1alpha1/types/common.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1alpha1/types/common.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1alpha1/types/lva.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1alpha1/types/lva.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1alpha1/types/lva_resources.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1alpha1/types/lva_resources.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1alpha1/types/lva_service.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1alpha1/types/lva_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1alpha1/types/streaming_resources.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1alpha1/types/streaming_resources.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1alpha1/types/streaming_service.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1alpha1/types/streaming_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1alpha1/types/streams_resources.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1alpha1/types/streams_resources.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1alpha1/types/streams_service.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1alpha1/types/streams_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/google/cloud/visionai_v1alpha1/types/warehouse.py
+++ b/packages/google-cloud-visionai/google/cloud/visionai_v1alpha1/types/warehouse.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_app_platform_add_application_stream_input_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_app_platform_add_application_stream_input_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_app_platform_create_application_instances_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_app_platform_create_application_instances_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_app_platform_create_application_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_app_platform_create_application_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_app_platform_create_draft_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_app_platform_create_draft_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_app_platform_create_processor_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_app_platform_create_processor_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_app_platform_delete_application_instances_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_app_platform_delete_application_instances_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_app_platform_delete_application_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_app_platform_delete_application_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_app_platform_delete_draft_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_app_platform_delete_draft_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_app_platform_delete_processor_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_app_platform_delete_processor_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_app_platform_deploy_application_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_app_platform_deploy_application_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_app_platform_get_application_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_app_platform_get_application_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_app_platform_get_application_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_app_platform_get_application_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_app_platform_get_draft_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_app_platform_get_draft_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_app_platform_get_draft_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_app_platform_get_draft_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_app_platform_get_instance_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_app_platform_get_instance_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_app_platform_get_instance_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_app_platform_get_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_app_platform_get_processor_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_app_platform_get_processor_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_app_platform_get_processor_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_app_platform_get_processor_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_app_platform_list_applications_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_app_platform_list_applications_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_app_platform_list_applications_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_app_platform_list_applications_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_app_platform_list_drafts_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_app_platform_list_drafts_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_app_platform_list_drafts_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_app_platform_list_drafts_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_app_platform_list_instances_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_app_platform_list_instances_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_app_platform_list_instances_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_app_platform_list_instances_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_app_platform_list_prebuilt_processors_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_app_platform_list_prebuilt_processors_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_app_platform_list_prebuilt_processors_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_app_platform_list_prebuilt_processors_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_app_platform_list_processors_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_app_platform_list_processors_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_app_platform_list_processors_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_app_platform_list_processors_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_app_platform_remove_application_stream_input_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_app_platform_remove_application_stream_input_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_app_platform_undeploy_application_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_app_platform_undeploy_application_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_app_platform_update_application_instances_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_app_platform_update_application_instances_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_app_platform_update_application_stream_input_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_app_platform_update_application_stream_input_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_app_platform_update_application_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_app_platform_update_application_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_app_platform_update_draft_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_app_platform_update_draft_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_app_platform_update_processor_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_app_platform_update_processor_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_health_check_service_health_check_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_health_check_service_health_check_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_health_check_service_health_check_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_health_check_service_health_check_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_live_video_analytics_batch_run_process_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_live_video_analytics_batch_run_process_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_live_video_analytics_create_analysis_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_live_video_analytics_create_analysis_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_live_video_analytics_create_operator_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_live_video_analytics_create_operator_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_live_video_analytics_create_process_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_live_video_analytics_create_process_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_live_video_analytics_delete_analysis_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_live_video_analytics_delete_analysis_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_live_video_analytics_delete_operator_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_live_video_analytics_delete_operator_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_live_video_analytics_delete_process_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_live_video_analytics_delete_process_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_live_video_analytics_get_analysis_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_live_video_analytics_get_analysis_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_live_video_analytics_get_analysis_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_live_video_analytics_get_analysis_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_live_video_analytics_get_operator_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_live_video_analytics_get_operator_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_live_video_analytics_get_operator_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_live_video_analytics_get_operator_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_live_video_analytics_get_process_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_live_video_analytics_get_process_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_live_video_analytics_get_process_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_live_video_analytics_get_process_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_live_video_analytics_list_analyses_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_live_video_analytics_list_analyses_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_live_video_analytics_list_analyses_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_live_video_analytics_list_analyses_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_live_video_analytics_list_operators_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_live_video_analytics_list_operators_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_live_video_analytics_list_operators_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_live_video_analytics_list_operators_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_live_video_analytics_list_processes_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_live_video_analytics_list_processes_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_live_video_analytics_list_processes_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_live_video_analytics_list_processes_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_live_video_analytics_list_public_operators_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_live_video_analytics_list_public_operators_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_live_video_analytics_list_public_operators_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_live_video_analytics_list_public_operators_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_live_video_analytics_resolve_operator_info_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_live_video_analytics_resolve_operator_info_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_live_video_analytics_resolve_operator_info_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_live_video_analytics_resolve_operator_info_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_live_video_analytics_update_analysis_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_live_video_analytics_update_analysis_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_live_video_analytics_update_operator_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_live_video_analytics_update_operator_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_live_video_analytics_update_process_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_live_video_analytics_update_process_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_streaming_service_acquire_lease_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_streaming_service_acquire_lease_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_streaming_service_acquire_lease_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_streaming_service_acquire_lease_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_streaming_service_receive_events_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_streaming_service_receive_events_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_streaming_service_receive_events_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_streaming_service_receive_events_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_streaming_service_receive_packets_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_streaming_service_receive_packets_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_streaming_service_receive_packets_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_streaming_service_receive_packets_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_streaming_service_release_lease_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_streaming_service_release_lease_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_streaming_service_release_lease_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_streaming_service_release_lease_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_streaming_service_renew_lease_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_streaming_service_renew_lease_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_streaming_service_renew_lease_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_streaming_service_renew_lease_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_streaming_service_send_packets_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_streaming_service_send_packets_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_streaming_service_send_packets_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_streaming_service_send_packets_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_streams_service_create_cluster_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_streams_service_create_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_streams_service_create_event_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_streams_service_create_event_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_streams_service_create_series_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_streams_service_create_series_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_streams_service_create_stream_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_streams_service_create_stream_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_streams_service_delete_cluster_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_streams_service_delete_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_streams_service_delete_event_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_streams_service_delete_event_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_streams_service_delete_series_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_streams_service_delete_series_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_streams_service_delete_stream_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_streams_service_delete_stream_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_streams_service_generate_stream_hls_token_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_streams_service_generate_stream_hls_token_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_streams_service_generate_stream_hls_token_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_streams_service_generate_stream_hls_token_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_streams_service_get_cluster_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_streams_service_get_cluster_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_streams_service_get_cluster_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_streams_service_get_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_streams_service_get_event_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_streams_service_get_event_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_streams_service_get_event_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_streams_service_get_event_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_streams_service_get_series_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_streams_service_get_series_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_streams_service_get_series_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_streams_service_get_series_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_streams_service_get_stream_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_streams_service_get_stream_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_streams_service_get_stream_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_streams_service_get_stream_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_streams_service_get_stream_thumbnail_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_streams_service_get_stream_thumbnail_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_streams_service_list_clusters_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_streams_service_list_clusters_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_streams_service_list_clusters_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_streams_service_list_clusters_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_streams_service_list_events_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_streams_service_list_events_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_streams_service_list_events_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_streams_service_list_events_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_streams_service_list_series_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_streams_service_list_series_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_streams_service_list_series_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_streams_service_list_series_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_streams_service_list_streams_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_streams_service_list_streams_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_streams_service_list_streams_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_streams_service_list_streams_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_streams_service_materialize_channel_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_streams_service_materialize_channel_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_streams_service_update_cluster_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_streams_service_update_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_streams_service_update_event_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_streams_service_update_event_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_streams_service_update_series_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_streams_service_update_series_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_streams_service_update_stream_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1_generated_streams_service_update_stream_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_app_platform_add_application_stream_input_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_app_platform_add_application_stream_input_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_app_platform_create_application_instances_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_app_platform_create_application_instances_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_app_platform_create_application_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_app_platform_create_application_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_app_platform_create_draft_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_app_platform_create_draft_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_app_platform_create_processor_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_app_platform_create_processor_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_app_platform_delete_application_instances_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_app_platform_delete_application_instances_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_app_platform_delete_application_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_app_platform_delete_application_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_app_platform_delete_draft_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_app_platform_delete_draft_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_app_platform_delete_processor_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_app_platform_delete_processor_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_app_platform_deploy_application_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_app_platform_deploy_application_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_app_platform_get_application_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_app_platform_get_application_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_app_platform_get_application_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_app_platform_get_application_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_app_platform_get_draft_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_app_platform_get_draft_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_app_platform_get_draft_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_app_platform_get_draft_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_app_platform_get_instance_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_app_platform_get_instance_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_app_platform_get_instance_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_app_platform_get_instance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_app_platform_get_processor_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_app_platform_get_processor_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_app_platform_get_processor_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_app_platform_get_processor_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_app_platform_list_applications_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_app_platform_list_applications_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_app_platform_list_applications_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_app_platform_list_applications_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_app_platform_list_drafts_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_app_platform_list_drafts_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_app_platform_list_drafts_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_app_platform_list_drafts_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_app_platform_list_instances_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_app_platform_list_instances_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_app_platform_list_instances_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_app_platform_list_instances_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_app_platform_list_prebuilt_processors_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_app_platform_list_prebuilt_processors_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_app_platform_list_prebuilt_processors_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_app_platform_list_prebuilt_processors_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_app_platform_list_processors_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_app_platform_list_processors_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_app_platform_list_processors_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_app_platform_list_processors_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_app_platform_remove_application_stream_input_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_app_platform_remove_application_stream_input_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_app_platform_undeploy_application_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_app_platform_undeploy_application_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_app_platform_update_application_instances_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_app_platform_update_application_instances_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_app_platform_update_application_stream_input_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_app_platform_update_application_stream_input_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_app_platform_update_application_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_app_platform_update_application_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_app_platform_update_draft_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_app_platform_update_draft_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_app_platform_update_processor_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_app_platform_update_processor_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_live_video_analytics_create_analysis_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_live_video_analytics_create_analysis_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_live_video_analytics_delete_analysis_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_live_video_analytics_delete_analysis_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_live_video_analytics_get_analysis_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_live_video_analytics_get_analysis_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_live_video_analytics_get_analysis_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_live_video_analytics_get_analysis_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_live_video_analytics_list_analyses_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_live_video_analytics_list_analyses_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_live_video_analytics_list_analyses_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_live_video_analytics_list_analyses_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_live_video_analytics_update_analysis_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_live_video_analytics_update_analysis_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_streaming_service_acquire_lease_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_streaming_service_acquire_lease_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_streaming_service_acquire_lease_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_streaming_service_acquire_lease_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_streaming_service_receive_events_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_streaming_service_receive_events_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_streaming_service_receive_events_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_streaming_service_receive_events_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_streaming_service_receive_packets_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_streaming_service_receive_packets_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_streaming_service_receive_packets_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_streaming_service_receive_packets_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_streaming_service_release_lease_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_streaming_service_release_lease_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_streaming_service_release_lease_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_streaming_service_release_lease_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_streaming_service_renew_lease_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_streaming_service_renew_lease_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_streaming_service_renew_lease_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_streaming_service_renew_lease_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_streaming_service_send_packets_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_streaming_service_send_packets_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_streaming_service_send_packets_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_streaming_service_send_packets_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_streams_service_create_cluster_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_streams_service_create_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_streams_service_create_event_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_streams_service_create_event_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_streams_service_create_series_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_streams_service_create_series_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_streams_service_create_stream_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_streams_service_create_stream_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_streams_service_delete_cluster_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_streams_service_delete_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_streams_service_delete_event_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_streams_service_delete_event_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_streams_service_delete_series_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_streams_service_delete_series_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_streams_service_delete_stream_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_streams_service_delete_stream_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_streams_service_generate_stream_hls_token_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_streams_service_generate_stream_hls_token_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_streams_service_generate_stream_hls_token_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_streams_service_generate_stream_hls_token_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_streams_service_get_cluster_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_streams_service_get_cluster_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_streams_service_get_cluster_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_streams_service_get_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_streams_service_get_event_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_streams_service_get_event_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_streams_service_get_event_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_streams_service_get_event_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_streams_service_get_series_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_streams_service_get_series_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_streams_service_get_series_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_streams_service_get_series_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_streams_service_get_stream_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_streams_service_get_stream_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_streams_service_get_stream_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_streams_service_get_stream_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_streams_service_list_clusters_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_streams_service_list_clusters_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_streams_service_list_clusters_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_streams_service_list_clusters_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_streams_service_list_events_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_streams_service_list_events_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_streams_service_list_events_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_streams_service_list_events_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_streams_service_list_series_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_streams_service_list_series_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_streams_service_list_series_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_streams_service_list_series_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_streams_service_list_streams_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_streams_service_list_streams_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_streams_service_list_streams_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_streams_service_list_streams_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_streams_service_materialize_channel_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_streams_service_materialize_channel_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_streams_service_update_cluster_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_streams_service_update_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_streams_service_update_event_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_streams_service_update_event_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_streams_service_update_series_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_streams_service_update_series_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_streams_service_update_stream_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_streams_service_update_stream_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_warehouse_clip_asset_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_warehouse_clip_asset_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_warehouse_clip_asset_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_warehouse_clip_asset_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_warehouse_create_annotation_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_warehouse_create_annotation_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_warehouse_create_annotation_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_warehouse_create_annotation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_warehouse_create_asset_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_warehouse_create_asset_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_warehouse_create_asset_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_warehouse_create_asset_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_warehouse_create_corpus_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_warehouse_create_corpus_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_warehouse_create_data_schema_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_warehouse_create_data_schema_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_warehouse_create_data_schema_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_warehouse_create_data_schema_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_warehouse_create_search_config_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_warehouse_create_search_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_warehouse_create_search_config_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_warehouse_create_search_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_warehouse_delete_annotation_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_warehouse_delete_annotation_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_warehouse_delete_annotation_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_warehouse_delete_annotation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_warehouse_delete_asset_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_warehouse_delete_asset_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_warehouse_delete_corpus_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_warehouse_delete_corpus_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_warehouse_delete_corpus_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_warehouse_delete_corpus_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_warehouse_delete_data_schema_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_warehouse_delete_data_schema_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_warehouse_delete_data_schema_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_warehouse_delete_data_schema_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_warehouse_delete_search_config_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_warehouse_delete_search_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_warehouse_delete_search_config_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_warehouse_delete_search_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_warehouse_generate_hls_uri_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_warehouse_generate_hls_uri_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_warehouse_generate_hls_uri_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_warehouse_generate_hls_uri_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_warehouse_get_annotation_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_warehouse_get_annotation_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_warehouse_get_annotation_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_warehouse_get_annotation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_warehouse_get_asset_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_warehouse_get_asset_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_warehouse_get_asset_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_warehouse_get_asset_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_warehouse_get_corpus_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_warehouse_get_corpus_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_warehouse_get_corpus_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_warehouse_get_corpus_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_warehouse_get_data_schema_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_warehouse_get_data_schema_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_warehouse_get_data_schema_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_warehouse_get_data_schema_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_warehouse_get_search_config_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_warehouse_get_search_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_warehouse_get_search_config_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_warehouse_get_search_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_warehouse_ingest_asset_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_warehouse_ingest_asset_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_warehouse_ingest_asset_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_warehouse_ingest_asset_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_warehouse_list_annotations_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_warehouse_list_annotations_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_warehouse_list_annotations_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_warehouse_list_annotations_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_warehouse_list_assets_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_warehouse_list_assets_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_warehouse_list_assets_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_warehouse_list_assets_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_warehouse_list_corpora_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_warehouse_list_corpora_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_warehouse_list_corpora_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_warehouse_list_corpora_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_warehouse_list_data_schemas_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_warehouse_list_data_schemas_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_warehouse_list_data_schemas_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_warehouse_list_data_schemas_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_warehouse_list_search_configs_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_warehouse_list_search_configs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_warehouse_list_search_configs_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_warehouse_list_search_configs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_warehouse_search_assets_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_warehouse_search_assets_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_warehouse_search_assets_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_warehouse_search_assets_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_warehouse_update_annotation_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_warehouse_update_annotation_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_warehouse_update_annotation_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_warehouse_update_annotation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_warehouse_update_asset_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_warehouse_update_asset_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_warehouse_update_asset_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_warehouse_update_asset_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_warehouse_update_corpus_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_warehouse_update_corpus_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_warehouse_update_corpus_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_warehouse_update_corpus_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_warehouse_update_data_schema_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_warehouse_update_data_schema_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_warehouse_update_data_schema_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_warehouse_update_data_schema_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_warehouse_update_search_config_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_warehouse_update_search_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_warehouse_update_search_config_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/visionai_v1alpha1_generated_warehouse_update_search_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_add_collection_item_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_add_collection_item_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_add_collection_item_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_add_collection_item_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_analyze_asset_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_analyze_asset_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_analyze_corpus_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_analyze_corpus_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_clip_asset_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_clip_asset_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_clip_asset_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_clip_asset_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_create_annotation_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_create_annotation_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_create_annotation_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_create_annotation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_create_asset_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_create_asset_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_create_asset_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_create_asset_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_create_collection_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_create_collection_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_create_corpus_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_create_corpus_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_create_data_schema_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_create_data_schema_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_create_data_schema_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_create_data_schema_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_create_index_endpoint_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_create_index_endpoint_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_create_index_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_create_index_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_create_search_config_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_create_search_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_create_search_config_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_create_search_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_create_search_hypernym_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_create_search_hypernym_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_create_search_hypernym_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_create_search_hypernym_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_delete_annotation_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_delete_annotation_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_delete_annotation_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_delete_annotation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_delete_asset_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_delete_asset_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_delete_collection_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_delete_collection_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_delete_corpus_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_delete_corpus_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_delete_corpus_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_delete_corpus_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_delete_data_schema_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_delete_data_schema_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_delete_data_schema_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_delete_data_schema_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_delete_index_endpoint_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_delete_index_endpoint_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_delete_index_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_delete_index_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_delete_search_config_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_delete_search_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_delete_search_config_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_delete_search_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_delete_search_hypernym_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_delete_search_hypernym_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_delete_search_hypernym_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_delete_search_hypernym_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_deploy_index_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_deploy_index_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_generate_hls_uri_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_generate_hls_uri_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_generate_hls_uri_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_generate_hls_uri_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_generate_retrieval_url_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_generate_retrieval_url_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_generate_retrieval_url_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_generate_retrieval_url_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_get_annotation_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_get_annotation_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_get_annotation_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_get_annotation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_get_asset_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_get_asset_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_get_asset_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_get_asset_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_get_collection_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_get_collection_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_get_collection_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_get_collection_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_get_corpus_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_get_corpus_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_get_corpus_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_get_corpus_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_get_data_schema_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_get_data_schema_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_get_data_schema_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_get_data_schema_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_get_index_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_get_index_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_get_index_endpoint_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_get_index_endpoint_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_get_index_endpoint_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_get_index_endpoint_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_get_index_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_get_index_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_get_search_config_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_get_search_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_get_search_config_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_get_search_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_get_search_hypernym_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_get_search_hypernym_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_get_search_hypernym_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_get_search_hypernym_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_import_assets_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_import_assets_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_index_asset_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_index_asset_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_ingest_asset_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_ingest_asset_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_ingest_asset_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_ingest_asset_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_list_annotations_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_list_annotations_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_list_annotations_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_list_annotations_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_list_assets_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_list_assets_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_list_assets_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_list_assets_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_list_collections_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_list_collections_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_list_collections_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_list_collections_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_list_corpora_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_list_corpora_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_list_corpora_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_list_corpora_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_list_data_schemas_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_list_data_schemas_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_list_data_schemas_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_list_data_schemas_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_list_index_endpoints_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_list_index_endpoints_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_list_index_endpoints_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_list_index_endpoints_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_list_indexes_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_list_indexes_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_list_indexes_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_list_indexes_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_list_search_configs_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_list_search_configs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_list_search_configs_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_list_search_configs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_list_search_hypernyms_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_list_search_hypernyms_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_list_search_hypernyms_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_list_search_hypernyms_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_remove_collection_item_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_remove_collection_item_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_remove_collection_item_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_remove_collection_item_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_remove_index_asset_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_remove_index_asset_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_search_assets_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_search_assets_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_search_assets_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_search_assets_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_search_index_endpoint_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_search_index_endpoint_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_search_index_endpoint_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_search_index_endpoint_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_undeploy_index_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_undeploy_index_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_update_annotation_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_update_annotation_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_update_annotation_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_update_annotation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_update_asset_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_update_asset_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_update_asset_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_update_asset_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_update_collection_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_update_collection_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_update_collection_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_update_collection_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_update_corpus_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_update_corpus_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_update_corpus_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_update_corpus_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_update_data_schema_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_update_data_schema_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_update_data_schema_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_update_data_schema_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_update_index_endpoint_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_update_index_endpoint_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_update_index_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_update_index_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_update_search_config_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_update_search_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_update_search_config_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_update_search_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_update_search_hypernym_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_update_search_hypernym_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_update_search_hypernym_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_update_search_hypernym_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_upload_asset_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_upload_asset_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_view_collection_items_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_view_collection_items_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_view_collection_items_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_view_collection_items_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_view_indexed_assets_async.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_view_indexed_assets_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_view_indexed_assets_sync.py
+++ b/packages/google-cloud-visionai/samples/generated_samples/warehouse-visionai_v1_generated_warehouse_view_indexed_assets_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/tests/__init__.py
+++ b/packages/google-cloud-visionai/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/tests/unit/__init__.py
+++ b/packages/google-cloud-visionai/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-visionai/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/tests/unit/gapic/visionai_v1/__init__.py
+++ b/packages/google-cloud-visionai/tests/unit/gapic/visionai_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-visionai/tests/unit/gapic/visionai_v1alpha1/__init__.py
+++ b/packages/google-cloud-visionai/tests/unit/gapic/visionai_v1alpha1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vm-migration/.flake8
+++ b/packages/google-cloud-vm-migration/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vm-migration/MANIFEST.in
+++ b/packages/google-cloud-vm-migration/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vm-migration/google/cloud/vmmigration/__init__.py
+++ b/packages/google-cloud-vm-migration/google/cloud/vmmigration/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vm-migration/google/cloud/vmmigration/gapic_version.py
+++ b/packages/google-cloud-vm-migration/google/cloud/vmmigration/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vm-migration/google/cloud/vmmigration_v1/gapic_version.py
+++ b/packages/google-cloud-vm-migration/google/cloud/vmmigration_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vm-migration/google/cloud/vmmigration_v1/services/__init__.py
+++ b/packages/google-cloud-vm-migration/google/cloud/vmmigration_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vm-migration/google/cloud/vmmigration_v1/services/vm_migration/__init__.py
+++ b/packages/google-cloud-vm-migration/google/cloud/vmmigration_v1/services/vm_migration/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vm-migration/google/cloud/vmmigration_v1/services/vm_migration/client.py
+++ b/packages/google-cloud-vm-migration/google/cloud/vmmigration_v1/services/vm_migration/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vm-migration/google/cloud/vmmigration_v1/services/vm_migration/pagers.py
+++ b/packages/google-cloud-vm-migration/google/cloud/vmmigration_v1/services/vm_migration/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vm-migration/google/cloud/vmmigration_v1/services/vm_migration/transports/__init__.py
+++ b/packages/google-cloud-vm-migration/google/cloud/vmmigration_v1/services/vm_migration/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vm-migration/google/cloud/vmmigration_v1/services/vm_migration/transports/base.py
+++ b/packages/google-cloud-vm-migration/google/cloud/vmmigration_v1/services/vm_migration/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vm-migration/google/cloud/vmmigration_v1/services/vm_migration/transports/grpc.py
+++ b/packages/google-cloud-vm-migration/google/cloud/vmmigration_v1/services/vm_migration/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vm-migration/google/cloud/vmmigration_v1/services/vm_migration/transports/grpc_asyncio.py
+++ b/packages/google-cloud-vm-migration/google/cloud/vmmigration_v1/services/vm_migration/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vm-migration/google/cloud/vmmigration_v1/services/vm_migration/transports/rest.py
+++ b/packages/google-cloud-vm-migration/google/cloud/vmmigration_v1/services/vm_migration/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vm-migration/google/cloud/vmmigration_v1/services/vm_migration/transports/rest_base.py
+++ b/packages/google-cloud-vm-migration/google/cloud/vmmigration_v1/services/vm_migration/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vm-migration/google/cloud/vmmigration_v1/types/__init__.py
+++ b/packages/google-cloud-vm-migration/google/cloud/vmmigration_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vm-migration/google/cloud/vmmigration_v1/types/vmmigration.py
+++ b/packages/google-cloud-vm-migration/google/cloud/vmmigration_v1/types/vmmigration.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_add_group_migration_sync.py
+++ b/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_add_group_migration_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_cancel_clone_job_sync.py
+++ b/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_cancel_clone_job_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_cancel_cutover_job_sync.py
+++ b/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_cancel_cutover_job_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_cancel_disk_migration_job_sync.py
+++ b/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_cancel_disk_migration_job_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_cancel_image_import_job_sync.py
+++ b/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_cancel_image_import_job_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_create_clone_job_sync.py
+++ b/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_create_clone_job_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_create_cutover_job_sync.py
+++ b/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_create_cutover_job_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_create_datacenter_connector_sync.py
+++ b/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_create_datacenter_connector_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_create_disk_migration_job_sync.py
+++ b/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_create_disk_migration_job_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_create_group_sync.py
+++ b/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_create_group_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_create_image_import_sync.py
+++ b/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_create_image_import_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_create_migrating_vm_sync.py
+++ b/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_create_migrating_vm_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_create_source_sync.py
+++ b/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_create_source_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_create_target_project_sync.py
+++ b/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_create_target_project_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_create_utilization_report_sync.py
+++ b/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_create_utilization_report_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_delete_datacenter_connector_sync.py
+++ b/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_delete_datacenter_connector_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_delete_disk_migration_job_sync.py
+++ b/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_delete_disk_migration_job_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_delete_group_sync.py
+++ b/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_delete_group_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_delete_image_import_sync.py
+++ b/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_delete_image_import_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_delete_migrating_vm_sync.py
+++ b/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_delete_migrating_vm_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_delete_source_sync.py
+++ b/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_delete_source_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_delete_target_project_sync.py
+++ b/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_delete_target_project_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_delete_utilization_report_sync.py
+++ b/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_delete_utilization_report_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_extend_migration_sync.py
+++ b/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_extend_migration_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_fetch_inventory_async.py
+++ b/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_fetch_inventory_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_fetch_inventory_sync.py
+++ b/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_fetch_inventory_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_fetch_storage_inventory_async.py
+++ b/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_fetch_storage_inventory_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_fetch_storage_inventory_sync.py
+++ b/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_fetch_storage_inventory_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_finalize_migration_sync.py
+++ b/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_finalize_migration_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_get_clone_job_async.py
+++ b/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_get_clone_job_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_get_clone_job_sync.py
+++ b/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_get_clone_job_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_get_cutover_job_async.py
+++ b/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_get_cutover_job_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_get_cutover_job_sync.py
+++ b/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_get_cutover_job_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_get_datacenter_connector_async.py
+++ b/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_get_datacenter_connector_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_get_datacenter_connector_sync.py
+++ b/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_get_datacenter_connector_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_get_disk_migration_job_async.py
+++ b/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_get_disk_migration_job_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_get_disk_migration_job_sync.py
+++ b/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_get_disk_migration_job_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_get_group_async.py
+++ b/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_get_group_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_get_group_sync.py
+++ b/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_get_group_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_get_image_import_async.py
+++ b/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_get_image_import_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_get_image_import_job_async.py
+++ b/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_get_image_import_job_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_get_image_import_job_sync.py
+++ b/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_get_image_import_job_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_get_image_import_sync.py
+++ b/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_get_image_import_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_get_migrating_vm_async.py
+++ b/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_get_migrating_vm_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_get_migrating_vm_sync.py
+++ b/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_get_migrating_vm_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_get_replication_cycle_async.py
+++ b/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_get_replication_cycle_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_get_replication_cycle_sync.py
+++ b/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_get_replication_cycle_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_get_source_async.py
+++ b/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_get_source_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_get_source_sync.py
+++ b/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_get_source_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_get_target_project_async.py
+++ b/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_get_target_project_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_get_target_project_sync.py
+++ b/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_get_target_project_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_get_utilization_report_async.py
+++ b/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_get_utilization_report_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_get_utilization_report_sync.py
+++ b/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_get_utilization_report_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_list_clone_jobs_async.py
+++ b/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_list_clone_jobs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_list_clone_jobs_sync.py
+++ b/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_list_clone_jobs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_list_cutover_jobs_async.py
+++ b/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_list_cutover_jobs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_list_cutover_jobs_sync.py
+++ b/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_list_cutover_jobs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_list_datacenter_connectors_async.py
+++ b/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_list_datacenter_connectors_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_list_datacenter_connectors_sync.py
+++ b/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_list_datacenter_connectors_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_list_disk_migration_jobs_async.py
+++ b/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_list_disk_migration_jobs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_list_disk_migration_jobs_sync.py
+++ b/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_list_disk_migration_jobs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_list_groups_async.py
+++ b/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_list_groups_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_list_groups_sync.py
+++ b/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_list_groups_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_list_image_import_jobs_async.py
+++ b/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_list_image_import_jobs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_list_image_import_jobs_sync.py
+++ b/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_list_image_import_jobs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_list_image_imports_async.py
+++ b/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_list_image_imports_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_list_image_imports_sync.py
+++ b/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_list_image_imports_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_list_migrating_vms_async.py
+++ b/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_list_migrating_vms_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_list_migrating_vms_sync.py
+++ b/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_list_migrating_vms_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_list_replication_cycles_async.py
+++ b/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_list_replication_cycles_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_list_replication_cycles_sync.py
+++ b/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_list_replication_cycles_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_list_sources_async.py
+++ b/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_list_sources_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_list_sources_sync.py
+++ b/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_list_sources_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_list_target_projects_async.py
+++ b/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_list_target_projects_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_list_target_projects_sync.py
+++ b/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_list_target_projects_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_list_utilization_reports_async.py
+++ b/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_list_utilization_reports_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_list_utilization_reports_sync.py
+++ b/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_list_utilization_reports_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_pause_migration_sync.py
+++ b/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_pause_migration_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_remove_group_migration_sync.py
+++ b/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_remove_group_migration_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_resume_migration_sync.py
+++ b/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_resume_migration_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_run_disk_migration_job_sync.py
+++ b/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_run_disk_migration_job_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_start_migration_sync.py
+++ b/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_start_migration_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_update_disk_migration_job_sync.py
+++ b/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_update_disk_migration_job_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_update_group_sync.py
+++ b/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_update_group_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_update_migrating_vm_sync.py
+++ b/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_update_migrating_vm_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_update_source_sync.py
+++ b/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_update_source_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_update_target_project_sync.py
+++ b/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_update_target_project_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_upgrade_appliance_sync.py
+++ b/packages/google-cloud-vm-migration/samples/generated_samples/vmmigration_v1_generated_vm_migration_upgrade_appliance_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vm-migration/tests/__init__.py
+++ b/packages/google-cloud-vm-migration/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vm-migration/tests/unit/__init__.py
+++ b/packages/google-cloud-vm-migration/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vm-migration/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-vm-migration/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vm-migration/tests/unit/gapic/vmmigration_v1/__init__.py
+++ b/packages/google-cloud-vm-migration/tests/unit/gapic/vmmigration_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/.flake8
+++ b/packages/google-cloud-vmwareengine/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/MANIFEST.in
+++ b/packages/google-cloud-vmwareengine/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/google/cloud/vmwareengine/__init__.py
+++ b/packages/google-cloud-vmwareengine/google/cloud/vmwareengine/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/google/cloud/vmwareengine/gapic_version.py
+++ b/packages/google-cloud-vmwareengine/google/cloud/vmwareengine/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/google/cloud/vmwareengine_v1/gapic_version.py
+++ b/packages/google-cloud-vmwareengine/google/cloud/vmwareengine_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/google/cloud/vmwareengine_v1/services/__init__.py
+++ b/packages/google-cloud-vmwareengine/google/cloud/vmwareengine_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/google/cloud/vmwareengine_v1/services/vmware_engine/__init__.py
+++ b/packages/google-cloud-vmwareengine/google/cloud/vmwareengine_v1/services/vmware_engine/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/google/cloud/vmwareengine_v1/services/vmware_engine/client.py
+++ b/packages/google-cloud-vmwareengine/google/cloud/vmwareengine_v1/services/vmware_engine/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/google/cloud/vmwareengine_v1/services/vmware_engine/pagers.py
+++ b/packages/google-cloud-vmwareengine/google/cloud/vmwareengine_v1/services/vmware_engine/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/google/cloud/vmwareengine_v1/services/vmware_engine/transports/__init__.py
+++ b/packages/google-cloud-vmwareengine/google/cloud/vmwareengine_v1/services/vmware_engine/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/google/cloud/vmwareengine_v1/services/vmware_engine/transports/base.py
+++ b/packages/google-cloud-vmwareengine/google/cloud/vmwareengine_v1/services/vmware_engine/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/google/cloud/vmwareengine_v1/services/vmware_engine/transports/grpc.py
+++ b/packages/google-cloud-vmwareengine/google/cloud/vmwareengine_v1/services/vmware_engine/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/google/cloud/vmwareengine_v1/services/vmware_engine/transports/grpc_asyncio.py
+++ b/packages/google-cloud-vmwareengine/google/cloud/vmwareengine_v1/services/vmware_engine/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/google/cloud/vmwareengine_v1/services/vmware_engine/transports/rest.py
+++ b/packages/google-cloud-vmwareengine/google/cloud/vmwareengine_v1/services/vmware_engine/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/google/cloud/vmwareengine_v1/services/vmware_engine/transports/rest_base.py
+++ b/packages/google-cloud-vmwareengine/google/cloud/vmwareengine_v1/services/vmware_engine/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/google/cloud/vmwareengine_v1/types/__init__.py
+++ b/packages/google-cloud-vmwareengine/google/cloud/vmwareengine_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/google/cloud/vmwareengine_v1/types/vmwareengine.py
+++ b/packages/google-cloud-vmwareengine/google/cloud/vmwareengine_v1/types/vmwareengine.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/google/cloud/vmwareengine_v1/types/vmwareengine_resources.py
+++ b/packages/google-cloud-vmwareengine/google/cloud/vmwareengine_v1/types/vmwareengine_resources.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_create_cluster_sync.py
+++ b/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_create_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_create_external_access_rule_sync.py
+++ b/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_create_external_access_rule_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_create_external_address_sync.py
+++ b/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_create_external_address_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_create_hcx_activation_key_sync.py
+++ b/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_create_hcx_activation_key_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_create_logging_server_sync.py
+++ b/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_create_logging_server_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_create_management_dns_zone_binding_sync.py
+++ b/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_create_management_dns_zone_binding_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_create_network_peering_sync.py
+++ b/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_create_network_peering_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_create_network_policy_sync.py
+++ b/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_create_network_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_create_private_cloud_sync.py
+++ b/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_create_private_cloud_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_create_private_connection_sync.py
+++ b/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_create_private_connection_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_create_vmware_engine_network_sync.py
+++ b/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_create_vmware_engine_network_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_delete_cluster_sync.py
+++ b/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_delete_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_delete_external_access_rule_sync.py
+++ b/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_delete_external_access_rule_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_delete_external_address_sync.py
+++ b/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_delete_external_address_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_delete_logging_server_sync.py
+++ b/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_delete_logging_server_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_delete_management_dns_zone_binding_sync.py
+++ b/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_delete_management_dns_zone_binding_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_delete_network_peering_sync.py
+++ b/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_delete_network_peering_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_delete_network_policy_sync.py
+++ b/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_delete_network_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_delete_private_cloud_sync.py
+++ b/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_delete_private_cloud_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_delete_private_connection_sync.py
+++ b/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_delete_private_connection_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_delete_vmware_engine_network_sync.py
+++ b/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_delete_vmware_engine_network_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_fetch_network_policy_external_addresses_async.py
+++ b/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_fetch_network_policy_external_addresses_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_fetch_network_policy_external_addresses_sync.py
+++ b/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_fetch_network_policy_external_addresses_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_get_cluster_async.py
+++ b/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_get_cluster_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_get_cluster_sync.py
+++ b/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_get_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_get_dns_bind_permission_async.py
+++ b/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_get_dns_bind_permission_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_get_dns_bind_permission_sync.py
+++ b/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_get_dns_bind_permission_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_get_dns_forwarding_async.py
+++ b/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_get_dns_forwarding_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_get_dns_forwarding_sync.py
+++ b/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_get_dns_forwarding_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_get_external_access_rule_async.py
+++ b/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_get_external_access_rule_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_get_external_access_rule_sync.py
+++ b/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_get_external_access_rule_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_get_external_address_async.py
+++ b/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_get_external_address_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_get_external_address_sync.py
+++ b/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_get_external_address_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_get_hcx_activation_key_async.py
+++ b/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_get_hcx_activation_key_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_get_hcx_activation_key_sync.py
+++ b/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_get_hcx_activation_key_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_get_logging_server_async.py
+++ b/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_get_logging_server_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_get_logging_server_sync.py
+++ b/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_get_logging_server_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_get_management_dns_zone_binding_async.py
+++ b/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_get_management_dns_zone_binding_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_get_management_dns_zone_binding_sync.py
+++ b/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_get_management_dns_zone_binding_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_get_network_peering_async.py
+++ b/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_get_network_peering_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_get_network_peering_sync.py
+++ b/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_get_network_peering_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_get_network_policy_async.py
+++ b/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_get_network_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_get_network_policy_sync.py
+++ b/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_get_network_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_get_node_async.py
+++ b/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_get_node_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_get_node_sync.py
+++ b/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_get_node_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_get_node_type_async.py
+++ b/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_get_node_type_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_get_node_type_sync.py
+++ b/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_get_node_type_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_get_private_cloud_async.py
+++ b/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_get_private_cloud_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_get_private_cloud_sync.py
+++ b/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_get_private_cloud_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_get_private_connection_async.py
+++ b/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_get_private_connection_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_get_private_connection_sync.py
+++ b/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_get_private_connection_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_get_subnet_async.py
+++ b/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_get_subnet_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_get_subnet_sync.py
+++ b/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_get_subnet_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_get_vmware_engine_network_async.py
+++ b/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_get_vmware_engine_network_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_get_vmware_engine_network_sync.py
+++ b/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_get_vmware_engine_network_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_grant_dns_bind_permission_sync.py
+++ b/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_grant_dns_bind_permission_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_list_clusters_async.py
+++ b/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_list_clusters_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_list_clusters_sync.py
+++ b/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_list_clusters_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_list_external_access_rules_async.py
+++ b/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_list_external_access_rules_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_list_external_access_rules_sync.py
+++ b/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_list_external_access_rules_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_list_external_addresses_async.py
+++ b/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_list_external_addresses_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_list_external_addresses_sync.py
+++ b/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_list_external_addresses_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_list_hcx_activation_keys_async.py
+++ b/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_list_hcx_activation_keys_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_list_hcx_activation_keys_sync.py
+++ b/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_list_hcx_activation_keys_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_list_logging_servers_async.py
+++ b/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_list_logging_servers_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_list_logging_servers_sync.py
+++ b/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_list_logging_servers_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_list_management_dns_zone_bindings_async.py
+++ b/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_list_management_dns_zone_bindings_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_list_management_dns_zone_bindings_sync.py
+++ b/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_list_management_dns_zone_bindings_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_list_network_peerings_async.py
+++ b/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_list_network_peerings_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_list_network_peerings_sync.py
+++ b/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_list_network_peerings_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_list_network_policies_async.py
+++ b/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_list_network_policies_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_list_network_policies_sync.py
+++ b/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_list_network_policies_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_list_node_types_async.py
+++ b/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_list_node_types_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_list_node_types_sync.py
+++ b/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_list_node_types_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_list_nodes_async.py
+++ b/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_list_nodes_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_list_nodes_sync.py
+++ b/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_list_nodes_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_list_peering_routes_async.py
+++ b/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_list_peering_routes_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_list_peering_routes_sync.py
+++ b/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_list_peering_routes_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_list_private_clouds_async.py
+++ b/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_list_private_clouds_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_list_private_clouds_sync.py
+++ b/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_list_private_clouds_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_list_private_connection_peering_routes_async.py
+++ b/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_list_private_connection_peering_routes_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_list_private_connection_peering_routes_sync.py
+++ b/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_list_private_connection_peering_routes_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_list_private_connections_async.py
+++ b/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_list_private_connections_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_list_private_connections_sync.py
+++ b/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_list_private_connections_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_list_subnets_async.py
+++ b/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_list_subnets_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_list_subnets_sync.py
+++ b/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_list_subnets_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_list_vmware_engine_networks_async.py
+++ b/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_list_vmware_engine_networks_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_list_vmware_engine_networks_sync.py
+++ b/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_list_vmware_engine_networks_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_repair_management_dns_zone_binding_sync.py
+++ b/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_repair_management_dns_zone_binding_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_reset_nsx_credentials_sync.py
+++ b/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_reset_nsx_credentials_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_reset_vcenter_credentials_sync.py
+++ b/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_reset_vcenter_credentials_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_revoke_dns_bind_permission_sync.py
+++ b/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_revoke_dns_bind_permission_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_show_nsx_credentials_async.py
+++ b/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_show_nsx_credentials_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_show_nsx_credentials_sync.py
+++ b/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_show_nsx_credentials_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_show_vcenter_credentials_async.py
+++ b/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_show_vcenter_credentials_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_show_vcenter_credentials_sync.py
+++ b/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_show_vcenter_credentials_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_undelete_private_cloud_sync.py
+++ b/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_undelete_private_cloud_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_update_cluster_sync.py
+++ b/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_update_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_update_dns_forwarding_sync.py
+++ b/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_update_dns_forwarding_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_update_external_access_rule_sync.py
+++ b/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_update_external_access_rule_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_update_external_address_sync.py
+++ b/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_update_external_address_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_update_logging_server_sync.py
+++ b/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_update_logging_server_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_update_management_dns_zone_binding_sync.py
+++ b/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_update_management_dns_zone_binding_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_update_network_peering_sync.py
+++ b/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_update_network_peering_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_update_network_policy_sync.py
+++ b/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_update_network_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_update_private_cloud_sync.py
+++ b/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_update_private_cloud_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_update_private_connection_sync.py
+++ b/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_update_private_connection_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_update_subnet_sync.py
+++ b/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_update_subnet_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_update_vmware_engine_network_sync.py
+++ b/packages/google-cloud-vmwareengine/samples/generated_samples/vmwareengine_v1_generated_vmware_engine_update_vmware_engine_network_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/tests/__init__.py
+++ b/packages/google-cloud-vmwareengine/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/tests/unit/__init__.py
+++ b/packages/google-cloud-vmwareengine/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-vmwareengine/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vmwareengine/tests/unit/gapic/vmwareengine_v1/__init__.py
+++ b/packages/google-cloud-vmwareengine/tests/unit/gapic/vmwareengine_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vpc-access/.flake8
+++ b/packages/google-cloud-vpc-access/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vpc-access/MANIFEST.in
+++ b/packages/google-cloud-vpc-access/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vpc-access/google/cloud/vpcaccess/__init__.py
+++ b/packages/google-cloud-vpc-access/google/cloud/vpcaccess/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vpc-access/google/cloud/vpcaccess/gapic_version.py
+++ b/packages/google-cloud-vpc-access/google/cloud/vpcaccess/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vpc-access/google/cloud/vpcaccess_v1/gapic_version.py
+++ b/packages/google-cloud-vpc-access/google/cloud/vpcaccess_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vpc-access/google/cloud/vpcaccess_v1/services/__init__.py
+++ b/packages/google-cloud-vpc-access/google/cloud/vpcaccess_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vpc-access/google/cloud/vpcaccess_v1/services/vpc_access_service/__init__.py
+++ b/packages/google-cloud-vpc-access/google/cloud/vpcaccess_v1/services/vpc_access_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vpc-access/google/cloud/vpcaccess_v1/services/vpc_access_service/client.py
+++ b/packages/google-cloud-vpc-access/google/cloud/vpcaccess_v1/services/vpc_access_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vpc-access/google/cloud/vpcaccess_v1/services/vpc_access_service/pagers.py
+++ b/packages/google-cloud-vpc-access/google/cloud/vpcaccess_v1/services/vpc_access_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vpc-access/google/cloud/vpcaccess_v1/services/vpc_access_service/transports/__init__.py
+++ b/packages/google-cloud-vpc-access/google/cloud/vpcaccess_v1/services/vpc_access_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vpc-access/google/cloud/vpcaccess_v1/services/vpc_access_service/transports/base.py
+++ b/packages/google-cloud-vpc-access/google/cloud/vpcaccess_v1/services/vpc_access_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vpc-access/google/cloud/vpcaccess_v1/services/vpc_access_service/transports/grpc.py
+++ b/packages/google-cloud-vpc-access/google/cloud/vpcaccess_v1/services/vpc_access_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vpc-access/google/cloud/vpcaccess_v1/services/vpc_access_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-vpc-access/google/cloud/vpcaccess_v1/services/vpc_access_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vpc-access/google/cloud/vpcaccess_v1/services/vpc_access_service/transports/rest.py
+++ b/packages/google-cloud-vpc-access/google/cloud/vpcaccess_v1/services/vpc_access_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vpc-access/google/cloud/vpcaccess_v1/services/vpc_access_service/transports/rest_base.py
+++ b/packages/google-cloud-vpc-access/google/cloud/vpcaccess_v1/services/vpc_access_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vpc-access/google/cloud/vpcaccess_v1/types/__init__.py
+++ b/packages/google-cloud-vpc-access/google/cloud/vpcaccess_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vpc-access/google/cloud/vpcaccess_v1/types/vpc_access.py
+++ b/packages/google-cloud-vpc-access/google/cloud/vpcaccess_v1/types/vpc_access.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vpc-access/samples/generated_samples/vpcaccess_v1_generated_vpc_access_service_create_connector_sync.py
+++ b/packages/google-cloud-vpc-access/samples/generated_samples/vpcaccess_v1_generated_vpc_access_service_create_connector_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vpc-access/samples/generated_samples/vpcaccess_v1_generated_vpc_access_service_delete_connector_sync.py
+++ b/packages/google-cloud-vpc-access/samples/generated_samples/vpcaccess_v1_generated_vpc_access_service_delete_connector_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vpc-access/samples/generated_samples/vpcaccess_v1_generated_vpc_access_service_get_connector_async.py
+++ b/packages/google-cloud-vpc-access/samples/generated_samples/vpcaccess_v1_generated_vpc_access_service_get_connector_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vpc-access/samples/generated_samples/vpcaccess_v1_generated_vpc_access_service_get_connector_sync.py
+++ b/packages/google-cloud-vpc-access/samples/generated_samples/vpcaccess_v1_generated_vpc_access_service_get_connector_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vpc-access/samples/generated_samples/vpcaccess_v1_generated_vpc_access_service_list_connectors_async.py
+++ b/packages/google-cloud-vpc-access/samples/generated_samples/vpcaccess_v1_generated_vpc_access_service_list_connectors_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vpc-access/samples/generated_samples/vpcaccess_v1_generated_vpc_access_service_list_connectors_sync.py
+++ b/packages/google-cloud-vpc-access/samples/generated_samples/vpcaccess_v1_generated_vpc_access_service_list_connectors_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vpc-access/tests/__init__.py
+++ b/packages/google-cloud-vpc-access/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vpc-access/tests/unit/__init__.py
+++ b/packages/google-cloud-vpc-access/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vpc-access/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-vpc-access/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-vpc-access/tests/unit/gapic/vpcaccess_v1/__init__.py
+++ b/packages/google-cloud-vpc-access/tests/unit/gapic/vpcaccess_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-webrisk/.flake8
+++ b/packages/google-cloud-webrisk/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-webrisk/MANIFEST.in
+++ b/packages/google-cloud-webrisk/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-webrisk/google/cloud/webrisk/__init__.py
+++ b/packages/google-cloud-webrisk/google/cloud/webrisk/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-webrisk/google/cloud/webrisk/gapic_version.py
+++ b/packages/google-cloud-webrisk/google/cloud/webrisk/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-webrisk/google/cloud/webrisk_v1/gapic_version.py
+++ b/packages/google-cloud-webrisk/google/cloud/webrisk_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-webrisk/google/cloud/webrisk_v1/services/__init__.py
+++ b/packages/google-cloud-webrisk/google/cloud/webrisk_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-webrisk/google/cloud/webrisk_v1/services/web_risk_service/__init__.py
+++ b/packages/google-cloud-webrisk/google/cloud/webrisk_v1/services/web_risk_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-webrisk/google/cloud/webrisk_v1/services/web_risk_service/client.py
+++ b/packages/google-cloud-webrisk/google/cloud/webrisk_v1/services/web_risk_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-webrisk/google/cloud/webrisk_v1/services/web_risk_service/transports/__init__.py
+++ b/packages/google-cloud-webrisk/google/cloud/webrisk_v1/services/web_risk_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-webrisk/google/cloud/webrisk_v1/services/web_risk_service/transports/base.py
+++ b/packages/google-cloud-webrisk/google/cloud/webrisk_v1/services/web_risk_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-webrisk/google/cloud/webrisk_v1/services/web_risk_service/transports/grpc.py
+++ b/packages/google-cloud-webrisk/google/cloud/webrisk_v1/services/web_risk_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-webrisk/google/cloud/webrisk_v1/services/web_risk_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-webrisk/google/cloud/webrisk_v1/services/web_risk_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-webrisk/google/cloud/webrisk_v1/services/web_risk_service/transports/rest.py
+++ b/packages/google-cloud-webrisk/google/cloud/webrisk_v1/services/web_risk_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-webrisk/google/cloud/webrisk_v1/services/web_risk_service/transports/rest_base.py
+++ b/packages/google-cloud-webrisk/google/cloud/webrisk_v1/services/web_risk_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-webrisk/google/cloud/webrisk_v1/types/__init__.py
+++ b/packages/google-cloud-webrisk/google/cloud/webrisk_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-webrisk/google/cloud/webrisk_v1/types/webrisk.py
+++ b/packages/google-cloud-webrisk/google/cloud/webrisk_v1/types/webrisk.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-webrisk/google/cloud/webrisk_v1beta1/gapic_version.py
+++ b/packages/google-cloud-webrisk/google/cloud/webrisk_v1beta1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-webrisk/google/cloud/webrisk_v1beta1/services/__init__.py
+++ b/packages/google-cloud-webrisk/google/cloud/webrisk_v1beta1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-webrisk/google/cloud/webrisk_v1beta1/services/web_risk_service_v1_beta1/__init__.py
+++ b/packages/google-cloud-webrisk/google/cloud/webrisk_v1beta1/services/web_risk_service_v1_beta1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-webrisk/google/cloud/webrisk_v1beta1/services/web_risk_service_v1_beta1/async_client.py
+++ b/packages/google-cloud-webrisk/google/cloud/webrisk_v1beta1/services/web_risk_service_v1_beta1/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-webrisk/google/cloud/webrisk_v1beta1/services/web_risk_service_v1_beta1/client.py
+++ b/packages/google-cloud-webrisk/google/cloud/webrisk_v1beta1/services/web_risk_service_v1_beta1/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-webrisk/google/cloud/webrisk_v1beta1/services/web_risk_service_v1_beta1/transports/__init__.py
+++ b/packages/google-cloud-webrisk/google/cloud/webrisk_v1beta1/services/web_risk_service_v1_beta1/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-webrisk/google/cloud/webrisk_v1beta1/services/web_risk_service_v1_beta1/transports/base.py
+++ b/packages/google-cloud-webrisk/google/cloud/webrisk_v1beta1/services/web_risk_service_v1_beta1/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-webrisk/google/cloud/webrisk_v1beta1/services/web_risk_service_v1_beta1/transports/grpc.py
+++ b/packages/google-cloud-webrisk/google/cloud/webrisk_v1beta1/services/web_risk_service_v1_beta1/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-webrisk/google/cloud/webrisk_v1beta1/services/web_risk_service_v1_beta1/transports/grpc_asyncio.py
+++ b/packages/google-cloud-webrisk/google/cloud/webrisk_v1beta1/services/web_risk_service_v1_beta1/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-webrisk/google/cloud/webrisk_v1beta1/services/web_risk_service_v1_beta1/transports/rest.py
+++ b/packages/google-cloud-webrisk/google/cloud/webrisk_v1beta1/services/web_risk_service_v1_beta1/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-webrisk/google/cloud/webrisk_v1beta1/services/web_risk_service_v1_beta1/transports/rest_base.py
+++ b/packages/google-cloud-webrisk/google/cloud/webrisk_v1beta1/services/web_risk_service_v1_beta1/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-webrisk/google/cloud/webrisk_v1beta1/types/__init__.py
+++ b/packages/google-cloud-webrisk/google/cloud/webrisk_v1beta1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-webrisk/google/cloud/webrisk_v1beta1/types/webrisk.py
+++ b/packages/google-cloud-webrisk/google/cloud/webrisk_v1beta1/types/webrisk.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-webrisk/samples/generated_samples/webrisk_v1_generated_web_risk_service_compute_threat_list_diff_async.py
+++ b/packages/google-cloud-webrisk/samples/generated_samples/webrisk_v1_generated_web_risk_service_compute_threat_list_diff_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-webrisk/samples/generated_samples/webrisk_v1_generated_web_risk_service_compute_threat_list_diff_sync.py
+++ b/packages/google-cloud-webrisk/samples/generated_samples/webrisk_v1_generated_web_risk_service_compute_threat_list_diff_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-webrisk/samples/generated_samples/webrisk_v1_generated_web_risk_service_create_submission_async.py
+++ b/packages/google-cloud-webrisk/samples/generated_samples/webrisk_v1_generated_web_risk_service_create_submission_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-webrisk/samples/generated_samples/webrisk_v1_generated_web_risk_service_create_submission_sync.py
+++ b/packages/google-cloud-webrisk/samples/generated_samples/webrisk_v1_generated_web_risk_service_create_submission_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-webrisk/samples/generated_samples/webrisk_v1_generated_web_risk_service_search_hashes_async.py
+++ b/packages/google-cloud-webrisk/samples/generated_samples/webrisk_v1_generated_web_risk_service_search_hashes_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-webrisk/samples/generated_samples/webrisk_v1_generated_web_risk_service_search_hashes_sync.py
+++ b/packages/google-cloud-webrisk/samples/generated_samples/webrisk_v1_generated_web_risk_service_search_hashes_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-webrisk/samples/generated_samples/webrisk_v1_generated_web_risk_service_search_uris_async.py
+++ b/packages/google-cloud-webrisk/samples/generated_samples/webrisk_v1_generated_web_risk_service_search_uris_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-webrisk/samples/generated_samples/webrisk_v1_generated_web_risk_service_search_uris_sync.py
+++ b/packages/google-cloud-webrisk/samples/generated_samples/webrisk_v1_generated_web_risk_service_search_uris_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-webrisk/samples/generated_samples/webrisk_v1_generated_web_risk_service_submit_uri_sync.py
+++ b/packages/google-cloud-webrisk/samples/generated_samples/webrisk_v1_generated_web_risk_service_submit_uri_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-webrisk/samples/generated_samples/webrisk_v1beta1_generated_web_risk_service_v1_beta1_compute_threat_list_diff_async.py
+++ b/packages/google-cloud-webrisk/samples/generated_samples/webrisk_v1beta1_generated_web_risk_service_v1_beta1_compute_threat_list_diff_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-webrisk/samples/generated_samples/webrisk_v1beta1_generated_web_risk_service_v1_beta1_compute_threat_list_diff_sync.py
+++ b/packages/google-cloud-webrisk/samples/generated_samples/webrisk_v1beta1_generated_web_risk_service_v1_beta1_compute_threat_list_diff_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-webrisk/samples/generated_samples/webrisk_v1beta1_generated_web_risk_service_v1_beta1_search_hashes_async.py
+++ b/packages/google-cloud-webrisk/samples/generated_samples/webrisk_v1beta1_generated_web_risk_service_v1_beta1_search_hashes_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-webrisk/samples/generated_samples/webrisk_v1beta1_generated_web_risk_service_v1_beta1_search_hashes_sync.py
+++ b/packages/google-cloud-webrisk/samples/generated_samples/webrisk_v1beta1_generated_web_risk_service_v1_beta1_search_hashes_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-webrisk/samples/generated_samples/webrisk_v1beta1_generated_web_risk_service_v1_beta1_search_uris_async.py
+++ b/packages/google-cloud-webrisk/samples/generated_samples/webrisk_v1beta1_generated_web_risk_service_v1_beta1_search_uris_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-webrisk/samples/generated_samples/webrisk_v1beta1_generated_web_risk_service_v1_beta1_search_uris_sync.py
+++ b/packages/google-cloud-webrisk/samples/generated_samples/webrisk_v1beta1_generated_web_risk_service_v1_beta1_search_uris_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-webrisk/tests/__init__.py
+++ b/packages/google-cloud-webrisk/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-webrisk/tests/unit/__init__.py
+++ b/packages/google-cloud-webrisk/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-webrisk/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-webrisk/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-webrisk/tests/unit/gapic/webrisk_v1/__init__.py
+++ b/packages/google-cloud-webrisk/tests/unit/gapic/webrisk_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-webrisk/tests/unit/gapic/webrisk_v1beta1/__init__.py
+++ b/packages/google-cloud-webrisk/tests/unit/gapic/webrisk_v1beta1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/.flake8
+++ b/packages/google-cloud-websecurityscanner/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/MANIFEST.in
+++ b/packages/google-cloud-websecurityscanner/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner/__init__.py
+++ b/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner/gapic_version.py
+++ b/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1/gapic_version.py
+++ b/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1/services/__init__.py
+++ b/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1/services/web_security_scanner/__init__.py
+++ b/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1/services/web_security_scanner/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1/services/web_security_scanner/async_client.py
+++ b/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1/services/web_security_scanner/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1/services/web_security_scanner/client.py
+++ b/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1/services/web_security_scanner/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1/services/web_security_scanner/pagers.py
+++ b/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1/services/web_security_scanner/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1/services/web_security_scanner/transports/__init__.py
+++ b/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1/services/web_security_scanner/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1/services/web_security_scanner/transports/base.py
+++ b/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1/services/web_security_scanner/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1/services/web_security_scanner/transports/grpc.py
+++ b/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1/services/web_security_scanner/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1/services/web_security_scanner/transports/grpc_asyncio.py
+++ b/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1/services/web_security_scanner/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1/services/web_security_scanner/transports/rest.py
+++ b/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1/services/web_security_scanner/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1/services/web_security_scanner/transports/rest_base.py
+++ b/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1/services/web_security_scanner/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1/types/__init__.py
+++ b/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1/types/crawled_url.py
+++ b/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1/types/crawled_url.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1/types/finding.py
+++ b/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1/types/finding.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1/types/finding_addon.py
+++ b/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1/types/finding_addon.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1/types/finding_type_stats.py
+++ b/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1/types/finding_type_stats.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1/types/scan_config.py
+++ b/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1/types/scan_config.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1/types/scan_config_error.py
+++ b/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1/types/scan_config_error.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1/types/scan_run.py
+++ b/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1/types/scan_run.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1/types/scan_run_error_trace.py
+++ b/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1/types/scan_run_error_trace.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1/types/scan_run_log.py
+++ b/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1/types/scan_run_log.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1/types/scan_run_warning_trace.py
+++ b/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1/types/scan_run_warning_trace.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1/types/web_security_scanner.py
+++ b/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1/types/web_security_scanner.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1alpha/gapic_version.py
+++ b/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1alpha/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1alpha/services/__init__.py
+++ b/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1alpha/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1alpha/services/web_security_scanner/__init__.py
+++ b/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1alpha/services/web_security_scanner/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1alpha/services/web_security_scanner/async_client.py
+++ b/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1alpha/services/web_security_scanner/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1alpha/services/web_security_scanner/client.py
+++ b/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1alpha/services/web_security_scanner/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1alpha/services/web_security_scanner/pagers.py
+++ b/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1alpha/services/web_security_scanner/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1alpha/services/web_security_scanner/transports/__init__.py
+++ b/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1alpha/services/web_security_scanner/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1alpha/services/web_security_scanner/transports/base.py
+++ b/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1alpha/services/web_security_scanner/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1alpha/services/web_security_scanner/transports/grpc.py
+++ b/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1alpha/services/web_security_scanner/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1alpha/services/web_security_scanner/transports/grpc_asyncio.py
+++ b/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1alpha/services/web_security_scanner/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1alpha/services/web_security_scanner/transports/rest.py
+++ b/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1alpha/services/web_security_scanner/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1alpha/services/web_security_scanner/transports/rest_base.py
+++ b/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1alpha/services/web_security_scanner/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1alpha/types/__init__.py
+++ b/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1alpha/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1alpha/types/crawled_url.py
+++ b/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1alpha/types/crawled_url.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1alpha/types/finding.py
+++ b/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1alpha/types/finding.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1alpha/types/finding_addon.py
+++ b/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1alpha/types/finding_addon.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1alpha/types/finding_type_stats.py
+++ b/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1alpha/types/finding_type_stats.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1alpha/types/scan_config.py
+++ b/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1alpha/types/scan_config.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1alpha/types/scan_run.py
+++ b/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1alpha/types/scan_run.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1alpha/types/web_security_scanner.py
+++ b/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1alpha/types/web_security_scanner.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1beta/gapic_version.py
+++ b/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1beta/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1beta/services/__init__.py
+++ b/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1beta/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1beta/services/web_security_scanner/__init__.py
+++ b/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1beta/services/web_security_scanner/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1beta/services/web_security_scanner/async_client.py
+++ b/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1beta/services/web_security_scanner/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1beta/services/web_security_scanner/client.py
+++ b/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1beta/services/web_security_scanner/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1beta/services/web_security_scanner/pagers.py
+++ b/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1beta/services/web_security_scanner/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1beta/services/web_security_scanner/transports/__init__.py
+++ b/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1beta/services/web_security_scanner/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1beta/services/web_security_scanner/transports/base.py
+++ b/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1beta/services/web_security_scanner/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1beta/services/web_security_scanner/transports/grpc.py
+++ b/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1beta/services/web_security_scanner/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1beta/services/web_security_scanner/transports/grpc_asyncio.py
+++ b/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1beta/services/web_security_scanner/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1beta/services/web_security_scanner/transports/rest.py
+++ b/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1beta/services/web_security_scanner/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1beta/services/web_security_scanner/transports/rest_base.py
+++ b/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1beta/services/web_security_scanner/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1beta/types/__init__.py
+++ b/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1beta/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1beta/types/crawled_url.py
+++ b/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1beta/types/crawled_url.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1beta/types/finding.py
+++ b/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1beta/types/finding.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1beta/types/finding_addon.py
+++ b/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1beta/types/finding_addon.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1beta/types/finding_type_stats.py
+++ b/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1beta/types/finding_type_stats.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1beta/types/scan_config.py
+++ b/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1beta/types/scan_config.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1beta/types/scan_config_error.py
+++ b/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1beta/types/scan_config_error.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1beta/types/scan_run.py
+++ b/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1beta/types/scan_run.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1beta/types/scan_run_error_trace.py
+++ b/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1beta/types/scan_run_error_trace.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1beta/types/scan_run_warning_trace.py
+++ b/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1beta/types/scan_run_warning_trace.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1beta/types/web_security_scanner.py
+++ b/packages/google-cloud-websecurityscanner/google/cloud/websecurityscanner_v1beta/types/web_security_scanner.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1_generated_web_security_scanner_create_scan_config_async.py
+++ b/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1_generated_web_security_scanner_create_scan_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1_generated_web_security_scanner_create_scan_config_sync.py
+++ b/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1_generated_web_security_scanner_create_scan_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1_generated_web_security_scanner_delete_scan_config_async.py
+++ b/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1_generated_web_security_scanner_delete_scan_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1_generated_web_security_scanner_delete_scan_config_sync.py
+++ b/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1_generated_web_security_scanner_delete_scan_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1_generated_web_security_scanner_get_finding_async.py
+++ b/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1_generated_web_security_scanner_get_finding_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1_generated_web_security_scanner_get_finding_sync.py
+++ b/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1_generated_web_security_scanner_get_finding_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1_generated_web_security_scanner_get_scan_config_async.py
+++ b/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1_generated_web_security_scanner_get_scan_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1_generated_web_security_scanner_get_scan_config_sync.py
+++ b/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1_generated_web_security_scanner_get_scan_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1_generated_web_security_scanner_get_scan_run_async.py
+++ b/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1_generated_web_security_scanner_get_scan_run_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1_generated_web_security_scanner_get_scan_run_sync.py
+++ b/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1_generated_web_security_scanner_get_scan_run_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1_generated_web_security_scanner_list_crawled_urls_async.py
+++ b/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1_generated_web_security_scanner_list_crawled_urls_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1_generated_web_security_scanner_list_crawled_urls_sync.py
+++ b/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1_generated_web_security_scanner_list_crawled_urls_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1_generated_web_security_scanner_list_finding_type_stats_async.py
+++ b/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1_generated_web_security_scanner_list_finding_type_stats_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1_generated_web_security_scanner_list_finding_type_stats_sync.py
+++ b/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1_generated_web_security_scanner_list_finding_type_stats_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1_generated_web_security_scanner_list_findings_async.py
+++ b/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1_generated_web_security_scanner_list_findings_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1_generated_web_security_scanner_list_findings_sync.py
+++ b/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1_generated_web_security_scanner_list_findings_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1_generated_web_security_scanner_list_scan_configs_async.py
+++ b/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1_generated_web_security_scanner_list_scan_configs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1_generated_web_security_scanner_list_scan_configs_sync.py
+++ b/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1_generated_web_security_scanner_list_scan_configs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1_generated_web_security_scanner_list_scan_runs_async.py
+++ b/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1_generated_web_security_scanner_list_scan_runs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1_generated_web_security_scanner_list_scan_runs_sync.py
+++ b/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1_generated_web_security_scanner_list_scan_runs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1_generated_web_security_scanner_start_scan_run_async.py
+++ b/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1_generated_web_security_scanner_start_scan_run_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1_generated_web_security_scanner_start_scan_run_sync.py
+++ b/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1_generated_web_security_scanner_start_scan_run_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1_generated_web_security_scanner_stop_scan_run_async.py
+++ b/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1_generated_web_security_scanner_stop_scan_run_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1_generated_web_security_scanner_stop_scan_run_sync.py
+++ b/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1_generated_web_security_scanner_stop_scan_run_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1_generated_web_security_scanner_update_scan_config_async.py
+++ b/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1_generated_web_security_scanner_update_scan_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1_generated_web_security_scanner_update_scan_config_sync.py
+++ b/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1_generated_web_security_scanner_update_scan_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1alpha_generated_web_security_scanner_create_scan_config_async.py
+++ b/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1alpha_generated_web_security_scanner_create_scan_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1alpha_generated_web_security_scanner_create_scan_config_sync.py
+++ b/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1alpha_generated_web_security_scanner_create_scan_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1alpha_generated_web_security_scanner_delete_scan_config_async.py
+++ b/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1alpha_generated_web_security_scanner_delete_scan_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1alpha_generated_web_security_scanner_delete_scan_config_sync.py
+++ b/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1alpha_generated_web_security_scanner_delete_scan_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1alpha_generated_web_security_scanner_get_finding_async.py
+++ b/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1alpha_generated_web_security_scanner_get_finding_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1alpha_generated_web_security_scanner_get_finding_sync.py
+++ b/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1alpha_generated_web_security_scanner_get_finding_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1alpha_generated_web_security_scanner_get_scan_config_async.py
+++ b/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1alpha_generated_web_security_scanner_get_scan_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1alpha_generated_web_security_scanner_get_scan_config_sync.py
+++ b/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1alpha_generated_web_security_scanner_get_scan_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1alpha_generated_web_security_scanner_get_scan_run_async.py
+++ b/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1alpha_generated_web_security_scanner_get_scan_run_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1alpha_generated_web_security_scanner_get_scan_run_sync.py
+++ b/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1alpha_generated_web_security_scanner_get_scan_run_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1alpha_generated_web_security_scanner_list_crawled_urls_async.py
+++ b/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1alpha_generated_web_security_scanner_list_crawled_urls_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1alpha_generated_web_security_scanner_list_crawled_urls_sync.py
+++ b/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1alpha_generated_web_security_scanner_list_crawled_urls_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1alpha_generated_web_security_scanner_list_finding_type_stats_async.py
+++ b/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1alpha_generated_web_security_scanner_list_finding_type_stats_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1alpha_generated_web_security_scanner_list_finding_type_stats_sync.py
+++ b/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1alpha_generated_web_security_scanner_list_finding_type_stats_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1alpha_generated_web_security_scanner_list_findings_async.py
+++ b/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1alpha_generated_web_security_scanner_list_findings_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1alpha_generated_web_security_scanner_list_findings_sync.py
+++ b/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1alpha_generated_web_security_scanner_list_findings_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1alpha_generated_web_security_scanner_list_scan_configs_async.py
+++ b/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1alpha_generated_web_security_scanner_list_scan_configs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1alpha_generated_web_security_scanner_list_scan_configs_sync.py
+++ b/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1alpha_generated_web_security_scanner_list_scan_configs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1alpha_generated_web_security_scanner_list_scan_runs_async.py
+++ b/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1alpha_generated_web_security_scanner_list_scan_runs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1alpha_generated_web_security_scanner_list_scan_runs_sync.py
+++ b/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1alpha_generated_web_security_scanner_list_scan_runs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1alpha_generated_web_security_scanner_start_scan_run_async.py
+++ b/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1alpha_generated_web_security_scanner_start_scan_run_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1alpha_generated_web_security_scanner_start_scan_run_sync.py
+++ b/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1alpha_generated_web_security_scanner_start_scan_run_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1alpha_generated_web_security_scanner_stop_scan_run_async.py
+++ b/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1alpha_generated_web_security_scanner_stop_scan_run_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1alpha_generated_web_security_scanner_stop_scan_run_sync.py
+++ b/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1alpha_generated_web_security_scanner_stop_scan_run_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1alpha_generated_web_security_scanner_update_scan_config_async.py
+++ b/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1alpha_generated_web_security_scanner_update_scan_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1alpha_generated_web_security_scanner_update_scan_config_sync.py
+++ b/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1alpha_generated_web_security_scanner_update_scan_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1beta_generated_web_security_scanner_create_scan_config_async.py
+++ b/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1beta_generated_web_security_scanner_create_scan_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1beta_generated_web_security_scanner_create_scan_config_sync.py
+++ b/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1beta_generated_web_security_scanner_create_scan_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1beta_generated_web_security_scanner_delete_scan_config_async.py
+++ b/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1beta_generated_web_security_scanner_delete_scan_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1beta_generated_web_security_scanner_delete_scan_config_sync.py
+++ b/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1beta_generated_web_security_scanner_delete_scan_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1beta_generated_web_security_scanner_get_finding_async.py
+++ b/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1beta_generated_web_security_scanner_get_finding_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1beta_generated_web_security_scanner_get_finding_sync.py
+++ b/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1beta_generated_web_security_scanner_get_finding_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1beta_generated_web_security_scanner_get_scan_config_async.py
+++ b/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1beta_generated_web_security_scanner_get_scan_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1beta_generated_web_security_scanner_get_scan_config_sync.py
+++ b/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1beta_generated_web_security_scanner_get_scan_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1beta_generated_web_security_scanner_get_scan_run_async.py
+++ b/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1beta_generated_web_security_scanner_get_scan_run_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1beta_generated_web_security_scanner_get_scan_run_sync.py
+++ b/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1beta_generated_web_security_scanner_get_scan_run_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1beta_generated_web_security_scanner_list_crawled_urls_async.py
+++ b/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1beta_generated_web_security_scanner_list_crawled_urls_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1beta_generated_web_security_scanner_list_crawled_urls_sync.py
+++ b/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1beta_generated_web_security_scanner_list_crawled_urls_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1beta_generated_web_security_scanner_list_finding_type_stats_async.py
+++ b/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1beta_generated_web_security_scanner_list_finding_type_stats_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1beta_generated_web_security_scanner_list_finding_type_stats_sync.py
+++ b/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1beta_generated_web_security_scanner_list_finding_type_stats_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1beta_generated_web_security_scanner_list_findings_async.py
+++ b/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1beta_generated_web_security_scanner_list_findings_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1beta_generated_web_security_scanner_list_findings_sync.py
+++ b/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1beta_generated_web_security_scanner_list_findings_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1beta_generated_web_security_scanner_list_scan_configs_async.py
+++ b/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1beta_generated_web_security_scanner_list_scan_configs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1beta_generated_web_security_scanner_list_scan_configs_sync.py
+++ b/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1beta_generated_web_security_scanner_list_scan_configs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1beta_generated_web_security_scanner_list_scan_runs_async.py
+++ b/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1beta_generated_web_security_scanner_list_scan_runs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1beta_generated_web_security_scanner_list_scan_runs_sync.py
+++ b/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1beta_generated_web_security_scanner_list_scan_runs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1beta_generated_web_security_scanner_start_scan_run_async.py
+++ b/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1beta_generated_web_security_scanner_start_scan_run_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1beta_generated_web_security_scanner_start_scan_run_sync.py
+++ b/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1beta_generated_web_security_scanner_start_scan_run_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1beta_generated_web_security_scanner_stop_scan_run_async.py
+++ b/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1beta_generated_web_security_scanner_stop_scan_run_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1beta_generated_web_security_scanner_stop_scan_run_sync.py
+++ b/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1beta_generated_web_security_scanner_stop_scan_run_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1beta_generated_web_security_scanner_update_scan_config_async.py
+++ b/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1beta_generated_web_security_scanner_update_scan_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1beta_generated_web_security_scanner_update_scan_config_sync.py
+++ b/packages/google-cloud-websecurityscanner/samples/generated_samples/websecurityscanner_v1beta_generated_web_security_scanner_update_scan_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/tests/__init__.py
+++ b/packages/google-cloud-websecurityscanner/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/tests/unit/__init__.py
+++ b/packages/google-cloud-websecurityscanner/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-websecurityscanner/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/tests/unit/gapic/websecurityscanner_v1/__init__.py
+++ b/packages/google-cloud-websecurityscanner/tests/unit/gapic/websecurityscanner_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/tests/unit/gapic/websecurityscanner_v1alpha/__init__.py
+++ b/packages/google-cloud-websecurityscanner/tests/unit/gapic/websecurityscanner_v1alpha/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-websecurityscanner/tests/unit/gapic/websecurityscanner_v1beta/__init__.py
+++ b/packages/google-cloud-websecurityscanner/tests/unit/gapic/websecurityscanner_v1beta/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workflows/.flake8
+++ b/packages/google-cloud-workflows/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workflows/MANIFEST.in
+++ b/packages/google-cloud-workflows/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workflows/google/cloud/workflows/__init__.py
+++ b/packages/google-cloud-workflows/google/cloud/workflows/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workflows/google/cloud/workflows/executions/__init__.py
+++ b/packages/google-cloud-workflows/google/cloud/workflows/executions/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workflows/google/cloud/workflows/executions/gapic_version.py
+++ b/packages/google-cloud-workflows/google/cloud/workflows/executions/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workflows/google/cloud/workflows/executions_v1/gapic_version.py
+++ b/packages/google-cloud-workflows/google/cloud/workflows/executions_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workflows/google/cloud/workflows/executions_v1/services/__init__.py
+++ b/packages/google-cloud-workflows/google/cloud/workflows/executions_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workflows/google/cloud/workflows/executions_v1/services/executions/__init__.py
+++ b/packages/google-cloud-workflows/google/cloud/workflows/executions_v1/services/executions/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workflows/google/cloud/workflows/executions_v1/services/executions/async_client.py
+++ b/packages/google-cloud-workflows/google/cloud/workflows/executions_v1/services/executions/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workflows/google/cloud/workflows/executions_v1/services/executions/client.py
+++ b/packages/google-cloud-workflows/google/cloud/workflows/executions_v1/services/executions/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workflows/google/cloud/workflows/executions_v1/services/executions/pagers.py
+++ b/packages/google-cloud-workflows/google/cloud/workflows/executions_v1/services/executions/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workflows/google/cloud/workflows/executions_v1/services/executions/transports/__init__.py
+++ b/packages/google-cloud-workflows/google/cloud/workflows/executions_v1/services/executions/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workflows/google/cloud/workflows/executions_v1/services/executions/transports/base.py
+++ b/packages/google-cloud-workflows/google/cloud/workflows/executions_v1/services/executions/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workflows/google/cloud/workflows/executions_v1/services/executions/transports/grpc.py
+++ b/packages/google-cloud-workflows/google/cloud/workflows/executions_v1/services/executions/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workflows/google/cloud/workflows/executions_v1/services/executions/transports/grpc_asyncio.py
+++ b/packages/google-cloud-workflows/google/cloud/workflows/executions_v1/services/executions/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workflows/google/cloud/workflows/executions_v1/types/__init__.py
+++ b/packages/google-cloud-workflows/google/cloud/workflows/executions_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workflows/google/cloud/workflows/executions_v1/types/executions.py
+++ b/packages/google-cloud-workflows/google/cloud/workflows/executions_v1/types/executions.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workflows/google/cloud/workflows/executions_v1beta/gapic_version.py
+++ b/packages/google-cloud-workflows/google/cloud/workflows/executions_v1beta/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workflows/google/cloud/workflows/executions_v1beta/services/__init__.py
+++ b/packages/google-cloud-workflows/google/cloud/workflows/executions_v1beta/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workflows/google/cloud/workflows/executions_v1beta/services/executions/__init__.py
+++ b/packages/google-cloud-workflows/google/cloud/workflows/executions_v1beta/services/executions/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workflows/google/cloud/workflows/executions_v1beta/services/executions/async_client.py
+++ b/packages/google-cloud-workflows/google/cloud/workflows/executions_v1beta/services/executions/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workflows/google/cloud/workflows/executions_v1beta/services/executions/client.py
+++ b/packages/google-cloud-workflows/google/cloud/workflows/executions_v1beta/services/executions/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workflows/google/cloud/workflows/executions_v1beta/services/executions/pagers.py
+++ b/packages/google-cloud-workflows/google/cloud/workflows/executions_v1beta/services/executions/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workflows/google/cloud/workflows/executions_v1beta/services/executions/transports/__init__.py
+++ b/packages/google-cloud-workflows/google/cloud/workflows/executions_v1beta/services/executions/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workflows/google/cloud/workflows/executions_v1beta/services/executions/transports/base.py
+++ b/packages/google-cloud-workflows/google/cloud/workflows/executions_v1beta/services/executions/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workflows/google/cloud/workflows/executions_v1beta/services/executions/transports/grpc.py
+++ b/packages/google-cloud-workflows/google/cloud/workflows/executions_v1beta/services/executions/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workflows/google/cloud/workflows/executions_v1beta/services/executions/transports/grpc_asyncio.py
+++ b/packages/google-cloud-workflows/google/cloud/workflows/executions_v1beta/services/executions/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workflows/google/cloud/workflows/executions_v1beta/types/__init__.py
+++ b/packages/google-cloud-workflows/google/cloud/workflows/executions_v1beta/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workflows/google/cloud/workflows/executions_v1beta/types/executions.py
+++ b/packages/google-cloud-workflows/google/cloud/workflows/executions_v1beta/types/executions.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workflows/google/cloud/workflows/gapic_version.py
+++ b/packages/google-cloud-workflows/google/cloud/workflows/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workflows/google/cloud/workflows_v1/gapic_version.py
+++ b/packages/google-cloud-workflows/google/cloud/workflows_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workflows/google/cloud/workflows_v1/services/__init__.py
+++ b/packages/google-cloud-workflows/google/cloud/workflows_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workflows/google/cloud/workflows_v1/services/workflows/__init__.py
+++ b/packages/google-cloud-workflows/google/cloud/workflows_v1/services/workflows/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workflows/google/cloud/workflows_v1/services/workflows/client.py
+++ b/packages/google-cloud-workflows/google/cloud/workflows_v1/services/workflows/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workflows/google/cloud/workflows_v1/services/workflows/pagers.py
+++ b/packages/google-cloud-workflows/google/cloud/workflows_v1/services/workflows/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workflows/google/cloud/workflows_v1/services/workflows/transports/__init__.py
+++ b/packages/google-cloud-workflows/google/cloud/workflows_v1/services/workflows/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workflows/google/cloud/workflows_v1/services/workflows/transports/base.py
+++ b/packages/google-cloud-workflows/google/cloud/workflows_v1/services/workflows/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workflows/google/cloud/workflows_v1/services/workflows/transports/grpc.py
+++ b/packages/google-cloud-workflows/google/cloud/workflows_v1/services/workflows/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workflows/google/cloud/workflows_v1/services/workflows/transports/grpc_asyncio.py
+++ b/packages/google-cloud-workflows/google/cloud/workflows_v1/services/workflows/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workflows/google/cloud/workflows_v1/services/workflows/transports/rest.py
+++ b/packages/google-cloud-workflows/google/cloud/workflows_v1/services/workflows/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workflows/google/cloud/workflows_v1/services/workflows/transports/rest_base.py
+++ b/packages/google-cloud-workflows/google/cloud/workflows_v1/services/workflows/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workflows/google/cloud/workflows_v1/types/__init__.py
+++ b/packages/google-cloud-workflows/google/cloud/workflows_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workflows/google/cloud/workflows_v1beta/gapic_version.py
+++ b/packages/google-cloud-workflows/google/cloud/workflows_v1beta/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workflows/google/cloud/workflows_v1beta/services/__init__.py
+++ b/packages/google-cloud-workflows/google/cloud/workflows_v1beta/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workflows/google/cloud/workflows_v1beta/services/workflows/__init__.py
+++ b/packages/google-cloud-workflows/google/cloud/workflows_v1beta/services/workflows/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workflows/google/cloud/workflows_v1beta/services/workflows/client.py
+++ b/packages/google-cloud-workflows/google/cloud/workflows_v1beta/services/workflows/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workflows/google/cloud/workflows_v1beta/services/workflows/pagers.py
+++ b/packages/google-cloud-workflows/google/cloud/workflows_v1beta/services/workflows/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workflows/google/cloud/workflows_v1beta/services/workflows/transports/__init__.py
+++ b/packages/google-cloud-workflows/google/cloud/workflows_v1beta/services/workflows/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workflows/google/cloud/workflows_v1beta/services/workflows/transports/base.py
+++ b/packages/google-cloud-workflows/google/cloud/workflows_v1beta/services/workflows/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workflows/google/cloud/workflows_v1beta/services/workflows/transports/grpc.py
+++ b/packages/google-cloud-workflows/google/cloud/workflows_v1beta/services/workflows/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workflows/google/cloud/workflows_v1beta/services/workflows/transports/grpc_asyncio.py
+++ b/packages/google-cloud-workflows/google/cloud/workflows_v1beta/services/workflows/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workflows/google/cloud/workflows_v1beta/services/workflows/transports/rest.py
+++ b/packages/google-cloud-workflows/google/cloud/workflows_v1beta/services/workflows/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workflows/google/cloud/workflows_v1beta/services/workflows/transports/rest_base.py
+++ b/packages/google-cloud-workflows/google/cloud/workflows_v1beta/services/workflows/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workflows/google/cloud/workflows_v1beta/types/__init__.py
+++ b/packages/google-cloud-workflows/google/cloud/workflows_v1beta/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workflows/google/cloud/workflows_v1beta/types/workflows.py
+++ b/packages/google-cloud-workflows/google/cloud/workflows_v1beta/types/workflows.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workflows/samples/generated_samples/workflowexecutions_v1_generated_executions_cancel_execution_async.py
+++ b/packages/google-cloud-workflows/samples/generated_samples/workflowexecutions_v1_generated_executions_cancel_execution_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workflows/samples/generated_samples/workflowexecutions_v1_generated_executions_cancel_execution_sync.py
+++ b/packages/google-cloud-workflows/samples/generated_samples/workflowexecutions_v1_generated_executions_cancel_execution_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workflows/samples/generated_samples/workflowexecutions_v1_generated_executions_create_execution_async.py
+++ b/packages/google-cloud-workflows/samples/generated_samples/workflowexecutions_v1_generated_executions_create_execution_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workflows/samples/generated_samples/workflowexecutions_v1_generated_executions_create_execution_sync.py
+++ b/packages/google-cloud-workflows/samples/generated_samples/workflowexecutions_v1_generated_executions_create_execution_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workflows/samples/generated_samples/workflowexecutions_v1_generated_executions_get_execution_async.py
+++ b/packages/google-cloud-workflows/samples/generated_samples/workflowexecutions_v1_generated_executions_get_execution_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workflows/samples/generated_samples/workflowexecutions_v1_generated_executions_get_execution_sync.py
+++ b/packages/google-cloud-workflows/samples/generated_samples/workflowexecutions_v1_generated_executions_get_execution_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workflows/samples/generated_samples/workflowexecutions_v1_generated_executions_list_executions_async.py
+++ b/packages/google-cloud-workflows/samples/generated_samples/workflowexecutions_v1_generated_executions_list_executions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workflows/samples/generated_samples/workflowexecutions_v1_generated_executions_list_executions_sync.py
+++ b/packages/google-cloud-workflows/samples/generated_samples/workflowexecutions_v1_generated_executions_list_executions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workflows/samples/generated_samples/workflowexecutions_v1beta_generated_executions_cancel_execution_async.py
+++ b/packages/google-cloud-workflows/samples/generated_samples/workflowexecutions_v1beta_generated_executions_cancel_execution_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workflows/samples/generated_samples/workflowexecutions_v1beta_generated_executions_cancel_execution_sync.py
+++ b/packages/google-cloud-workflows/samples/generated_samples/workflowexecutions_v1beta_generated_executions_cancel_execution_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workflows/samples/generated_samples/workflowexecutions_v1beta_generated_executions_create_execution_async.py
+++ b/packages/google-cloud-workflows/samples/generated_samples/workflowexecutions_v1beta_generated_executions_create_execution_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workflows/samples/generated_samples/workflowexecutions_v1beta_generated_executions_create_execution_sync.py
+++ b/packages/google-cloud-workflows/samples/generated_samples/workflowexecutions_v1beta_generated_executions_create_execution_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workflows/samples/generated_samples/workflowexecutions_v1beta_generated_executions_get_execution_async.py
+++ b/packages/google-cloud-workflows/samples/generated_samples/workflowexecutions_v1beta_generated_executions_get_execution_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workflows/samples/generated_samples/workflowexecutions_v1beta_generated_executions_get_execution_sync.py
+++ b/packages/google-cloud-workflows/samples/generated_samples/workflowexecutions_v1beta_generated_executions_get_execution_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workflows/samples/generated_samples/workflowexecutions_v1beta_generated_executions_list_executions_async.py
+++ b/packages/google-cloud-workflows/samples/generated_samples/workflowexecutions_v1beta_generated_executions_list_executions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workflows/samples/generated_samples/workflowexecutions_v1beta_generated_executions_list_executions_sync.py
+++ b/packages/google-cloud-workflows/samples/generated_samples/workflowexecutions_v1beta_generated_executions_list_executions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workflows/samples/generated_samples/workflows_v1_generated_workflows_create_workflow_sync.py
+++ b/packages/google-cloud-workflows/samples/generated_samples/workflows_v1_generated_workflows_create_workflow_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workflows/samples/generated_samples/workflows_v1_generated_workflows_delete_workflow_sync.py
+++ b/packages/google-cloud-workflows/samples/generated_samples/workflows_v1_generated_workflows_delete_workflow_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workflows/samples/generated_samples/workflows_v1_generated_workflows_get_workflow_async.py
+++ b/packages/google-cloud-workflows/samples/generated_samples/workflows_v1_generated_workflows_get_workflow_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workflows/samples/generated_samples/workflows_v1_generated_workflows_get_workflow_sync.py
+++ b/packages/google-cloud-workflows/samples/generated_samples/workflows_v1_generated_workflows_get_workflow_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workflows/samples/generated_samples/workflows_v1_generated_workflows_list_workflow_revisions_async.py
+++ b/packages/google-cloud-workflows/samples/generated_samples/workflows_v1_generated_workflows_list_workflow_revisions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workflows/samples/generated_samples/workflows_v1_generated_workflows_list_workflow_revisions_sync.py
+++ b/packages/google-cloud-workflows/samples/generated_samples/workflows_v1_generated_workflows_list_workflow_revisions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workflows/samples/generated_samples/workflows_v1_generated_workflows_list_workflows_async.py
+++ b/packages/google-cloud-workflows/samples/generated_samples/workflows_v1_generated_workflows_list_workflows_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workflows/samples/generated_samples/workflows_v1_generated_workflows_list_workflows_sync.py
+++ b/packages/google-cloud-workflows/samples/generated_samples/workflows_v1_generated_workflows_list_workflows_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workflows/samples/generated_samples/workflows_v1_generated_workflows_update_workflow_sync.py
+++ b/packages/google-cloud-workflows/samples/generated_samples/workflows_v1_generated_workflows_update_workflow_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workflows/samples/generated_samples/workflows_v1beta_generated_workflows_create_workflow_sync.py
+++ b/packages/google-cloud-workflows/samples/generated_samples/workflows_v1beta_generated_workflows_create_workflow_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workflows/samples/generated_samples/workflows_v1beta_generated_workflows_delete_workflow_sync.py
+++ b/packages/google-cloud-workflows/samples/generated_samples/workflows_v1beta_generated_workflows_delete_workflow_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workflows/samples/generated_samples/workflows_v1beta_generated_workflows_get_workflow_async.py
+++ b/packages/google-cloud-workflows/samples/generated_samples/workflows_v1beta_generated_workflows_get_workflow_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workflows/samples/generated_samples/workflows_v1beta_generated_workflows_get_workflow_sync.py
+++ b/packages/google-cloud-workflows/samples/generated_samples/workflows_v1beta_generated_workflows_get_workflow_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workflows/samples/generated_samples/workflows_v1beta_generated_workflows_list_workflows_async.py
+++ b/packages/google-cloud-workflows/samples/generated_samples/workflows_v1beta_generated_workflows_list_workflows_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workflows/samples/generated_samples/workflows_v1beta_generated_workflows_list_workflows_sync.py
+++ b/packages/google-cloud-workflows/samples/generated_samples/workflows_v1beta_generated_workflows_list_workflows_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workflows/samples/generated_samples/workflows_v1beta_generated_workflows_update_workflow_sync.py
+++ b/packages/google-cloud-workflows/samples/generated_samples/workflows_v1beta_generated_workflows_update_workflow_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workflows/tests/__init__.py
+++ b/packages/google-cloud-workflows/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workflows/tests/unit/__init__.py
+++ b/packages/google-cloud-workflows/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workflows/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-workflows/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workflows/tests/unit/gapic/executions_v1/__init__.py
+++ b/packages/google-cloud-workflows/tests/unit/gapic/executions_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workflows/tests/unit/gapic/executions_v1beta/__init__.py
+++ b/packages/google-cloud-workflows/tests/unit/gapic/executions_v1beta/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workflows/tests/unit/gapic/workflows_v1/__init__.py
+++ b/packages/google-cloud-workflows/tests/unit/gapic/workflows_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workflows/tests/unit/gapic/workflows_v1beta/__init__.py
+++ b/packages/google-cloud-workflows/tests/unit/gapic/workflows_v1beta/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workloadmanager/.flake8
+++ b/packages/google-cloud-workloadmanager/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workloadmanager/MANIFEST.in
+++ b/packages/google-cloud-workloadmanager/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workloadmanager/google/cloud/workloadmanager/__init__.py
+++ b/packages/google-cloud-workloadmanager/google/cloud/workloadmanager/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workloadmanager/google/cloud/workloadmanager/gapic_version.py
+++ b/packages/google-cloud-workloadmanager/google/cloud/workloadmanager/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workloadmanager/google/cloud/workloadmanager_v1/gapic_version.py
+++ b/packages/google-cloud-workloadmanager/google/cloud/workloadmanager_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workloadmanager/google/cloud/workloadmanager_v1/services/__init__.py
+++ b/packages/google-cloud-workloadmanager/google/cloud/workloadmanager_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workloadmanager/google/cloud/workloadmanager_v1/services/workload_manager/__init__.py
+++ b/packages/google-cloud-workloadmanager/google/cloud/workloadmanager_v1/services/workload_manager/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workloadmanager/google/cloud/workloadmanager_v1/services/workload_manager/client.py
+++ b/packages/google-cloud-workloadmanager/google/cloud/workloadmanager_v1/services/workload_manager/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workloadmanager/google/cloud/workloadmanager_v1/services/workload_manager/pagers.py
+++ b/packages/google-cloud-workloadmanager/google/cloud/workloadmanager_v1/services/workload_manager/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workloadmanager/google/cloud/workloadmanager_v1/services/workload_manager/transports/__init__.py
+++ b/packages/google-cloud-workloadmanager/google/cloud/workloadmanager_v1/services/workload_manager/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workloadmanager/google/cloud/workloadmanager_v1/services/workload_manager/transports/base.py
+++ b/packages/google-cloud-workloadmanager/google/cloud/workloadmanager_v1/services/workload_manager/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workloadmanager/google/cloud/workloadmanager_v1/services/workload_manager/transports/grpc.py
+++ b/packages/google-cloud-workloadmanager/google/cloud/workloadmanager_v1/services/workload_manager/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workloadmanager/google/cloud/workloadmanager_v1/services/workload_manager/transports/grpc_asyncio.py
+++ b/packages/google-cloud-workloadmanager/google/cloud/workloadmanager_v1/services/workload_manager/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workloadmanager/google/cloud/workloadmanager_v1/services/workload_manager/transports/rest.py
+++ b/packages/google-cloud-workloadmanager/google/cloud/workloadmanager_v1/services/workload_manager/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workloadmanager/google/cloud/workloadmanager_v1/services/workload_manager/transports/rest_base.py
+++ b/packages/google-cloud-workloadmanager/google/cloud/workloadmanager_v1/services/workload_manager/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workloadmanager/google/cloud/workloadmanager_v1/types/__init__.py
+++ b/packages/google-cloud-workloadmanager/google/cloud/workloadmanager_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workloadmanager/google/cloud/workloadmanager_v1/types/service.py
+++ b/packages/google-cloud-workloadmanager/google/cloud/workloadmanager_v1/types/service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workloadmanager/samples/generated_samples/workloadmanager_v1_generated_workload_manager_create_evaluation_sync.py
+++ b/packages/google-cloud-workloadmanager/samples/generated_samples/workloadmanager_v1_generated_workload_manager_create_evaluation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workloadmanager/samples/generated_samples/workloadmanager_v1_generated_workload_manager_delete_evaluation_sync.py
+++ b/packages/google-cloud-workloadmanager/samples/generated_samples/workloadmanager_v1_generated_workload_manager_delete_evaluation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workloadmanager/samples/generated_samples/workloadmanager_v1_generated_workload_manager_delete_execution_sync.py
+++ b/packages/google-cloud-workloadmanager/samples/generated_samples/workloadmanager_v1_generated_workload_manager_delete_execution_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workloadmanager/samples/generated_samples/workloadmanager_v1_generated_workload_manager_get_evaluation_async.py
+++ b/packages/google-cloud-workloadmanager/samples/generated_samples/workloadmanager_v1_generated_workload_manager_get_evaluation_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workloadmanager/samples/generated_samples/workloadmanager_v1_generated_workload_manager_get_evaluation_sync.py
+++ b/packages/google-cloud-workloadmanager/samples/generated_samples/workloadmanager_v1_generated_workload_manager_get_evaluation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workloadmanager/samples/generated_samples/workloadmanager_v1_generated_workload_manager_get_execution_async.py
+++ b/packages/google-cloud-workloadmanager/samples/generated_samples/workloadmanager_v1_generated_workload_manager_get_execution_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workloadmanager/samples/generated_samples/workloadmanager_v1_generated_workload_manager_get_execution_sync.py
+++ b/packages/google-cloud-workloadmanager/samples/generated_samples/workloadmanager_v1_generated_workload_manager_get_execution_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workloadmanager/samples/generated_samples/workloadmanager_v1_generated_workload_manager_list_evaluations_async.py
+++ b/packages/google-cloud-workloadmanager/samples/generated_samples/workloadmanager_v1_generated_workload_manager_list_evaluations_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workloadmanager/samples/generated_samples/workloadmanager_v1_generated_workload_manager_list_evaluations_sync.py
+++ b/packages/google-cloud-workloadmanager/samples/generated_samples/workloadmanager_v1_generated_workload_manager_list_evaluations_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workloadmanager/samples/generated_samples/workloadmanager_v1_generated_workload_manager_list_execution_results_async.py
+++ b/packages/google-cloud-workloadmanager/samples/generated_samples/workloadmanager_v1_generated_workload_manager_list_execution_results_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workloadmanager/samples/generated_samples/workloadmanager_v1_generated_workload_manager_list_execution_results_sync.py
+++ b/packages/google-cloud-workloadmanager/samples/generated_samples/workloadmanager_v1_generated_workload_manager_list_execution_results_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workloadmanager/samples/generated_samples/workloadmanager_v1_generated_workload_manager_list_executions_async.py
+++ b/packages/google-cloud-workloadmanager/samples/generated_samples/workloadmanager_v1_generated_workload_manager_list_executions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workloadmanager/samples/generated_samples/workloadmanager_v1_generated_workload_manager_list_executions_sync.py
+++ b/packages/google-cloud-workloadmanager/samples/generated_samples/workloadmanager_v1_generated_workload_manager_list_executions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workloadmanager/samples/generated_samples/workloadmanager_v1_generated_workload_manager_list_rules_async.py
+++ b/packages/google-cloud-workloadmanager/samples/generated_samples/workloadmanager_v1_generated_workload_manager_list_rules_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workloadmanager/samples/generated_samples/workloadmanager_v1_generated_workload_manager_list_rules_sync.py
+++ b/packages/google-cloud-workloadmanager/samples/generated_samples/workloadmanager_v1_generated_workload_manager_list_rules_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workloadmanager/samples/generated_samples/workloadmanager_v1_generated_workload_manager_list_scanned_resources_async.py
+++ b/packages/google-cloud-workloadmanager/samples/generated_samples/workloadmanager_v1_generated_workload_manager_list_scanned_resources_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workloadmanager/samples/generated_samples/workloadmanager_v1_generated_workload_manager_list_scanned_resources_sync.py
+++ b/packages/google-cloud-workloadmanager/samples/generated_samples/workloadmanager_v1_generated_workload_manager_list_scanned_resources_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workloadmanager/samples/generated_samples/workloadmanager_v1_generated_workload_manager_run_evaluation_sync.py
+++ b/packages/google-cloud-workloadmanager/samples/generated_samples/workloadmanager_v1_generated_workload_manager_run_evaluation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workloadmanager/samples/generated_samples/workloadmanager_v1_generated_workload_manager_update_evaluation_sync.py
+++ b/packages/google-cloud-workloadmanager/samples/generated_samples/workloadmanager_v1_generated_workload_manager_update_evaluation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workloadmanager/tests/__init__.py
+++ b/packages/google-cloud-workloadmanager/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workloadmanager/tests/unit/__init__.py
+++ b/packages/google-cloud-workloadmanager/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workloadmanager/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-workloadmanager/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workloadmanager/tests/unit/gapic/workloadmanager_v1/__init__.py
+++ b/packages/google-cloud-workloadmanager/tests/unit/gapic/workloadmanager_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workstations/.flake8
+++ b/packages/google-cloud-workstations/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workstations/MANIFEST.in
+++ b/packages/google-cloud-workstations/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workstations/google/cloud/workstations/__init__.py
+++ b/packages/google-cloud-workstations/google/cloud/workstations/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workstations/google/cloud/workstations/gapic_version.py
+++ b/packages/google-cloud-workstations/google/cloud/workstations/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workstations/google/cloud/workstations_v1/gapic_version.py
+++ b/packages/google-cloud-workstations/google/cloud/workstations_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workstations/google/cloud/workstations_v1/services/__init__.py
+++ b/packages/google-cloud-workstations/google/cloud/workstations_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workstations/google/cloud/workstations_v1/services/workstations/__init__.py
+++ b/packages/google-cloud-workstations/google/cloud/workstations_v1/services/workstations/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workstations/google/cloud/workstations_v1/services/workstations/client.py
+++ b/packages/google-cloud-workstations/google/cloud/workstations_v1/services/workstations/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workstations/google/cloud/workstations_v1/services/workstations/pagers.py
+++ b/packages/google-cloud-workstations/google/cloud/workstations_v1/services/workstations/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workstations/google/cloud/workstations_v1/services/workstations/transports/__init__.py
+++ b/packages/google-cloud-workstations/google/cloud/workstations_v1/services/workstations/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workstations/google/cloud/workstations_v1/services/workstations/transports/base.py
+++ b/packages/google-cloud-workstations/google/cloud/workstations_v1/services/workstations/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workstations/google/cloud/workstations_v1/services/workstations/transports/grpc.py
+++ b/packages/google-cloud-workstations/google/cloud/workstations_v1/services/workstations/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workstations/google/cloud/workstations_v1/services/workstations/transports/grpc_asyncio.py
+++ b/packages/google-cloud-workstations/google/cloud/workstations_v1/services/workstations/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workstations/google/cloud/workstations_v1/services/workstations/transports/rest.py
+++ b/packages/google-cloud-workstations/google/cloud/workstations_v1/services/workstations/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workstations/google/cloud/workstations_v1/services/workstations/transports/rest_base.py
+++ b/packages/google-cloud-workstations/google/cloud/workstations_v1/services/workstations/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workstations/google/cloud/workstations_v1/types/__init__.py
+++ b/packages/google-cloud-workstations/google/cloud/workstations_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workstations/google/cloud/workstations_v1/types/workstations.py
+++ b/packages/google-cloud-workstations/google/cloud/workstations_v1/types/workstations.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workstations/google/cloud/workstations_v1beta/gapic_version.py
+++ b/packages/google-cloud-workstations/google/cloud/workstations_v1beta/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workstations/google/cloud/workstations_v1beta/services/__init__.py
+++ b/packages/google-cloud-workstations/google/cloud/workstations_v1beta/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workstations/google/cloud/workstations_v1beta/services/workstations/__init__.py
+++ b/packages/google-cloud-workstations/google/cloud/workstations_v1beta/services/workstations/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workstations/google/cloud/workstations_v1beta/services/workstations/client.py
+++ b/packages/google-cloud-workstations/google/cloud/workstations_v1beta/services/workstations/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workstations/google/cloud/workstations_v1beta/services/workstations/pagers.py
+++ b/packages/google-cloud-workstations/google/cloud/workstations_v1beta/services/workstations/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workstations/google/cloud/workstations_v1beta/services/workstations/transports/__init__.py
+++ b/packages/google-cloud-workstations/google/cloud/workstations_v1beta/services/workstations/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workstations/google/cloud/workstations_v1beta/services/workstations/transports/base.py
+++ b/packages/google-cloud-workstations/google/cloud/workstations_v1beta/services/workstations/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workstations/google/cloud/workstations_v1beta/services/workstations/transports/grpc.py
+++ b/packages/google-cloud-workstations/google/cloud/workstations_v1beta/services/workstations/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workstations/google/cloud/workstations_v1beta/services/workstations/transports/grpc_asyncio.py
+++ b/packages/google-cloud-workstations/google/cloud/workstations_v1beta/services/workstations/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workstations/google/cloud/workstations_v1beta/services/workstations/transports/rest.py
+++ b/packages/google-cloud-workstations/google/cloud/workstations_v1beta/services/workstations/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workstations/google/cloud/workstations_v1beta/services/workstations/transports/rest_base.py
+++ b/packages/google-cloud-workstations/google/cloud/workstations_v1beta/services/workstations/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workstations/google/cloud/workstations_v1beta/types/__init__.py
+++ b/packages/google-cloud-workstations/google/cloud/workstations_v1beta/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workstations/google/cloud/workstations_v1beta/types/workstations.py
+++ b/packages/google-cloud-workstations/google/cloud/workstations_v1beta/types/workstations.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workstations/samples/generated_samples/workstations_v1_generated_workstations_create_workstation_cluster_sync.py
+++ b/packages/google-cloud-workstations/samples/generated_samples/workstations_v1_generated_workstations_create_workstation_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workstations/samples/generated_samples/workstations_v1_generated_workstations_create_workstation_config_sync.py
+++ b/packages/google-cloud-workstations/samples/generated_samples/workstations_v1_generated_workstations_create_workstation_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workstations/samples/generated_samples/workstations_v1_generated_workstations_create_workstation_sync.py
+++ b/packages/google-cloud-workstations/samples/generated_samples/workstations_v1_generated_workstations_create_workstation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workstations/samples/generated_samples/workstations_v1_generated_workstations_delete_workstation_cluster_sync.py
+++ b/packages/google-cloud-workstations/samples/generated_samples/workstations_v1_generated_workstations_delete_workstation_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workstations/samples/generated_samples/workstations_v1_generated_workstations_delete_workstation_config_sync.py
+++ b/packages/google-cloud-workstations/samples/generated_samples/workstations_v1_generated_workstations_delete_workstation_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workstations/samples/generated_samples/workstations_v1_generated_workstations_delete_workstation_sync.py
+++ b/packages/google-cloud-workstations/samples/generated_samples/workstations_v1_generated_workstations_delete_workstation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workstations/samples/generated_samples/workstations_v1_generated_workstations_generate_access_token_async.py
+++ b/packages/google-cloud-workstations/samples/generated_samples/workstations_v1_generated_workstations_generate_access_token_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workstations/samples/generated_samples/workstations_v1_generated_workstations_generate_access_token_sync.py
+++ b/packages/google-cloud-workstations/samples/generated_samples/workstations_v1_generated_workstations_generate_access_token_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workstations/samples/generated_samples/workstations_v1_generated_workstations_get_workstation_async.py
+++ b/packages/google-cloud-workstations/samples/generated_samples/workstations_v1_generated_workstations_get_workstation_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workstations/samples/generated_samples/workstations_v1_generated_workstations_get_workstation_cluster_async.py
+++ b/packages/google-cloud-workstations/samples/generated_samples/workstations_v1_generated_workstations_get_workstation_cluster_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workstations/samples/generated_samples/workstations_v1_generated_workstations_get_workstation_cluster_sync.py
+++ b/packages/google-cloud-workstations/samples/generated_samples/workstations_v1_generated_workstations_get_workstation_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workstations/samples/generated_samples/workstations_v1_generated_workstations_get_workstation_config_async.py
+++ b/packages/google-cloud-workstations/samples/generated_samples/workstations_v1_generated_workstations_get_workstation_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workstations/samples/generated_samples/workstations_v1_generated_workstations_get_workstation_config_sync.py
+++ b/packages/google-cloud-workstations/samples/generated_samples/workstations_v1_generated_workstations_get_workstation_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workstations/samples/generated_samples/workstations_v1_generated_workstations_get_workstation_sync.py
+++ b/packages/google-cloud-workstations/samples/generated_samples/workstations_v1_generated_workstations_get_workstation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workstations/samples/generated_samples/workstations_v1_generated_workstations_list_usable_workstation_configs_async.py
+++ b/packages/google-cloud-workstations/samples/generated_samples/workstations_v1_generated_workstations_list_usable_workstation_configs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workstations/samples/generated_samples/workstations_v1_generated_workstations_list_usable_workstation_configs_sync.py
+++ b/packages/google-cloud-workstations/samples/generated_samples/workstations_v1_generated_workstations_list_usable_workstation_configs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workstations/samples/generated_samples/workstations_v1_generated_workstations_list_usable_workstations_async.py
+++ b/packages/google-cloud-workstations/samples/generated_samples/workstations_v1_generated_workstations_list_usable_workstations_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workstations/samples/generated_samples/workstations_v1_generated_workstations_list_usable_workstations_sync.py
+++ b/packages/google-cloud-workstations/samples/generated_samples/workstations_v1_generated_workstations_list_usable_workstations_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workstations/samples/generated_samples/workstations_v1_generated_workstations_list_workstation_clusters_async.py
+++ b/packages/google-cloud-workstations/samples/generated_samples/workstations_v1_generated_workstations_list_workstation_clusters_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workstations/samples/generated_samples/workstations_v1_generated_workstations_list_workstation_clusters_sync.py
+++ b/packages/google-cloud-workstations/samples/generated_samples/workstations_v1_generated_workstations_list_workstation_clusters_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workstations/samples/generated_samples/workstations_v1_generated_workstations_list_workstation_configs_async.py
+++ b/packages/google-cloud-workstations/samples/generated_samples/workstations_v1_generated_workstations_list_workstation_configs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workstations/samples/generated_samples/workstations_v1_generated_workstations_list_workstation_configs_sync.py
+++ b/packages/google-cloud-workstations/samples/generated_samples/workstations_v1_generated_workstations_list_workstation_configs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workstations/samples/generated_samples/workstations_v1_generated_workstations_list_workstations_async.py
+++ b/packages/google-cloud-workstations/samples/generated_samples/workstations_v1_generated_workstations_list_workstations_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workstations/samples/generated_samples/workstations_v1_generated_workstations_list_workstations_sync.py
+++ b/packages/google-cloud-workstations/samples/generated_samples/workstations_v1_generated_workstations_list_workstations_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workstations/samples/generated_samples/workstations_v1_generated_workstations_start_workstation_sync.py
+++ b/packages/google-cloud-workstations/samples/generated_samples/workstations_v1_generated_workstations_start_workstation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workstations/samples/generated_samples/workstations_v1_generated_workstations_stop_workstation_sync.py
+++ b/packages/google-cloud-workstations/samples/generated_samples/workstations_v1_generated_workstations_stop_workstation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workstations/samples/generated_samples/workstations_v1_generated_workstations_update_workstation_cluster_sync.py
+++ b/packages/google-cloud-workstations/samples/generated_samples/workstations_v1_generated_workstations_update_workstation_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workstations/samples/generated_samples/workstations_v1_generated_workstations_update_workstation_config_sync.py
+++ b/packages/google-cloud-workstations/samples/generated_samples/workstations_v1_generated_workstations_update_workstation_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workstations/samples/generated_samples/workstations_v1_generated_workstations_update_workstation_sync.py
+++ b/packages/google-cloud-workstations/samples/generated_samples/workstations_v1_generated_workstations_update_workstation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workstations/samples/generated_samples/workstations_v1beta_generated_workstations_create_workstation_cluster_sync.py
+++ b/packages/google-cloud-workstations/samples/generated_samples/workstations_v1beta_generated_workstations_create_workstation_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workstations/samples/generated_samples/workstations_v1beta_generated_workstations_create_workstation_config_sync.py
+++ b/packages/google-cloud-workstations/samples/generated_samples/workstations_v1beta_generated_workstations_create_workstation_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workstations/samples/generated_samples/workstations_v1beta_generated_workstations_create_workstation_sync.py
+++ b/packages/google-cloud-workstations/samples/generated_samples/workstations_v1beta_generated_workstations_create_workstation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workstations/samples/generated_samples/workstations_v1beta_generated_workstations_delete_workstation_cluster_sync.py
+++ b/packages/google-cloud-workstations/samples/generated_samples/workstations_v1beta_generated_workstations_delete_workstation_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workstations/samples/generated_samples/workstations_v1beta_generated_workstations_delete_workstation_config_sync.py
+++ b/packages/google-cloud-workstations/samples/generated_samples/workstations_v1beta_generated_workstations_delete_workstation_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workstations/samples/generated_samples/workstations_v1beta_generated_workstations_delete_workstation_sync.py
+++ b/packages/google-cloud-workstations/samples/generated_samples/workstations_v1beta_generated_workstations_delete_workstation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workstations/samples/generated_samples/workstations_v1beta_generated_workstations_generate_access_token_async.py
+++ b/packages/google-cloud-workstations/samples/generated_samples/workstations_v1beta_generated_workstations_generate_access_token_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workstations/samples/generated_samples/workstations_v1beta_generated_workstations_generate_access_token_sync.py
+++ b/packages/google-cloud-workstations/samples/generated_samples/workstations_v1beta_generated_workstations_generate_access_token_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workstations/samples/generated_samples/workstations_v1beta_generated_workstations_get_workstation_async.py
+++ b/packages/google-cloud-workstations/samples/generated_samples/workstations_v1beta_generated_workstations_get_workstation_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workstations/samples/generated_samples/workstations_v1beta_generated_workstations_get_workstation_cluster_async.py
+++ b/packages/google-cloud-workstations/samples/generated_samples/workstations_v1beta_generated_workstations_get_workstation_cluster_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workstations/samples/generated_samples/workstations_v1beta_generated_workstations_get_workstation_cluster_sync.py
+++ b/packages/google-cloud-workstations/samples/generated_samples/workstations_v1beta_generated_workstations_get_workstation_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workstations/samples/generated_samples/workstations_v1beta_generated_workstations_get_workstation_config_async.py
+++ b/packages/google-cloud-workstations/samples/generated_samples/workstations_v1beta_generated_workstations_get_workstation_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workstations/samples/generated_samples/workstations_v1beta_generated_workstations_get_workstation_config_sync.py
+++ b/packages/google-cloud-workstations/samples/generated_samples/workstations_v1beta_generated_workstations_get_workstation_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workstations/samples/generated_samples/workstations_v1beta_generated_workstations_get_workstation_sync.py
+++ b/packages/google-cloud-workstations/samples/generated_samples/workstations_v1beta_generated_workstations_get_workstation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workstations/samples/generated_samples/workstations_v1beta_generated_workstations_list_usable_workstation_configs_async.py
+++ b/packages/google-cloud-workstations/samples/generated_samples/workstations_v1beta_generated_workstations_list_usable_workstation_configs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workstations/samples/generated_samples/workstations_v1beta_generated_workstations_list_usable_workstation_configs_sync.py
+++ b/packages/google-cloud-workstations/samples/generated_samples/workstations_v1beta_generated_workstations_list_usable_workstation_configs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workstations/samples/generated_samples/workstations_v1beta_generated_workstations_list_usable_workstations_async.py
+++ b/packages/google-cloud-workstations/samples/generated_samples/workstations_v1beta_generated_workstations_list_usable_workstations_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workstations/samples/generated_samples/workstations_v1beta_generated_workstations_list_usable_workstations_sync.py
+++ b/packages/google-cloud-workstations/samples/generated_samples/workstations_v1beta_generated_workstations_list_usable_workstations_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workstations/samples/generated_samples/workstations_v1beta_generated_workstations_list_workstation_clusters_async.py
+++ b/packages/google-cloud-workstations/samples/generated_samples/workstations_v1beta_generated_workstations_list_workstation_clusters_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workstations/samples/generated_samples/workstations_v1beta_generated_workstations_list_workstation_clusters_sync.py
+++ b/packages/google-cloud-workstations/samples/generated_samples/workstations_v1beta_generated_workstations_list_workstation_clusters_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workstations/samples/generated_samples/workstations_v1beta_generated_workstations_list_workstation_configs_async.py
+++ b/packages/google-cloud-workstations/samples/generated_samples/workstations_v1beta_generated_workstations_list_workstation_configs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workstations/samples/generated_samples/workstations_v1beta_generated_workstations_list_workstation_configs_sync.py
+++ b/packages/google-cloud-workstations/samples/generated_samples/workstations_v1beta_generated_workstations_list_workstation_configs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workstations/samples/generated_samples/workstations_v1beta_generated_workstations_list_workstations_async.py
+++ b/packages/google-cloud-workstations/samples/generated_samples/workstations_v1beta_generated_workstations_list_workstations_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workstations/samples/generated_samples/workstations_v1beta_generated_workstations_list_workstations_sync.py
+++ b/packages/google-cloud-workstations/samples/generated_samples/workstations_v1beta_generated_workstations_list_workstations_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workstations/samples/generated_samples/workstations_v1beta_generated_workstations_start_workstation_sync.py
+++ b/packages/google-cloud-workstations/samples/generated_samples/workstations_v1beta_generated_workstations_start_workstation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workstations/samples/generated_samples/workstations_v1beta_generated_workstations_stop_workstation_sync.py
+++ b/packages/google-cloud-workstations/samples/generated_samples/workstations_v1beta_generated_workstations_stop_workstation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workstations/samples/generated_samples/workstations_v1beta_generated_workstations_update_workstation_cluster_sync.py
+++ b/packages/google-cloud-workstations/samples/generated_samples/workstations_v1beta_generated_workstations_update_workstation_cluster_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workstations/samples/generated_samples/workstations_v1beta_generated_workstations_update_workstation_config_sync.py
+++ b/packages/google-cloud-workstations/samples/generated_samples/workstations_v1beta_generated_workstations_update_workstation_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workstations/samples/generated_samples/workstations_v1beta_generated_workstations_update_workstation_sync.py
+++ b/packages/google-cloud-workstations/samples/generated_samples/workstations_v1beta_generated_workstations_update_workstation_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workstations/tests/__init__.py
+++ b/packages/google-cloud-workstations/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workstations/tests/unit/__init__.py
+++ b/packages/google-cloud-workstations/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workstations/tests/unit/gapic/__init__.py
+++ b/packages/google-cloud-workstations/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workstations/tests/unit/gapic/workstations_v1/__init__.py
+++ b/packages/google-cloud-workstations/tests/unit/gapic/workstations_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-cloud-workstations/tests/unit/gapic/workstations_v1beta/__init__.py
+++ b/packages/google-cloud-workstations/tests/unit/gapic/workstations_v1beta/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
This is the result of regenerating all packages, but only committing files which have only changed in a single line, and that's a copyright line.
