### PR TITLE
chore: regenerate packages in google-maps, copyright changes only

### DIFF
--- a/packages/google-maps-addressvalidation/.flake8
+++ b/packages/google-maps-addressvalidation/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-addressvalidation/MANIFEST.in
+++ b/packages/google-maps-addressvalidation/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-addressvalidation/google/maps/addressvalidation/__init__.py
+++ b/packages/google-maps-addressvalidation/google/maps/addressvalidation/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-addressvalidation/google/maps/addressvalidation/gapic_version.py
+++ b/packages/google-maps-addressvalidation/google/maps/addressvalidation/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-addressvalidation/google/maps/addressvalidation_v1/gapic_version.py
+++ b/packages/google-maps-addressvalidation/google/maps/addressvalidation_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-addressvalidation/google/maps/addressvalidation_v1/services/__init__.py
+++ b/packages/google-maps-addressvalidation/google/maps/addressvalidation_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-addressvalidation/google/maps/addressvalidation_v1/services/address_validation/__init__.py
+++ b/packages/google-maps-addressvalidation/google/maps/addressvalidation_v1/services/address_validation/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-addressvalidation/google/maps/addressvalidation_v1/services/address_validation/async_client.py
+++ b/packages/google-maps-addressvalidation/google/maps/addressvalidation_v1/services/address_validation/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-addressvalidation/google/maps/addressvalidation_v1/services/address_validation/client.py
+++ b/packages/google-maps-addressvalidation/google/maps/addressvalidation_v1/services/address_validation/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-addressvalidation/google/maps/addressvalidation_v1/services/address_validation/transports/__init__.py
+++ b/packages/google-maps-addressvalidation/google/maps/addressvalidation_v1/services/address_validation/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-addressvalidation/google/maps/addressvalidation_v1/services/address_validation/transports/base.py
+++ b/packages/google-maps-addressvalidation/google/maps/addressvalidation_v1/services/address_validation/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-addressvalidation/google/maps/addressvalidation_v1/services/address_validation/transports/grpc.py
+++ b/packages/google-maps-addressvalidation/google/maps/addressvalidation_v1/services/address_validation/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-addressvalidation/google/maps/addressvalidation_v1/services/address_validation/transports/grpc_asyncio.py
+++ b/packages/google-maps-addressvalidation/google/maps/addressvalidation_v1/services/address_validation/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-addressvalidation/google/maps/addressvalidation_v1/services/address_validation/transports/rest.py
+++ b/packages/google-maps-addressvalidation/google/maps/addressvalidation_v1/services/address_validation/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-addressvalidation/google/maps/addressvalidation_v1/services/address_validation/transports/rest_base.py
+++ b/packages/google-maps-addressvalidation/google/maps/addressvalidation_v1/services/address_validation/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-addressvalidation/google/maps/addressvalidation_v1/types/__init__.py
+++ b/packages/google-maps-addressvalidation/google/maps/addressvalidation_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-addressvalidation/google/maps/addressvalidation_v1/types/address.py
+++ b/packages/google-maps-addressvalidation/google/maps/addressvalidation_v1/types/address.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-addressvalidation/google/maps/addressvalidation_v1/types/address_validation_service.py
+++ b/packages/google-maps-addressvalidation/google/maps/addressvalidation_v1/types/address_validation_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-addressvalidation/google/maps/addressvalidation_v1/types/geocode.py
+++ b/packages/google-maps-addressvalidation/google/maps/addressvalidation_v1/types/geocode.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-addressvalidation/google/maps/addressvalidation_v1/types/metadata_.py
+++ b/packages/google-maps-addressvalidation/google/maps/addressvalidation_v1/types/metadata_.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-addressvalidation/google/maps/addressvalidation_v1/types/usps_data.py
+++ b/packages/google-maps-addressvalidation/google/maps/addressvalidation_v1/types/usps_data.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-addressvalidation/samples/generated_samples/addressvalidation_v1_generated_address_validation_provide_validation_feedback_async.py
+++ b/packages/google-maps-addressvalidation/samples/generated_samples/addressvalidation_v1_generated_address_validation_provide_validation_feedback_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-addressvalidation/samples/generated_samples/addressvalidation_v1_generated_address_validation_provide_validation_feedback_sync.py
+++ b/packages/google-maps-addressvalidation/samples/generated_samples/addressvalidation_v1_generated_address_validation_provide_validation_feedback_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-addressvalidation/samples/generated_samples/addressvalidation_v1_generated_address_validation_validate_address_async.py
+++ b/packages/google-maps-addressvalidation/samples/generated_samples/addressvalidation_v1_generated_address_validation_validate_address_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-addressvalidation/samples/generated_samples/addressvalidation_v1_generated_address_validation_validate_address_sync.py
+++ b/packages/google-maps-addressvalidation/samples/generated_samples/addressvalidation_v1_generated_address_validation_validate_address_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-addressvalidation/tests/__init__.py
+++ b/packages/google-maps-addressvalidation/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-addressvalidation/tests/unit/__init__.py
+++ b/packages/google-maps-addressvalidation/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-addressvalidation/tests/unit/gapic/__init__.py
+++ b/packages/google-maps-addressvalidation/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-addressvalidation/tests/unit/gapic/addressvalidation_v1/__init__.py
+++ b/packages/google-maps-addressvalidation/tests/unit/gapic/addressvalidation_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-areainsights/.flake8
+++ b/packages/google-maps-areainsights/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-areainsights/MANIFEST.in
+++ b/packages/google-maps-areainsights/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-areainsights/google/maps/areainsights/__init__.py
+++ b/packages/google-maps-areainsights/google/maps/areainsights/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-areainsights/google/maps/areainsights/gapic_version.py
+++ b/packages/google-maps-areainsights/google/maps/areainsights/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-areainsights/google/maps/areainsights_v1/gapic_version.py
+++ b/packages/google-maps-areainsights/google/maps/areainsights_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-areainsights/google/maps/areainsights_v1/services/__init__.py
+++ b/packages/google-maps-areainsights/google/maps/areainsights_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-areainsights/google/maps/areainsights_v1/services/area_insights/__init__.py
+++ b/packages/google-maps-areainsights/google/maps/areainsights_v1/services/area_insights/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-areainsights/google/maps/areainsights_v1/services/area_insights/async_client.py
+++ b/packages/google-maps-areainsights/google/maps/areainsights_v1/services/area_insights/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-areainsights/google/maps/areainsights_v1/services/area_insights/client.py
+++ b/packages/google-maps-areainsights/google/maps/areainsights_v1/services/area_insights/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-areainsights/google/maps/areainsights_v1/services/area_insights/transports/__init__.py
+++ b/packages/google-maps-areainsights/google/maps/areainsights_v1/services/area_insights/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-areainsights/google/maps/areainsights_v1/services/area_insights/transports/base.py
+++ b/packages/google-maps-areainsights/google/maps/areainsights_v1/services/area_insights/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-areainsights/google/maps/areainsights_v1/services/area_insights/transports/grpc.py
+++ b/packages/google-maps-areainsights/google/maps/areainsights_v1/services/area_insights/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-areainsights/google/maps/areainsights_v1/services/area_insights/transports/grpc_asyncio.py
+++ b/packages/google-maps-areainsights/google/maps/areainsights_v1/services/area_insights/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-areainsights/google/maps/areainsights_v1/services/area_insights/transports/rest.py
+++ b/packages/google-maps-areainsights/google/maps/areainsights_v1/services/area_insights/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-areainsights/google/maps/areainsights_v1/services/area_insights/transports/rest_base.py
+++ b/packages/google-maps-areainsights/google/maps/areainsights_v1/services/area_insights/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-areainsights/google/maps/areainsights_v1/types/__init__.py
+++ b/packages/google-maps-areainsights/google/maps/areainsights_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-areainsights/google/maps/areainsights_v1/types/area_insights_service.py
+++ b/packages/google-maps-areainsights/google/maps/areainsights_v1/types/area_insights_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-areainsights/samples/generated_samples/areainsights_v1_generated_area_insights_compute_insights_async.py
+++ b/packages/google-maps-areainsights/samples/generated_samples/areainsights_v1_generated_area_insights_compute_insights_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-areainsights/samples/generated_samples/areainsights_v1_generated_area_insights_compute_insights_sync.py
+++ b/packages/google-maps-areainsights/samples/generated_samples/areainsights_v1_generated_area_insights_compute_insights_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-areainsights/tests/__init__.py
+++ b/packages/google-maps-areainsights/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-areainsights/tests/unit/__init__.py
+++ b/packages/google-maps-areainsights/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-areainsights/tests/unit/gapic/__init__.py
+++ b/packages/google-maps-areainsights/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-areainsights/tests/unit/gapic/areainsights_v1/__init__.py
+++ b/packages/google-maps-areainsights/tests/unit/gapic/areainsights_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-fleetengine-delivery/.flake8
+++ b/packages/google-maps-fleetengine-delivery/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-fleetengine-delivery/MANIFEST.in
+++ b/packages/google-maps-fleetengine-delivery/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-fleetengine-delivery/google/maps/fleetengine_delivery/__init__.py
+++ b/packages/google-maps-fleetengine-delivery/google/maps/fleetengine_delivery/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-fleetengine-delivery/google/maps/fleetengine_delivery/gapic_version.py
+++ b/packages/google-maps-fleetengine-delivery/google/maps/fleetengine_delivery/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-fleetengine-delivery/google/maps/fleetengine_delivery_v1/gapic_version.py
+++ b/packages/google-maps-fleetengine-delivery/google/maps/fleetengine_delivery_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-fleetengine-delivery/google/maps/fleetengine_delivery_v1/services/__init__.py
+++ b/packages/google-maps-fleetengine-delivery/google/maps/fleetengine_delivery_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-fleetengine-delivery/google/maps/fleetengine_delivery_v1/services/delivery_service/__init__.py
+++ b/packages/google-maps-fleetengine-delivery/google/maps/fleetengine_delivery_v1/services/delivery_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-fleetengine-delivery/google/maps/fleetengine_delivery_v1/services/delivery_service/async_client.py
+++ b/packages/google-maps-fleetengine-delivery/google/maps/fleetengine_delivery_v1/services/delivery_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-fleetengine-delivery/google/maps/fleetengine_delivery_v1/services/delivery_service/client.py
+++ b/packages/google-maps-fleetengine-delivery/google/maps/fleetengine_delivery_v1/services/delivery_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-fleetengine-delivery/google/maps/fleetengine_delivery_v1/services/delivery_service/pagers.py
+++ b/packages/google-maps-fleetengine-delivery/google/maps/fleetengine_delivery_v1/services/delivery_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-fleetengine-delivery/google/maps/fleetengine_delivery_v1/services/delivery_service/transports/__init__.py
+++ b/packages/google-maps-fleetengine-delivery/google/maps/fleetengine_delivery_v1/services/delivery_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-fleetengine-delivery/google/maps/fleetengine_delivery_v1/services/delivery_service/transports/base.py
+++ b/packages/google-maps-fleetengine-delivery/google/maps/fleetengine_delivery_v1/services/delivery_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-fleetengine-delivery/google/maps/fleetengine_delivery_v1/services/delivery_service/transports/grpc.py
+++ b/packages/google-maps-fleetengine-delivery/google/maps/fleetengine_delivery_v1/services/delivery_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-fleetengine-delivery/google/maps/fleetengine_delivery_v1/services/delivery_service/transports/grpc_asyncio.py
+++ b/packages/google-maps-fleetengine-delivery/google/maps/fleetengine_delivery_v1/services/delivery_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-fleetengine-delivery/google/maps/fleetengine_delivery_v1/services/delivery_service/transports/rest.py
+++ b/packages/google-maps-fleetengine-delivery/google/maps/fleetengine_delivery_v1/services/delivery_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-fleetengine-delivery/google/maps/fleetengine_delivery_v1/services/delivery_service/transports/rest_base.py
+++ b/packages/google-maps-fleetengine-delivery/google/maps/fleetengine_delivery_v1/services/delivery_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-fleetengine-delivery/google/maps/fleetengine_delivery_v1/types/__init__.py
+++ b/packages/google-maps-fleetengine-delivery/google/maps/fleetengine_delivery_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-fleetengine-delivery/google/maps/fleetengine_delivery_v1/types/common.py
+++ b/packages/google-maps-fleetengine-delivery/google/maps/fleetengine_delivery_v1/types/common.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-fleetengine-delivery/google/maps/fleetengine_delivery_v1/types/delivery_api.py
+++ b/packages/google-maps-fleetengine-delivery/google/maps/fleetengine_delivery_v1/types/delivery_api.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-fleetengine-delivery/google/maps/fleetengine_delivery_v1/types/delivery_vehicles.py
+++ b/packages/google-maps-fleetengine-delivery/google/maps/fleetengine_delivery_v1/types/delivery_vehicles.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-fleetengine-delivery/google/maps/fleetengine_delivery_v1/types/header.py
+++ b/packages/google-maps-fleetengine-delivery/google/maps/fleetengine_delivery_v1/types/header.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-fleetengine-delivery/google/maps/fleetengine_delivery_v1/types/task_tracking_info.py
+++ b/packages/google-maps-fleetengine-delivery/google/maps/fleetengine_delivery_v1/types/task_tracking_info.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-fleetengine-delivery/google/maps/fleetengine_delivery_v1/types/tasks.py
+++ b/packages/google-maps-fleetengine-delivery/google/maps/fleetengine_delivery_v1/types/tasks.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-fleetengine-delivery/samples/generated_samples/fleetengine_v1_generated_delivery_service_batch_create_tasks_async.py
+++ b/packages/google-maps-fleetengine-delivery/samples/generated_samples/fleetengine_v1_generated_delivery_service_batch_create_tasks_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-fleetengine-delivery/samples/generated_samples/fleetengine_v1_generated_delivery_service_batch_create_tasks_sync.py
+++ b/packages/google-maps-fleetengine-delivery/samples/generated_samples/fleetengine_v1_generated_delivery_service_batch_create_tasks_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-fleetengine-delivery/samples/generated_samples/fleetengine_v1_generated_delivery_service_create_delivery_vehicle_async.py
+++ b/packages/google-maps-fleetengine-delivery/samples/generated_samples/fleetengine_v1_generated_delivery_service_create_delivery_vehicle_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-fleetengine-delivery/samples/generated_samples/fleetengine_v1_generated_delivery_service_create_delivery_vehicle_sync.py
+++ b/packages/google-maps-fleetengine-delivery/samples/generated_samples/fleetengine_v1_generated_delivery_service_create_delivery_vehicle_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-fleetengine-delivery/samples/generated_samples/fleetengine_v1_generated_delivery_service_create_task_async.py
+++ b/packages/google-maps-fleetengine-delivery/samples/generated_samples/fleetengine_v1_generated_delivery_service_create_task_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-fleetengine-delivery/samples/generated_samples/fleetengine_v1_generated_delivery_service_create_task_sync.py
+++ b/packages/google-maps-fleetengine-delivery/samples/generated_samples/fleetengine_v1_generated_delivery_service_create_task_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-fleetengine-delivery/samples/generated_samples/fleetengine_v1_generated_delivery_service_delete_delivery_vehicle_async.py
+++ b/packages/google-maps-fleetengine-delivery/samples/generated_samples/fleetengine_v1_generated_delivery_service_delete_delivery_vehicle_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-fleetengine-delivery/samples/generated_samples/fleetengine_v1_generated_delivery_service_delete_delivery_vehicle_sync.py
+++ b/packages/google-maps-fleetengine-delivery/samples/generated_samples/fleetengine_v1_generated_delivery_service_delete_delivery_vehicle_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-fleetengine-delivery/samples/generated_samples/fleetengine_v1_generated_delivery_service_delete_task_async.py
+++ b/packages/google-maps-fleetengine-delivery/samples/generated_samples/fleetengine_v1_generated_delivery_service_delete_task_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-fleetengine-delivery/samples/generated_samples/fleetengine_v1_generated_delivery_service_delete_task_sync.py
+++ b/packages/google-maps-fleetengine-delivery/samples/generated_samples/fleetengine_v1_generated_delivery_service_delete_task_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-fleetengine-delivery/samples/generated_samples/fleetengine_v1_generated_delivery_service_get_delivery_vehicle_async.py
+++ b/packages/google-maps-fleetengine-delivery/samples/generated_samples/fleetengine_v1_generated_delivery_service_get_delivery_vehicle_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-fleetengine-delivery/samples/generated_samples/fleetengine_v1_generated_delivery_service_get_delivery_vehicle_sync.py
+++ b/packages/google-maps-fleetengine-delivery/samples/generated_samples/fleetengine_v1_generated_delivery_service_get_delivery_vehicle_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-fleetengine-delivery/samples/generated_samples/fleetengine_v1_generated_delivery_service_get_task_async.py
+++ b/packages/google-maps-fleetengine-delivery/samples/generated_samples/fleetengine_v1_generated_delivery_service_get_task_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-fleetengine-delivery/samples/generated_samples/fleetengine_v1_generated_delivery_service_get_task_sync.py
+++ b/packages/google-maps-fleetengine-delivery/samples/generated_samples/fleetengine_v1_generated_delivery_service_get_task_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-fleetengine-delivery/samples/generated_samples/fleetengine_v1_generated_delivery_service_get_task_tracking_info_async.py
+++ b/packages/google-maps-fleetengine-delivery/samples/generated_samples/fleetengine_v1_generated_delivery_service_get_task_tracking_info_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-fleetengine-delivery/samples/generated_samples/fleetengine_v1_generated_delivery_service_get_task_tracking_info_sync.py
+++ b/packages/google-maps-fleetengine-delivery/samples/generated_samples/fleetengine_v1_generated_delivery_service_get_task_tracking_info_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-fleetengine-delivery/samples/generated_samples/fleetengine_v1_generated_delivery_service_list_delivery_vehicles_async.py
+++ b/packages/google-maps-fleetengine-delivery/samples/generated_samples/fleetengine_v1_generated_delivery_service_list_delivery_vehicles_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-fleetengine-delivery/samples/generated_samples/fleetengine_v1_generated_delivery_service_list_delivery_vehicles_sync.py
+++ b/packages/google-maps-fleetengine-delivery/samples/generated_samples/fleetengine_v1_generated_delivery_service_list_delivery_vehicles_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-fleetengine-delivery/samples/generated_samples/fleetengine_v1_generated_delivery_service_list_tasks_async.py
+++ b/packages/google-maps-fleetengine-delivery/samples/generated_samples/fleetengine_v1_generated_delivery_service_list_tasks_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-fleetengine-delivery/samples/generated_samples/fleetengine_v1_generated_delivery_service_list_tasks_sync.py
+++ b/packages/google-maps-fleetengine-delivery/samples/generated_samples/fleetengine_v1_generated_delivery_service_list_tasks_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-fleetengine-delivery/samples/generated_samples/fleetengine_v1_generated_delivery_service_update_delivery_vehicle_async.py
+++ b/packages/google-maps-fleetengine-delivery/samples/generated_samples/fleetengine_v1_generated_delivery_service_update_delivery_vehicle_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-fleetengine-delivery/samples/generated_samples/fleetengine_v1_generated_delivery_service_update_delivery_vehicle_sync.py
+++ b/packages/google-maps-fleetengine-delivery/samples/generated_samples/fleetengine_v1_generated_delivery_service_update_delivery_vehicle_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-fleetengine-delivery/samples/generated_samples/fleetengine_v1_generated_delivery_service_update_task_async.py
+++ b/packages/google-maps-fleetengine-delivery/samples/generated_samples/fleetengine_v1_generated_delivery_service_update_task_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-fleetengine-delivery/samples/generated_samples/fleetengine_v1_generated_delivery_service_update_task_sync.py
+++ b/packages/google-maps-fleetengine-delivery/samples/generated_samples/fleetengine_v1_generated_delivery_service_update_task_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-fleetengine-delivery/tests/__init__.py
+++ b/packages/google-maps-fleetengine-delivery/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-fleetengine-delivery/tests/unit/__init__.py
+++ b/packages/google-maps-fleetengine-delivery/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-fleetengine-delivery/tests/unit/gapic/__init__.py
+++ b/packages/google-maps-fleetengine-delivery/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-fleetengine-delivery/tests/unit/gapic/fleetengine_delivery_v1/__init__.py
+++ b/packages/google-maps-fleetengine-delivery/tests/unit/gapic/fleetengine_delivery_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-fleetengine/.flake8
+++ b/packages/google-maps-fleetengine/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-fleetengine/MANIFEST.in
+++ b/packages/google-maps-fleetengine/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-fleetengine/google/maps/fleetengine/__init__.py
+++ b/packages/google-maps-fleetengine/google/maps/fleetengine/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-fleetengine/google/maps/fleetengine/gapic_version.py
+++ b/packages/google-maps-fleetengine/google/maps/fleetengine/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-fleetengine/google/maps/fleetengine_v1/gapic_version.py
+++ b/packages/google-maps-fleetengine/google/maps/fleetengine_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-fleetengine/google/maps/fleetengine_v1/services/__init__.py
+++ b/packages/google-maps-fleetengine/google/maps/fleetengine_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-fleetengine/google/maps/fleetengine_v1/services/trip_service/__init__.py
+++ b/packages/google-maps-fleetengine/google/maps/fleetengine_v1/services/trip_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-fleetengine/google/maps/fleetengine_v1/services/trip_service/async_client.py
+++ b/packages/google-maps-fleetengine/google/maps/fleetengine_v1/services/trip_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-fleetengine/google/maps/fleetengine_v1/services/trip_service/client.py
+++ b/packages/google-maps-fleetengine/google/maps/fleetengine_v1/services/trip_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-fleetengine/google/maps/fleetengine_v1/services/trip_service/pagers.py
+++ b/packages/google-maps-fleetengine/google/maps/fleetengine_v1/services/trip_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-fleetengine/google/maps/fleetengine_v1/services/trip_service/transports/__init__.py
+++ b/packages/google-maps-fleetengine/google/maps/fleetengine_v1/services/trip_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-fleetengine/google/maps/fleetengine_v1/services/trip_service/transports/base.py
+++ b/packages/google-maps-fleetengine/google/maps/fleetengine_v1/services/trip_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-fleetengine/google/maps/fleetengine_v1/services/trip_service/transports/grpc.py
+++ b/packages/google-maps-fleetengine/google/maps/fleetengine_v1/services/trip_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-fleetengine/google/maps/fleetengine_v1/services/trip_service/transports/grpc_asyncio.py
+++ b/packages/google-maps-fleetengine/google/maps/fleetengine_v1/services/trip_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-fleetengine/google/maps/fleetengine_v1/services/vehicle_service/__init__.py
+++ b/packages/google-maps-fleetengine/google/maps/fleetengine_v1/services/vehicle_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-fleetengine/google/maps/fleetengine_v1/services/vehicle_service/async_client.py
+++ b/packages/google-maps-fleetengine/google/maps/fleetengine_v1/services/vehicle_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-fleetengine/google/maps/fleetengine_v1/services/vehicle_service/client.py
+++ b/packages/google-maps-fleetengine/google/maps/fleetengine_v1/services/vehicle_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-fleetengine/google/maps/fleetengine_v1/services/vehicle_service/pagers.py
+++ b/packages/google-maps-fleetengine/google/maps/fleetengine_v1/services/vehicle_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-fleetengine/google/maps/fleetengine_v1/services/vehicle_service/transports/__init__.py
+++ b/packages/google-maps-fleetengine/google/maps/fleetengine_v1/services/vehicle_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-fleetengine/google/maps/fleetengine_v1/services/vehicle_service/transports/base.py
+++ b/packages/google-maps-fleetengine/google/maps/fleetengine_v1/services/vehicle_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-fleetengine/google/maps/fleetengine_v1/services/vehicle_service/transports/grpc.py
+++ b/packages/google-maps-fleetengine/google/maps/fleetengine_v1/services/vehicle_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-fleetengine/google/maps/fleetengine_v1/services/vehicle_service/transports/grpc_asyncio.py
+++ b/packages/google-maps-fleetengine/google/maps/fleetengine_v1/services/vehicle_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-fleetengine/google/maps/fleetengine_v1/types/__init__.py
+++ b/packages/google-maps-fleetengine/google/maps/fleetengine_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-fleetengine/google/maps/fleetengine_v1/types/fleetengine.py
+++ b/packages/google-maps-fleetengine/google/maps/fleetengine_v1/types/fleetengine.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-fleetengine/google/maps/fleetengine_v1/types/header.py
+++ b/packages/google-maps-fleetengine/google/maps/fleetengine_v1/types/header.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-fleetengine/google/maps/fleetengine_v1/types/traffic.py
+++ b/packages/google-maps-fleetengine/google/maps/fleetengine_v1/types/traffic.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-fleetengine/google/maps/fleetengine_v1/types/trip_api.py
+++ b/packages/google-maps-fleetengine/google/maps/fleetengine_v1/types/trip_api.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-fleetengine/google/maps/fleetengine_v1/types/trips.py
+++ b/packages/google-maps-fleetengine/google/maps/fleetengine_v1/types/trips.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-fleetengine/google/maps/fleetengine_v1/types/vehicle_api.py
+++ b/packages/google-maps-fleetengine/google/maps/fleetengine_v1/types/vehicle_api.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-fleetengine/google/maps/fleetengine_v1/types/vehicles.py
+++ b/packages/google-maps-fleetengine/google/maps/fleetengine_v1/types/vehicles.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-fleetengine/samples/generated_samples/fleetengine_v1_generated_trip_service_create_trip_async.py
+++ b/packages/google-maps-fleetengine/samples/generated_samples/fleetengine_v1_generated_trip_service_create_trip_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-fleetengine/samples/generated_samples/fleetengine_v1_generated_trip_service_create_trip_sync.py
+++ b/packages/google-maps-fleetengine/samples/generated_samples/fleetengine_v1_generated_trip_service_create_trip_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-fleetengine/samples/generated_samples/fleetengine_v1_generated_trip_service_delete_trip_async.py
+++ b/packages/google-maps-fleetengine/samples/generated_samples/fleetengine_v1_generated_trip_service_delete_trip_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-fleetengine/samples/generated_samples/fleetengine_v1_generated_trip_service_delete_trip_sync.py
+++ b/packages/google-maps-fleetengine/samples/generated_samples/fleetengine_v1_generated_trip_service_delete_trip_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-fleetengine/samples/generated_samples/fleetengine_v1_generated_trip_service_get_trip_async.py
+++ b/packages/google-maps-fleetengine/samples/generated_samples/fleetengine_v1_generated_trip_service_get_trip_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-fleetengine/samples/generated_samples/fleetengine_v1_generated_trip_service_get_trip_sync.py
+++ b/packages/google-maps-fleetengine/samples/generated_samples/fleetengine_v1_generated_trip_service_get_trip_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-fleetengine/samples/generated_samples/fleetengine_v1_generated_trip_service_report_billable_trip_async.py
+++ b/packages/google-maps-fleetengine/samples/generated_samples/fleetengine_v1_generated_trip_service_report_billable_trip_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-fleetengine/samples/generated_samples/fleetengine_v1_generated_trip_service_report_billable_trip_sync.py
+++ b/packages/google-maps-fleetengine/samples/generated_samples/fleetengine_v1_generated_trip_service_report_billable_trip_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-fleetengine/samples/generated_samples/fleetengine_v1_generated_trip_service_search_trips_async.py
+++ b/packages/google-maps-fleetengine/samples/generated_samples/fleetengine_v1_generated_trip_service_search_trips_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-fleetengine/samples/generated_samples/fleetengine_v1_generated_trip_service_search_trips_sync.py
+++ b/packages/google-maps-fleetengine/samples/generated_samples/fleetengine_v1_generated_trip_service_search_trips_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-fleetengine/samples/generated_samples/fleetengine_v1_generated_trip_service_update_trip_async.py
+++ b/packages/google-maps-fleetengine/samples/generated_samples/fleetengine_v1_generated_trip_service_update_trip_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-fleetengine/samples/generated_samples/fleetengine_v1_generated_trip_service_update_trip_sync.py
+++ b/packages/google-maps-fleetengine/samples/generated_samples/fleetengine_v1_generated_trip_service_update_trip_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-fleetengine/samples/generated_samples/fleetengine_v1_generated_vehicle_service_create_vehicle_async.py
+++ b/packages/google-maps-fleetengine/samples/generated_samples/fleetengine_v1_generated_vehicle_service_create_vehicle_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-fleetengine/samples/generated_samples/fleetengine_v1_generated_vehicle_service_create_vehicle_sync.py
+++ b/packages/google-maps-fleetengine/samples/generated_samples/fleetengine_v1_generated_vehicle_service_create_vehicle_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-fleetengine/samples/generated_samples/fleetengine_v1_generated_vehicle_service_delete_vehicle_async.py
+++ b/packages/google-maps-fleetengine/samples/generated_samples/fleetengine_v1_generated_vehicle_service_delete_vehicle_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-fleetengine/samples/generated_samples/fleetengine_v1_generated_vehicle_service_delete_vehicle_sync.py
+++ b/packages/google-maps-fleetengine/samples/generated_samples/fleetengine_v1_generated_vehicle_service_delete_vehicle_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-fleetengine/samples/generated_samples/fleetengine_v1_generated_vehicle_service_get_vehicle_async.py
+++ b/packages/google-maps-fleetengine/samples/generated_samples/fleetengine_v1_generated_vehicle_service_get_vehicle_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-fleetengine/samples/generated_samples/fleetengine_v1_generated_vehicle_service_get_vehicle_sync.py
+++ b/packages/google-maps-fleetengine/samples/generated_samples/fleetengine_v1_generated_vehicle_service_get_vehicle_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-fleetengine/samples/generated_samples/fleetengine_v1_generated_vehicle_service_list_vehicles_async.py
+++ b/packages/google-maps-fleetengine/samples/generated_samples/fleetengine_v1_generated_vehicle_service_list_vehicles_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-fleetengine/samples/generated_samples/fleetengine_v1_generated_vehicle_service_list_vehicles_sync.py
+++ b/packages/google-maps-fleetengine/samples/generated_samples/fleetengine_v1_generated_vehicle_service_list_vehicles_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-fleetengine/samples/generated_samples/fleetengine_v1_generated_vehicle_service_search_vehicles_async.py
+++ b/packages/google-maps-fleetengine/samples/generated_samples/fleetengine_v1_generated_vehicle_service_search_vehicles_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-fleetengine/samples/generated_samples/fleetengine_v1_generated_vehicle_service_search_vehicles_sync.py
+++ b/packages/google-maps-fleetengine/samples/generated_samples/fleetengine_v1_generated_vehicle_service_search_vehicles_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-fleetengine/samples/generated_samples/fleetengine_v1_generated_vehicle_service_update_vehicle_async.py
+++ b/packages/google-maps-fleetengine/samples/generated_samples/fleetengine_v1_generated_vehicle_service_update_vehicle_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-fleetengine/samples/generated_samples/fleetengine_v1_generated_vehicle_service_update_vehicle_attributes_async.py
+++ b/packages/google-maps-fleetengine/samples/generated_samples/fleetengine_v1_generated_vehicle_service_update_vehicle_attributes_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-fleetengine/samples/generated_samples/fleetengine_v1_generated_vehicle_service_update_vehicle_attributes_sync.py
+++ b/packages/google-maps-fleetengine/samples/generated_samples/fleetengine_v1_generated_vehicle_service_update_vehicle_attributes_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-fleetengine/samples/generated_samples/fleetengine_v1_generated_vehicle_service_update_vehicle_sync.py
+++ b/packages/google-maps-fleetengine/samples/generated_samples/fleetengine_v1_generated_vehicle_service_update_vehicle_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-fleetengine/tests/__init__.py
+++ b/packages/google-maps-fleetengine/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-fleetengine/tests/unit/__init__.py
+++ b/packages/google-maps-fleetengine/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-fleetengine/tests/unit/gapic/__init__.py
+++ b/packages/google-maps-fleetengine/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-fleetengine/tests/unit/gapic/fleetengine_v1/__init__.py
+++ b/packages/google-maps-fleetengine/tests/unit/gapic/fleetengine_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-geocode/.flake8
+++ b/packages/google-maps-geocode/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-geocode/MANIFEST.in
+++ b/packages/google-maps-geocode/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-geocode/google/maps/geocode/__init__.py
+++ b/packages/google-maps-geocode/google/maps/geocode/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-geocode/google/maps/geocode/gapic_version.py
+++ b/packages/google-maps-geocode/google/maps/geocode/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-geocode/google/maps/geocode_v4/gapic_version.py
+++ b/packages/google-maps-geocode/google/maps/geocode_v4/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-geocode/google/maps/geocode_v4/services/__init__.py
+++ b/packages/google-maps-geocode/google/maps/geocode_v4/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-geocode/google/maps/geocode_v4/services/destination_service/__init__.py
+++ b/packages/google-maps-geocode/google/maps/geocode_v4/services/destination_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-geocode/google/maps/geocode_v4/services/destination_service/async_client.py
+++ b/packages/google-maps-geocode/google/maps/geocode_v4/services/destination_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-geocode/google/maps/geocode_v4/services/destination_service/client.py
+++ b/packages/google-maps-geocode/google/maps/geocode_v4/services/destination_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-geocode/google/maps/geocode_v4/services/destination_service/transports/__init__.py
+++ b/packages/google-maps-geocode/google/maps/geocode_v4/services/destination_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-geocode/google/maps/geocode_v4/services/destination_service/transports/base.py
+++ b/packages/google-maps-geocode/google/maps/geocode_v4/services/destination_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-geocode/google/maps/geocode_v4/services/destination_service/transports/grpc.py
+++ b/packages/google-maps-geocode/google/maps/geocode_v4/services/destination_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-geocode/google/maps/geocode_v4/services/destination_service/transports/grpc_asyncio.py
+++ b/packages/google-maps-geocode/google/maps/geocode_v4/services/destination_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-geocode/google/maps/geocode_v4/services/destination_service/transports/rest.py
+++ b/packages/google-maps-geocode/google/maps/geocode_v4/services/destination_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-geocode/google/maps/geocode_v4/services/destination_service/transports/rest_base.py
+++ b/packages/google-maps-geocode/google/maps/geocode_v4/services/destination_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-geocode/google/maps/geocode_v4/services/geocode_service/__init__.py
+++ b/packages/google-maps-geocode/google/maps/geocode_v4/services/geocode_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-geocode/google/maps/geocode_v4/services/geocode_service/async_client.py
+++ b/packages/google-maps-geocode/google/maps/geocode_v4/services/geocode_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-geocode/google/maps/geocode_v4/services/geocode_service/client.py
+++ b/packages/google-maps-geocode/google/maps/geocode_v4/services/geocode_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-geocode/google/maps/geocode_v4/services/geocode_service/transports/__init__.py
+++ b/packages/google-maps-geocode/google/maps/geocode_v4/services/geocode_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-geocode/google/maps/geocode_v4/services/geocode_service/transports/base.py
+++ b/packages/google-maps-geocode/google/maps/geocode_v4/services/geocode_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-geocode/google/maps/geocode_v4/services/geocode_service/transports/grpc.py
+++ b/packages/google-maps-geocode/google/maps/geocode_v4/services/geocode_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-geocode/google/maps/geocode_v4/services/geocode_service/transports/grpc_asyncio.py
+++ b/packages/google-maps-geocode/google/maps/geocode_v4/services/geocode_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-geocode/google/maps/geocode_v4/services/geocode_service/transports/rest.py
+++ b/packages/google-maps-geocode/google/maps/geocode_v4/services/geocode_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-geocode/google/maps/geocode_v4/services/geocode_service/transports/rest_base.py
+++ b/packages/google-maps-geocode/google/maps/geocode_v4/services/geocode_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-geocode/google/maps/geocode_v4/types/__init__.py
+++ b/packages/google-maps-geocode/google/maps/geocode_v4/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-geocode/google/maps/geocode_v4/types/destination_service.py
+++ b/packages/google-maps-geocode/google/maps/geocode_v4/types/destination_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-geocode/google/maps/geocode_v4/types/geocode_service.py
+++ b/packages/google-maps-geocode/google/maps/geocode_v4/types/geocode_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-geocode/samples/generated_samples/geocoding-backend_v4_generated_destination_service_search_destinations_async.py
+++ b/packages/google-maps-geocode/samples/generated_samples/geocoding-backend_v4_generated_destination_service_search_destinations_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-geocode/samples/generated_samples/geocoding-backend_v4_generated_destination_service_search_destinations_sync.py
+++ b/packages/google-maps-geocode/samples/generated_samples/geocoding-backend_v4_generated_destination_service_search_destinations_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-geocode/samples/generated_samples/geocoding-backend_v4_generated_geocode_service_geocode_address_async.py
+++ b/packages/google-maps-geocode/samples/generated_samples/geocoding-backend_v4_generated_geocode_service_geocode_address_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-geocode/samples/generated_samples/geocoding-backend_v4_generated_geocode_service_geocode_address_sync.py
+++ b/packages/google-maps-geocode/samples/generated_samples/geocoding-backend_v4_generated_geocode_service_geocode_address_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-geocode/samples/generated_samples/geocoding-backend_v4_generated_geocode_service_geocode_location_async.py
+++ b/packages/google-maps-geocode/samples/generated_samples/geocoding-backend_v4_generated_geocode_service_geocode_location_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-geocode/samples/generated_samples/geocoding-backend_v4_generated_geocode_service_geocode_location_sync.py
+++ b/packages/google-maps-geocode/samples/generated_samples/geocoding-backend_v4_generated_geocode_service_geocode_location_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-geocode/samples/generated_samples/geocoding-backend_v4_generated_geocode_service_geocode_place_async.py
+++ b/packages/google-maps-geocode/samples/generated_samples/geocoding-backend_v4_generated_geocode_service_geocode_place_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-geocode/samples/generated_samples/geocoding-backend_v4_generated_geocode_service_geocode_place_sync.py
+++ b/packages/google-maps-geocode/samples/generated_samples/geocoding-backend_v4_generated_geocode_service_geocode_place_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-geocode/tests/__init__.py
+++ b/packages/google-maps-geocode/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-geocode/tests/unit/__init__.py
+++ b/packages/google-maps-geocode/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-geocode/tests/unit/gapic/__init__.py
+++ b/packages/google-maps-geocode/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-geocode/tests/unit/gapic/geocode_v4/__init__.py
+++ b/packages/google-maps-geocode/tests/unit/gapic/geocode_v4/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-mapmanagement/.flake8
+++ b/packages/google-maps-mapmanagement/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-mapmanagement/MANIFEST.in
+++ b/packages/google-maps-mapmanagement/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-mapmanagement/google/maps/mapmanagement/__init__.py
+++ b/packages/google-maps-mapmanagement/google/maps/mapmanagement/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-mapmanagement/google/maps/mapmanagement/gapic_version.py
+++ b/packages/google-maps-mapmanagement/google/maps/mapmanagement/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-mapmanagement/google/maps/mapmanagement_v2beta/gapic_version.py
+++ b/packages/google-maps-mapmanagement/google/maps/mapmanagement_v2beta/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-mapmanagement/google/maps/mapmanagement_v2beta/services/__init__.py
+++ b/packages/google-maps-mapmanagement/google/maps/mapmanagement_v2beta/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-mapmanagement/google/maps/mapmanagement_v2beta/services/map_management/__init__.py
+++ b/packages/google-maps-mapmanagement/google/maps/mapmanagement_v2beta/services/map_management/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-mapmanagement/google/maps/mapmanagement_v2beta/services/map_management/async_client.py
+++ b/packages/google-maps-mapmanagement/google/maps/mapmanagement_v2beta/services/map_management/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-mapmanagement/google/maps/mapmanagement_v2beta/services/map_management/client.py
+++ b/packages/google-maps-mapmanagement/google/maps/mapmanagement_v2beta/services/map_management/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-mapmanagement/google/maps/mapmanagement_v2beta/services/map_management/pagers.py
+++ b/packages/google-maps-mapmanagement/google/maps/mapmanagement_v2beta/services/map_management/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-mapmanagement/google/maps/mapmanagement_v2beta/services/map_management/transports/__init__.py
+++ b/packages/google-maps-mapmanagement/google/maps/mapmanagement_v2beta/services/map_management/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-mapmanagement/google/maps/mapmanagement_v2beta/services/map_management/transports/base.py
+++ b/packages/google-maps-mapmanagement/google/maps/mapmanagement_v2beta/services/map_management/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-mapmanagement/google/maps/mapmanagement_v2beta/services/map_management/transports/grpc.py
+++ b/packages/google-maps-mapmanagement/google/maps/mapmanagement_v2beta/services/map_management/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-mapmanagement/google/maps/mapmanagement_v2beta/services/map_management/transports/grpc_asyncio.py
+++ b/packages/google-maps-mapmanagement/google/maps/mapmanagement_v2beta/services/map_management/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-mapmanagement/google/maps/mapmanagement_v2beta/services/map_management/transports/rest.py
+++ b/packages/google-maps-mapmanagement/google/maps/mapmanagement_v2beta/services/map_management/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-mapmanagement/google/maps/mapmanagement_v2beta/services/map_management/transports/rest_base.py
+++ b/packages/google-maps-mapmanagement/google/maps/mapmanagement_v2beta/services/map_management/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-mapmanagement/google/maps/mapmanagement_v2beta/types/__init__.py
+++ b/packages/google-maps-mapmanagement/google/maps/mapmanagement_v2beta/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-mapmanagement/google/maps/mapmanagement_v2beta/types/map_management_service.py
+++ b/packages/google-maps-mapmanagement/google/maps/mapmanagement_v2beta/types/map_management_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-mapmanagement/samples/generated_samples/mapmanagement_v2beta_generated_map_management_create_map_config_async.py
+++ b/packages/google-maps-mapmanagement/samples/generated_samples/mapmanagement_v2beta_generated_map_management_create_map_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-mapmanagement/samples/generated_samples/mapmanagement_v2beta_generated_map_management_create_map_config_sync.py
+++ b/packages/google-maps-mapmanagement/samples/generated_samples/mapmanagement_v2beta_generated_map_management_create_map_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-mapmanagement/samples/generated_samples/mapmanagement_v2beta_generated_map_management_create_map_context_config_async.py
+++ b/packages/google-maps-mapmanagement/samples/generated_samples/mapmanagement_v2beta_generated_map_management_create_map_context_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-mapmanagement/samples/generated_samples/mapmanagement_v2beta_generated_map_management_create_map_context_config_sync.py
+++ b/packages/google-maps-mapmanagement/samples/generated_samples/mapmanagement_v2beta_generated_map_management_create_map_context_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-mapmanagement/samples/generated_samples/mapmanagement_v2beta_generated_map_management_create_style_config_async.py
+++ b/packages/google-maps-mapmanagement/samples/generated_samples/mapmanagement_v2beta_generated_map_management_create_style_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-mapmanagement/samples/generated_samples/mapmanagement_v2beta_generated_map_management_create_style_config_sync.py
+++ b/packages/google-maps-mapmanagement/samples/generated_samples/mapmanagement_v2beta_generated_map_management_create_style_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-mapmanagement/samples/generated_samples/mapmanagement_v2beta_generated_map_management_delete_map_config_async.py
+++ b/packages/google-maps-mapmanagement/samples/generated_samples/mapmanagement_v2beta_generated_map_management_delete_map_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-mapmanagement/samples/generated_samples/mapmanagement_v2beta_generated_map_management_delete_map_config_sync.py
+++ b/packages/google-maps-mapmanagement/samples/generated_samples/mapmanagement_v2beta_generated_map_management_delete_map_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-mapmanagement/samples/generated_samples/mapmanagement_v2beta_generated_map_management_delete_map_context_config_async.py
+++ b/packages/google-maps-mapmanagement/samples/generated_samples/mapmanagement_v2beta_generated_map_management_delete_map_context_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-mapmanagement/samples/generated_samples/mapmanagement_v2beta_generated_map_management_delete_map_context_config_sync.py
+++ b/packages/google-maps-mapmanagement/samples/generated_samples/mapmanagement_v2beta_generated_map_management_delete_map_context_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-mapmanagement/samples/generated_samples/mapmanagement_v2beta_generated_map_management_delete_style_config_async.py
+++ b/packages/google-maps-mapmanagement/samples/generated_samples/mapmanagement_v2beta_generated_map_management_delete_style_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-mapmanagement/samples/generated_samples/mapmanagement_v2beta_generated_map_management_delete_style_config_sync.py
+++ b/packages/google-maps-mapmanagement/samples/generated_samples/mapmanagement_v2beta_generated_map_management_delete_style_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-mapmanagement/samples/generated_samples/mapmanagement_v2beta_generated_map_management_get_map_config_async.py
+++ b/packages/google-maps-mapmanagement/samples/generated_samples/mapmanagement_v2beta_generated_map_management_get_map_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-mapmanagement/samples/generated_samples/mapmanagement_v2beta_generated_map_management_get_map_config_sync.py
+++ b/packages/google-maps-mapmanagement/samples/generated_samples/mapmanagement_v2beta_generated_map_management_get_map_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-mapmanagement/samples/generated_samples/mapmanagement_v2beta_generated_map_management_get_map_context_config_async.py
+++ b/packages/google-maps-mapmanagement/samples/generated_samples/mapmanagement_v2beta_generated_map_management_get_map_context_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-mapmanagement/samples/generated_samples/mapmanagement_v2beta_generated_map_management_get_map_context_config_sync.py
+++ b/packages/google-maps-mapmanagement/samples/generated_samples/mapmanagement_v2beta_generated_map_management_get_map_context_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-mapmanagement/samples/generated_samples/mapmanagement_v2beta_generated_map_management_get_style_config_async.py
+++ b/packages/google-maps-mapmanagement/samples/generated_samples/mapmanagement_v2beta_generated_map_management_get_style_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-mapmanagement/samples/generated_samples/mapmanagement_v2beta_generated_map_management_get_style_config_sync.py
+++ b/packages/google-maps-mapmanagement/samples/generated_samples/mapmanagement_v2beta_generated_map_management_get_style_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-mapmanagement/samples/generated_samples/mapmanagement_v2beta_generated_map_management_list_map_configs_async.py
+++ b/packages/google-maps-mapmanagement/samples/generated_samples/mapmanagement_v2beta_generated_map_management_list_map_configs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-mapmanagement/samples/generated_samples/mapmanagement_v2beta_generated_map_management_list_map_configs_sync.py
+++ b/packages/google-maps-mapmanagement/samples/generated_samples/mapmanagement_v2beta_generated_map_management_list_map_configs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-mapmanagement/samples/generated_samples/mapmanagement_v2beta_generated_map_management_list_map_context_configs_async.py
+++ b/packages/google-maps-mapmanagement/samples/generated_samples/mapmanagement_v2beta_generated_map_management_list_map_context_configs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-mapmanagement/samples/generated_samples/mapmanagement_v2beta_generated_map_management_list_map_context_configs_sync.py
+++ b/packages/google-maps-mapmanagement/samples/generated_samples/mapmanagement_v2beta_generated_map_management_list_map_context_configs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-mapmanagement/samples/generated_samples/mapmanagement_v2beta_generated_map_management_list_style_configs_async.py
+++ b/packages/google-maps-mapmanagement/samples/generated_samples/mapmanagement_v2beta_generated_map_management_list_style_configs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-mapmanagement/samples/generated_samples/mapmanagement_v2beta_generated_map_management_list_style_configs_sync.py
+++ b/packages/google-maps-mapmanagement/samples/generated_samples/mapmanagement_v2beta_generated_map_management_list_style_configs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-mapmanagement/samples/generated_samples/mapmanagement_v2beta_generated_map_management_update_map_config_async.py
+++ b/packages/google-maps-mapmanagement/samples/generated_samples/mapmanagement_v2beta_generated_map_management_update_map_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-mapmanagement/samples/generated_samples/mapmanagement_v2beta_generated_map_management_update_map_config_sync.py
+++ b/packages/google-maps-mapmanagement/samples/generated_samples/mapmanagement_v2beta_generated_map_management_update_map_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-mapmanagement/samples/generated_samples/mapmanagement_v2beta_generated_map_management_update_map_context_config_async.py
+++ b/packages/google-maps-mapmanagement/samples/generated_samples/mapmanagement_v2beta_generated_map_management_update_map_context_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-mapmanagement/samples/generated_samples/mapmanagement_v2beta_generated_map_management_update_map_context_config_sync.py
+++ b/packages/google-maps-mapmanagement/samples/generated_samples/mapmanagement_v2beta_generated_map_management_update_map_context_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-mapmanagement/samples/generated_samples/mapmanagement_v2beta_generated_map_management_update_style_config_async.py
+++ b/packages/google-maps-mapmanagement/samples/generated_samples/mapmanagement_v2beta_generated_map_management_update_style_config_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-mapmanagement/samples/generated_samples/mapmanagement_v2beta_generated_map_management_update_style_config_sync.py
+++ b/packages/google-maps-mapmanagement/samples/generated_samples/mapmanagement_v2beta_generated_map_management_update_style_config_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-mapmanagement/tests/__init__.py
+++ b/packages/google-maps-mapmanagement/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-mapmanagement/tests/unit/__init__.py
+++ b/packages/google-maps-mapmanagement/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-mapmanagement/tests/unit/gapic/__init__.py
+++ b/packages/google-maps-mapmanagement/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-mapmanagement/tests/unit/gapic/mapmanagement_v2beta/__init__.py
+++ b/packages/google-maps-mapmanagement/tests/unit/gapic/mapmanagement_v2beta/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-mapsplatformdatasets/.flake8
+++ b/packages/google-maps-mapsplatformdatasets/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-mapsplatformdatasets/MANIFEST.in
+++ b/packages/google-maps-mapsplatformdatasets/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-mapsplatformdatasets/google/maps/mapsplatformdatasets/__init__.py
+++ b/packages/google-maps-mapsplatformdatasets/google/maps/mapsplatformdatasets/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-mapsplatformdatasets/google/maps/mapsplatformdatasets/gapic_version.py
+++ b/packages/google-maps-mapsplatformdatasets/google/maps/mapsplatformdatasets/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-mapsplatformdatasets/google/maps/mapsplatformdatasets_v1/gapic_version.py
+++ b/packages/google-maps-mapsplatformdatasets/google/maps/mapsplatformdatasets_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-mapsplatformdatasets/google/maps/mapsplatformdatasets_v1/services/__init__.py
+++ b/packages/google-maps-mapsplatformdatasets/google/maps/mapsplatformdatasets_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-mapsplatformdatasets/google/maps/mapsplatformdatasets_v1/services/maps_platform_datasets/__init__.py
+++ b/packages/google-maps-mapsplatformdatasets/google/maps/mapsplatformdatasets_v1/services/maps_platform_datasets/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-mapsplatformdatasets/google/maps/mapsplatformdatasets_v1/services/maps_platform_datasets/async_client.py
+++ b/packages/google-maps-mapsplatformdatasets/google/maps/mapsplatformdatasets_v1/services/maps_platform_datasets/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-mapsplatformdatasets/google/maps/mapsplatformdatasets_v1/services/maps_platform_datasets/client.py
+++ b/packages/google-maps-mapsplatformdatasets/google/maps/mapsplatformdatasets_v1/services/maps_platform_datasets/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-mapsplatformdatasets/google/maps/mapsplatformdatasets_v1/services/maps_platform_datasets/pagers.py
+++ b/packages/google-maps-mapsplatformdatasets/google/maps/mapsplatformdatasets_v1/services/maps_platform_datasets/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-mapsplatformdatasets/google/maps/mapsplatformdatasets_v1/services/maps_platform_datasets/transports/__init__.py
+++ b/packages/google-maps-mapsplatformdatasets/google/maps/mapsplatformdatasets_v1/services/maps_platform_datasets/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-mapsplatformdatasets/google/maps/mapsplatformdatasets_v1/services/maps_platform_datasets/transports/base.py
+++ b/packages/google-maps-mapsplatformdatasets/google/maps/mapsplatformdatasets_v1/services/maps_platform_datasets/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-mapsplatformdatasets/google/maps/mapsplatformdatasets_v1/services/maps_platform_datasets/transports/grpc.py
+++ b/packages/google-maps-mapsplatformdatasets/google/maps/mapsplatformdatasets_v1/services/maps_platform_datasets/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-mapsplatformdatasets/google/maps/mapsplatformdatasets_v1/services/maps_platform_datasets/transports/grpc_asyncio.py
+++ b/packages/google-maps-mapsplatformdatasets/google/maps/mapsplatformdatasets_v1/services/maps_platform_datasets/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-mapsplatformdatasets/google/maps/mapsplatformdatasets_v1/services/maps_platform_datasets/transports/rest.py
+++ b/packages/google-maps-mapsplatformdatasets/google/maps/mapsplatformdatasets_v1/services/maps_platform_datasets/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-mapsplatformdatasets/google/maps/mapsplatformdatasets_v1/services/maps_platform_datasets/transports/rest_base.py
+++ b/packages/google-maps-mapsplatformdatasets/google/maps/mapsplatformdatasets_v1/services/maps_platform_datasets/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-mapsplatformdatasets/google/maps/mapsplatformdatasets_v1/types/__init__.py
+++ b/packages/google-maps-mapsplatformdatasets/google/maps/mapsplatformdatasets_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-mapsplatformdatasets/google/maps/mapsplatformdatasets_v1/types/data_source.py
+++ b/packages/google-maps-mapsplatformdatasets/google/maps/mapsplatformdatasets_v1/types/data_source.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-mapsplatformdatasets/google/maps/mapsplatformdatasets_v1/types/dataset.py
+++ b/packages/google-maps-mapsplatformdatasets/google/maps/mapsplatformdatasets_v1/types/dataset.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-mapsplatformdatasets/google/maps/mapsplatformdatasets_v1/types/maps_platform_datasets.py
+++ b/packages/google-maps-mapsplatformdatasets/google/maps/mapsplatformdatasets_v1/types/maps_platform_datasets.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-mapsplatformdatasets/google/maps/mapsplatformdatasets_v1/types/maps_platform_datasets_service.py
+++ b/packages/google-maps-mapsplatformdatasets/google/maps/mapsplatformdatasets_v1/types/maps_platform_datasets_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-mapsplatformdatasets/samples/generated_samples/mapsplatformdatasets_v1_generated_maps_platform_datasets_create_dataset_async.py
+++ b/packages/google-maps-mapsplatformdatasets/samples/generated_samples/mapsplatformdatasets_v1_generated_maps_platform_datasets_create_dataset_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-mapsplatformdatasets/samples/generated_samples/mapsplatformdatasets_v1_generated_maps_platform_datasets_create_dataset_sync.py
+++ b/packages/google-maps-mapsplatformdatasets/samples/generated_samples/mapsplatformdatasets_v1_generated_maps_platform_datasets_create_dataset_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-mapsplatformdatasets/samples/generated_samples/mapsplatformdatasets_v1_generated_maps_platform_datasets_delete_dataset_async.py
+++ b/packages/google-maps-mapsplatformdatasets/samples/generated_samples/mapsplatformdatasets_v1_generated_maps_platform_datasets_delete_dataset_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-mapsplatformdatasets/samples/generated_samples/mapsplatformdatasets_v1_generated_maps_platform_datasets_delete_dataset_sync.py
+++ b/packages/google-maps-mapsplatformdatasets/samples/generated_samples/mapsplatformdatasets_v1_generated_maps_platform_datasets_delete_dataset_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-mapsplatformdatasets/samples/generated_samples/mapsplatformdatasets_v1_generated_maps_platform_datasets_fetch_dataset_errors_async.py
+++ b/packages/google-maps-mapsplatformdatasets/samples/generated_samples/mapsplatformdatasets_v1_generated_maps_platform_datasets_fetch_dataset_errors_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-mapsplatformdatasets/samples/generated_samples/mapsplatformdatasets_v1_generated_maps_platform_datasets_fetch_dataset_errors_sync.py
+++ b/packages/google-maps-mapsplatformdatasets/samples/generated_samples/mapsplatformdatasets_v1_generated_maps_platform_datasets_fetch_dataset_errors_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-mapsplatformdatasets/samples/generated_samples/mapsplatformdatasets_v1_generated_maps_platform_datasets_get_dataset_async.py
+++ b/packages/google-maps-mapsplatformdatasets/samples/generated_samples/mapsplatformdatasets_v1_generated_maps_platform_datasets_get_dataset_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-mapsplatformdatasets/samples/generated_samples/mapsplatformdatasets_v1_generated_maps_platform_datasets_get_dataset_sync.py
+++ b/packages/google-maps-mapsplatformdatasets/samples/generated_samples/mapsplatformdatasets_v1_generated_maps_platform_datasets_get_dataset_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-mapsplatformdatasets/samples/generated_samples/mapsplatformdatasets_v1_generated_maps_platform_datasets_list_datasets_async.py
+++ b/packages/google-maps-mapsplatformdatasets/samples/generated_samples/mapsplatformdatasets_v1_generated_maps_platform_datasets_list_datasets_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-mapsplatformdatasets/samples/generated_samples/mapsplatformdatasets_v1_generated_maps_platform_datasets_list_datasets_sync.py
+++ b/packages/google-maps-mapsplatformdatasets/samples/generated_samples/mapsplatformdatasets_v1_generated_maps_platform_datasets_list_datasets_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-mapsplatformdatasets/samples/generated_samples/mapsplatformdatasets_v1_generated_maps_platform_datasets_update_dataset_metadata_async.py
+++ b/packages/google-maps-mapsplatformdatasets/samples/generated_samples/mapsplatformdatasets_v1_generated_maps_platform_datasets_update_dataset_metadata_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-mapsplatformdatasets/samples/generated_samples/mapsplatformdatasets_v1_generated_maps_platform_datasets_update_dataset_metadata_sync.py
+++ b/packages/google-maps-mapsplatformdatasets/samples/generated_samples/mapsplatformdatasets_v1_generated_maps_platform_datasets_update_dataset_metadata_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-mapsplatformdatasets/tests/__init__.py
+++ b/packages/google-maps-mapsplatformdatasets/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-mapsplatformdatasets/tests/unit/__init__.py
+++ b/packages/google-maps-mapsplatformdatasets/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-mapsplatformdatasets/tests/unit/gapic/__init__.py
+++ b/packages/google-maps-mapsplatformdatasets/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-mapsplatformdatasets/tests/unit/gapic/mapsplatformdatasets_v1/__init__.py
+++ b/packages/google-maps-mapsplatformdatasets/tests/unit/gapic/mapsplatformdatasets_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-navconnect/.flake8
+++ b/packages/google-maps-navconnect/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-navconnect/MANIFEST.in
+++ b/packages/google-maps-navconnect/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-navconnect/google/maps/navconnect/__init__.py
+++ b/packages/google-maps-navconnect/google/maps/navconnect/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-navconnect/google/maps/navconnect/gapic_version.py
+++ b/packages/google-maps-navconnect/google/maps/navconnect/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-navconnect/google/maps/navconnect_v1/gapic_version.py
+++ b/packages/google-maps-navconnect/google/maps/navconnect_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-navconnect/google/maps/navconnect_v1/services/__init__.py
+++ b/packages/google-maps-navconnect/google/maps/navconnect_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-navconnect/google/maps/navconnect_v1/services/nav_connect_service/__init__.py
+++ b/packages/google-maps-navconnect/google/maps/navconnect_v1/services/nav_connect_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-navconnect/google/maps/navconnect_v1/services/nav_connect_service/async_client.py
+++ b/packages/google-maps-navconnect/google/maps/navconnect_v1/services/nav_connect_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-navconnect/google/maps/navconnect_v1/services/nav_connect_service/client.py
+++ b/packages/google-maps-navconnect/google/maps/navconnect_v1/services/nav_connect_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-navconnect/google/maps/navconnect_v1/services/nav_connect_service/transports/__init__.py
+++ b/packages/google-maps-navconnect/google/maps/navconnect_v1/services/nav_connect_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-navconnect/google/maps/navconnect_v1/services/nav_connect_service/transports/base.py
+++ b/packages/google-maps-navconnect/google/maps/navconnect_v1/services/nav_connect_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-navconnect/google/maps/navconnect_v1/services/nav_connect_service/transports/grpc.py
+++ b/packages/google-maps-navconnect/google/maps/navconnect_v1/services/nav_connect_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-navconnect/google/maps/navconnect_v1/services/nav_connect_service/transports/grpc_asyncio.py
+++ b/packages/google-maps-navconnect/google/maps/navconnect_v1/services/nav_connect_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-navconnect/google/maps/navconnect_v1/services/nav_connect_service/transports/rest.py
+++ b/packages/google-maps-navconnect/google/maps/navconnect_v1/services/nav_connect_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-navconnect/google/maps/navconnect_v1/services/nav_connect_service/transports/rest_base.py
+++ b/packages/google-maps-navconnect/google/maps/navconnect_v1/services/nav_connect_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-navconnect/google/maps/navconnect_v1/types/__init__.py
+++ b/packages/google-maps-navconnect/google/maps/navconnect_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-navconnect/google/maps/navconnect_v1/types/navconnect_service.py
+++ b/packages/google-maps-navconnect/google/maps/navconnect_v1/types/navconnect_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-navconnect/samples/generated_samples/navigationconnect_v1_generated_nav_connect_service_create_trip_async.py
+++ b/packages/google-maps-navconnect/samples/generated_samples/navigationconnect_v1_generated_nav_connect_service_create_trip_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-navconnect/samples/generated_samples/navigationconnect_v1_generated_nav_connect_service_create_trip_sync.py
+++ b/packages/google-maps-navconnect/samples/generated_samples/navigationconnect_v1_generated_nav_connect_service_create_trip_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-navconnect/samples/generated_samples/navigationconnect_v1_generated_nav_connect_service_get_trip_async.py
+++ b/packages/google-maps-navconnect/samples/generated_samples/navigationconnect_v1_generated_nav_connect_service_get_trip_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-navconnect/samples/generated_samples/navigationconnect_v1_generated_nav_connect_service_get_trip_sync.py
+++ b/packages/google-maps-navconnect/samples/generated_samples/navigationconnect_v1_generated_nav_connect_service_get_trip_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-navconnect/tests/__init__.py
+++ b/packages/google-maps-navconnect/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-navconnect/tests/unit/__init__.py
+++ b/packages/google-maps-navconnect/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-navconnect/tests/unit/gapic/__init__.py
+++ b/packages/google-maps-navconnect/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-navconnect/tests/unit/gapic/navconnect_v1/__init__.py
+++ b/packages/google-maps-navconnect/tests/unit/gapic/navconnect_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-places/.flake8
+++ b/packages/google-maps-places/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-places/MANIFEST.in
+++ b/packages/google-maps-places/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-places/google/maps/places/__init__.py
+++ b/packages/google-maps-places/google/maps/places/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-places/google/maps/places/gapic_version.py
+++ b/packages/google-maps-places/google/maps/places/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-places/google/maps/places_v1/gapic_version.py
+++ b/packages/google-maps-places/google/maps/places_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-places/google/maps/places_v1/services/__init__.py
+++ b/packages/google-maps-places/google/maps/places_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-places/google/maps/places_v1/services/places/__init__.py
+++ b/packages/google-maps-places/google/maps/places_v1/services/places/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-places/google/maps/places_v1/services/places/async_client.py
+++ b/packages/google-maps-places/google/maps/places_v1/services/places/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-places/google/maps/places_v1/services/places/client.py
+++ b/packages/google-maps-places/google/maps/places_v1/services/places/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-places/google/maps/places_v1/services/places/transports/__init__.py
+++ b/packages/google-maps-places/google/maps/places_v1/services/places/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-places/google/maps/places_v1/services/places/transports/base.py
+++ b/packages/google-maps-places/google/maps/places_v1/services/places/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-places/google/maps/places_v1/services/places/transports/grpc.py
+++ b/packages/google-maps-places/google/maps/places_v1/services/places/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-places/google/maps/places_v1/services/places/transports/grpc_asyncio.py
+++ b/packages/google-maps-places/google/maps/places_v1/services/places/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-places/google/maps/places_v1/services/places/transports/rest.py
+++ b/packages/google-maps-places/google/maps/places_v1/services/places/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-places/google/maps/places_v1/services/places/transports/rest_base.py
+++ b/packages/google-maps-places/google/maps/places_v1/services/places/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-places/google/maps/places_v1/types/__init__.py
+++ b/packages/google-maps-places/google/maps/places_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-places/google/maps/places_v1/types/address_descriptor.py
+++ b/packages/google-maps-places/google/maps/places_v1/types/address_descriptor.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-places/google/maps/places_v1/types/attribution.py
+++ b/packages/google-maps-places/google/maps/places_v1/types/attribution.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-places/google/maps/places_v1/types/content_block.py
+++ b/packages/google-maps-places/google/maps/places_v1/types/content_block.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-places/google/maps/places_v1/types/contextual_content.py
+++ b/packages/google-maps-places/google/maps/places_v1/types/contextual_content.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-places/google/maps/places_v1/types/ev_charging.py
+++ b/packages/google-maps-places/google/maps/places_v1/types/ev_charging.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-places/google/maps/places_v1/types/fuel_options.py
+++ b/packages/google-maps-places/google/maps/places_v1/types/fuel_options.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-places/google/maps/places_v1/types/geometry.py
+++ b/packages/google-maps-places/google/maps/places_v1/types/geometry.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-places/google/maps/places_v1/types/photo.py
+++ b/packages/google-maps-places/google/maps/places_v1/types/photo.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-places/google/maps/places_v1/types/place.py
+++ b/packages/google-maps-places/google/maps/places_v1/types/place.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-places/google/maps/places_v1/types/places_service.py
+++ b/packages/google-maps-places/google/maps/places_v1/types/places_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-places/google/maps/places_v1/types/polyline.py
+++ b/packages/google-maps-places/google/maps/places_v1/types/polyline.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-places/google/maps/places_v1/types/price_range.py
+++ b/packages/google-maps-places/google/maps/places_v1/types/price_range.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-places/google/maps/places_v1/types/reference.py
+++ b/packages/google-maps-places/google/maps/places_v1/types/reference.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-places/google/maps/places_v1/types/review.py
+++ b/packages/google-maps-places/google/maps/places_v1/types/review.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-places/google/maps/places_v1/types/route_modifiers.py
+++ b/packages/google-maps-places/google/maps/places_v1/types/route_modifiers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-places/google/maps/places_v1/types/routing_preference.py
+++ b/packages/google-maps-places/google/maps/places_v1/types/routing_preference.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-places/google/maps/places_v1/types/routing_summary.py
+++ b/packages/google-maps-places/google/maps/places_v1/types/routing_summary.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-places/google/maps/places_v1/types/travel_mode.py
+++ b/packages/google-maps-places/google/maps/places_v1/types/travel_mode.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-places/tests/__init__.py
+++ b/packages/google-maps-places/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-places/tests/unit/__init__.py
+++ b/packages/google-maps-places/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-places/tests/unit/gapic/__init__.py
+++ b/packages/google-maps-places/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-places/tests/unit/gapic/places_v1/__init__.py
+++ b/packages/google-maps-places/tests/unit/gapic/places_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-routeoptimization/.flake8
+++ b/packages/google-maps-routeoptimization/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-routeoptimization/MANIFEST.in
+++ b/packages/google-maps-routeoptimization/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-routeoptimization/google/maps/routeoptimization/__init__.py
+++ b/packages/google-maps-routeoptimization/google/maps/routeoptimization/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-routeoptimization/google/maps/routeoptimization/gapic_version.py
+++ b/packages/google-maps-routeoptimization/google/maps/routeoptimization/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-routeoptimization/google/maps/routeoptimization_v1/gapic_version.py
+++ b/packages/google-maps-routeoptimization/google/maps/routeoptimization_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-routeoptimization/google/maps/routeoptimization_v1/services/__init__.py
+++ b/packages/google-maps-routeoptimization/google/maps/routeoptimization_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-routeoptimization/google/maps/routeoptimization_v1/services/route_optimization/__init__.py
+++ b/packages/google-maps-routeoptimization/google/maps/routeoptimization_v1/services/route_optimization/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-routeoptimization/google/maps/routeoptimization_v1/services/route_optimization/client.py
+++ b/packages/google-maps-routeoptimization/google/maps/routeoptimization_v1/services/route_optimization/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-routeoptimization/google/maps/routeoptimization_v1/services/route_optimization/transports/__init__.py
+++ b/packages/google-maps-routeoptimization/google/maps/routeoptimization_v1/services/route_optimization/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-routeoptimization/google/maps/routeoptimization_v1/services/route_optimization/transports/base.py
+++ b/packages/google-maps-routeoptimization/google/maps/routeoptimization_v1/services/route_optimization/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-routeoptimization/google/maps/routeoptimization_v1/services/route_optimization/transports/grpc.py
+++ b/packages/google-maps-routeoptimization/google/maps/routeoptimization_v1/services/route_optimization/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-routeoptimization/google/maps/routeoptimization_v1/services/route_optimization/transports/grpc_asyncio.py
+++ b/packages/google-maps-routeoptimization/google/maps/routeoptimization_v1/services/route_optimization/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-routeoptimization/google/maps/routeoptimization_v1/services/route_optimization/transports/rest.py
+++ b/packages/google-maps-routeoptimization/google/maps/routeoptimization_v1/services/route_optimization/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-routeoptimization/google/maps/routeoptimization_v1/services/route_optimization/transports/rest_base.py
+++ b/packages/google-maps-routeoptimization/google/maps/routeoptimization_v1/services/route_optimization/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-routeoptimization/google/maps/routeoptimization_v1/types/__init__.py
+++ b/packages/google-maps-routeoptimization/google/maps/routeoptimization_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-routeoptimization/samples/generated_samples/routeoptimization_v1_generated_route_optimization_batch_optimize_tours_sync.py
+++ b/packages/google-maps-routeoptimization/samples/generated_samples/routeoptimization_v1_generated_route_optimization_batch_optimize_tours_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-routeoptimization/samples/generated_samples/routeoptimization_v1_generated_route_optimization_optimize_tours_async.py
+++ b/packages/google-maps-routeoptimization/samples/generated_samples/routeoptimization_v1_generated_route_optimization_optimize_tours_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-routeoptimization/samples/generated_samples/routeoptimization_v1_generated_route_optimization_optimize_tours_long_running_sync.py
+++ b/packages/google-maps-routeoptimization/samples/generated_samples/routeoptimization_v1_generated_route_optimization_optimize_tours_long_running_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-routeoptimization/samples/generated_samples/routeoptimization_v1_generated_route_optimization_optimize_tours_sync.py
+++ b/packages/google-maps-routeoptimization/samples/generated_samples/routeoptimization_v1_generated_route_optimization_optimize_tours_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-routeoptimization/samples/generated_samples/routeoptimization_v1_generated_route_optimization_optimize_tours_uri_sync.py
+++ b/packages/google-maps-routeoptimization/samples/generated_samples/routeoptimization_v1_generated_route_optimization_optimize_tours_uri_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-routeoptimization/tests/__init__.py
+++ b/packages/google-maps-routeoptimization/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-routeoptimization/tests/unit/__init__.py
+++ b/packages/google-maps-routeoptimization/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-routeoptimization/tests/unit/gapic/__init__.py
+++ b/packages/google-maps-routeoptimization/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-routeoptimization/tests/unit/gapic/routeoptimization_v1/__init__.py
+++ b/packages/google-maps-routeoptimization/tests/unit/gapic/routeoptimization_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-routing/.flake8
+++ b/packages/google-maps-routing/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-routing/MANIFEST.in
+++ b/packages/google-maps-routing/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-routing/google/maps/routing/__init__.py
+++ b/packages/google-maps-routing/google/maps/routing/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-routing/google/maps/routing/gapic_version.py
+++ b/packages/google-maps-routing/google/maps/routing/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-routing/google/maps/routing_v2/gapic_version.py
+++ b/packages/google-maps-routing/google/maps/routing_v2/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-routing/google/maps/routing_v2/services/__init__.py
+++ b/packages/google-maps-routing/google/maps/routing_v2/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-routing/google/maps/routing_v2/services/routes/__init__.py
+++ b/packages/google-maps-routing/google/maps/routing_v2/services/routes/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-routing/google/maps/routing_v2/services/routes/async_client.py
+++ b/packages/google-maps-routing/google/maps/routing_v2/services/routes/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-routing/google/maps/routing_v2/services/routes/client.py
+++ b/packages/google-maps-routing/google/maps/routing_v2/services/routes/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-routing/google/maps/routing_v2/services/routes/transports/__init__.py
+++ b/packages/google-maps-routing/google/maps/routing_v2/services/routes/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-routing/google/maps/routing_v2/services/routes/transports/base.py
+++ b/packages/google-maps-routing/google/maps/routing_v2/services/routes/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-routing/google/maps/routing_v2/services/routes/transports/grpc.py
+++ b/packages/google-maps-routing/google/maps/routing_v2/services/routes/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-routing/google/maps/routing_v2/services/routes/transports/grpc_asyncio.py
+++ b/packages/google-maps-routing/google/maps/routing_v2/services/routes/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-routing/google/maps/routing_v2/services/routes/transports/rest.py
+++ b/packages/google-maps-routing/google/maps/routing_v2/services/routes/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-routing/google/maps/routing_v2/services/routes/transports/rest_base.py
+++ b/packages/google-maps-routing/google/maps/routing_v2/services/routes/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-routing/google/maps/routing_v2/types/__init__.py
+++ b/packages/google-maps-routing/google/maps/routing_v2/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-routing/google/maps/routing_v2/types/fallback_info.py
+++ b/packages/google-maps-routing/google/maps/routing_v2/types/fallback_info.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-routing/google/maps/routing_v2/types/geocoding_results.py
+++ b/packages/google-maps-routing/google/maps/routing_v2/types/geocoding_results.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-routing/google/maps/routing_v2/types/localized_time.py
+++ b/packages/google-maps-routing/google/maps/routing_v2/types/localized_time.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-routing/google/maps/routing_v2/types/location.py
+++ b/packages/google-maps-routing/google/maps/routing_v2/types/location.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-routing/google/maps/routing_v2/types/maneuver.py
+++ b/packages/google-maps-routing/google/maps/routing_v2/types/maneuver.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-routing/google/maps/routing_v2/types/navigation_instruction.py
+++ b/packages/google-maps-routing/google/maps/routing_v2/types/navigation_instruction.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-routing/google/maps/routing_v2/types/polyline.py
+++ b/packages/google-maps-routing/google/maps/routing_v2/types/polyline.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-routing/google/maps/routing_v2/types/polyline_details.py
+++ b/packages/google-maps-routing/google/maps/routing_v2/types/polyline_details.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-routing/google/maps/routing_v2/types/route.py
+++ b/packages/google-maps-routing/google/maps/routing_v2/types/route.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-routing/google/maps/routing_v2/types/route_label.py
+++ b/packages/google-maps-routing/google/maps/routing_v2/types/route_label.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-routing/google/maps/routing_v2/types/route_modifiers.py
+++ b/packages/google-maps-routing/google/maps/routing_v2/types/route_modifiers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-routing/google/maps/routing_v2/types/route_travel_mode.py
+++ b/packages/google-maps-routing/google/maps/routing_v2/types/route_travel_mode.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-routing/google/maps/routing_v2/types/routes_service.py
+++ b/packages/google-maps-routing/google/maps/routing_v2/types/routes_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-routing/google/maps/routing_v2/types/routing_preference.py
+++ b/packages/google-maps-routing/google/maps/routing_v2/types/routing_preference.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-routing/google/maps/routing_v2/types/speed_reading_interval.py
+++ b/packages/google-maps-routing/google/maps/routing_v2/types/speed_reading_interval.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-routing/google/maps/routing_v2/types/toll_info.py
+++ b/packages/google-maps-routing/google/maps/routing_v2/types/toll_info.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-routing/google/maps/routing_v2/types/traffic_model.py
+++ b/packages/google-maps-routing/google/maps/routing_v2/types/traffic_model.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-routing/google/maps/routing_v2/types/transit.py
+++ b/packages/google-maps-routing/google/maps/routing_v2/types/transit.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-routing/google/maps/routing_v2/types/transit_preferences.py
+++ b/packages/google-maps-routing/google/maps/routing_v2/types/transit_preferences.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-routing/google/maps/routing_v2/types/units.py
+++ b/packages/google-maps-routing/google/maps/routing_v2/types/units.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-routing/google/maps/routing_v2/types/vehicle_emission_type.py
+++ b/packages/google-maps-routing/google/maps/routing_v2/types/vehicle_emission_type.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-routing/google/maps/routing_v2/types/vehicle_info.py
+++ b/packages/google-maps-routing/google/maps/routing_v2/types/vehicle_info.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-routing/google/maps/routing_v2/types/waypoint.py
+++ b/packages/google-maps-routing/google/maps/routing_v2/types/waypoint.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-routing/samples/generated_samples/routes_v2_generated_routes_compute_route_matrix_async.py
+++ b/packages/google-maps-routing/samples/generated_samples/routes_v2_generated_routes_compute_route_matrix_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-routing/samples/generated_samples/routes_v2_generated_routes_compute_route_matrix_sync.py
+++ b/packages/google-maps-routing/samples/generated_samples/routes_v2_generated_routes_compute_route_matrix_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-routing/samples/generated_samples/routes_v2_generated_routes_compute_routes_async.py
+++ b/packages/google-maps-routing/samples/generated_samples/routes_v2_generated_routes_compute_routes_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-routing/samples/generated_samples/routes_v2_generated_routes_compute_routes_sync.py
+++ b/packages/google-maps-routing/samples/generated_samples/routes_v2_generated_routes_compute_routes_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-routing/tests/__init__.py
+++ b/packages/google-maps-routing/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-routing/tests/unit/__init__.py
+++ b/packages/google-maps-routing/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-routing/tests/unit/gapic/__init__.py
+++ b/packages/google-maps-routing/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-routing/tests/unit/gapic/routing_v2/__init__.py
+++ b/packages/google-maps-routing/tests/unit/gapic/routing_v2/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-solar/.flake8
+++ b/packages/google-maps-solar/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-solar/MANIFEST.in
+++ b/packages/google-maps-solar/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-solar/google/maps/solar/__init__.py
+++ b/packages/google-maps-solar/google/maps/solar/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-solar/google/maps/solar/gapic_version.py
+++ b/packages/google-maps-solar/google/maps/solar/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-solar/google/maps/solar_v1/gapic_version.py
+++ b/packages/google-maps-solar/google/maps/solar_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-solar/google/maps/solar_v1/services/__init__.py
+++ b/packages/google-maps-solar/google/maps/solar_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-solar/google/maps/solar_v1/services/solar/__init__.py
+++ b/packages/google-maps-solar/google/maps/solar_v1/services/solar/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-solar/google/maps/solar_v1/services/solar/async_client.py
+++ b/packages/google-maps-solar/google/maps/solar_v1/services/solar/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-solar/google/maps/solar_v1/services/solar/client.py
+++ b/packages/google-maps-solar/google/maps/solar_v1/services/solar/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-solar/google/maps/solar_v1/services/solar/transports/__init__.py
+++ b/packages/google-maps-solar/google/maps/solar_v1/services/solar/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-solar/google/maps/solar_v1/services/solar/transports/base.py
+++ b/packages/google-maps-solar/google/maps/solar_v1/services/solar/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-solar/google/maps/solar_v1/services/solar/transports/grpc.py
+++ b/packages/google-maps-solar/google/maps/solar_v1/services/solar/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-solar/google/maps/solar_v1/services/solar/transports/grpc_asyncio.py
+++ b/packages/google-maps-solar/google/maps/solar_v1/services/solar/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-solar/google/maps/solar_v1/services/solar/transports/rest.py
+++ b/packages/google-maps-solar/google/maps/solar_v1/services/solar/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-solar/google/maps/solar_v1/services/solar/transports/rest_base.py
+++ b/packages/google-maps-solar/google/maps/solar_v1/services/solar/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-solar/google/maps/solar_v1/types/__init__.py
+++ b/packages/google-maps-solar/google/maps/solar_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-solar/google/maps/solar_v1/types/solar_service.py
+++ b/packages/google-maps-solar/google/maps/solar_v1/types/solar_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-solar/samples/generated_samples/solar_v1_generated_solar_find_closest_building_insights_async.py
+++ b/packages/google-maps-solar/samples/generated_samples/solar_v1_generated_solar_find_closest_building_insights_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-solar/samples/generated_samples/solar_v1_generated_solar_find_closest_building_insights_sync.py
+++ b/packages/google-maps-solar/samples/generated_samples/solar_v1_generated_solar_find_closest_building_insights_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-solar/samples/generated_samples/solar_v1_generated_solar_get_data_layers_async.py
+++ b/packages/google-maps-solar/samples/generated_samples/solar_v1_generated_solar_get_data_layers_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-solar/samples/generated_samples/solar_v1_generated_solar_get_data_layers_sync.py
+++ b/packages/google-maps-solar/samples/generated_samples/solar_v1_generated_solar_get_data_layers_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-solar/samples/generated_samples/solar_v1_generated_solar_get_geo_tiff_async.py
+++ b/packages/google-maps-solar/samples/generated_samples/solar_v1_generated_solar_get_geo_tiff_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-solar/samples/generated_samples/solar_v1_generated_solar_get_geo_tiff_sync.py
+++ b/packages/google-maps-solar/samples/generated_samples/solar_v1_generated_solar_get_geo_tiff_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-solar/tests/__init__.py
+++ b/packages/google-maps-solar/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-solar/tests/unit/__init__.py
+++ b/packages/google-maps-solar/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-solar/tests/unit/gapic/__init__.py
+++ b/packages/google-maps-solar/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-maps-solar/tests/unit/gapic/solar_v1/__init__.py
+++ b/packages/google-maps-solar/tests/unit/gapic/solar_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
This is the result of regenerating all packages, but only committing files which have only changed in a single line, and that's a copyright line.
