### PR TITLE
chore: regenerate packages in google-shopping, copyright changes only

### DIFF
--- a/packages/google-shopping-css/.flake8
+++ b/packages/google-shopping-css/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-css/MANIFEST.in
+++ b/packages/google-shopping-css/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-css/google/shopping/css/__init__.py
+++ b/packages/google-shopping-css/google/shopping/css/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-css/google/shopping/css/gapic_version.py
+++ b/packages/google-shopping-css/google/shopping/css/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-css/google/shopping/css_v1/gapic_version.py
+++ b/packages/google-shopping-css/google/shopping/css_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-css/google/shopping/css_v1/services/__init__.py
+++ b/packages/google-shopping-css/google/shopping/css_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-css/google/shopping/css_v1/services/account_labels_service/__init__.py
+++ b/packages/google-shopping-css/google/shopping/css_v1/services/account_labels_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-css/google/shopping/css_v1/services/account_labels_service/async_client.py
+++ b/packages/google-shopping-css/google/shopping/css_v1/services/account_labels_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-css/google/shopping/css_v1/services/account_labels_service/client.py
+++ b/packages/google-shopping-css/google/shopping/css_v1/services/account_labels_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-css/google/shopping/css_v1/services/account_labels_service/pagers.py
+++ b/packages/google-shopping-css/google/shopping/css_v1/services/account_labels_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-css/google/shopping/css_v1/services/account_labels_service/transports/__init__.py
+++ b/packages/google-shopping-css/google/shopping/css_v1/services/account_labels_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-css/google/shopping/css_v1/services/account_labels_service/transports/base.py
+++ b/packages/google-shopping-css/google/shopping/css_v1/services/account_labels_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-css/google/shopping/css_v1/services/account_labels_service/transports/grpc.py
+++ b/packages/google-shopping-css/google/shopping/css_v1/services/account_labels_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-css/google/shopping/css_v1/services/account_labels_service/transports/grpc_asyncio.py
+++ b/packages/google-shopping-css/google/shopping/css_v1/services/account_labels_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-css/google/shopping/css_v1/services/account_labels_service/transports/rest.py
+++ b/packages/google-shopping-css/google/shopping/css_v1/services/account_labels_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-css/google/shopping/css_v1/services/account_labels_service/transports/rest_base.py
+++ b/packages/google-shopping-css/google/shopping/css_v1/services/account_labels_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-css/google/shopping/css_v1/services/accounts_service/__init__.py
+++ b/packages/google-shopping-css/google/shopping/css_v1/services/accounts_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-css/google/shopping/css_v1/services/accounts_service/async_client.py
+++ b/packages/google-shopping-css/google/shopping/css_v1/services/accounts_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-css/google/shopping/css_v1/services/accounts_service/client.py
+++ b/packages/google-shopping-css/google/shopping/css_v1/services/accounts_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-css/google/shopping/css_v1/services/accounts_service/pagers.py
+++ b/packages/google-shopping-css/google/shopping/css_v1/services/accounts_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-css/google/shopping/css_v1/services/accounts_service/transports/__init__.py
+++ b/packages/google-shopping-css/google/shopping/css_v1/services/accounts_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-css/google/shopping/css_v1/services/accounts_service/transports/base.py
+++ b/packages/google-shopping-css/google/shopping/css_v1/services/accounts_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-css/google/shopping/css_v1/services/accounts_service/transports/grpc.py
+++ b/packages/google-shopping-css/google/shopping/css_v1/services/accounts_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-css/google/shopping/css_v1/services/accounts_service/transports/grpc_asyncio.py
+++ b/packages/google-shopping-css/google/shopping/css_v1/services/accounts_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-css/google/shopping/css_v1/services/accounts_service/transports/rest.py
+++ b/packages/google-shopping-css/google/shopping/css_v1/services/accounts_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-css/google/shopping/css_v1/services/accounts_service/transports/rest_base.py
+++ b/packages/google-shopping-css/google/shopping/css_v1/services/accounts_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-css/google/shopping/css_v1/services/css_product_inputs_service/__init__.py
+++ b/packages/google-shopping-css/google/shopping/css_v1/services/css_product_inputs_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-css/google/shopping/css_v1/services/css_product_inputs_service/async_client.py
+++ b/packages/google-shopping-css/google/shopping/css_v1/services/css_product_inputs_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-css/google/shopping/css_v1/services/css_product_inputs_service/client.py
+++ b/packages/google-shopping-css/google/shopping/css_v1/services/css_product_inputs_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-css/google/shopping/css_v1/services/css_product_inputs_service/transports/__init__.py
+++ b/packages/google-shopping-css/google/shopping/css_v1/services/css_product_inputs_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-css/google/shopping/css_v1/services/css_product_inputs_service/transports/base.py
+++ b/packages/google-shopping-css/google/shopping/css_v1/services/css_product_inputs_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-css/google/shopping/css_v1/services/css_product_inputs_service/transports/grpc.py
+++ b/packages/google-shopping-css/google/shopping/css_v1/services/css_product_inputs_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-css/google/shopping/css_v1/services/css_product_inputs_service/transports/grpc_asyncio.py
+++ b/packages/google-shopping-css/google/shopping/css_v1/services/css_product_inputs_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-css/google/shopping/css_v1/services/css_product_inputs_service/transports/rest.py
+++ b/packages/google-shopping-css/google/shopping/css_v1/services/css_product_inputs_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-css/google/shopping/css_v1/services/css_product_inputs_service/transports/rest_base.py
+++ b/packages/google-shopping-css/google/shopping/css_v1/services/css_product_inputs_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-css/google/shopping/css_v1/services/css_products_service/__init__.py
+++ b/packages/google-shopping-css/google/shopping/css_v1/services/css_products_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-css/google/shopping/css_v1/services/css_products_service/async_client.py
+++ b/packages/google-shopping-css/google/shopping/css_v1/services/css_products_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-css/google/shopping/css_v1/services/css_products_service/client.py
+++ b/packages/google-shopping-css/google/shopping/css_v1/services/css_products_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-css/google/shopping/css_v1/services/css_products_service/pagers.py
+++ b/packages/google-shopping-css/google/shopping/css_v1/services/css_products_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-css/google/shopping/css_v1/services/css_products_service/transports/__init__.py
+++ b/packages/google-shopping-css/google/shopping/css_v1/services/css_products_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-css/google/shopping/css_v1/services/css_products_service/transports/base.py
+++ b/packages/google-shopping-css/google/shopping/css_v1/services/css_products_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-css/google/shopping/css_v1/services/css_products_service/transports/grpc.py
+++ b/packages/google-shopping-css/google/shopping/css_v1/services/css_products_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-css/google/shopping/css_v1/services/css_products_service/transports/grpc_asyncio.py
+++ b/packages/google-shopping-css/google/shopping/css_v1/services/css_products_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-css/google/shopping/css_v1/services/css_products_service/transports/rest.py
+++ b/packages/google-shopping-css/google/shopping/css_v1/services/css_products_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-css/google/shopping/css_v1/services/css_products_service/transports/rest_base.py
+++ b/packages/google-shopping-css/google/shopping/css_v1/services/css_products_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-css/google/shopping/css_v1/services/quota_service/__init__.py
+++ b/packages/google-shopping-css/google/shopping/css_v1/services/quota_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-css/google/shopping/css_v1/services/quota_service/async_client.py
+++ b/packages/google-shopping-css/google/shopping/css_v1/services/quota_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-css/google/shopping/css_v1/services/quota_service/client.py
+++ b/packages/google-shopping-css/google/shopping/css_v1/services/quota_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-css/google/shopping/css_v1/services/quota_service/pagers.py
+++ b/packages/google-shopping-css/google/shopping/css_v1/services/quota_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-css/google/shopping/css_v1/services/quota_service/transports/__init__.py
+++ b/packages/google-shopping-css/google/shopping/css_v1/services/quota_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-css/google/shopping/css_v1/services/quota_service/transports/base.py
+++ b/packages/google-shopping-css/google/shopping/css_v1/services/quota_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-css/google/shopping/css_v1/services/quota_service/transports/grpc.py
+++ b/packages/google-shopping-css/google/shopping/css_v1/services/quota_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-css/google/shopping/css_v1/services/quota_service/transports/grpc_asyncio.py
+++ b/packages/google-shopping-css/google/shopping/css_v1/services/quota_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-css/google/shopping/css_v1/services/quota_service/transports/rest.py
+++ b/packages/google-shopping-css/google/shopping/css_v1/services/quota_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-css/google/shopping/css_v1/services/quota_service/transports/rest_base.py
+++ b/packages/google-shopping-css/google/shopping/css_v1/services/quota_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-css/google/shopping/css_v1/types/__init__.py
+++ b/packages/google-shopping-css/google/shopping/css_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-css/google/shopping/css_v1/types/accounts.py
+++ b/packages/google-shopping-css/google/shopping/css_v1/types/accounts.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-css/google/shopping/css_v1/types/accounts_labels.py
+++ b/packages/google-shopping-css/google/shopping/css_v1/types/accounts_labels.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-css/google/shopping/css_v1/types/css_product_common.py
+++ b/packages/google-shopping-css/google/shopping/css_v1/types/css_product_common.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-css/google/shopping/css_v1/types/css_product_inputs.py
+++ b/packages/google-shopping-css/google/shopping/css_v1/types/css_product_inputs.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-css/google/shopping/css_v1/types/css_products.py
+++ b/packages/google-shopping-css/google/shopping/css_v1/types/css_products.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-css/google/shopping/css_v1/types/quota.py
+++ b/packages/google-shopping-css/google/shopping/css_v1/types/quota.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-css/samples/generated_samples/css_v1_generated_account_labels_service_create_account_label_async.py
+++ b/packages/google-shopping-css/samples/generated_samples/css_v1_generated_account_labels_service_create_account_label_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-css/samples/generated_samples/css_v1_generated_account_labels_service_create_account_label_sync.py
+++ b/packages/google-shopping-css/samples/generated_samples/css_v1_generated_account_labels_service_create_account_label_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-css/samples/generated_samples/css_v1_generated_account_labels_service_delete_account_label_async.py
+++ b/packages/google-shopping-css/samples/generated_samples/css_v1_generated_account_labels_service_delete_account_label_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-css/samples/generated_samples/css_v1_generated_account_labels_service_delete_account_label_sync.py
+++ b/packages/google-shopping-css/samples/generated_samples/css_v1_generated_account_labels_service_delete_account_label_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-css/samples/generated_samples/css_v1_generated_account_labels_service_list_account_labels_async.py
+++ b/packages/google-shopping-css/samples/generated_samples/css_v1_generated_account_labels_service_list_account_labels_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-css/samples/generated_samples/css_v1_generated_account_labels_service_list_account_labels_sync.py
+++ b/packages/google-shopping-css/samples/generated_samples/css_v1_generated_account_labels_service_list_account_labels_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-css/samples/generated_samples/css_v1_generated_account_labels_service_update_account_label_async.py
+++ b/packages/google-shopping-css/samples/generated_samples/css_v1_generated_account_labels_service_update_account_label_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-css/samples/generated_samples/css_v1_generated_account_labels_service_update_account_label_sync.py
+++ b/packages/google-shopping-css/samples/generated_samples/css_v1_generated_account_labels_service_update_account_label_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-css/samples/generated_samples/css_v1_generated_accounts_service_get_account_async.py
+++ b/packages/google-shopping-css/samples/generated_samples/css_v1_generated_accounts_service_get_account_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-css/samples/generated_samples/css_v1_generated_accounts_service_get_account_sync.py
+++ b/packages/google-shopping-css/samples/generated_samples/css_v1_generated_accounts_service_get_account_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-css/samples/generated_samples/css_v1_generated_accounts_service_list_child_accounts_async.py
+++ b/packages/google-shopping-css/samples/generated_samples/css_v1_generated_accounts_service_list_child_accounts_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-css/samples/generated_samples/css_v1_generated_accounts_service_list_child_accounts_sync.py
+++ b/packages/google-shopping-css/samples/generated_samples/css_v1_generated_accounts_service_list_child_accounts_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-css/samples/generated_samples/css_v1_generated_accounts_service_update_labels_async.py
+++ b/packages/google-shopping-css/samples/generated_samples/css_v1_generated_accounts_service_update_labels_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-css/samples/generated_samples/css_v1_generated_accounts_service_update_labels_sync.py
+++ b/packages/google-shopping-css/samples/generated_samples/css_v1_generated_accounts_service_update_labels_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-css/samples/generated_samples/css_v1_generated_css_product_inputs_service_delete_css_product_input_async.py
+++ b/packages/google-shopping-css/samples/generated_samples/css_v1_generated_css_product_inputs_service_delete_css_product_input_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-css/samples/generated_samples/css_v1_generated_css_product_inputs_service_delete_css_product_input_sync.py
+++ b/packages/google-shopping-css/samples/generated_samples/css_v1_generated_css_product_inputs_service_delete_css_product_input_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-css/samples/generated_samples/css_v1_generated_css_product_inputs_service_insert_css_product_input_async.py
+++ b/packages/google-shopping-css/samples/generated_samples/css_v1_generated_css_product_inputs_service_insert_css_product_input_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-css/samples/generated_samples/css_v1_generated_css_product_inputs_service_insert_css_product_input_sync.py
+++ b/packages/google-shopping-css/samples/generated_samples/css_v1_generated_css_product_inputs_service_insert_css_product_input_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-css/samples/generated_samples/css_v1_generated_css_product_inputs_service_update_css_product_input_async.py
+++ b/packages/google-shopping-css/samples/generated_samples/css_v1_generated_css_product_inputs_service_update_css_product_input_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-css/samples/generated_samples/css_v1_generated_css_product_inputs_service_update_css_product_input_sync.py
+++ b/packages/google-shopping-css/samples/generated_samples/css_v1_generated_css_product_inputs_service_update_css_product_input_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-css/samples/generated_samples/css_v1_generated_css_products_service_get_css_product_async.py
+++ b/packages/google-shopping-css/samples/generated_samples/css_v1_generated_css_products_service_get_css_product_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-css/samples/generated_samples/css_v1_generated_css_products_service_get_css_product_sync.py
+++ b/packages/google-shopping-css/samples/generated_samples/css_v1_generated_css_products_service_get_css_product_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-css/samples/generated_samples/css_v1_generated_css_products_service_list_css_products_async.py
+++ b/packages/google-shopping-css/samples/generated_samples/css_v1_generated_css_products_service_list_css_products_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-css/samples/generated_samples/css_v1_generated_css_products_service_list_css_products_sync.py
+++ b/packages/google-shopping-css/samples/generated_samples/css_v1_generated_css_products_service_list_css_products_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-css/samples/generated_samples/css_v1_generated_quota_service_list_quota_groups_async.py
+++ b/packages/google-shopping-css/samples/generated_samples/css_v1_generated_quota_service_list_quota_groups_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-css/samples/generated_samples/css_v1_generated_quota_service_list_quota_groups_sync.py
+++ b/packages/google-shopping-css/samples/generated_samples/css_v1_generated_quota_service_list_quota_groups_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-css/tests/__init__.py
+++ b/packages/google-shopping-css/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-css/tests/unit/__init__.py
+++ b/packages/google-shopping-css/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-css/tests/unit/gapic/__init__.py
+++ b/packages/google-shopping-css/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-css/tests/unit/gapic/css_v1/__init__.py
+++ b/packages/google-shopping-css/tests/unit/gapic/css_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/.flake8
+++ b/packages/google-shopping-merchant-accounts/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/MANIFEST.in
+++ b/packages/google-shopping-merchant-accounts/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts/__init__.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts/gapic_version.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/gapic_version.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/__init__.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/account_issue_service/__init__.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/account_issue_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/account_issue_service/async_client.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/account_issue_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/account_issue_service/client.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/account_issue_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/account_issue_service/pagers.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/account_issue_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/account_issue_service/transports/__init__.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/account_issue_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/account_issue_service/transports/base.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/account_issue_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/account_issue_service/transports/grpc.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/account_issue_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/account_issue_service/transports/grpc_asyncio.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/account_issue_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/account_issue_service/transports/rest.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/account_issue_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/account_issue_service/transports/rest_base.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/account_issue_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/account_relationships_service/__init__.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/account_relationships_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/account_relationships_service/async_client.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/account_relationships_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/account_relationships_service/client.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/account_relationships_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/account_relationships_service/pagers.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/account_relationships_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/account_relationships_service/transports/__init__.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/account_relationships_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/account_relationships_service/transports/base.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/account_relationships_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/account_relationships_service/transports/grpc.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/account_relationships_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/account_relationships_service/transports/grpc_asyncio.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/account_relationships_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/account_relationships_service/transports/rest.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/account_relationships_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/account_relationships_service/transports/rest_base.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/account_relationships_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/account_services_service/__init__.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/account_services_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/account_services_service/async_client.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/account_services_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/account_services_service/client.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/account_services_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/account_services_service/pagers.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/account_services_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/account_services_service/transports/__init__.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/account_services_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/account_services_service/transports/base.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/account_services_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/account_services_service/transports/grpc.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/account_services_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/account_services_service/transports/grpc_asyncio.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/account_services_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/account_services_service/transports/rest.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/account_services_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/account_services_service/transports/rest_base.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/account_services_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/accounts_service/__init__.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/accounts_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/accounts_service/async_client.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/accounts_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/accounts_service/client.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/accounts_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/accounts_service/pagers.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/accounts_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/accounts_service/transports/__init__.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/accounts_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/accounts_service/transports/base.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/accounts_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/accounts_service/transports/grpc.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/accounts_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/accounts_service/transports/grpc_asyncio.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/accounts_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/accounts_service/transports/rest.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/accounts_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/accounts_service/transports/rest_base.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/accounts_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/autofeed_settings_service/__init__.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/autofeed_settings_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/autofeed_settings_service/async_client.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/autofeed_settings_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/autofeed_settings_service/client.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/autofeed_settings_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/autofeed_settings_service/transports/__init__.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/autofeed_settings_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/autofeed_settings_service/transports/base.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/autofeed_settings_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/autofeed_settings_service/transports/grpc.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/autofeed_settings_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/autofeed_settings_service/transports/grpc_asyncio.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/autofeed_settings_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/autofeed_settings_service/transports/rest.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/autofeed_settings_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/autofeed_settings_service/transports/rest_base.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/autofeed_settings_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/automatic_improvements_service/__init__.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/automatic_improvements_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/automatic_improvements_service/async_client.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/automatic_improvements_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/automatic_improvements_service/client.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/automatic_improvements_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/automatic_improvements_service/transports/__init__.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/automatic_improvements_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/automatic_improvements_service/transports/base.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/automatic_improvements_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/automatic_improvements_service/transports/grpc.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/automatic_improvements_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/automatic_improvements_service/transports/grpc_asyncio.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/automatic_improvements_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/automatic_improvements_service/transports/rest.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/automatic_improvements_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/automatic_improvements_service/transports/rest_base.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/automatic_improvements_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/business_identity_service/__init__.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/business_identity_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/business_identity_service/async_client.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/business_identity_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/business_identity_service/client.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/business_identity_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/business_identity_service/transports/__init__.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/business_identity_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/business_identity_service/transports/base.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/business_identity_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/business_identity_service/transports/grpc.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/business_identity_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/business_identity_service/transports/grpc_asyncio.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/business_identity_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/business_identity_service/transports/rest.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/business_identity_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/business_identity_service/transports/rest_base.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/business_identity_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/business_info_service/__init__.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/business_info_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/business_info_service/async_client.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/business_info_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/business_info_service/client.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/business_info_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/business_info_service/transports/__init__.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/business_info_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/business_info_service/transports/base.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/business_info_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/business_info_service/transports/grpc.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/business_info_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/business_info_service/transports/grpc_asyncio.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/business_info_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/business_info_service/transports/rest.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/business_info_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/business_info_service/transports/rest_base.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/business_info_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/checkout_settings_service/__init__.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/checkout_settings_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/checkout_settings_service/async_client.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/checkout_settings_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/checkout_settings_service/client.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/checkout_settings_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/checkout_settings_service/transports/__init__.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/checkout_settings_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/checkout_settings_service/transports/base.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/checkout_settings_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/checkout_settings_service/transports/grpc.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/checkout_settings_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/checkout_settings_service/transports/grpc_asyncio.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/checkout_settings_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/checkout_settings_service/transports/rest.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/checkout_settings_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/checkout_settings_service/transports/rest_base.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/checkout_settings_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/developer_registration_service/__init__.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/developer_registration_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/developer_registration_service/async_client.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/developer_registration_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/developer_registration_service/client.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/developer_registration_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/developer_registration_service/transports/__init__.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/developer_registration_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/developer_registration_service/transports/base.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/developer_registration_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/developer_registration_service/transports/grpc.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/developer_registration_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/developer_registration_service/transports/grpc_asyncio.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/developer_registration_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/developer_registration_service/transports/rest.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/developer_registration_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/developer_registration_service/transports/rest_base.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/developer_registration_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/email_preferences_service/__init__.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/email_preferences_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/email_preferences_service/async_client.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/email_preferences_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/email_preferences_service/client.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/email_preferences_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/email_preferences_service/transports/__init__.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/email_preferences_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/email_preferences_service/transports/base.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/email_preferences_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/email_preferences_service/transports/grpc.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/email_preferences_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/email_preferences_service/transports/grpc_asyncio.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/email_preferences_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/email_preferences_service/transports/rest.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/email_preferences_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/email_preferences_service/transports/rest_base.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/email_preferences_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/gbp_accounts_service/__init__.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/gbp_accounts_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/gbp_accounts_service/async_client.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/gbp_accounts_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/gbp_accounts_service/client.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/gbp_accounts_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/gbp_accounts_service/pagers.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/gbp_accounts_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/gbp_accounts_service/transports/__init__.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/gbp_accounts_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/gbp_accounts_service/transports/base.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/gbp_accounts_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/gbp_accounts_service/transports/grpc.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/gbp_accounts_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/gbp_accounts_service/transports/grpc_asyncio.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/gbp_accounts_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/gbp_accounts_service/transports/rest.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/gbp_accounts_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/gbp_accounts_service/transports/rest_base.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/gbp_accounts_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/homepage_service/__init__.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/homepage_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/homepage_service/async_client.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/homepage_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/homepage_service/client.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/homepage_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/homepage_service/transports/__init__.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/homepage_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/homepage_service/transports/base.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/homepage_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/homepage_service/transports/grpc.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/homepage_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/homepage_service/transports/grpc_asyncio.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/homepage_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/homepage_service/transports/rest.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/homepage_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/homepage_service/transports/rest_base.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/homepage_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/lfp_providers_service/__init__.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/lfp_providers_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/lfp_providers_service/async_client.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/lfp_providers_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/lfp_providers_service/client.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/lfp_providers_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/lfp_providers_service/pagers.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/lfp_providers_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/lfp_providers_service/transports/__init__.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/lfp_providers_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/lfp_providers_service/transports/base.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/lfp_providers_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/lfp_providers_service/transports/grpc.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/lfp_providers_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/lfp_providers_service/transports/grpc_asyncio.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/lfp_providers_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/lfp_providers_service/transports/rest.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/lfp_providers_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/lfp_providers_service/transports/rest_base.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/lfp_providers_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/omnichannel_settings_service/__init__.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/omnichannel_settings_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/omnichannel_settings_service/pagers.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/omnichannel_settings_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/omnichannel_settings_service/transports/__init__.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/omnichannel_settings_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/omnichannel_settings_service/transports/base.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/omnichannel_settings_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/omnichannel_settings_service/transports/rest.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/omnichannel_settings_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/omnichannel_settings_service/transports/rest_base.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/omnichannel_settings_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/online_return_policy_service/__init__.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/online_return_policy_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/online_return_policy_service/pagers.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/online_return_policy_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/online_return_policy_service/transports/__init__.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/online_return_policy_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/online_return_policy_service/transports/base.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/online_return_policy_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/online_return_policy_service/transports/rest.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/online_return_policy_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/online_return_policy_service/transports/rest_base.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/online_return_policy_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/programs_service/__init__.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/programs_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/programs_service/async_client.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/programs_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/programs_service/client.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/programs_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/programs_service/pagers.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/programs_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/programs_service/transports/__init__.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/programs_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/programs_service/transports/base.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/programs_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/programs_service/transports/grpc.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/programs_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/programs_service/transports/grpc_asyncio.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/programs_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/programs_service/transports/rest.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/programs_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/programs_service/transports/rest_base.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/programs_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/regions_service/__init__.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/regions_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/regions_service/async_client.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/regions_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/regions_service/client.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/regions_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/regions_service/pagers.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/regions_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/regions_service/transports/__init__.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/regions_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/regions_service/transports/base.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/regions_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/regions_service/transports/grpc.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/regions_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/regions_service/transports/grpc_asyncio.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/regions_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/regions_service/transports/rest.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/regions_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/regions_service/transports/rest_base.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/regions_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/shipping_settings_service/__init__.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/shipping_settings_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/shipping_settings_service/async_client.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/shipping_settings_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/shipping_settings_service/client.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/shipping_settings_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/shipping_settings_service/transports/__init__.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/shipping_settings_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/shipping_settings_service/transports/base.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/shipping_settings_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/shipping_settings_service/transports/grpc.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/shipping_settings_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/shipping_settings_service/transports/grpc_asyncio.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/shipping_settings_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/shipping_settings_service/transports/rest.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/shipping_settings_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/shipping_settings_service/transports/rest_base.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/shipping_settings_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/terms_of_service_agreement_state_service/__init__.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/terms_of_service_agreement_state_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/terms_of_service_agreement_state_service/async_client.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/terms_of_service_agreement_state_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/terms_of_service_agreement_state_service/client.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/terms_of_service_agreement_state_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/terms_of_service_agreement_state_service/transports/__init__.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/terms_of_service_agreement_state_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/terms_of_service_agreement_state_service/transports/base.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/terms_of_service_agreement_state_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/terms_of_service_agreement_state_service/transports/grpc.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/terms_of_service_agreement_state_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/terms_of_service_agreement_state_service/transports/grpc_asyncio.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/terms_of_service_agreement_state_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/terms_of_service_agreement_state_service/transports/rest.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/terms_of_service_agreement_state_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/terms_of_service_agreement_state_service/transports/rest_base.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/terms_of_service_agreement_state_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/terms_of_service_service/__init__.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/terms_of_service_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/terms_of_service_service/async_client.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/terms_of_service_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/terms_of_service_service/client.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/terms_of_service_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/terms_of_service_service/transports/__init__.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/terms_of_service_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/terms_of_service_service/transports/base.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/terms_of_service_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/terms_of_service_service/transports/grpc.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/terms_of_service_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/terms_of_service_service/transports/grpc_asyncio.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/terms_of_service_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/terms_of_service_service/transports/rest.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/terms_of_service_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/terms_of_service_service/transports/rest_base.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/terms_of_service_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/user_service/__init__.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/user_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/user_service/async_client.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/user_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/user_service/client.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/user_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/user_service/pagers.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/user_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/user_service/transports/__init__.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/user_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/user_service/transports/base.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/user_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/user_service/transports/grpc.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/user_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/user_service/transports/grpc_asyncio.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/user_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/user_service/transports/rest.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/user_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/user_service/transports/rest_base.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/services/user_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/types/__init__.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/types/accessright.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/types/accessright.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/types/accountissue.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/types/accountissue.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/types/accountrelationships.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/types/accountrelationships.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/types/accounts.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/types/accounts.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/types/accountservices.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/types/accountservices.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/types/autofeedsettings.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/types/autofeedsettings.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/types/automaticimprovements.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/types/automaticimprovements.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/types/businessidentity.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/types/businessidentity.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/types/businessinfo.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/types/businessinfo.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/types/checkoutsettings.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/types/checkoutsettings.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/types/customerservice.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/types/customerservice.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/types/developerregistration.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/types/developerregistration.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/types/emailpreferences.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/types/emailpreferences.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/types/gbpaccounts.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/types/gbpaccounts.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/types/homepage.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/types/homepage.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/types/lfpproviders.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/types/lfpproviders.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/types/omnichannelsettings.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/types/omnichannelsettings.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/types/online_return_policy.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/types/online_return_policy.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/types/phoneverificationstate.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/types/phoneverificationstate.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/types/programs.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/types/programs.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/types/regions.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/types/regions.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/types/shippingsettings.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/types/shippingsettings.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/types/termsofservice.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/types/termsofservice.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/types/termsofserviceagreementstate.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/types/termsofserviceagreementstate.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/types/termsofservicekind.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/types/termsofservicekind.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/types/user.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/types/user.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/types/verificationmailsettings.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1/types/verificationmailsettings.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/gapic_version.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/__init__.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/account_issue_service/__init__.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/account_issue_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/account_issue_service/async_client.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/account_issue_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/account_issue_service/client.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/account_issue_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/account_issue_service/pagers.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/account_issue_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/account_issue_service/transports/__init__.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/account_issue_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/account_issue_service/transports/base.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/account_issue_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/account_issue_service/transports/grpc.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/account_issue_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/account_issue_service/transports/grpc_asyncio.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/account_issue_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/account_issue_service/transports/rest.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/account_issue_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/account_issue_service/transports/rest_base.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/account_issue_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/account_tax_service/__init__.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/account_tax_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/account_tax_service/async_client.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/account_tax_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/account_tax_service/client.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/account_tax_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/account_tax_service/pagers.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/account_tax_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/account_tax_service/transports/__init__.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/account_tax_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/account_tax_service/transports/base.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/account_tax_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/account_tax_service/transports/grpc.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/account_tax_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/account_tax_service/transports/grpc_asyncio.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/account_tax_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/account_tax_service/transports/rest.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/account_tax_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/account_tax_service/transports/rest_base.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/account_tax_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/accounts_service/__init__.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/accounts_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/accounts_service/async_client.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/accounts_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/accounts_service/client.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/accounts_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/accounts_service/pagers.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/accounts_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/accounts_service/transports/__init__.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/accounts_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/accounts_service/transports/base.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/accounts_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/accounts_service/transports/grpc.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/accounts_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/accounts_service/transports/grpc_asyncio.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/accounts_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/accounts_service/transports/rest.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/accounts_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/accounts_service/transports/rest_base.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/accounts_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/autofeed_settings_service/__init__.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/autofeed_settings_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/autofeed_settings_service/async_client.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/autofeed_settings_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/autofeed_settings_service/client.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/autofeed_settings_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/autofeed_settings_service/transports/__init__.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/autofeed_settings_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/autofeed_settings_service/transports/base.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/autofeed_settings_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/autofeed_settings_service/transports/grpc.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/autofeed_settings_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/autofeed_settings_service/transports/grpc_asyncio.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/autofeed_settings_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/autofeed_settings_service/transports/rest.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/autofeed_settings_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/autofeed_settings_service/transports/rest_base.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/autofeed_settings_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/automatic_improvements_service/__init__.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/automatic_improvements_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/automatic_improvements_service/async_client.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/automatic_improvements_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/automatic_improvements_service/client.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/automatic_improvements_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/automatic_improvements_service/transports/__init__.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/automatic_improvements_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/automatic_improvements_service/transports/base.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/automatic_improvements_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/automatic_improvements_service/transports/grpc.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/automatic_improvements_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/automatic_improvements_service/transports/grpc_asyncio.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/automatic_improvements_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/automatic_improvements_service/transports/rest.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/automatic_improvements_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/automatic_improvements_service/transports/rest_base.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/automatic_improvements_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/business_identity_service/__init__.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/business_identity_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/business_identity_service/async_client.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/business_identity_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/business_identity_service/client.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/business_identity_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/business_identity_service/transports/__init__.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/business_identity_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/business_identity_service/transports/base.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/business_identity_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/business_identity_service/transports/grpc.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/business_identity_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/business_identity_service/transports/grpc_asyncio.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/business_identity_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/business_identity_service/transports/rest.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/business_identity_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/business_identity_service/transports/rest_base.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/business_identity_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/business_info_service/__init__.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/business_info_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/business_info_service/async_client.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/business_info_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/business_info_service/client.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/business_info_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/business_info_service/transports/__init__.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/business_info_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/business_info_service/transports/base.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/business_info_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/business_info_service/transports/grpc.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/business_info_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/business_info_service/transports/grpc_asyncio.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/business_info_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/business_info_service/transports/rest.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/business_info_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/business_info_service/transports/rest_base.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/business_info_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/checkout_settings_service/__init__.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/checkout_settings_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/checkout_settings_service/async_client.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/checkout_settings_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/checkout_settings_service/client.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/checkout_settings_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/checkout_settings_service/transports/__init__.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/checkout_settings_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/checkout_settings_service/transports/base.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/checkout_settings_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/checkout_settings_service/transports/grpc.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/checkout_settings_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/checkout_settings_service/transports/grpc_asyncio.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/checkout_settings_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/checkout_settings_service/transports/rest.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/checkout_settings_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/checkout_settings_service/transports/rest_base.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/checkout_settings_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/email_preferences_service/__init__.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/email_preferences_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/email_preferences_service/async_client.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/email_preferences_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/email_preferences_service/client.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/email_preferences_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/email_preferences_service/transports/__init__.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/email_preferences_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/email_preferences_service/transports/base.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/email_preferences_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/email_preferences_service/transports/grpc.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/email_preferences_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/email_preferences_service/transports/grpc_asyncio.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/email_preferences_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/email_preferences_service/transports/rest.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/email_preferences_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/email_preferences_service/transports/rest_base.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/email_preferences_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/gbp_accounts_service/__init__.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/gbp_accounts_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/gbp_accounts_service/async_client.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/gbp_accounts_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/gbp_accounts_service/client.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/gbp_accounts_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/gbp_accounts_service/pagers.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/gbp_accounts_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/gbp_accounts_service/transports/__init__.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/gbp_accounts_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/gbp_accounts_service/transports/base.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/gbp_accounts_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/gbp_accounts_service/transports/grpc.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/gbp_accounts_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/gbp_accounts_service/transports/grpc_asyncio.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/gbp_accounts_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/gbp_accounts_service/transports/rest.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/gbp_accounts_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/gbp_accounts_service/transports/rest_base.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/gbp_accounts_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/homepage_service/__init__.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/homepage_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/homepage_service/async_client.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/homepage_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/homepage_service/client.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/homepage_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/homepage_service/transports/__init__.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/homepage_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/homepage_service/transports/base.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/homepage_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/homepage_service/transports/grpc.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/homepage_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/homepage_service/transports/grpc_asyncio.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/homepage_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/homepage_service/transports/rest.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/homepage_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/homepage_service/transports/rest_base.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/homepage_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/lfp_providers_service/__init__.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/lfp_providers_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/lfp_providers_service/async_client.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/lfp_providers_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/lfp_providers_service/client.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/lfp_providers_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/lfp_providers_service/pagers.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/lfp_providers_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/lfp_providers_service/transports/__init__.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/lfp_providers_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/lfp_providers_service/transports/base.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/lfp_providers_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/lfp_providers_service/transports/grpc.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/lfp_providers_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/lfp_providers_service/transports/grpc_asyncio.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/lfp_providers_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/lfp_providers_service/transports/rest.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/lfp_providers_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/lfp_providers_service/transports/rest_base.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/lfp_providers_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/omnichannel_settings_service/__init__.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/omnichannel_settings_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/omnichannel_settings_service/pagers.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/omnichannel_settings_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/omnichannel_settings_service/transports/__init__.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/omnichannel_settings_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/omnichannel_settings_service/transports/base.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/omnichannel_settings_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/omnichannel_settings_service/transports/rest.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/omnichannel_settings_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/omnichannel_settings_service/transports/rest_base.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/omnichannel_settings_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/online_return_policy_service/__init__.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/online_return_policy_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/online_return_policy_service/pagers.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/online_return_policy_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/online_return_policy_service/transports/__init__.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/online_return_policy_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/online_return_policy_service/transports/base.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/online_return_policy_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/online_return_policy_service/transports/rest.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/online_return_policy_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/online_return_policy_service/transports/rest_base.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/online_return_policy_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/programs_service/__init__.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/programs_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/programs_service/async_client.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/programs_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/programs_service/client.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/programs_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/programs_service/pagers.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/programs_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/programs_service/transports/__init__.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/programs_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/programs_service/transports/base.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/programs_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/programs_service/transports/grpc.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/programs_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/programs_service/transports/grpc_asyncio.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/programs_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/programs_service/transports/rest.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/programs_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/programs_service/transports/rest_base.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/programs_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/regions_service/__init__.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/regions_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/regions_service/async_client.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/regions_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/regions_service/client.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/regions_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/regions_service/pagers.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/regions_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/regions_service/transports/__init__.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/regions_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/regions_service/transports/base.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/regions_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/regions_service/transports/grpc.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/regions_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/regions_service/transports/grpc_asyncio.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/regions_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/regions_service/transports/rest.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/regions_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/regions_service/transports/rest_base.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/regions_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/shipping_settings_service/__init__.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/shipping_settings_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/shipping_settings_service/async_client.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/shipping_settings_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/shipping_settings_service/client.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/shipping_settings_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/shipping_settings_service/transports/__init__.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/shipping_settings_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/shipping_settings_service/transports/base.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/shipping_settings_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/shipping_settings_service/transports/grpc.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/shipping_settings_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/shipping_settings_service/transports/grpc_asyncio.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/shipping_settings_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/shipping_settings_service/transports/rest.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/shipping_settings_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/shipping_settings_service/transports/rest_base.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/shipping_settings_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/terms_of_service_agreement_state_service/__init__.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/terms_of_service_agreement_state_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/terms_of_service_agreement_state_service/async_client.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/terms_of_service_agreement_state_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/terms_of_service_agreement_state_service/client.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/terms_of_service_agreement_state_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/terms_of_service_agreement_state_service/transports/__init__.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/terms_of_service_agreement_state_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/terms_of_service_agreement_state_service/transports/base.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/terms_of_service_agreement_state_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/terms_of_service_agreement_state_service/transports/grpc.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/terms_of_service_agreement_state_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/terms_of_service_agreement_state_service/transports/grpc_asyncio.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/terms_of_service_agreement_state_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/terms_of_service_agreement_state_service/transports/rest.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/terms_of_service_agreement_state_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/terms_of_service_agreement_state_service/transports/rest_base.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/terms_of_service_agreement_state_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/terms_of_service_service/__init__.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/terms_of_service_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/terms_of_service_service/async_client.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/terms_of_service_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/terms_of_service_service/client.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/terms_of_service_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/terms_of_service_service/transports/__init__.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/terms_of_service_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/terms_of_service_service/transports/base.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/terms_of_service_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/terms_of_service_service/transports/grpc.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/terms_of_service_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/terms_of_service_service/transports/grpc_asyncio.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/terms_of_service_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/terms_of_service_service/transports/rest.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/terms_of_service_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/terms_of_service_service/transports/rest_base.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/terms_of_service_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/user_service/__init__.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/user_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/user_service/async_client.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/user_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/user_service/client.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/user_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/user_service/pagers.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/user_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/user_service/transports/__init__.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/user_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/user_service/transports/base.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/user_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/user_service/transports/grpc.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/user_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/user_service/transports/grpc_asyncio.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/user_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/user_service/transports/rest.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/user_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/user_service/transports/rest_base.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/services/user_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/types/__init__.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/types/accessright.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/types/accessright.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/types/account_tax.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/types/account_tax.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/types/accountissue.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/types/accountissue.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/types/accounts.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/types/accounts.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/types/accountservices.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/types/accountservices.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/types/autofeedsettings.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/types/autofeedsettings.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/types/automaticimprovements.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/types/automaticimprovements.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/types/businessidentity.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/types/businessidentity.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/types/businessinfo.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/types/businessinfo.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/types/checkoutsettings.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/types/checkoutsettings.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/types/customerservice.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/types/customerservice.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/types/emailpreferences.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/types/emailpreferences.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/types/gbpaccounts.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/types/gbpaccounts.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/types/homepage.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/types/homepage.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/types/lfpproviders.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/types/lfpproviders.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/types/omnichannelsettings.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/types/omnichannelsettings.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/types/online_return_policy.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/types/online_return_policy.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/types/phoneverificationstate.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/types/phoneverificationstate.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/types/programs.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/types/programs.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/types/regions.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/types/regions.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/types/tax_rule.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/types/tax_rule.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/types/termsofservice.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/types/termsofservice.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/types/termsofserviceagreementstate.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/types/termsofserviceagreementstate.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/types/termsofservicekind.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/types/termsofservicekind.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/types/user.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/types/user.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/types/verificationmailsettings.py
+++ b/packages/google-shopping-merchant-accounts/google/shopping/merchant_accounts_v1beta/types/verificationmailsettings.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_account_issue_service_list_account_issues_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_account_issue_service_list_account_issues_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_account_issue_service_list_account_issues_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_account_issue_service_list_account_issues_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_account_relationships_service_get_account_relationship_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_account_relationships_service_get_account_relationship_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_account_relationships_service_get_account_relationship_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_account_relationships_service_get_account_relationship_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_account_relationships_service_list_account_relationships_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_account_relationships_service_list_account_relationships_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_account_relationships_service_list_account_relationships_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_account_relationships_service_list_account_relationships_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_account_relationships_service_update_account_relationship_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_account_relationships_service_update_account_relationship_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_account_relationships_service_update_account_relationship_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_account_relationships_service_update_account_relationship_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_account_services_service_approve_account_service_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_account_services_service_approve_account_service_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_account_services_service_approve_account_service_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_account_services_service_approve_account_service_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_account_services_service_get_account_service_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_account_services_service_get_account_service_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_account_services_service_get_account_service_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_account_services_service_get_account_service_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_account_services_service_list_account_services_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_account_services_service_list_account_services_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_account_services_service_list_account_services_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_account_services_service_list_account_services_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_account_services_service_propose_account_service_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_account_services_service_propose_account_service_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_account_services_service_propose_account_service_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_account_services_service_propose_account_service_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_account_services_service_reject_account_service_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_account_services_service_reject_account_service_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_account_services_service_reject_account_service_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_account_services_service_reject_account_service_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_accounts_service_create_and_configure_account_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_accounts_service_create_and_configure_account_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_accounts_service_create_and_configure_account_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_accounts_service_create_and_configure_account_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_accounts_service_create_test_account_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_accounts_service_create_test_account_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_accounts_service_create_test_account_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_accounts_service_create_test_account_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_accounts_service_delete_account_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_accounts_service_delete_account_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_accounts_service_delete_account_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_accounts_service_delete_account_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_accounts_service_get_account_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_accounts_service_get_account_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_accounts_service_get_account_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_accounts_service_get_account_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_accounts_service_list_accounts_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_accounts_service_list_accounts_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_accounts_service_list_accounts_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_accounts_service_list_accounts_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_accounts_service_list_sub_accounts_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_accounts_service_list_sub_accounts_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_accounts_service_list_sub_accounts_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_accounts_service_list_sub_accounts_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_accounts_service_update_account_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_accounts_service_update_account_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_accounts_service_update_account_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_accounts_service_update_account_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_autofeed_settings_service_get_autofeed_settings_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_autofeed_settings_service_get_autofeed_settings_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_autofeed_settings_service_get_autofeed_settings_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_autofeed_settings_service_get_autofeed_settings_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_autofeed_settings_service_update_autofeed_settings_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_autofeed_settings_service_update_autofeed_settings_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_autofeed_settings_service_update_autofeed_settings_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_autofeed_settings_service_update_autofeed_settings_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_automatic_improvements_service_get_automatic_improvements_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_automatic_improvements_service_get_automatic_improvements_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_automatic_improvements_service_get_automatic_improvements_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_automatic_improvements_service_get_automatic_improvements_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_automatic_improvements_service_update_automatic_improvements_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_automatic_improvements_service_update_automatic_improvements_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_automatic_improvements_service_update_automatic_improvements_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_automatic_improvements_service_update_automatic_improvements_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_business_identity_service_get_business_identity_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_business_identity_service_get_business_identity_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_business_identity_service_get_business_identity_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_business_identity_service_get_business_identity_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_business_identity_service_update_business_identity_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_business_identity_service_update_business_identity_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_business_identity_service_update_business_identity_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_business_identity_service_update_business_identity_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_business_info_service_get_business_info_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_business_info_service_get_business_info_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_business_info_service_get_business_info_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_business_info_service_get_business_info_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_business_info_service_update_business_info_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_business_info_service_update_business_info_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_business_info_service_update_business_info_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_business_info_service_update_business_info_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_checkout_settings_service_create_checkout_settings_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_checkout_settings_service_create_checkout_settings_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_checkout_settings_service_create_checkout_settings_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_checkout_settings_service_create_checkout_settings_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_checkout_settings_service_delete_checkout_settings_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_checkout_settings_service_delete_checkout_settings_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_checkout_settings_service_delete_checkout_settings_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_checkout_settings_service_delete_checkout_settings_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_checkout_settings_service_get_checkout_settings_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_checkout_settings_service_get_checkout_settings_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_checkout_settings_service_get_checkout_settings_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_checkout_settings_service_get_checkout_settings_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_checkout_settings_service_update_checkout_settings_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_checkout_settings_service_update_checkout_settings_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_checkout_settings_service_update_checkout_settings_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_checkout_settings_service_update_checkout_settings_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_developer_registration_service_get_account_for_gcp_registration_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_developer_registration_service_get_account_for_gcp_registration_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_developer_registration_service_get_account_for_gcp_registration_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_developer_registration_service_get_account_for_gcp_registration_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_developer_registration_service_get_developer_registration_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_developer_registration_service_get_developer_registration_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_developer_registration_service_get_developer_registration_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_developer_registration_service_get_developer_registration_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_developer_registration_service_register_gcp_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_developer_registration_service_register_gcp_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_developer_registration_service_register_gcp_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_developer_registration_service_register_gcp_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_developer_registration_service_unregister_gcp_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_developer_registration_service_unregister_gcp_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_developer_registration_service_unregister_gcp_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_developer_registration_service_unregister_gcp_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_email_preferences_service_get_email_preferences_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_email_preferences_service_get_email_preferences_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_email_preferences_service_get_email_preferences_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_email_preferences_service_get_email_preferences_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_email_preferences_service_update_email_preferences_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_email_preferences_service_update_email_preferences_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_email_preferences_service_update_email_preferences_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_email_preferences_service_update_email_preferences_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_gbp_accounts_service_link_gbp_account_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_gbp_accounts_service_link_gbp_account_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_gbp_accounts_service_link_gbp_account_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_gbp_accounts_service_link_gbp_account_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_gbp_accounts_service_list_gbp_accounts_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_gbp_accounts_service_list_gbp_accounts_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_gbp_accounts_service_list_gbp_accounts_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_gbp_accounts_service_list_gbp_accounts_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_homepage_service_claim_homepage_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_homepage_service_claim_homepage_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_homepage_service_claim_homepage_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_homepage_service_claim_homepage_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_homepage_service_get_homepage_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_homepage_service_get_homepage_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_homepage_service_get_homepage_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_homepage_service_get_homepage_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_homepage_service_unclaim_homepage_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_homepage_service_unclaim_homepage_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_homepage_service_unclaim_homepage_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_homepage_service_unclaim_homepage_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_homepage_service_update_homepage_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_homepage_service_update_homepage_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_homepage_service_update_homepage_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_homepage_service_update_homepage_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_lfp_providers_service_find_lfp_providers_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_lfp_providers_service_find_lfp_providers_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_lfp_providers_service_find_lfp_providers_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_lfp_providers_service_find_lfp_providers_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_lfp_providers_service_link_lfp_provider_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_lfp_providers_service_link_lfp_provider_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_lfp_providers_service_link_lfp_provider_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_lfp_providers_service_link_lfp_provider_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_omnichannel_settings_service_create_omnichannel_setting_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_omnichannel_settings_service_create_omnichannel_setting_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_omnichannel_settings_service_create_omnichannel_setting_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_omnichannel_settings_service_create_omnichannel_setting_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_omnichannel_settings_service_get_omnichannel_setting_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_omnichannel_settings_service_get_omnichannel_setting_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_omnichannel_settings_service_get_omnichannel_setting_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_omnichannel_settings_service_get_omnichannel_setting_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_omnichannel_settings_service_list_omnichannel_settings_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_omnichannel_settings_service_list_omnichannel_settings_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_omnichannel_settings_service_list_omnichannel_settings_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_omnichannel_settings_service_list_omnichannel_settings_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_omnichannel_settings_service_request_inventory_verification_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_omnichannel_settings_service_request_inventory_verification_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_omnichannel_settings_service_request_inventory_verification_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_omnichannel_settings_service_request_inventory_verification_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_omnichannel_settings_service_update_omnichannel_setting_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_omnichannel_settings_service_update_omnichannel_setting_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_omnichannel_settings_service_update_omnichannel_setting_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_omnichannel_settings_service_update_omnichannel_setting_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_online_return_policy_service_create_online_return_policy_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_online_return_policy_service_create_online_return_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_online_return_policy_service_create_online_return_policy_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_online_return_policy_service_create_online_return_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_online_return_policy_service_delete_online_return_policy_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_online_return_policy_service_delete_online_return_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_online_return_policy_service_delete_online_return_policy_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_online_return_policy_service_delete_online_return_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_online_return_policy_service_get_online_return_policy_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_online_return_policy_service_get_online_return_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_online_return_policy_service_get_online_return_policy_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_online_return_policy_service_get_online_return_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_online_return_policy_service_list_online_return_policies_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_online_return_policy_service_list_online_return_policies_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_online_return_policy_service_list_online_return_policies_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_online_return_policy_service_list_online_return_policies_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_programs_service_disable_program_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_programs_service_disable_program_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_programs_service_disable_program_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_programs_service_disable_program_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_programs_service_enable_program_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_programs_service_enable_program_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_programs_service_enable_program_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_programs_service_enable_program_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_programs_service_get_program_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_programs_service_get_program_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_programs_service_get_program_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_programs_service_get_program_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_programs_service_list_programs_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_programs_service_list_programs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_programs_service_list_programs_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_programs_service_list_programs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_regions_service_batch_create_regions_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_regions_service_batch_create_regions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_regions_service_batch_create_regions_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_regions_service_batch_create_regions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_regions_service_batch_delete_regions_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_regions_service_batch_delete_regions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_regions_service_batch_delete_regions_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_regions_service_batch_delete_regions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_regions_service_batch_update_regions_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_regions_service_batch_update_regions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_regions_service_batch_update_regions_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_regions_service_batch_update_regions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_regions_service_create_region_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_regions_service_create_region_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_regions_service_create_region_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_regions_service_create_region_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_regions_service_delete_region_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_regions_service_delete_region_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_regions_service_delete_region_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_regions_service_delete_region_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_regions_service_get_region_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_regions_service_get_region_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_regions_service_get_region_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_regions_service_get_region_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_regions_service_list_regions_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_regions_service_list_regions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_regions_service_list_regions_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_regions_service_list_regions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_regions_service_update_region_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_regions_service_update_region_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_regions_service_update_region_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_regions_service_update_region_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_shipping_settings_service_get_shipping_settings_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_shipping_settings_service_get_shipping_settings_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_shipping_settings_service_get_shipping_settings_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_shipping_settings_service_get_shipping_settings_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_shipping_settings_service_insert_shipping_settings_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_shipping_settings_service_insert_shipping_settings_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_shipping_settings_service_insert_shipping_settings_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_shipping_settings_service_insert_shipping_settings_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_terms_of_service_agreement_state_service_get_terms_of_service_agreement_state_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_terms_of_service_agreement_state_service_get_terms_of_service_agreement_state_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_terms_of_service_agreement_state_service_get_terms_of_service_agreement_state_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_terms_of_service_agreement_state_service_get_terms_of_service_agreement_state_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_terms_of_service_agreement_state_service_retrieve_for_application_terms_of_service_agreement_state_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_terms_of_service_agreement_state_service_retrieve_for_application_terms_of_service_agreement_state_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_terms_of_service_agreement_state_service_retrieve_for_application_terms_of_service_agreement_state_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_terms_of_service_agreement_state_service_retrieve_for_application_terms_of_service_agreement_state_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_terms_of_service_service_accept_terms_of_service_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_terms_of_service_service_accept_terms_of_service_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_terms_of_service_service_accept_terms_of_service_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_terms_of_service_service_accept_terms_of_service_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_terms_of_service_service_get_terms_of_service_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_terms_of_service_service_get_terms_of_service_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_terms_of_service_service_get_terms_of_service_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_terms_of_service_service_get_terms_of_service_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_terms_of_service_service_retrieve_latest_terms_of_service_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_terms_of_service_service_retrieve_latest_terms_of_service_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_terms_of_service_service_retrieve_latest_terms_of_service_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_terms_of_service_service_retrieve_latest_terms_of_service_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_user_service_create_user_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_user_service_create_user_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_user_service_create_user_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_user_service_create_user_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_user_service_delete_user_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_user_service_delete_user_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_user_service_delete_user_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_user_service_delete_user_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_user_service_get_user_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_user_service_get_user_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_user_service_get_user_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_user_service_get_user_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_user_service_list_users_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_user_service_list_users_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_user_service_list_users_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_user_service_list_users_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_user_service_update_user_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_user_service_update_user_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_user_service_update_user_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_user_service_update_user_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_user_service_verify_self_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_user_service_verify_self_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_user_service_verify_self_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1_generated_user_service_verify_self_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_account_issue_service_list_account_issues_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_account_issue_service_list_account_issues_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_account_issue_service_list_account_issues_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_account_issue_service_list_account_issues_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_account_tax_service_get_account_tax_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_account_tax_service_get_account_tax_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_account_tax_service_get_account_tax_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_account_tax_service_get_account_tax_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_account_tax_service_list_account_tax_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_account_tax_service_list_account_tax_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_account_tax_service_list_account_tax_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_account_tax_service_list_account_tax_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_account_tax_service_update_account_tax_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_account_tax_service_update_account_tax_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_account_tax_service_update_account_tax_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_account_tax_service_update_account_tax_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_accounts_service_create_and_configure_account_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_accounts_service_create_and_configure_account_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_accounts_service_create_and_configure_account_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_accounts_service_create_and_configure_account_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_accounts_service_delete_account_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_accounts_service_delete_account_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_accounts_service_delete_account_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_accounts_service_delete_account_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_accounts_service_get_account_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_accounts_service_get_account_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_accounts_service_get_account_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_accounts_service_get_account_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_accounts_service_list_accounts_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_accounts_service_list_accounts_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_accounts_service_list_accounts_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_accounts_service_list_accounts_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_accounts_service_list_sub_accounts_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_accounts_service_list_sub_accounts_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_accounts_service_list_sub_accounts_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_accounts_service_list_sub_accounts_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_accounts_service_update_account_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_accounts_service_update_account_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_accounts_service_update_account_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_accounts_service_update_account_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_autofeed_settings_service_get_autofeed_settings_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_autofeed_settings_service_get_autofeed_settings_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_autofeed_settings_service_get_autofeed_settings_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_autofeed_settings_service_get_autofeed_settings_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_autofeed_settings_service_update_autofeed_settings_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_autofeed_settings_service_update_autofeed_settings_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_autofeed_settings_service_update_autofeed_settings_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_autofeed_settings_service_update_autofeed_settings_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_automatic_improvements_service_get_automatic_improvements_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_automatic_improvements_service_get_automatic_improvements_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_automatic_improvements_service_get_automatic_improvements_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_automatic_improvements_service_get_automatic_improvements_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_automatic_improvements_service_update_automatic_improvements_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_automatic_improvements_service_update_automatic_improvements_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_automatic_improvements_service_update_automatic_improvements_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_automatic_improvements_service_update_automatic_improvements_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_business_identity_service_get_business_identity_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_business_identity_service_get_business_identity_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_business_identity_service_get_business_identity_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_business_identity_service_get_business_identity_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_business_identity_service_update_business_identity_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_business_identity_service_update_business_identity_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_business_identity_service_update_business_identity_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_business_identity_service_update_business_identity_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_business_info_service_get_business_info_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_business_info_service_get_business_info_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_business_info_service_get_business_info_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_business_info_service_get_business_info_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_business_info_service_update_business_info_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_business_info_service_update_business_info_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_business_info_service_update_business_info_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_business_info_service_update_business_info_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_checkout_settings_service_create_checkout_settings_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_checkout_settings_service_create_checkout_settings_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_checkout_settings_service_create_checkout_settings_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_checkout_settings_service_create_checkout_settings_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_checkout_settings_service_delete_checkout_settings_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_checkout_settings_service_delete_checkout_settings_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_checkout_settings_service_delete_checkout_settings_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_checkout_settings_service_delete_checkout_settings_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_checkout_settings_service_get_checkout_settings_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_checkout_settings_service_get_checkout_settings_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_checkout_settings_service_get_checkout_settings_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_checkout_settings_service_get_checkout_settings_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_checkout_settings_service_update_checkout_settings_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_checkout_settings_service_update_checkout_settings_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_checkout_settings_service_update_checkout_settings_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_checkout_settings_service_update_checkout_settings_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_email_preferences_service_get_email_preferences_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_email_preferences_service_get_email_preferences_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_email_preferences_service_get_email_preferences_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_email_preferences_service_get_email_preferences_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_email_preferences_service_update_email_preferences_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_email_preferences_service_update_email_preferences_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_email_preferences_service_update_email_preferences_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_email_preferences_service_update_email_preferences_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_gbp_accounts_service_link_gbp_account_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_gbp_accounts_service_link_gbp_account_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_gbp_accounts_service_link_gbp_account_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_gbp_accounts_service_link_gbp_account_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_gbp_accounts_service_list_gbp_accounts_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_gbp_accounts_service_list_gbp_accounts_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_gbp_accounts_service_list_gbp_accounts_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_gbp_accounts_service_list_gbp_accounts_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_homepage_service_claim_homepage_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_homepage_service_claim_homepage_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_homepage_service_claim_homepage_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_homepage_service_claim_homepage_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_homepage_service_get_homepage_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_homepage_service_get_homepage_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_homepage_service_get_homepage_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_homepage_service_get_homepage_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_homepage_service_unclaim_homepage_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_homepage_service_unclaim_homepage_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_homepage_service_unclaim_homepage_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_homepage_service_unclaim_homepage_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_homepage_service_update_homepage_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_homepage_service_update_homepage_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_homepage_service_update_homepage_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_homepage_service_update_homepage_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_lfp_providers_service_find_lfp_providers_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_lfp_providers_service_find_lfp_providers_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_lfp_providers_service_find_lfp_providers_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_lfp_providers_service_find_lfp_providers_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_lfp_providers_service_link_lfp_provider_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_lfp_providers_service_link_lfp_provider_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_lfp_providers_service_link_lfp_provider_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_lfp_providers_service_link_lfp_provider_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_omnichannel_settings_service_create_omnichannel_setting_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_omnichannel_settings_service_create_omnichannel_setting_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_omnichannel_settings_service_create_omnichannel_setting_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_omnichannel_settings_service_create_omnichannel_setting_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_omnichannel_settings_service_get_omnichannel_setting_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_omnichannel_settings_service_get_omnichannel_setting_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_omnichannel_settings_service_get_omnichannel_setting_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_omnichannel_settings_service_get_omnichannel_setting_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_omnichannel_settings_service_list_omnichannel_settings_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_omnichannel_settings_service_list_omnichannel_settings_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_omnichannel_settings_service_list_omnichannel_settings_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_omnichannel_settings_service_list_omnichannel_settings_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_omnichannel_settings_service_request_inventory_verification_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_omnichannel_settings_service_request_inventory_verification_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_omnichannel_settings_service_request_inventory_verification_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_omnichannel_settings_service_request_inventory_verification_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_omnichannel_settings_service_update_omnichannel_setting_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_omnichannel_settings_service_update_omnichannel_setting_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_omnichannel_settings_service_update_omnichannel_setting_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_omnichannel_settings_service_update_omnichannel_setting_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_online_return_policy_service_create_online_return_policy_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_online_return_policy_service_create_online_return_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_online_return_policy_service_create_online_return_policy_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_online_return_policy_service_create_online_return_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_online_return_policy_service_delete_online_return_policy_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_online_return_policy_service_delete_online_return_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_online_return_policy_service_delete_online_return_policy_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_online_return_policy_service_delete_online_return_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_online_return_policy_service_get_online_return_policy_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_online_return_policy_service_get_online_return_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_online_return_policy_service_get_online_return_policy_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_online_return_policy_service_get_online_return_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_online_return_policy_service_list_online_return_policies_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_online_return_policy_service_list_online_return_policies_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_online_return_policy_service_list_online_return_policies_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_online_return_policy_service_list_online_return_policies_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_online_return_policy_service_update_online_return_policy_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_online_return_policy_service_update_online_return_policy_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_online_return_policy_service_update_online_return_policy_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_online_return_policy_service_update_online_return_policy_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_programs_service_disable_program_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_programs_service_disable_program_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_programs_service_disable_program_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_programs_service_disable_program_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_programs_service_enable_program_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_programs_service_enable_program_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_programs_service_enable_program_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_programs_service_enable_program_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_programs_service_get_program_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_programs_service_get_program_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_programs_service_get_program_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_programs_service_get_program_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_programs_service_list_programs_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_programs_service_list_programs_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_programs_service_list_programs_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_programs_service_list_programs_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_regions_service_create_region_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_regions_service_create_region_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_regions_service_create_region_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_regions_service_create_region_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_regions_service_delete_region_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_regions_service_delete_region_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_regions_service_delete_region_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_regions_service_delete_region_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_regions_service_get_region_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_regions_service_get_region_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_regions_service_get_region_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_regions_service_get_region_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_regions_service_list_regions_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_regions_service_list_regions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_regions_service_list_regions_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_regions_service_list_regions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_regions_service_update_region_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_regions_service_update_region_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_regions_service_update_region_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_regions_service_update_region_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_shipping_settings_service_get_shipping_settings_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_shipping_settings_service_get_shipping_settings_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_shipping_settings_service_get_shipping_settings_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_shipping_settings_service_get_shipping_settings_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_shipping_settings_service_insert_shipping_settings_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_shipping_settings_service_insert_shipping_settings_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_shipping_settings_service_insert_shipping_settings_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_shipping_settings_service_insert_shipping_settings_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_terms_of_service_agreement_state_service_get_terms_of_service_agreement_state_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_terms_of_service_agreement_state_service_get_terms_of_service_agreement_state_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_terms_of_service_agreement_state_service_get_terms_of_service_agreement_state_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_terms_of_service_agreement_state_service_get_terms_of_service_agreement_state_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_terms_of_service_agreement_state_service_retrieve_for_application_terms_of_service_agreement_state_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_terms_of_service_agreement_state_service_retrieve_for_application_terms_of_service_agreement_state_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_terms_of_service_agreement_state_service_retrieve_for_application_terms_of_service_agreement_state_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_terms_of_service_agreement_state_service_retrieve_for_application_terms_of_service_agreement_state_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_terms_of_service_service_accept_terms_of_service_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_terms_of_service_service_accept_terms_of_service_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_terms_of_service_service_accept_terms_of_service_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_terms_of_service_service_accept_terms_of_service_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_terms_of_service_service_get_terms_of_service_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_terms_of_service_service_get_terms_of_service_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_terms_of_service_service_get_terms_of_service_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_terms_of_service_service_get_terms_of_service_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_terms_of_service_service_retrieve_latest_terms_of_service_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_terms_of_service_service_retrieve_latest_terms_of_service_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_terms_of_service_service_retrieve_latest_terms_of_service_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_terms_of_service_service_retrieve_latest_terms_of_service_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_user_service_create_user_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_user_service_create_user_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_user_service_create_user_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_user_service_create_user_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_user_service_delete_user_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_user_service_delete_user_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_user_service_delete_user_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_user_service_delete_user_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_user_service_get_user_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_user_service_get_user_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_user_service_get_user_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_user_service_get_user_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_user_service_list_users_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_user_service_list_users_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_user_service_list_users_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_user_service_list_users_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_user_service_update_user_async.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_user_service_update_user_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_user_service_update_user_sync.py
+++ b/packages/google-shopping-merchant-accounts/samples/generated_samples/merchantapi_v1beta_generated_user_service_update_user_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/tests/__init__.py
+++ b/packages/google-shopping-merchant-accounts/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/tests/unit/__init__.py
+++ b/packages/google-shopping-merchant-accounts/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/tests/unit/gapic/__init__.py
+++ b/packages/google-shopping-merchant-accounts/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/tests/unit/gapic/merchant_accounts_v1/__init__.py
+++ b/packages/google-shopping-merchant-accounts/tests/unit/gapic/merchant_accounts_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-accounts/tests/unit/gapic/merchant_accounts_v1beta/__init__.py
+++ b/packages/google-shopping-merchant-accounts/tests/unit/gapic/merchant_accounts_v1beta/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-conversions/.flake8
+++ b/packages/google-shopping-merchant-conversions/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-conversions/MANIFEST.in
+++ b/packages/google-shopping-merchant-conversions/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-conversions/google/shopping/merchant_conversions/__init__.py
+++ b/packages/google-shopping-merchant-conversions/google/shopping/merchant_conversions/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-conversions/google/shopping/merchant_conversions/gapic_version.py
+++ b/packages/google-shopping-merchant-conversions/google/shopping/merchant_conversions/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-conversions/google/shopping/merchant_conversions_v1/gapic_version.py
+++ b/packages/google-shopping-merchant-conversions/google/shopping/merchant_conversions_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-conversions/google/shopping/merchant_conversions_v1/services/__init__.py
+++ b/packages/google-shopping-merchant-conversions/google/shopping/merchant_conversions_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-conversions/google/shopping/merchant_conversions_v1/services/conversion_sources_service/__init__.py
+++ b/packages/google-shopping-merchant-conversions/google/shopping/merchant_conversions_v1/services/conversion_sources_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-conversions/google/shopping/merchant_conversions_v1/services/conversion_sources_service/async_client.py
+++ b/packages/google-shopping-merchant-conversions/google/shopping/merchant_conversions_v1/services/conversion_sources_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-conversions/google/shopping/merchant_conversions_v1/services/conversion_sources_service/client.py
+++ b/packages/google-shopping-merchant-conversions/google/shopping/merchant_conversions_v1/services/conversion_sources_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-conversions/google/shopping/merchant_conversions_v1/services/conversion_sources_service/pagers.py
+++ b/packages/google-shopping-merchant-conversions/google/shopping/merchant_conversions_v1/services/conversion_sources_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-conversions/google/shopping/merchant_conversions_v1/services/conversion_sources_service/transports/__init__.py
+++ b/packages/google-shopping-merchant-conversions/google/shopping/merchant_conversions_v1/services/conversion_sources_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-conversions/google/shopping/merchant_conversions_v1/services/conversion_sources_service/transports/base.py
+++ b/packages/google-shopping-merchant-conversions/google/shopping/merchant_conversions_v1/services/conversion_sources_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-conversions/google/shopping/merchant_conversions_v1/services/conversion_sources_service/transports/grpc.py
+++ b/packages/google-shopping-merchant-conversions/google/shopping/merchant_conversions_v1/services/conversion_sources_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-conversions/google/shopping/merchant_conversions_v1/services/conversion_sources_service/transports/grpc_asyncio.py
+++ b/packages/google-shopping-merchant-conversions/google/shopping/merchant_conversions_v1/services/conversion_sources_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-conversions/google/shopping/merchant_conversions_v1/services/conversion_sources_service/transports/rest.py
+++ b/packages/google-shopping-merchant-conversions/google/shopping/merchant_conversions_v1/services/conversion_sources_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-conversions/google/shopping/merchant_conversions_v1/services/conversion_sources_service/transports/rest_base.py
+++ b/packages/google-shopping-merchant-conversions/google/shopping/merchant_conversions_v1/services/conversion_sources_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-conversions/google/shopping/merchant_conversions_v1/types/__init__.py
+++ b/packages/google-shopping-merchant-conversions/google/shopping/merchant_conversions_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-conversions/google/shopping/merchant_conversions_v1/types/conversionsources.py
+++ b/packages/google-shopping-merchant-conversions/google/shopping/merchant_conversions_v1/types/conversionsources.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-conversions/google/shopping/merchant_conversions_v1beta/gapic_version.py
+++ b/packages/google-shopping-merchant-conversions/google/shopping/merchant_conversions_v1beta/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-conversions/google/shopping/merchant_conversions_v1beta/services/__init__.py
+++ b/packages/google-shopping-merchant-conversions/google/shopping/merchant_conversions_v1beta/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-conversions/google/shopping/merchant_conversions_v1beta/services/conversion_sources_service/__init__.py
+++ b/packages/google-shopping-merchant-conversions/google/shopping/merchant_conversions_v1beta/services/conversion_sources_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-conversions/google/shopping/merchant_conversions_v1beta/services/conversion_sources_service/async_client.py
+++ b/packages/google-shopping-merchant-conversions/google/shopping/merchant_conversions_v1beta/services/conversion_sources_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-conversions/google/shopping/merchant_conversions_v1beta/services/conversion_sources_service/client.py
+++ b/packages/google-shopping-merchant-conversions/google/shopping/merchant_conversions_v1beta/services/conversion_sources_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-conversions/google/shopping/merchant_conversions_v1beta/services/conversion_sources_service/pagers.py
+++ b/packages/google-shopping-merchant-conversions/google/shopping/merchant_conversions_v1beta/services/conversion_sources_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-conversions/google/shopping/merchant_conversions_v1beta/services/conversion_sources_service/transports/__init__.py
+++ b/packages/google-shopping-merchant-conversions/google/shopping/merchant_conversions_v1beta/services/conversion_sources_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-conversions/google/shopping/merchant_conversions_v1beta/services/conversion_sources_service/transports/base.py
+++ b/packages/google-shopping-merchant-conversions/google/shopping/merchant_conversions_v1beta/services/conversion_sources_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-conversions/google/shopping/merchant_conversions_v1beta/services/conversion_sources_service/transports/grpc.py
+++ b/packages/google-shopping-merchant-conversions/google/shopping/merchant_conversions_v1beta/services/conversion_sources_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-conversions/google/shopping/merchant_conversions_v1beta/services/conversion_sources_service/transports/grpc_asyncio.py
+++ b/packages/google-shopping-merchant-conversions/google/shopping/merchant_conversions_v1beta/services/conversion_sources_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-conversions/google/shopping/merchant_conversions_v1beta/services/conversion_sources_service/transports/rest.py
+++ b/packages/google-shopping-merchant-conversions/google/shopping/merchant_conversions_v1beta/services/conversion_sources_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-conversions/google/shopping/merchant_conversions_v1beta/services/conversion_sources_service/transports/rest_base.py
+++ b/packages/google-shopping-merchant-conversions/google/shopping/merchant_conversions_v1beta/services/conversion_sources_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-conversions/google/shopping/merchant_conversions_v1beta/types/__init__.py
+++ b/packages/google-shopping-merchant-conversions/google/shopping/merchant_conversions_v1beta/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-conversions/google/shopping/merchant_conversions_v1beta/types/conversionsources.py
+++ b/packages/google-shopping-merchant-conversions/google/shopping/merchant_conversions_v1beta/types/conversionsources.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-conversions/samples/generated_samples/merchantapi_v1_generated_conversion_sources_service_create_conversion_source_async.py
+++ b/packages/google-shopping-merchant-conversions/samples/generated_samples/merchantapi_v1_generated_conversion_sources_service_create_conversion_source_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-conversions/samples/generated_samples/merchantapi_v1_generated_conversion_sources_service_create_conversion_source_sync.py
+++ b/packages/google-shopping-merchant-conversions/samples/generated_samples/merchantapi_v1_generated_conversion_sources_service_create_conversion_source_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-conversions/samples/generated_samples/merchantapi_v1_generated_conversion_sources_service_delete_conversion_source_async.py
+++ b/packages/google-shopping-merchant-conversions/samples/generated_samples/merchantapi_v1_generated_conversion_sources_service_delete_conversion_source_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-conversions/samples/generated_samples/merchantapi_v1_generated_conversion_sources_service_delete_conversion_source_sync.py
+++ b/packages/google-shopping-merchant-conversions/samples/generated_samples/merchantapi_v1_generated_conversion_sources_service_delete_conversion_source_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-conversions/samples/generated_samples/merchantapi_v1_generated_conversion_sources_service_get_conversion_source_async.py
+++ b/packages/google-shopping-merchant-conversions/samples/generated_samples/merchantapi_v1_generated_conversion_sources_service_get_conversion_source_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-conversions/samples/generated_samples/merchantapi_v1_generated_conversion_sources_service_get_conversion_source_sync.py
+++ b/packages/google-shopping-merchant-conversions/samples/generated_samples/merchantapi_v1_generated_conversion_sources_service_get_conversion_source_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-conversions/samples/generated_samples/merchantapi_v1_generated_conversion_sources_service_list_conversion_sources_async.py
+++ b/packages/google-shopping-merchant-conversions/samples/generated_samples/merchantapi_v1_generated_conversion_sources_service_list_conversion_sources_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-conversions/samples/generated_samples/merchantapi_v1_generated_conversion_sources_service_list_conversion_sources_sync.py
+++ b/packages/google-shopping-merchant-conversions/samples/generated_samples/merchantapi_v1_generated_conversion_sources_service_list_conversion_sources_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-conversions/samples/generated_samples/merchantapi_v1_generated_conversion_sources_service_undelete_conversion_source_async.py
+++ b/packages/google-shopping-merchant-conversions/samples/generated_samples/merchantapi_v1_generated_conversion_sources_service_undelete_conversion_source_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-conversions/samples/generated_samples/merchantapi_v1_generated_conversion_sources_service_undelete_conversion_source_sync.py
+++ b/packages/google-shopping-merchant-conversions/samples/generated_samples/merchantapi_v1_generated_conversion_sources_service_undelete_conversion_source_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-conversions/samples/generated_samples/merchantapi_v1_generated_conversion_sources_service_update_conversion_source_async.py
+++ b/packages/google-shopping-merchant-conversions/samples/generated_samples/merchantapi_v1_generated_conversion_sources_service_update_conversion_source_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-conversions/samples/generated_samples/merchantapi_v1_generated_conversion_sources_service_update_conversion_source_sync.py
+++ b/packages/google-shopping-merchant-conversions/samples/generated_samples/merchantapi_v1_generated_conversion_sources_service_update_conversion_source_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-conversions/samples/generated_samples/merchantapi_v1beta_generated_conversion_sources_service_create_conversion_source_async.py
+++ b/packages/google-shopping-merchant-conversions/samples/generated_samples/merchantapi_v1beta_generated_conversion_sources_service_create_conversion_source_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-conversions/samples/generated_samples/merchantapi_v1beta_generated_conversion_sources_service_create_conversion_source_sync.py
+++ b/packages/google-shopping-merchant-conversions/samples/generated_samples/merchantapi_v1beta_generated_conversion_sources_service_create_conversion_source_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-conversions/samples/generated_samples/merchantapi_v1beta_generated_conversion_sources_service_delete_conversion_source_async.py
+++ b/packages/google-shopping-merchant-conversions/samples/generated_samples/merchantapi_v1beta_generated_conversion_sources_service_delete_conversion_source_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-conversions/samples/generated_samples/merchantapi_v1beta_generated_conversion_sources_service_delete_conversion_source_sync.py
+++ b/packages/google-shopping-merchant-conversions/samples/generated_samples/merchantapi_v1beta_generated_conversion_sources_service_delete_conversion_source_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-conversions/samples/generated_samples/merchantapi_v1beta_generated_conversion_sources_service_get_conversion_source_async.py
+++ b/packages/google-shopping-merchant-conversions/samples/generated_samples/merchantapi_v1beta_generated_conversion_sources_service_get_conversion_source_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-conversions/samples/generated_samples/merchantapi_v1beta_generated_conversion_sources_service_get_conversion_source_sync.py
+++ b/packages/google-shopping-merchant-conversions/samples/generated_samples/merchantapi_v1beta_generated_conversion_sources_service_get_conversion_source_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-conversions/samples/generated_samples/merchantapi_v1beta_generated_conversion_sources_service_list_conversion_sources_async.py
+++ b/packages/google-shopping-merchant-conversions/samples/generated_samples/merchantapi_v1beta_generated_conversion_sources_service_list_conversion_sources_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-conversions/samples/generated_samples/merchantapi_v1beta_generated_conversion_sources_service_list_conversion_sources_sync.py
+++ b/packages/google-shopping-merchant-conversions/samples/generated_samples/merchantapi_v1beta_generated_conversion_sources_service_list_conversion_sources_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-conversions/samples/generated_samples/merchantapi_v1beta_generated_conversion_sources_service_undelete_conversion_source_async.py
+++ b/packages/google-shopping-merchant-conversions/samples/generated_samples/merchantapi_v1beta_generated_conversion_sources_service_undelete_conversion_source_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-conversions/samples/generated_samples/merchantapi_v1beta_generated_conversion_sources_service_undelete_conversion_source_sync.py
+++ b/packages/google-shopping-merchant-conversions/samples/generated_samples/merchantapi_v1beta_generated_conversion_sources_service_undelete_conversion_source_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-conversions/samples/generated_samples/merchantapi_v1beta_generated_conversion_sources_service_update_conversion_source_async.py
+++ b/packages/google-shopping-merchant-conversions/samples/generated_samples/merchantapi_v1beta_generated_conversion_sources_service_update_conversion_source_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-conversions/samples/generated_samples/merchantapi_v1beta_generated_conversion_sources_service_update_conversion_source_sync.py
+++ b/packages/google-shopping-merchant-conversions/samples/generated_samples/merchantapi_v1beta_generated_conversion_sources_service_update_conversion_source_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-conversions/tests/__init__.py
+++ b/packages/google-shopping-merchant-conversions/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-conversions/tests/unit/__init__.py
+++ b/packages/google-shopping-merchant-conversions/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-conversions/tests/unit/gapic/__init__.py
+++ b/packages/google-shopping-merchant-conversions/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-conversions/tests/unit/gapic/merchant_conversions_v1/__init__.py
+++ b/packages/google-shopping-merchant-conversions/tests/unit/gapic/merchant_conversions_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-conversions/tests/unit/gapic/merchant_conversions_v1beta/__init__.py
+++ b/packages/google-shopping-merchant-conversions/tests/unit/gapic/merchant_conversions_v1beta/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-datasources/.flake8
+++ b/packages/google-shopping-merchant-datasources/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-datasources/MANIFEST.in
+++ b/packages/google-shopping-merchant-datasources/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-datasources/google/shopping/merchant_datasources/__init__.py
+++ b/packages/google-shopping-merchant-datasources/google/shopping/merchant_datasources/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-datasources/google/shopping/merchant_datasources/gapic_version.py
+++ b/packages/google-shopping-merchant-datasources/google/shopping/merchant_datasources/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-datasources/google/shopping/merchant_datasources_v1/gapic_version.py
+++ b/packages/google-shopping-merchant-datasources/google/shopping/merchant_datasources_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-datasources/google/shopping/merchant_datasources_v1/services/__init__.py
+++ b/packages/google-shopping-merchant-datasources/google/shopping/merchant_datasources_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-datasources/google/shopping/merchant_datasources_v1/services/data_sources_service/__init__.py
+++ b/packages/google-shopping-merchant-datasources/google/shopping/merchant_datasources_v1/services/data_sources_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-datasources/google/shopping/merchant_datasources_v1/services/data_sources_service/async_client.py
+++ b/packages/google-shopping-merchant-datasources/google/shopping/merchant_datasources_v1/services/data_sources_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-datasources/google/shopping/merchant_datasources_v1/services/data_sources_service/client.py
+++ b/packages/google-shopping-merchant-datasources/google/shopping/merchant_datasources_v1/services/data_sources_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-datasources/google/shopping/merchant_datasources_v1/services/data_sources_service/pagers.py
+++ b/packages/google-shopping-merchant-datasources/google/shopping/merchant_datasources_v1/services/data_sources_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-datasources/google/shopping/merchant_datasources_v1/services/data_sources_service/transports/__init__.py
+++ b/packages/google-shopping-merchant-datasources/google/shopping/merchant_datasources_v1/services/data_sources_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-datasources/google/shopping/merchant_datasources_v1/services/data_sources_service/transports/base.py
+++ b/packages/google-shopping-merchant-datasources/google/shopping/merchant_datasources_v1/services/data_sources_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-datasources/google/shopping/merchant_datasources_v1/services/data_sources_service/transports/grpc.py
+++ b/packages/google-shopping-merchant-datasources/google/shopping/merchant_datasources_v1/services/data_sources_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-datasources/google/shopping/merchant_datasources_v1/services/data_sources_service/transports/grpc_asyncio.py
+++ b/packages/google-shopping-merchant-datasources/google/shopping/merchant_datasources_v1/services/data_sources_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-datasources/google/shopping/merchant_datasources_v1/services/data_sources_service/transports/rest.py
+++ b/packages/google-shopping-merchant-datasources/google/shopping/merchant_datasources_v1/services/data_sources_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-datasources/google/shopping/merchant_datasources_v1/services/data_sources_service/transports/rest_base.py
+++ b/packages/google-shopping-merchant-datasources/google/shopping/merchant_datasources_v1/services/data_sources_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-datasources/google/shopping/merchant_datasources_v1/services/file_uploads_service/__init__.py
+++ b/packages/google-shopping-merchant-datasources/google/shopping/merchant_datasources_v1/services/file_uploads_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-datasources/google/shopping/merchant_datasources_v1/services/file_uploads_service/async_client.py
+++ b/packages/google-shopping-merchant-datasources/google/shopping/merchant_datasources_v1/services/file_uploads_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-datasources/google/shopping/merchant_datasources_v1/services/file_uploads_service/client.py
+++ b/packages/google-shopping-merchant-datasources/google/shopping/merchant_datasources_v1/services/file_uploads_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-datasources/google/shopping/merchant_datasources_v1/services/file_uploads_service/transports/__init__.py
+++ b/packages/google-shopping-merchant-datasources/google/shopping/merchant_datasources_v1/services/file_uploads_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-datasources/google/shopping/merchant_datasources_v1/services/file_uploads_service/transports/base.py
+++ b/packages/google-shopping-merchant-datasources/google/shopping/merchant_datasources_v1/services/file_uploads_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-datasources/google/shopping/merchant_datasources_v1/services/file_uploads_service/transports/grpc.py
+++ b/packages/google-shopping-merchant-datasources/google/shopping/merchant_datasources_v1/services/file_uploads_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-datasources/google/shopping/merchant_datasources_v1/services/file_uploads_service/transports/grpc_asyncio.py
+++ b/packages/google-shopping-merchant-datasources/google/shopping/merchant_datasources_v1/services/file_uploads_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-datasources/google/shopping/merchant_datasources_v1/services/file_uploads_service/transports/rest.py
+++ b/packages/google-shopping-merchant-datasources/google/shopping/merchant_datasources_v1/services/file_uploads_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-datasources/google/shopping/merchant_datasources_v1/services/file_uploads_service/transports/rest_base.py
+++ b/packages/google-shopping-merchant-datasources/google/shopping/merchant_datasources_v1/services/file_uploads_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-datasources/google/shopping/merchant_datasources_v1/types/__init__.py
+++ b/packages/google-shopping-merchant-datasources/google/shopping/merchant_datasources_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-datasources/google/shopping/merchant_datasources_v1/types/datasources.py
+++ b/packages/google-shopping-merchant-datasources/google/shopping/merchant_datasources_v1/types/datasources.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-datasources/google/shopping/merchant_datasources_v1/types/datasourcetypes.py
+++ b/packages/google-shopping-merchant-datasources/google/shopping/merchant_datasources_v1/types/datasourcetypes.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-datasources/google/shopping/merchant_datasources_v1/types/fileinputs.py
+++ b/packages/google-shopping-merchant-datasources/google/shopping/merchant_datasources_v1/types/fileinputs.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-datasources/google/shopping/merchant_datasources_v1/types/fileuploads.py
+++ b/packages/google-shopping-merchant-datasources/google/shopping/merchant_datasources_v1/types/fileuploads.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-datasources/google/shopping/merchant_datasources_v1beta/gapic_version.py
+++ b/packages/google-shopping-merchant-datasources/google/shopping/merchant_datasources_v1beta/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-datasources/google/shopping/merchant_datasources_v1beta/services/__init__.py
+++ b/packages/google-shopping-merchant-datasources/google/shopping/merchant_datasources_v1beta/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-datasources/google/shopping/merchant_datasources_v1beta/services/data_sources_service/__init__.py
+++ b/packages/google-shopping-merchant-datasources/google/shopping/merchant_datasources_v1beta/services/data_sources_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-datasources/google/shopping/merchant_datasources_v1beta/services/data_sources_service/async_client.py
+++ b/packages/google-shopping-merchant-datasources/google/shopping/merchant_datasources_v1beta/services/data_sources_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-datasources/google/shopping/merchant_datasources_v1beta/services/data_sources_service/client.py
+++ b/packages/google-shopping-merchant-datasources/google/shopping/merchant_datasources_v1beta/services/data_sources_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-datasources/google/shopping/merchant_datasources_v1beta/services/data_sources_service/pagers.py
+++ b/packages/google-shopping-merchant-datasources/google/shopping/merchant_datasources_v1beta/services/data_sources_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-datasources/google/shopping/merchant_datasources_v1beta/services/data_sources_service/transports/__init__.py
+++ b/packages/google-shopping-merchant-datasources/google/shopping/merchant_datasources_v1beta/services/data_sources_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-datasources/google/shopping/merchant_datasources_v1beta/services/data_sources_service/transports/base.py
+++ b/packages/google-shopping-merchant-datasources/google/shopping/merchant_datasources_v1beta/services/data_sources_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-datasources/google/shopping/merchant_datasources_v1beta/services/data_sources_service/transports/grpc.py
+++ b/packages/google-shopping-merchant-datasources/google/shopping/merchant_datasources_v1beta/services/data_sources_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-datasources/google/shopping/merchant_datasources_v1beta/services/data_sources_service/transports/grpc_asyncio.py
+++ b/packages/google-shopping-merchant-datasources/google/shopping/merchant_datasources_v1beta/services/data_sources_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-datasources/google/shopping/merchant_datasources_v1beta/services/data_sources_service/transports/rest.py
+++ b/packages/google-shopping-merchant-datasources/google/shopping/merchant_datasources_v1beta/services/data_sources_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-datasources/google/shopping/merchant_datasources_v1beta/services/data_sources_service/transports/rest_base.py
+++ b/packages/google-shopping-merchant-datasources/google/shopping/merchant_datasources_v1beta/services/data_sources_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-datasources/google/shopping/merchant_datasources_v1beta/services/file_uploads_service/__init__.py
+++ b/packages/google-shopping-merchant-datasources/google/shopping/merchant_datasources_v1beta/services/file_uploads_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-datasources/google/shopping/merchant_datasources_v1beta/services/file_uploads_service/async_client.py
+++ b/packages/google-shopping-merchant-datasources/google/shopping/merchant_datasources_v1beta/services/file_uploads_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-datasources/google/shopping/merchant_datasources_v1beta/services/file_uploads_service/client.py
+++ b/packages/google-shopping-merchant-datasources/google/shopping/merchant_datasources_v1beta/services/file_uploads_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-datasources/google/shopping/merchant_datasources_v1beta/services/file_uploads_service/transports/__init__.py
+++ b/packages/google-shopping-merchant-datasources/google/shopping/merchant_datasources_v1beta/services/file_uploads_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-datasources/google/shopping/merchant_datasources_v1beta/services/file_uploads_service/transports/base.py
+++ b/packages/google-shopping-merchant-datasources/google/shopping/merchant_datasources_v1beta/services/file_uploads_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-datasources/google/shopping/merchant_datasources_v1beta/services/file_uploads_service/transports/grpc.py
+++ b/packages/google-shopping-merchant-datasources/google/shopping/merchant_datasources_v1beta/services/file_uploads_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-datasources/google/shopping/merchant_datasources_v1beta/services/file_uploads_service/transports/grpc_asyncio.py
+++ b/packages/google-shopping-merchant-datasources/google/shopping/merchant_datasources_v1beta/services/file_uploads_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-datasources/google/shopping/merchant_datasources_v1beta/services/file_uploads_service/transports/rest.py
+++ b/packages/google-shopping-merchant-datasources/google/shopping/merchant_datasources_v1beta/services/file_uploads_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-datasources/google/shopping/merchant_datasources_v1beta/services/file_uploads_service/transports/rest_base.py
+++ b/packages/google-shopping-merchant-datasources/google/shopping/merchant_datasources_v1beta/services/file_uploads_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-datasources/google/shopping/merchant_datasources_v1beta/types/__init__.py
+++ b/packages/google-shopping-merchant-datasources/google/shopping/merchant_datasources_v1beta/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-datasources/google/shopping/merchant_datasources_v1beta/types/datasources.py
+++ b/packages/google-shopping-merchant-datasources/google/shopping/merchant_datasources_v1beta/types/datasources.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-datasources/google/shopping/merchant_datasources_v1beta/types/datasourcetypes.py
+++ b/packages/google-shopping-merchant-datasources/google/shopping/merchant_datasources_v1beta/types/datasourcetypes.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-datasources/google/shopping/merchant_datasources_v1beta/types/fileinputs.py
+++ b/packages/google-shopping-merchant-datasources/google/shopping/merchant_datasources_v1beta/types/fileinputs.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-datasources/google/shopping/merchant_datasources_v1beta/types/fileuploads.py
+++ b/packages/google-shopping-merchant-datasources/google/shopping/merchant_datasources_v1beta/types/fileuploads.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-datasources/samples/generated_samples/merchantapi_v1_generated_data_sources_service_create_data_source_async.py
+++ b/packages/google-shopping-merchant-datasources/samples/generated_samples/merchantapi_v1_generated_data_sources_service_create_data_source_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-datasources/samples/generated_samples/merchantapi_v1_generated_data_sources_service_create_data_source_sync.py
+++ b/packages/google-shopping-merchant-datasources/samples/generated_samples/merchantapi_v1_generated_data_sources_service_create_data_source_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-datasources/samples/generated_samples/merchantapi_v1_generated_data_sources_service_delete_data_source_async.py
+++ b/packages/google-shopping-merchant-datasources/samples/generated_samples/merchantapi_v1_generated_data_sources_service_delete_data_source_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-datasources/samples/generated_samples/merchantapi_v1_generated_data_sources_service_delete_data_source_sync.py
+++ b/packages/google-shopping-merchant-datasources/samples/generated_samples/merchantapi_v1_generated_data_sources_service_delete_data_source_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-datasources/samples/generated_samples/merchantapi_v1_generated_data_sources_service_fetch_data_source_async.py
+++ b/packages/google-shopping-merchant-datasources/samples/generated_samples/merchantapi_v1_generated_data_sources_service_fetch_data_source_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-datasources/samples/generated_samples/merchantapi_v1_generated_data_sources_service_fetch_data_source_sync.py
+++ b/packages/google-shopping-merchant-datasources/samples/generated_samples/merchantapi_v1_generated_data_sources_service_fetch_data_source_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-datasources/samples/generated_samples/merchantapi_v1_generated_data_sources_service_get_data_source_async.py
+++ b/packages/google-shopping-merchant-datasources/samples/generated_samples/merchantapi_v1_generated_data_sources_service_get_data_source_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-datasources/samples/generated_samples/merchantapi_v1_generated_data_sources_service_get_data_source_sync.py
+++ b/packages/google-shopping-merchant-datasources/samples/generated_samples/merchantapi_v1_generated_data_sources_service_get_data_source_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-datasources/samples/generated_samples/merchantapi_v1_generated_data_sources_service_list_data_sources_async.py
+++ b/packages/google-shopping-merchant-datasources/samples/generated_samples/merchantapi_v1_generated_data_sources_service_list_data_sources_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-datasources/samples/generated_samples/merchantapi_v1_generated_data_sources_service_list_data_sources_sync.py
+++ b/packages/google-shopping-merchant-datasources/samples/generated_samples/merchantapi_v1_generated_data_sources_service_list_data_sources_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-datasources/samples/generated_samples/merchantapi_v1_generated_data_sources_service_update_data_source_async.py
+++ b/packages/google-shopping-merchant-datasources/samples/generated_samples/merchantapi_v1_generated_data_sources_service_update_data_source_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-datasources/samples/generated_samples/merchantapi_v1_generated_data_sources_service_update_data_source_sync.py
+++ b/packages/google-shopping-merchant-datasources/samples/generated_samples/merchantapi_v1_generated_data_sources_service_update_data_source_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-datasources/samples/generated_samples/merchantapi_v1_generated_file_uploads_service_get_file_upload_async.py
+++ b/packages/google-shopping-merchant-datasources/samples/generated_samples/merchantapi_v1_generated_file_uploads_service_get_file_upload_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-datasources/samples/generated_samples/merchantapi_v1_generated_file_uploads_service_get_file_upload_sync.py
+++ b/packages/google-shopping-merchant-datasources/samples/generated_samples/merchantapi_v1_generated_file_uploads_service_get_file_upload_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-datasources/samples/generated_samples/merchantapi_v1beta_generated_data_sources_service_create_data_source_async.py
+++ b/packages/google-shopping-merchant-datasources/samples/generated_samples/merchantapi_v1beta_generated_data_sources_service_create_data_source_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-datasources/samples/generated_samples/merchantapi_v1beta_generated_data_sources_service_create_data_source_sync.py
+++ b/packages/google-shopping-merchant-datasources/samples/generated_samples/merchantapi_v1beta_generated_data_sources_service_create_data_source_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-datasources/samples/generated_samples/merchantapi_v1beta_generated_data_sources_service_delete_data_source_async.py
+++ b/packages/google-shopping-merchant-datasources/samples/generated_samples/merchantapi_v1beta_generated_data_sources_service_delete_data_source_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-datasources/samples/generated_samples/merchantapi_v1beta_generated_data_sources_service_delete_data_source_sync.py
+++ b/packages/google-shopping-merchant-datasources/samples/generated_samples/merchantapi_v1beta_generated_data_sources_service_delete_data_source_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-datasources/samples/generated_samples/merchantapi_v1beta_generated_data_sources_service_fetch_data_source_async.py
+++ b/packages/google-shopping-merchant-datasources/samples/generated_samples/merchantapi_v1beta_generated_data_sources_service_fetch_data_source_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-datasources/samples/generated_samples/merchantapi_v1beta_generated_data_sources_service_fetch_data_source_sync.py
+++ b/packages/google-shopping-merchant-datasources/samples/generated_samples/merchantapi_v1beta_generated_data_sources_service_fetch_data_source_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-datasources/samples/generated_samples/merchantapi_v1beta_generated_data_sources_service_get_data_source_async.py
+++ b/packages/google-shopping-merchant-datasources/samples/generated_samples/merchantapi_v1beta_generated_data_sources_service_get_data_source_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-datasources/samples/generated_samples/merchantapi_v1beta_generated_data_sources_service_get_data_source_sync.py
+++ b/packages/google-shopping-merchant-datasources/samples/generated_samples/merchantapi_v1beta_generated_data_sources_service_get_data_source_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-datasources/samples/generated_samples/merchantapi_v1beta_generated_data_sources_service_list_data_sources_async.py
+++ b/packages/google-shopping-merchant-datasources/samples/generated_samples/merchantapi_v1beta_generated_data_sources_service_list_data_sources_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-datasources/samples/generated_samples/merchantapi_v1beta_generated_data_sources_service_list_data_sources_sync.py
+++ b/packages/google-shopping-merchant-datasources/samples/generated_samples/merchantapi_v1beta_generated_data_sources_service_list_data_sources_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-datasources/samples/generated_samples/merchantapi_v1beta_generated_data_sources_service_update_data_source_async.py
+++ b/packages/google-shopping-merchant-datasources/samples/generated_samples/merchantapi_v1beta_generated_data_sources_service_update_data_source_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-datasources/samples/generated_samples/merchantapi_v1beta_generated_data_sources_service_update_data_source_sync.py
+++ b/packages/google-shopping-merchant-datasources/samples/generated_samples/merchantapi_v1beta_generated_data_sources_service_update_data_source_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-datasources/samples/generated_samples/merchantapi_v1beta_generated_file_uploads_service_get_file_upload_async.py
+++ b/packages/google-shopping-merchant-datasources/samples/generated_samples/merchantapi_v1beta_generated_file_uploads_service_get_file_upload_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-datasources/samples/generated_samples/merchantapi_v1beta_generated_file_uploads_service_get_file_upload_sync.py
+++ b/packages/google-shopping-merchant-datasources/samples/generated_samples/merchantapi_v1beta_generated_file_uploads_service_get_file_upload_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-datasources/tests/__init__.py
+++ b/packages/google-shopping-merchant-datasources/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-datasources/tests/unit/__init__.py
+++ b/packages/google-shopping-merchant-datasources/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-datasources/tests/unit/gapic/__init__.py
+++ b/packages/google-shopping-merchant-datasources/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-datasources/tests/unit/gapic/merchant_datasources_v1/__init__.py
+++ b/packages/google-shopping-merchant-datasources/tests/unit/gapic/merchant_datasources_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-datasources/tests/unit/gapic/merchant_datasources_v1beta/__init__.py
+++ b/packages/google-shopping-merchant-datasources/tests/unit/gapic/merchant_datasources_v1beta/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-inventories/.flake8
+++ b/packages/google-shopping-merchant-inventories/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-inventories/MANIFEST.in
+++ b/packages/google-shopping-merchant-inventories/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-inventories/google/shopping/merchant_inventories/__init__.py
+++ b/packages/google-shopping-merchant-inventories/google/shopping/merchant_inventories/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-inventories/google/shopping/merchant_inventories/gapic_version.py
+++ b/packages/google-shopping-merchant-inventories/google/shopping/merchant_inventories/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-inventories/google/shopping/merchant_inventories_v1/gapic_version.py
+++ b/packages/google-shopping-merchant-inventories/google/shopping/merchant_inventories_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-inventories/google/shopping/merchant_inventories_v1/services/__init__.py
+++ b/packages/google-shopping-merchant-inventories/google/shopping/merchant_inventories_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-inventories/google/shopping/merchant_inventories_v1/services/local_inventory_service/__init__.py
+++ b/packages/google-shopping-merchant-inventories/google/shopping/merchant_inventories_v1/services/local_inventory_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-inventories/google/shopping/merchant_inventories_v1/services/local_inventory_service/async_client.py
+++ b/packages/google-shopping-merchant-inventories/google/shopping/merchant_inventories_v1/services/local_inventory_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-inventories/google/shopping/merchant_inventories_v1/services/local_inventory_service/client.py
+++ b/packages/google-shopping-merchant-inventories/google/shopping/merchant_inventories_v1/services/local_inventory_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-inventories/google/shopping/merchant_inventories_v1/services/local_inventory_service/pagers.py
+++ b/packages/google-shopping-merchant-inventories/google/shopping/merchant_inventories_v1/services/local_inventory_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-inventories/google/shopping/merchant_inventories_v1/services/local_inventory_service/transports/__init__.py
+++ b/packages/google-shopping-merchant-inventories/google/shopping/merchant_inventories_v1/services/local_inventory_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-inventories/google/shopping/merchant_inventories_v1/services/local_inventory_service/transports/base.py
+++ b/packages/google-shopping-merchant-inventories/google/shopping/merchant_inventories_v1/services/local_inventory_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-inventories/google/shopping/merchant_inventories_v1/services/local_inventory_service/transports/grpc.py
+++ b/packages/google-shopping-merchant-inventories/google/shopping/merchant_inventories_v1/services/local_inventory_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-inventories/google/shopping/merchant_inventories_v1/services/local_inventory_service/transports/grpc_asyncio.py
+++ b/packages/google-shopping-merchant-inventories/google/shopping/merchant_inventories_v1/services/local_inventory_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-inventories/google/shopping/merchant_inventories_v1/services/local_inventory_service/transports/rest.py
+++ b/packages/google-shopping-merchant-inventories/google/shopping/merchant_inventories_v1/services/local_inventory_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-inventories/google/shopping/merchant_inventories_v1/services/local_inventory_service/transports/rest_base.py
+++ b/packages/google-shopping-merchant-inventories/google/shopping/merchant_inventories_v1/services/local_inventory_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-inventories/google/shopping/merchant_inventories_v1/services/regional_inventory_service/__init__.py
+++ b/packages/google-shopping-merchant-inventories/google/shopping/merchant_inventories_v1/services/regional_inventory_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-inventories/google/shopping/merchant_inventories_v1/services/regional_inventory_service/async_client.py
+++ b/packages/google-shopping-merchant-inventories/google/shopping/merchant_inventories_v1/services/regional_inventory_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-inventories/google/shopping/merchant_inventories_v1/services/regional_inventory_service/client.py
+++ b/packages/google-shopping-merchant-inventories/google/shopping/merchant_inventories_v1/services/regional_inventory_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-inventories/google/shopping/merchant_inventories_v1/services/regional_inventory_service/pagers.py
+++ b/packages/google-shopping-merchant-inventories/google/shopping/merchant_inventories_v1/services/regional_inventory_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-inventories/google/shopping/merchant_inventories_v1/services/regional_inventory_service/transports/__init__.py
+++ b/packages/google-shopping-merchant-inventories/google/shopping/merchant_inventories_v1/services/regional_inventory_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-inventories/google/shopping/merchant_inventories_v1/services/regional_inventory_service/transports/base.py
+++ b/packages/google-shopping-merchant-inventories/google/shopping/merchant_inventories_v1/services/regional_inventory_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-inventories/google/shopping/merchant_inventories_v1/services/regional_inventory_service/transports/grpc.py
+++ b/packages/google-shopping-merchant-inventories/google/shopping/merchant_inventories_v1/services/regional_inventory_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-inventories/google/shopping/merchant_inventories_v1/services/regional_inventory_service/transports/grpc_asyncio.py
+++ b/packages/google-shopping-merchant-inventories/google/shopping/merchant_inventories_v1/services/regional_inventory_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-inventories/google/shopping/merchant_inventories_v1/services/regional_inventory_service/transports/rest.py
+++ b/packages/google-shopping-merchant-inventories/google/shopping/merchant_inventories_v1/services/regional_inventory_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-inventories/google/shopping/merchant_inventories_v1/services/regional_inventory_service/transports/rest_base.py
+++ b/packages/google-shopping-merchant-inventories/google/shopping/merchant_inventories_v1/services/regional_inventory_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-inventories/google/shopping/merchant_inventories_v1/types/__init__.py
+++ b/packages/google-shopping-merchant-inventories/google/shopping/merchant_inventories_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-inventories/google/shopping/merchant_inventories_v1/types/inventories_common.py
+++ b/packages/google-shopping-merchant-inventories/google/shopping/merchant_inventories_v1/types/inventories_common.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-inventories/google/shopping/merchant_inventories_v1/types/localinventory.py
+++ b/packages/google-shopping-merchant-inventories/google/shopping/merchant_inventories_v1/types/localinventory.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-inventories/google/shopping/merchant_inventories_v1/types/regionalinventory.py
+++ b/packages/google-shopping-merchant-inventories/google/shopping/merchant_inventories_v1/types/regionalinventory.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-inventories/google/shopping/merchant_inventories_v1beta/gapic_version.py
+++ b/packages/google-shopping-merchant-inventories/google/shopping/merchant_inventories_v1beta/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-inventories/google/shopping/merchant_inventories_v1beta/services/__init__.py
+++ b/packages/google-shopping-merchant-inventories/google/shopping/merchant_inventories_v1beta/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-inventories/google/shopping/merchant_inventories_v1beta/services/local_inventory_service/__init__.py
+++ b/packages/google-shopping-merchant-inventories/google/shopping/merchant_inventories_v1beta/services/local_inventory_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-inventories/google/shopping/merchant_inventories_v1beta/services/local_inventory_service/async_client.py
+++ b/packages/google-shopping-merchant-inventories/google/shopping/merchant_inventories_v1beta/services/local_inventory_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-inventories/google/shopping/merchant_inventories_v1beta/services/local_inventory_service/client.py
+++ b/packages/google-shopping-merchant-inventories/google/shopping/merchant_inventories_v1beta/services/local_inventory_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-inventories/google/shopping/merchant_inventories_v1beta/services/local_inventory_service/pagers.py
+++ b/packages/google-shopping-merchant-inventories/google/shopping/merchant_inventories_v1beta/services/local_inventory_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-inventories/google/shopping/merchant_inventories_v1beta/services/local_inventory_service/transports/__init__.py
+++ b/packages/google-shopping-merchant-inventories/google/shopping/merchant_inventories_v1beta/services/local_inventory_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-inventories/google/shopping/merchant_inventories_v1beta/services/local_inventory_service/transports/base.py
+++ b/packages/google-shopping-merchant-inventories/google/shopping/merchant_inventories_v1beta/services/local_inventory_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-inventories/google/shopping/merchant_inventories_v1beta/services/local_inventory_service/transports/grpc.py
+++ b/packages/google-shopping-merchant-inventories/google/shopping/merchant_inventories_v1beta/services/local_inventory_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-inventories/google/shopping/merchant_inventories_v1beta/services/local_inventory_service/transports/grpc_asyncio.py
+++ b/packages/google-shopping-merchant-inventories/google/shopping/merchant_inventories_v1beta/services/local_inventory_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-inventories/google/shopping/merchant_inventories_v1beta/services/local_inventory_service/transports/rest.py
+++ b/packages/google-shopping-merchant-inventories/google/shopping/merchant_inventories_v1beta/services/local_inventory_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-inventories/google/shopping/merchant_inventories_v1beta/services/local_inventory_service/transports/rest_base.py
+++ b/packages/google-shopping-merchant-inventories/google/shopping/merchant_inventories_v1beta/services/local_inventory_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-inventories/google/shopping/merchant_inventories_v1beta/services/regional_inventory_service/__init__.py
+++ b/packages/google-shopping-merchant-inventories/google/shopping/merchant_inventories_v1beta/services/regional_inventory_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-inventories/google/shopping/merchant_inventories_v1beta/services/regional_inventory_service/async_client.py
+++ b/packages/google-shopping-merchant-inventories/google/shopping/merchant_inventories_v1beta/services/regional_inventory_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-inventories/google/shopping/merchant_inventories_v1beta/services/regional_inventory_service/client.py
+++ b/packages/google-shopping-merchant-inventories/google/shopping/merchant_inventories_v1beta/services/regional_inventory_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-inventories/google/shopping/merchant_inventories_v1beta/services/regional_inventory_service/pagers.py
+++ b/packages/google-shopping-merchant-inventories/google/shopping/merchant_inventories_v1beta/services/regional_inventory_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-inventories/google/shopping/merchant_inventories_v1beta/services/regional_inventory_service/transports/__init__.py
+++ b/packages/google-shopping-merchant-inventories/google/shopping/merchant_inventories_v1beta/services/regional_inventory_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-inventories/google/shopping/merchant_inventories_v1beta/services/regional_inventory_service/transports/base.py
+++ b/packages/google-shopping-merchant-inventories/google/shopping/merchant_inventories_v1beta/services/regional_inventory_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-inventories/google/shopping/merchant_inventories_v1beta/services/regional_inventory_service/transports/grpc.py
+++ b/packages/google-shopping-merchant-inventories/google/shopping/merchant_inventories_v1beta/services/regional_inventory_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-inventories/google/shopping/merchant_inventories_v1beta/services/regional_inventory_service/transports/grpc_asyncio.py
+++ b/packages/google-shopping-merchant-inventories/google/shopping/merchant_inventories_v1beta/services/regional_inventory_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-inventories/google/shopping/merchant_inventories_v1beta/services/regional_inventory_service/transports/rest.py
+++ b/packages/google-shopping-merchant-inventories/google/shopping/merchant_inventories_v1beta/services/regional_inventory_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-inventories/google/shopping/merchant_inventories_v1beta/services/regional_inventory_service/transports/rest_base.py
+++ b/packages/google-shopping-merchant-inventories/google/shopping/merchant_inventories_v1beta/services/regional_inventory_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-inventories/google/shopping/merchant_inventories_v1beta/types/__init__.py
+++ b/packages/google-shopping-merchant-inventories/google/shopping/merchant_inventories_v1beta/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-inventories/google/shopping/merchant_inventories_v1beta/types/localinventory.py
+++ b/packages/google-shopping-merchant-inventories/google/shopping/merchant_inventories_v1beta/types/localinventory.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-inventories/google/shopping/merchant_inventories_v1beta/types/regionalinventory.py
+++ b/packages/google-shopping-merchant-inventories/google/shopping/merchant_inventories_v1beta/types/regionalinventory.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-inventories/samples/generated_samples/merchantapi_v1_generated_local_inventory_service_delete_local_inventory_async.py
+++ b/packages/google-shopping-merchant-inventories/samples/generated_samples/merchantapi_v1_generated_local_inventory_service_delete_local_inventory_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-inventories/samples/generated_samples/merchantapi_v1_generated_local_inventory_service_delete_local_inventory_sync.py
+++ b/packages/google-shopping-merchant-inventories/samples/generated_samples/merchantapi_v1_generated_local_inventory_service_delete_local_inventory_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-inventories/samples/generated_samples/merchantapi_v1_generated_local_inventory_service_insert_local_inventory_async.py
+++ b/packages/google-shopping-merchant-inventories/samples/generated_samples/merchantapi_v1_generated_local_inventory_service_insert_local_inventory_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-inventories/samples/generated_samples/merchantapi_v1_generated_local_inventory_service_insert_local_inventory_sync.py
+++ b/packages/google-shopping-merchant-inventories/samples/generated_samples/merchantapi_v1_generated_local_inventory_service_insert_local_inventory_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-inventories/samples/generated_samples/merchantapi_v1_generated_local_inventory_service_list_local_inventories_async.py
+++ b/packages/google-shopping-merchant-inventories/samples/generated_samples/merchantapi_v1_generated_local_inventory_service_list_local_inventories_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-inventories/samples/generated_samples/merchantapi_v1_generated_local_inventory_service_list_local_inventories_sync.py
+++ b/packages/google-shopping-merchant-inventories/samples/generated_samples/merchantapi_v1_generated_local_inventory_service_list_local_inventories_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-inventories/samples/generated_samples/merchantapi_v1_generated_regional_inventory_service_delete_regional_inventory_async.py
+++ b/packages/google-shopping-merchant-inventories/samples/generated_samples/merchantapi_v1_generated_regional_inventory_service_delete_regional_inventory_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-inventories/samples/generated_samples/merchantapi_v1_generated_regional_inventory_service_delete_regional_inventory_sync.py
+++ b/packages/google-shopping-merchant-inventories/samples/generated_samples/merchantapi_v1_generated_regional_inventory_service_delete_regional_inventory_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-inventories/samples/generated_samples/merchantapi_v1_generated_regional_inventory_service_insert_regional_inventory_async.py
+++ b/packages/google-shopping-merchant-inventories/samples/generated_samples/merchantapi_v1_generated_regional_inventory_service_insert_regional_inventory_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-inventories/samples/generated_samples/merchantapi_v1_generated_regional_inventory_service_insert_regional_inventory_sync.py
+++ b/packages/google-shopping-merchant-inventories/samples/generated_samples/merchantapi_v1_generated_regional_inventory_service_insert_regional_inventory_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-inventories/samples/generated_samples/merchantapi_v1_generated_regional_inventory_service_list_regional_inventories_async.py
+++ b/packages/google-shopping-merchant-inventories/samples/generated_samples/merchantapi_v1_generated_regional_inventory_service_list_regional_inventories_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-inventories/samples/generated_samples/merchantapi_v1_generated_regional_inventory_service_list_regional_inventories_sync.py
+++ b/packages/google-shopping-merchant-inventories/samples/generated_samples/merchantapi_v1_generated_regional_inventory_service_list_regional_inventories_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-inventories/samples/generated_samples/merchantapi_v1beta_generated_local_inventory_service_delete_local_inventory_async.py
+++ b/packages/google-shopping-merchant-inventories/samples/generated_samples/merchantapi_v1beta_generated_local_inventory_service_delete_local_inventory_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-inventories/samples/generated_samples/merchantapi_v1beta_generated_local_inventory_service_delete_local_inventory_sync.py
+++ b/packages/google-shopping-merchant-inventories/samples/generated_samples/merchantapi_v1beta_generated_local_inventory_service_delete_local_inventory_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-inventories/samples/generated_samples/merchantapi_v1beta_generated_local_inventory_service_insert_local_inventory_async.py
+++ b/packages/google-shopping-merchant-inventories/samples/generated_samples/merchantapi_v1beta_generated_local_inventory_service_insert_local_inventory_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-inventories/samples/generated_samples/merchantapi_v1beta_generated_local_inventory_service_insert_local_inventory_sync.py
+++ b/packages/google-shopping-merchant-inventories/samples/generated_samples/merchantapi_v1beta_generated_local_inventory_service_insert_local_inventory_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-inventories/samples/generated_samples/merchantapi_v1beta_generated_local_inventory_service_list_local_inventories_async.py
+++ b/packages/google-shopping-merchant-inventories/samples/generated_samples/merchantapi_v1beta_generated_local_inventory_service_list_local_inventories_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-inventories/samples/generated_samples/merchantapi_v1beta_generated_local_inventory_service_list_local_inventories_sync.py
+++ b/packages/google-shopping-merchant-inventories/samples/generated_samples/merchantapi_v1beta_generated_local_inventory_service_list_local_inventories_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-inventories/samples/generated_samples/merchantapi_v1beta_generated_regional_inventory_service_delete_regional_inventory_async.py
+++ b/packages/google-shopping-merchant-inventories/samples/generated_samples/merchantapi_v1beta_generated_regional_inventory_service_delete_regional_inventory_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-inventories/samples/generated_samples/merchantapi_v1beta_generated_regional_inventory_service_delete_regional_inventory_sync.py
+++ b/packages/google-shopping-merchant-inventories/samples/generated_samples/merchantapi_v1beta_generated_regional_inventory_service_delete_regional_inventory_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-inventories/samples/generated_samples/merchantapi_v1beta_generated_regional_inventory_service_insert_regional_inventory_async.py
+++ b/packages/google-shopping-merchant-inventories/samples/generated_samples/merchantapi_v1beta_generated_regional_inventory_service_insert_regional_inventory_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-inventories/samples/generated_samples/merchantapi_v1beta_generated_regional_inventory_service_insert_regional_inventory_sync.py
+++ b/packages/google-shopping-merchant-inventories/samples/generated_samples/merchantapi_v1beta_generated_regional_inventory_service_insert_regional_inventory_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-inventories/samples/generated_samples/merchantapi_v1beta_generated_regional_inventory_service_list_regional_inventories_async.py
+++ b/packages/google-shopping-merchant-inventories/samples/generated_samples/merchantapi_v1beta_generated_regional_inventory_service_list_regional_inventories_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-inventories/samples/generated_samples/merchantapi_v1beta_generated_regional_inventory_service_list_regional_inventories_sync.py
+++ b/packages/google-shopping-merchant-inventories/samples/generated_samples/merchantapi_v1beta_generated_regional_inventory_service_list_regional_inventories_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-inventories/tests/__init__.py
+++ b/packages/google-shopping-merchant-inventories/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-inventories/tests/unit/__init__.py
+++ b/packages/google-shopping-merchant-inventories/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-inventories/tests/unit/gapic/__init__.py
+++ b/packages/google-shopping-merchant-inventories/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-inventories/tests/unit/gapic/merchant_inventories_v1/__init__.py
+++ b/packages/google-shopping-merchant-inventories/tests/unit/gapic/merchant_inventories_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-inventories/tests/unit/gapic/merchant_inventories_v1beta/__init__.py
+++ b/packages/google-shopping-merchant-inventories/tests/unit/gapic/merchant_inventories_v1beta/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-issueresolution/.flake8
+++ b/packages/google-shopping-merchant-issueresolution/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-issueresolution/MANIFEST.in
+++ b/packages/google-shopping-merchant-issueresolution/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-issueresolution/google/shopping/merchant_issueresolution/__init__.py
+++ b/packages/google-shopping-merchant-issueresolution/google/shopping/merchant_issueresolution/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-issueresolution/google/shopping/merchant_issueresolution/gapic_version.py
+++ b/packages/google-shopping-merchant-issueresolution/google/shopping/merchant_issueresolution/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-issueresolution/google/shopping/merchant_issueresolution_v1/gapic_version.py
+++ b/packages/google-shopping-merchant-issueresolution/google/shopping/merchant_issueresolution_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-issueresolution/google/shopping/merchant_issueresolution_v1/services/__init__.py
+++ b/packages/google-shopping-merchant-issueresolution/google/shopping/merchant_issueresolution_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-issueresolution/google/shopping/merchant_issueresolution_v1/services/aggregate_product_statuses_service/__init__.py
+++ b/packages/google-shopping-merchant-issueresolution/google/shopping/merchant_issueresolution_v1/services/aggregate_product_statuses_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-issueresolution/google/shopping/merchant_issueresolution_v1/services/aggregate_product_statuses_service/async_client.py
+++ b/packages/google-shopping-merchant-issueresolution/google/shopping/merchant_issueresolution_v1/services/aggregate_product_statuses_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-issueresolution/google/shopping/merchant_issueresolution_v1/services/aggregate_product_statuses_service/client.py
+++ b/packages/google-shopping-merchant-issueresolution/google/shopping/merchant_issueresolution_v1/services/aggregate_product_statuses_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-issueresolution/google/shopping/merchant_issueresolution_v1/services/aggregate_product_statuses_service/pagers.py
+++ b/packages/google-shopping-merchant-issueresolution/google/shopping/merchant_issueresolution_v1/services/aggregate_product_statuses_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-issueresolution/google/shopping/merchant_issueresolution_v1/services/aggregate_product_statuses_service/transports/__init__.py
+++ b/packages/google-shopping-merchant-issueresolution/google/shopping/merchant_issueresolution_v1/services/aggregate_product_statuses_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-issueresolution/google/shopping/merchant_issueresolution_v1/services/aggregate_product_statuses_service/transports/base.py
+++ b/packages/google-shopping-merchant-issueresolution/google/shopping/merchant_issueresolution_v1/services/aggregate_product_statuses_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-issueresolution/google/shopping/merchant_issueresolution_v1/services/aggregate_product_statuses_service/transports/grpc.py
+++ b/packages/google-shopping-merchant-issueresolution/google/shopping/merchant_issueresolution_v1/services/aggregate_product_statuses_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-issueresolution/google/shopping/merchant_issueresolution_v1/services/aggregate_product_statuses_service/transports/grpc_asyncio.py
+++ b/packages/google-shopping-merchant-issueresolution/google/shopping/merchant_issueresolution_v1/services/aggregate_product_statuses_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-issueresolution/google/shopping/merchant_issueresolution_v1/services/aggregate_product_statuses_service/transports/rest.py
+++ b/packages/google-shopping-merchant-issueresolution/google/shopping/merchant_issueresolution_v1/services/aggregate_product_statuses_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-issueresolution/google/shopping/merchant_issueresolution_v1/services/aggregate_product_statuses_service/transports/rest_base.py
+++ b/packages/google-shopping-merchant-issueresolution/google/shopping/merchant_issueresolution_v1/services/aggregate_product_statuses_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-issueresolution/google/shopping/merchant_issueresolution_v1/services/issue_resolution_service/__init__.py
+++ b/packages/google-shopping-merchant-issueresolution/google/shopping/merchant_issueresolution_v1/services/issue_resolution_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-issueresolution/google/shopping/merchant_issueresolution_v1/services/issue_resolution_service/async_client.py
+++ b/packages/google-shopping-merchant-issueresolution/google/shopping/merchant_issueresolution_v1/services/issue_resolution_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-issueresolution/google/shopping/merchant_issueresolution_v1/services/issue_resolution_service/client.py
+++ b/packages/google-shopping-merchant-issueresolution/google/shopping/merchant_issueresolution_v1/services/issue_resolution_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-issueresolution/google/shopping/merchant_issueresolution_v1/services/issue_resolution_service/transports/__init__.py
+++ b/packages/google-shopping-merchant-issueresolution/google/shopping/merchant_issueresolution_v1/services/issue_resolution_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-issueresolution/google/shopping/merchant_issueresolution_v1/services/issue_resolution_service/transports/base.py
+++ b/packages/google-shopping-merchant-issueresolution/google/shopping/merchant_issueresolution_v1/services/issue_resolution_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-issueresolution/google/shopping/merchant_issueresolution_v1/services/issue_resolution_service/transports/grpc.py
+++ b/packages/google-shopping-merchant-issueresolution/google/shopping/merchant_issueresolution_v1/services/issue_resolution_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-issueresolution/google/shopping/merchant_issueresolution_v1/services/issue_resolution_service/transports/grpc_asyncio.py
+++ b/packages/google-shopping-merchant-issueresolution/google/shopping/merchant_issueresolution_v1/services/issue_resolution_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-issueresolution/google/shopping/merchant_issueresolution_v1/services/issue_resolution_service/transports/rest.py
+++ b/packages/google-shopping-merchant-issueresolution/google/shopping/merchant_issueresolution_v1/services/issue_resolution_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-issueresolution/google/shopping/merchant_issueresolution_v1/services/issue_resolution_service/transports/rest_base.py
+++ b/packages/google-shopping-merchant-issueresolution/google/shopping/merchant_issueresolution_v1/services/issue_resolution_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-issueresolution/google/shopping/merchant_issueresolution_v1/types/__init__.py
+++ b/packages/google-shopping-merchant-issueresolution/google/shopping/merchant_issueresolution_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-issueresolution/google/shopping/merchant_issueresolution_v1/types/aggregateproductstatuses.py
+++ b/packages/google-shopping-merchant-issueresolution/google/shopping/merchant_issueresolution_v1/types/aggregateproductstatuses.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-issueresolution/google/shopping/merchant_issueresolution_v1/types/issueresolution.py
+++ b/packages/google-shopping-merchant-issueresolution/google/shopping/merchant_issueresolution_v1/types/issueresolution.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-issueresolution/google/shopping/merchant_issueresolution_v1beta/gapic_version.py
+++ b/packages/google-shopping-merchant-issueresolution/google/shopping/merchant_issueresolution_v1beta/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-issueresolution/google/shopping/merchant_issueresolution_v1beta/services/__init__.py
+++ b/packages/google-shopping-merchant-issueresolution/google/shopping/merchant_issueresolution_v1beta/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-issueresolution/google/shopping/merchant_issueresolution_v1beta/services/aggregate_product_statuses_service/__init__.py
+++ b/packages/google-shopping-merchant-issueresolution/google/shopping/merchant_issueresolution_v1beta/services/aggregate_product_statuses_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-issueresolution/google/shopping/merchant_issueresolution_v1beta/services/aggregate_product_statuses_service/async_client.py
+++ b/packages/google-shopping-merchant-issueresolution/google/shopping/merchant_issueresolution_v1beta/services/aggregate_product_statuses_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-issueresolution/google/shopping/merchant_issueresolution_v1beta/services/aggregate_product_statuses_service/client.py
+++ b/packages/google-shopping-merchant-issueresolution/google/shopping/merchant_issueresolution_v1beta/services/aggregate_product_statuses_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-issueresolution/google/shopping/merchant_issueresolution_v1beta/services/aggregate_product_statuses_service/pagers.py
+++ b/packages/google-shopping-merchant-issueresolution/google/shopping/merchant_issueresolution_v1beta/services/aggregate_product_statuses_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-issueresolution/google/shopping/merchant_issueresolution_v1beta/services/aggregate_product_statuses_service/transports/__init__.py
+++ b/packages/google-shopping-merchant-issueresolution/google/shopping/merchant_issueresolution_v1beta/services/aggregate_product_statuses_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-issueresolution/google/shopping/merchant_issueresolution_v1beta/services/aggregate_product_statuses_service/transports/base.py
+++ b/packages/google-shopping-merchant-issueresolution/google/shopping/merchant_issueresolution_v1beta/services/aggregate_product_statuses_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-issueresolution/google/shopping/merchant_issueresolution_v1beta/services/aggregate_product_statuses_service/transports/grpc.py
+++ b/packages/google-shopping-merchant-issueresolution/google/shopping/merchant_issueresolution_v1beta/services/aggregate_product_statuses_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-issueresolution/google/shopping/merchant_issueresolution_v1beta/services/aggregate_product_statuses_service/transports/grpc_asyncio.py
+++ b/packages/google-shopping-merchant-issueresolution/google/shopping/merchant_issueresolution_v1beta/services/aggregate_product_statuses_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-issueresolution/google/shopping/merchant_issueresolution_v1beta/services/aggregate_product_statuses_service/transports/rest.py
+++ b/packages/google-shopping-merchant-issueresolution/google/shopping/merchant_issueresolution_v1beta/services/aggregate_product_statuses_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-issueresolution/google/shopping/merchant_issueresolution_v1beta/services/aggregate_product_statuses_service/transports/rest_base.py
+++ b/packages/google-shopping-merchant-issueresolution/google/shopping/merchant_issueresolution_v1beta/services/aggregate_product_statuses_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-issueresolution/google/shopping/merchant_issueresolution_v1beta/services/issue_resolution_service/__init__.py
+++ b/packages/google-shopping-merchant-issueresolution/google/shopping/merchant_issueresolution_v1beta/services/issue_resolution_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-issueresolution/google/shopping/merchant_issueresolution_v1beta/services/issue_resolution_service/async_client.py
+++ b/packages/google-shopping-merchant-issueresolution/google/shopping/merchant_issueresolution_v1beta/services/issue_resolution_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-issueresolution/google/shopping/merchant_issueresolution_v1beta/services/issue_resolution_service/client.py
+++ b/packages/google-shopping-merchant-issueresolution/google/shopping/merchant_issueresolution_v1beta/services/issue_resolution_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-issueresolution/google/shopping/merchant_issueresolution_v1beta/services/issue_resolution_service/transports/__init__.py
+++ b/packages/google-shopping-merchant-issueresolution/google/shopping/merchant_issueresolution_v1beta/services/issue_resolution_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-issueresolution/google/shopping/merchant_issueresolution_v1beta/services/issue_resolution_service/transports/base.py
+++ b/packages/google-shopping-merchant-issueresolution/google/shopping/merchant_issueresolution_v1beta/services/issue_resolution_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-issueresolution/google/shopping/merchant_issueresolution_v1beta/services/issue_resolution_service/transports/grpc.py
+++ b/packages/google-shopping-merchant-issueresolution/google/shopping/merchant_issueresolution_v1beta/services/issue_resolution_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-issueresolution/google/shopping/merchant_issueresolution_v1beta/services/issue_resolution_service/transports/grpc_asyncio.py
+++ b/packages/google-shopping-merchant-issueresolution/google/shopping/merchant_issueresolution_v1beta/services/issue_resolution_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-issueresolution/google/shopping/merchant_issueresolution_v1beta/services/issue_resolution_service/transports/rest.py
+++ b/packages/google-shopping-merchant-issueresolution/google/shopping/merchant_issueresolution_v1beta/services/issue_resolution_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-issueresolution/google/shopping/merchant_issueresolution_v1beta/services/issue_resolution_service/transports/rest_base.py
+++ b/packages/google-shopping-merchant-issueresolution/google/shopping/merchant_issueresolution_v1beta/services/issue_resolution_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-issueresolution/google/shopping/merchant_issueresolution_v1beta/types/__init__.py
+++ b/packages/google-shopping-merchant-issueresolution/google/shopping/merchant_issueresolution_v1beta/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-issueresolution/google/shopping/merchant_issueresolution_v1beta/types/aggregateproductstatuses.py
+++ b/packages/google-shopping-merchant-issueresolution/google/shopping/merchant_issueresolution_v1beta/types/aggregateproductstatuses.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-issueresolution/google/shopping/merchant_issueresolution_v1beta/types/issueresolution.py
+++ b/packages/google-shopping-merchant-issueresolution/google/shopping/merchant_issueresolution_v1beta/types/issueresolution.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-issueresolution/samples/generated_samples/merchantapi_v1_generated_aggregate_product_statuses_service_list_aggregate_product_statuses_async.py
+++ b/packages/google-shopping-merchant-issueresolution/samples/generated_samples/merchantapi_v1_generated_aggregate_product_statuses_service_list_aggregate_product_statuses_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-issueresolution/samples/generated_samples/merchantapi_v1_generated_aggregate_product_statuses_service_list_aggregate_product_statuses_sync.py
+++ b/packages/google-shopping-merchant-issueresolution/samples/generated_samples/merchantapi_v1_generated_aggregate_product_statuses_service_list_aggregate_product_statuses_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-issueresolution/samples/generated_samples/merchantapi_v1_generated_issue_resolution_service_render_account_issues_async.py
+++ b/packages/google-shopping-merchant-issueresolution/samples/generated_samples/merchantapi_v1_generated_issue_resolution_service_render_account_issues_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-issueresolution/samples/generated_samples/merchantapi_v1_generated_issue_resolution_service_render_account_issues_sync.py
+++ b/packages/google-shopping-merchant-issueresolution/samples/generated_samples/merchantapi_v1_generated_issue_resolution_service_render_account_issues_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-issueresolution/samples/generated_samples/merchantapi_v1_generated_issue_resolution_service_render_product_issues_async.py
+++ b/packages/google-shopping-merchant-issueresolution/samples/generated_samples/merchantapi_v1_generated_issue_resolution_service_render_product_issues_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-issueresolution/samples/generated_samples/merchantapi_v1_generated_issue_resolution_service_render_product_issues_sync.py
+++ b/packages/google-shopping-merchant-issueresolution/samples/generated_samples/merchantapi_v1_generated_issue_resolution_service_render_product_issues_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-issueresolution/samples/generated_samples/merchantapi_v1_generated_issue_resolution_service_trigger_action_async.py
+++ b/packages/google-shopping-merchant-issueresolution/samples/generated_samples/merchantapi_v1_generated_issue_resolution_service_trigger_action_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-issueresolution/samples/generated_samples/merchantapi_v1_generated_issue_resolution_service_trigger_action_sync.py
+++ b/packages/google-shopping-merchant-issueresolution/samples/generated_samples/merchantapi_v1_generated_issue_resolution_service_trigger_action_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-issueresolution/samples/generated_samples/merchantapi_v1beta_generated_aggregate_product_statuses_service_list_aggregate_product_statuses_async.py
+++ b/packages/google-shopping-merchant-issueresolution/samples/generated_samples/merchantapi_v1beta_generated_aggregate_product_statuses_service_list_aggregate_product_statuses_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-issueresolution/samples/generated_samples/merchantapi_v1beta_generated_aggregate_product_statuses_service_list_aggregate_product_statuses_sync.py
+++ b/packages/google-shopping-merchant-issueresolution/samples/generated_samples/merchantapi_v1beta_generated_aggregate_product_statuses_service_list_aggregate_product_statuses_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-issueresolution/samples/generated_samples/merchantapi_v1beta_generated_issue_resolution_service_render_account_issues_async.py
+++ b/packages/google-shopping-merchant-issueresolution/samples/generated_samples/merchantapi_v1beta_generated_issue_resolution_service_render_account_issues_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-issueresolution/samples/generated_samples/merchantapi_v1beta_generated_issue_resolution_service_render_account_issues_sync.py
+++ b/packages/google-shopping-merchant-issueresolution/samples/generated_samples/merchantapi_v1beta_generated_issue_resolution_service_render_account_issues_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-issueresolution/samples/generated_samples/merchantapi_v1beta_generated_issue_resolution_service_render_product_issues_async.py
+++ b/packages/google-shopping-merchant-issueresolution/samples/generated_samples/merchantapi_v1beta_generated_issue_resolution_service_render_product_issues_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-issueresolution/samples/generated_samples/merchantapi_v1beta_generated_issue_resolution_service_render_product_issues_sync.py
+++ b/packages/google-shopping-merchant-issueresolution/samples/generated_samples/merchantapi_v1beta_generated_issue_resolution_service_render_product_issues_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-issueresolution/samples/generated_samples/merchantapi_v1beta_generated_issue_resolution_service_trigger_action_async.py
+++ b/packages/google-shopping-merchant-issueresolution/samples/generated_samples/merchantapi_v1beta_generated_issue_resolution_service_trigger_action_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-issueresolution/samples/generated_samples/merchantapi_v1beta_generated_issue_resolution_service_trigger_action_sync.py
+++ b/packages/google-shopping-merchant-issueresolution/samples/generated_samples/merchantapi_v1beta_generated_issue_resolution_service_trigger_action_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-issueresolution/tests/__init__.py
+++ b/packages/google-shopping-merchant-issueresolution/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-issueresolution/tests/unit/__init__.py
+++ b/packages/google-shopping-merchant-issueresolution/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-issueresolution/tests/unit/gapic/__init__.py
+++ b/packages/google-shopping-merchant-issueresolution/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-issueresolution/tests/unit/gapic/merchant_issueresolution_v1/__init__.py
+++ b/packages/google-shopping-merchant-issueresolution/tests/unit/gapic/merchant_issueresolution_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-issueresolution/tests/unit/gapic/merchant_issueresolution_v1beta/__init__.py
+++ b/packages/google-shopping-merchant-issueresolution/tests/unit/gapic/merchant_issueresolution_v1beta/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/.flake8
+++ b/packages/google-shopping-merchant-lfp/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/MANIFEST.in
+++ b/packages/google-shopping-merchant-lfp/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp/__init__.py
+++ b/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp/gapic_version.py
+++ b/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1/gapic_version.py
+++ b/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1/services/__init__.py
+++ b/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1/services/lfp_inventory_service/__init__.py
+++ b/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1/services/lfp_inventory_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1/services/lfp_inventory_service/async_client.py
+++ b/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1/services/lfp_inventory_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1/services/lfp_inventory_service/client.py
+++ b/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1/services/lfp_inventory_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1/services/lfp_inventory_service/transports/__init__.py
+++ b/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1/services/lfp_inventory_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1/services/lfp_inventory_service/transports/base.py
+++ b/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1/services/lfp_inventory_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1/services/lfp_inventory_service/transports/grpc.py
+++ b/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1/services/lfp_inventory_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1/services/lfp_inventory_service/transports/grpc_asyncio.py
+++ b/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1/services/lfp_inventory_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1/services/lfp_inventory_service/transports/rest.py
+++ b/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1/services/lfp_inventory_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1/services/lfp_inventory_service/transports/rest_base.py
+++ b/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1/services/lfp_inventory_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1/services/lfp_merchant_state_service/__init__.py
+++ b/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1/services/lfp_merchant_state_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1/services/lfp_merchant_state_service/async_client.py
+++ b/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1/services/lfp_merchant_state_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1/services/lfp_merchant_state_service/client.py
+++ b/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1/services/lfp_merchant_state_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1/services/lfp_merchant_state_service/transports/__init__.py
+++ b/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1/services/lfp_merchant_state_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1/services/lfp_merchant_state_service/transports/base.py
+++ b/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1/services/lfp_merchant_state_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1/services/lfp_merchant_state_service/transports/grpc.py
+++ b/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1/services/lfp_merchant_state_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1/services/lfp_merchant_state_service/transports/grpc_asyncio.py
+++ b/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1/services/lfp_merchant_state_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1/services/lfp_merchant_state_service/transports/rest.py
+++ b/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1/services/lfp_merchant_state_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1/services/lfp_merchant_state_service/transports/rest_base.py
+++ b/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1/services/lfp_merchant_state_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1/services/lfp_sale_service/__init__.py
+++ b/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1/services/lfp_sale_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1/services/lfp_sale_service/async_client.py
+++ b/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1/services/lfp_sale_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1/services/lfp_sale_service/client.py
+++ b/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1/services/lfp_sale_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1/services/lfp_sale_service/transports/__init__.py
+++ b/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1/services/lfp_sale_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1/services/lfp_sale_service/transports/base.py
+++ b/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1/services/lfp_sale_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1/services/lfp_sale_service/transports/grpc.py
+++ b/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1/services/lfp_sale_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1/services/lfp_sale_service/transports/grpc_asyncio.py
+++ b/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1/services/lfp_sale_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1/services/lfp_sale_service/transports/rest.py
+++ b/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1/services/lfp_sale_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1/services/lfp_sale_service/transports/rest_base.py
+++ b/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1/services/lfp_sale_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1/services/lfp_store_service/__init__.py
+++ b/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1/services/lfp_store_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1/services/lfp_store_service/async_client.py
+++ b/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1/services/lfp_store_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1/services/lfp_store_service/client.py
+++ b/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1/services/lfp_store_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1/services/lfp_store_service/pagers.py
+++ b/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1/services/lfp_store_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1/services/lfp_store_service/transports/__init__.py
+++ b/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1/services/lfp_store_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1/services/lfp_store_service/transports/base.py
+++ b/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1/services/lfp_store_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1/services/lfp_store_service/transports/grpc.py
+++ b/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1/services/lfp_store_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1/services/lfp_store_service/transports/grpc_asyncio.py
+++ b/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1/services/lfp_store_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1/services/lfp_store_service/transports/rest.py
+++ b/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1/services/lfp_store_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1/services/lfp_store_service/transports/rest_base.py
+++ b/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1/services/lfp_store_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1/types/__init__.py
+++ b/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1/types/lfpinventory.py
+++ b/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1/types/lfpinventory.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1/types/lfpmerchantstate.py
+++ b/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1/types/lfpmerchantstate.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1/types/lfpsale.py
+++ b/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1/types/lfpsale.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1/types/lfpstore.py
+++ b/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1/types/lfpstore.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1beta/gapic_version.py
+++ b/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1beta/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1beta/services/__init__.py
+++ b/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1beta/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1beta/services/lfp_inventory_service/__init__.py
+++ b/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1beta/services/lfp_inventory_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1beta/services/lfp_inventory_service/async_client.py
+++ b/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1beta/services/lfp_inventory_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1beta/services/lfp_inventory_service/client.py
+++ b/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1beta/services/lfp_inventory_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1beta/services/lfp_inventory_service/transports/__init__.py
+++ b/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1beta/services/lfp_inventory_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1beta/services/lfp_inventory_service/transports/base.py
+++ b/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1beta/services/lfp_inventory_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1beta/services/lfp_inventory_service/transports/grpc.py
+++ b/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1beta/services/lfp_inventory_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1beta/services/lfp_inventory_service/transports/grpc_asyncio.py
+++ b/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1beta/services/lfp_inventory_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1beta/services/lfp_inventory_service/transports/rest.py
+++ b/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1beta/services/lfp_inventory_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1beta/services/lfp_inventory_service/transports/rest_base.py
+++ b/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1beta/services/lfp_inventory_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1beta/services/lfp_merchant_state_service/__init__.py
+++ b/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1beta/services/lfp_merchant_state_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1beta/services/lfp_merchant_state_service/async_client.py
+++ b/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1beta/services/lfp_merchant_state_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1beta/services/lfp_merchant_state_service/client.py
+++ b/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1beta/services/lfp_merchant_state_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1beta/services/lfp_merchant_state_service/transports/__init__.py
+++ b/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1beta/services/lfp_merchant_state_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1beta/services/lfp_merchant_state_service/transports/base.py
+++ b/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1beta/services/lfp_merchant_state_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1beta/services/lfp_merchant_state_service/transports/grpc.py
+++ b/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1beta/services/lfp_merchant_state_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1beta/services/lfp_merchant_state_service/transports/grpc_asyncio.py
+++ b/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1beta/services/lfp_merchant_state_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1beta/services/lfp_merchant_state_service/transports/rest.py
+++ b/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1beta/services/lfp_merchant_state_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1beta/services/lfp_merchant_state_service/transports/rest_base.py
+++ b/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1beta/services/lfp_merchant_state_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1beta/services/lfp_sale_service/__init__.py
+++ b/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1beta/services/lfp_sale_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1beta/services/lfp_sale_service/async_client.py
+++ b/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1beta/services/lfp_sale_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1beta/services/lfp_sale_service/client.py
+++ b/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1beta/services/lfp_sale_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1beta/services/lfp_sale_service/transports/__init__.py
+++ b/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1beta/services/lfp_sale_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1beta/services/lfp_sale_service/transports/base.py
+++ b/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1beta/services/lfp_sale_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1beta/services/lfp_sale_service/transports/grpc.py
+++ b/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1beta/services/lfp_sale_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1beta/services/lfp_sale_service/transports/grpc_asyncio.py
+++ b/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1beta/services/lfp_sale_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1beta/services/lfp_sale_service/transports/rest.py
+++ b/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1beta/services/lfp_sale_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1beta/services/lfp_sale_service/transports/rest_base.py
+++ b/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1beta/services/lfp_sale_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1beta/services/lfp_store_service/__init__.py
+++ b/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1beta/services/lfp_store_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1beta/services/lfp_store_service/async_client.py
+++ b/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1beta/services/lfp_store_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1beta/services/lfp_store_service/client.py
+++ b/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1beta/services/lfp_store_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1beta/services/lfp_store_service/pagers.py
+++ b/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1beta/services/lfp_store_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1beta/services/lfp_store_service/transports/__init__.py
+++ b/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1beta/services/lfp_store_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1beta/services/lfp_store_service/transports/base.py
+++ b/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1beta/services/lfp_store_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1beta/services/lfp_store_service/transports/grpc.py
+++ b/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1beta/services/lfp_store_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1beta/services/lfp_store_service/transports/grpc_asyncio.py
+++ b/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1beta/services/lfp_store_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1beta/services/lfp_store_service/transports/rest.py
+++ b/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1beta/services/lfp_store_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1beta/services/lfp_store_service/transports/rest_base.py
+++ b/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1beta/services/lfp_store_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1beta/types/__init__.py
+++ b/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1beta/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1beta/types/lfpinventory.py
+++ b/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1beta/types/lfpinventory.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1beta/types/lfpmerchantstate.py
+++ b/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1beta/types/lfpmerchantstate.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1beta/types/lfpsale.py
+++ b/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1beta/types/lfpsale.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1beta/types/lfpstore.py
+++ b/packages/google-shopping-merchant-lfp/google/shopping/merchant_lfp_v1beta/types/lfpstore.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/samples/generated_samples/merchantapi_v1_generated_lfp_inventory_service_insert_lfp_inventory_async.py
+++ b/packages/google-shopping-merchant-lfp/samples/generated_samples/merchantapi_v1_generated_lfp_inventory_service_insert_lfp_inventory_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/samples/generated_samples/merchantapi_v1_generated_lfp_inventory_service_insert_lfp_inventory_sync.py
+++ b/packages/google-shopping-merchant-lfp/samples/generated_samples/merchantapi_v1_generated_lfp_inventory_service_insert_lfp_inventory_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/samples/generated_samples/merchantapi_v1_generated_lfp_merchant_state_service_get_lfp_merchant_state_async.py
+++ b/packages/google-shopping-merchant-lfp/samples/generated_samples/merchantapi_v1_generated_lfp_merchant_state_service_get_lfp_merchant_state_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/samples/generated_samples/merchantapi_v1_generated_lfp_merchant_state_service_get_lfp_merchant_state_sync.py
+++ b/packages/google-shopping-merchant-lfp/samples/generated_samples/merchantapi_v1_generated_lfp_merchant_state_service_get_lfp_merchant_state_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/samples/generated_samples/merchantapi_v1_generated_lfp_sale_service_insert_lfp_sale_async.py
+++ b/packages/google-shopping-merchant-lfp/samples/generated_samples/merchantapi_v1_generated_lfp_sale_service_insert_lfp_sale_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/samples/generated_samples/merchantapi_v1_generated_lfp_sale_service_insert_lfp_sale_sync.py
+++ b/packages/google-shopping-merchant-lfp/samples/generated_samples/merchantapi_v1_generated_lfp_sale_service_insert_lfp_sale_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/samples/generated_samples/merchantapi_v1_generated_lfp_store_service_delete_lfp_store_async.py
+++ b/packages/google-shopping-merchant-lfp/samples/generated_samples/merchantapi_v1_generated_lfp_store_service_delete_lfp_store_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/samples/generated_samples/merchantapi_v1_generated_lfp_store_service_delete_lfp_store_sync.py
+++ b/packages/google-shopping-merchant-lfp/samples/generated_samples/merchantapi_v1_generated_lfp_store_service_delete_lfp_store_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/samples/generated_samples/merchantapi_v1_generated_lfp_store_service_get_lfp_store_async.py
+++ b/packages/google-shopping-merchant-lfp/samples/generated_samples/merchantapi_v1_generated_lfp_store_service_get_lfp_store_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/samples/generated_samples/merchantapi_v1_generated_lfp_store_service_get_lfp_store_sync.py
+++ b/packages/google-shopping-merchant-lfp/samples/generated_samples/merchantapi_v1_generated_lfp_store_service_get_lfp_store_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/samples/generated_samples/merchantapi_v1_generated_lfp_store_service_insert_lfp_store_async.py
+++ b/packages/google-shopping-merchant-lfp/samples/generated_samples/merchantapi_v1_generated_lfp_store_service_insert_lfp_store_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/samples/generated_samples/merchantapi_v1_generated_lfp_store_service_insert_lfp_store_sync.py
+++ b/packages/google-shopping-merchant-lfp/samples/generated_samples/merchantapi_v1_generated_lfp_store_service_insert_lfp_store_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/samples/generated_samples/merchantapi_v1_generated_lfp_store_service_list_lfp_stores_async.py
+++ b/packages/google-shopping-merchant-lfp/samples/generated_samples/merchantapi_v1_generated_lfp_store_service_list_lfp_stores_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/samples/generated_samples/merchantapi_v1_generated_lfp_store_service_list_lfp_stores_sync.py
+++ b/packages/google-shopping-merchant-lfp/samples/generated_samples/merchantapi_v1_generated_lfp_store_service_list_lfp_stores_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/samples/generated_samples/merchantapi_v1beta_generated_lfp_inventory_service_insert_lfp_inventory_async.py
+++ b/packages/google-shopping-merchant-lfp/samples/generated_samples/merchantapi_v1beta_generated_lfp_inventory_service_insert_lfp_inventory_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/samples/generated_samples/merchantapi_v1beta_generated_lfp_inventory_service_insert_lfp_inventory_sync.py
+++ b/packages/google-shopping-merchant-lfp/samples/generated_samples/merchantapi_v1beta_generated_lfp_inventory_service_insert_lfp_inventory_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/samples/generated_samples/merchantapi_v1beta_generated_lfp_merchant_state_service_get_lfp_merchant_state_async.py
+++ b/packages/google-shopping-merchant-lfp/samples/generated_samples/merchantapi_v1beta_generated_lfp_merchant_state_service_get_lfp_merchant_state_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/samples/generated_samples/merchantapi_v1beta_generated_lfp_merchant_state_service_get_lfp_merchant_state_sync.py
+++ b/packages/google-shopping-merchant-lfp/samples/generated_samples/merchantapi_v1beta_generated_lfp_merchant_state_service_get_lfp_merchant_state_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/samples/generated_samples/merchantapi_v1beta_generated_lfp_sale_service_insert_lfp_sale_async.py
+++ b/packages/google-shopping-merchant-lfp/samples/generated_samples/merchantapi_v1beta_generated_lfp_sale_service_insert_lfp_sale_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/samples/generated_samples/merchantapi_v1beta_generated_lfp_sale_service_insert_lfp_sale_sync.py
+++ b/packages/google-shopping-merchant-lfp/samples/generated_samples/merchantapi_v1beta_generated_lfp_sale_service_insert_lfp_sale_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/samples/generated_samples/merchantapi_v1beta_generated_lfp_store_service_delete_lfp_store_async.py
+++ b/packages/google-shopping-merchant-lfp/samples/generated_samples/merchantapi_v1beta_generated_lfp_store_service_delete_lfp_store_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/samples/generated_samples/merchantapi_v1beta_generated_lfp_store_service_delete_lfp_store_sync.py
+++ b/packages/google-shopping-merchant-lfp/samples/generated_samples/merchantapi_v1beta_generated_lfp_store_service_delete_lfp_store_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/samples/generated_samples/merchantapi_v1beta_generated_lfp_store_service_get_lfp_store_async.py
+++ b/packages/google-shopping-merchant-lfp/samples/generated_samples/merchantapi_v1beta_generated_lfp_store_service_get_lfp_store_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/samples/generated_samples/merchantapi_v1beta_generated_lfp_store_service_get_lfp_store_sync.py
+++ b/packages/google-shopping-merchant-lfp/samples/generated_samples/merchantapi_v1beta_generated_lfp_store_service_get_lfp_store_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/samples/generated_samples/merchantapi_v1beta_generated_lfp_store_service_insert_lfp_store_async.py
+++ b/packages/google-shopping-merchant-lfp/samples/generated_samples/merchantapi_v1beta_generated_lfp_store_service_insert_lfp_store_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/samples/generated_samples/merchantapi_v1beta_generated_lfp_store_service_insert_lfp_store_sync.py
+++ b/packages/google-shopping-merchant-lfp/samples/generated_samples/merchantapi_v1beta_generated_lfp_store_service_insert_lfp_store_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/samples/generated_samples/merchantapi_v1beta_generated_lfp_store_service_list_lfp_stores_async.py
+++ b/packages/google-shopping-merchant-lfp/samples/generated_samples/merchantapi_v1beta_generated_lfp_store_service_list_lfp_stores_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/samples/generated_samples/merchantapi_v1beta_generated_lfp_store_service_list_lfp_stores_sync.py
+++ b/packages/google-shopping-merchant-lfp/samples/generated_samples/merchantapi_v1beta_generated_lfp_store_service_list_lfp_stores_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/tests/__init__.py
+++ b/packages/google-shopping-merchant-lfp/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/tests/unit/__init__.py
+++ b/packages/google-shopping-merchant-lfp/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/tests/unit/gapic/__init__.py
+++ b/packages/google-shopping-merchant-lfp/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/tests/unit/gapic/merchant_lfp_v1/__init__.py
+++ b/packages/google-shopping-merchant-lfp/tests/unit/gapic/merchant_lfp_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-lfp/tests/unit/gapic/merchant_lfp_v1beta/__init__.py
+++ b/packages/google-shopping-merchant-lfp/tests/unit/gapic/merchant_lfp_v1beta/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-notifications/.flake8
+++ b/packages/google-shopping-merchant-notifications/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-notifications/MANIFEST.in
+++ b/packages/google-shopping-merchant-notifications/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-notifications/google/shopping/merchant_notifications/__init__.py
+++ b/packages/google-shopping-merchant-notifications/google/shopping/merchant_notifications/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-notifications/google/shopping/merchant_notifications/gapic_version.py
+++ b/packages/google-shopping-merchant-notifications/google/shopping/merchant_notifications/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-notifications/google/shopping/merchant_notifications_v1/gapic_version.py
+++ b/packages/google-shopping-merchant-notifications/google/shopping/merchant_notifications_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-notifications/google/shopping/merchant_notifications_v1/services/__init__.py
+++ b/packages/google-shopping-merchant-notifications/google/shopping/merchant_notifications_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-notifications/google/shopping/merchant_notifications_v1/services/notifications_api_service/__init__.py
+++ b/packages/google-shopping-merchant-notifications/google/shopping/merchant_notifications_v1/services/notifications_api_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-notifications/google/shopping/merchant_notifications_v1/services/notifications_api_service/async_client.py
+++ b/packages/google-shopping-merchant-notifications/google/shopping/merchant_notifications_v1/services/notifications_api_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-notifications/google/shopping/merchant_notifications_v1/services/notifications_api_service/client.py
+++ b/packages/google-shopping-merchant-notifications/google/shopping/merchant_notifications_v1/services/notifications_api_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-notifications/google/shopping/merchant_notifications_v1/services/notifications_api_service/pagers.py
+++ b/packages/google-shopping-merchant-notifications/google/shopping/merchant_notifications_v1/services/notifications_api_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-notifications/google/shopping/merchant_notifications_v1/services/notifications_api_service/transports/__init__.py
+++ b/packages/google-shopping-merchant-notifications/google/shopping/merchant_notifications_v1/services/notifications_api_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-notifications/google/shopping/merchant_notifications_v1/services/notifications_api_service/transports/base.py
+++ b/packages/google-shopping-merchant-notifications/google/shopping/merchant_notifications_v1/services/notifications_api_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-notifications/google/shopping/merchant_notifications_v1/services/notifications_api_service/transports/grpc.py
+++ b/packages/google-shopping-merchant-notifications/google/shopping/merchant_notifications_v1/services/notifications_api_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-notifications/google/shopping/merchant_notifications_v1/services/notifications_api_service/transports/grpc_asyncio.py
+++ b/packages/google-shopping-merchant-notifications/google/shopping/merchant_notifications_v1/services/notifications_api_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-notifications/google/shopping/merchant_notifications_v1/services/notifications_api_service/transports/rest.py
+++ b/packages/google-shopping-merchant-notifications/google/shopping/merchant_notifications_v1/services/notifications_api_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-notifications/google/shopping/merchant_notifications_v1/services/notifications_api_service/transports/rest_base.py
+++ b/packages/google-shopping-merchant-notifications/google/shopping/merchant_notifications_v1/services/notifications_api_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-notifications/google/shopping/merchant_notifications_v1/types/__init__.py
+++ b/packages/google-shopping-merchant-notifications/google/shopping/merchant_notifications_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-notifications/google/shopping/merchant_notifications_v1/types/notificationsapi.py
+++ b/packages/google-shopping-merchant-notifications/google/shopping/merchant_notifications_v1/types/notificationsapi.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-notifications/google/shopping/merchant_notifications_v1beta/gapic_version.py
+++ b/packages/google-shopping-merchant-notifications/google/shopping/merchant_notifications_v1beta/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-notifications/google/shopping/merchant_notifications_v1beta/services/__init__.py
+++ b/packages/google-shopping-merchant-notifications/google/shopping/merchant_notifications_v1beta/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-notifications/google/shopping/merchant_notifications_v1beta/services/notifications_api_service/__init__.py
+++ b/packages/google-shopping-merchant-notifications/google/shopping/merchant_notifications_v1beta/services/notifications_api_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-notifications/google/shopping/merchant_notifications_v1beta/services/notifications_api_service/async_client.py
+++ b/packages/google-shopping-merchant-notifications/google/shopping/merchant_notifications_v1beta/services/notifications_api_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-notifications/google/shopping/merchant_notifications_v1beta/services/notifications_api_service/client.py
+++ b/packages/google-shopping-merchant-notifications/google/shopping/merchant_notifications_v1beta/services/notifications_api_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-notifications/google/shopping/merchant_notifications_v1beta/services/notifications_api_service/pagers.py
+++ b/packages/google-shopping-merchant-notifications/google/shopping/merchant_notifications_v1beta/services/notifications_api_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-notifications/google/shopping/merchant_notifications_v1beta/services/notifications_api_service/transports/__init__.py
+++ b/packages/google-shopping-merchant-notifications/google/shopping/merchant_notifications_v1beta/services/notifications_api_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-notifications/google/shopping/merchant_notifications_v1beta/services/notifications_api_service/transports/base.py
+++ b/packages/google-shopping-merchant-notifications/google/shopping/merchant_notifications_v1beta/services/notifications_api_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-notifications/google/shopping/merchant_notifications_v1beta/services/notifications_api_service/transports/grpc.py
+++ b/packages/google-shopping-merchant-notifications/google/shopping/merchant_notifications_v1beta/services/notifications_api_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-notifications/google/shopping/merchant_notifications_v1beta/services/notifications_api_service/transports/grpc_asyncio.py
+++ b/packages/google-shopping-merchant-notifications/google/shopping/merchant_notifications_v1beta/services/notifications_api_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-notifications/google/shopping/merchant_notifications_v1beta/services/notifications_api_service/transports/rest.py
+++ b/packages/google-shopping-merchant-notifications/google/shopping/merchant_notifications_v1beta/services/notifications_api_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-notifications/google/shopping/merchant_notifications_v1beta/services/notifications_api_service/transports/rest_base.py
+++ b/packages/google-shopping-merchant-notifications/google/shopping/merchant_notifications_v1beta/services/notifications_api_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-notifications/google/shopping/merchant_notifications_v1beta/types/__init__.py
+++ b/packages/google-shopping-merchant-notifications/google/shopping/merchant_notifications_v1beta/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-notifications/google/shopping/merchant_notifications_v1beta/types/notificationsapi.py
+++ b/packages/google-shopping-merchant-notifications/google/shopping/merchant_notifications_v1beta/types/notificationsapi.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-notifications/samples/generated_samples/merchantapi_v1_generated_notifications_api_service_create_notification_subscription_async.py
+++ b/packages/google-shopping-merchant-notifications/samples/generated_samples/merchantapi_v1_generated_notifications_api_service_create_notification_subscription_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-notifications/samples/generated_samples/merchantapi_v1_generated_notifications_api_service_create_notification_subscription_sync.py
+++ b/packages/google-shopping-merchant-notifications/samples/generated_samples/merchantapi_v1_generated_notifications_api_service_create_notification_subscription_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-notifications/samples/generated_samples/merchantapi_v1_generated_notifications_api_service_delete_notification_subscription_async.py
+++ b/packages/google-shopping-merchant-notifications/samples/generated_samples/merchantapi_v1_generated_notifications_api_service_delete_notification_subscription_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-notifications/samples/generated_samples/merchantapi_v1_generated_notifications_api_service_delete_notification_subscription_sync.py
+++ b/packages/google-shopping-merchant-notifications/samples/generated_samples/merchantapi_v1_generated_notifications_api_service_delete_notification_subscription_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-notifications/samples/generated_samples/merchantapi_v1_generated_notifications_api_service_get_notification_subscription_async.py
+++ b/packages/google-shopping-merchant-notifications/samples/generated_samples/merchantapi_v1_generated_notifications_api_service_get_notification_subscription_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-notifications/samples/generated_samples/merchantapi_v1_generated_notifications_api_service_get_notification_subscription_health_metrics_async.py
+++ b/packages/google-shopping-merchant-notifications/samples/generated_samples/merchantapi_v1_generated_notifications_api_service_get_notification_subscription_health_metrics_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-notifications/samples/generated_samples/merchantapi_v1_generated_notifications_api_service_get_notification_subscription_health_metrics_sync.py
+++ b/packages/google-shopping-merchant-notifications/samples/generated_samples/merchantapi_v1_generated_notifications_api_service_get_notification_subscription_health_metrics_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-notifications/samples/generated_samples/merchantapi_v1_generated_notifications_api_service_get_notification_subscription_sync.py
+++ b/packages/google-shopping-merchant-notifications/samples/generated_samples/merchantapi_v1_generated_notifications_api_service_get_notification_subscription_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-notifications/samples/generated_samples/merchantapi_v1_generated_notifications_api_service_list_notification_subscriptions_async.py
+++ b/packages/google-shopping-merchant-notifications/samples/generated_samples/merchantapi_v1_generated_notifications_api_service_list_notification_subscriptions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-notifications/samples/generated_samples/merchantapi_v1_generated_notifications_api_service_list_notification_subscriptions_sync.py
+++ b/packages/google-shopping-merchant-notifications/samples/generated_samples/merchantapi_v1_generated_notifications_api_service_list_notification_subscriptions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-notifications/samples/generated_samples/merchantapi_v1_generated_notifications_api_service_update_notification_subscription_async.py
+++ b/packages/google-shopping-merchant-notifications/samples/generated_samples/merchantapi_v1_generated_notifications_api_service_update_notification_subscription_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-notifications/samples/generated_samples/merchantapi_v1_generated_notifications_api_service_update_notification_subscription_sync.py
+++ b/packages/google-shopping-merchant-notifications/samples/generated_samples/merchantapi_v1_generated_notifications_api_service_update_notification_subscription_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-notifications/samples/generated_samples/merchantapi_v1beta_generated_notifications_api_service_create_notification_subscription_async.py
+++ b/packages/google-shopping-merchant-notifications/samples/generated_samples/merchantapi_v1beta_generated_notifications_api_service_create_notification_subscription_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-notifications/samples/generated_samples/merchantapi_v1beta_generated_notifications_api_service_create_notification_subscription_sync.py
+++ b/packages/google-shopping-merchant-notifications/samples/generated_samples/merchantapi_v1beta_generated_notifications_api_service_create_notification_subscription_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-notifications/samples/generated_samples/merchantapi_v1beta_generated_notifications_api_service_delete_notification_subscription_async.py
+++ b/packages/google-shopping-merchant-notifications/samples/generated_samples/merchantapi_v1beta_generated_notifications_api_service_delete_notification_subscription_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-notifications/samples/generated_samples/merchantapi_v1beta_generated_notifications_api_service_delete_notification_subscription_sync.py
+++ b/packages/google-shopping-merchant-notifications/samples/generated_samples/merchantapi_v1beta_generated_notifications_api_service_delete_notification_subscription_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-notifications/samples/generated_samples/merchantapi_v1beta_generated_notifications_api_service_get_notification_subscription_async.py
+++ b/packages/google-shopping-merchant-notifications/samples/generated_samples/merchantapi_v1beta_generated_notifications_api_service_get_notification_subscription_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-notifications/samples/generated_samples/merchantapi_v1beta_generated_notifications_api_service_get_notification_subscription_sync.py
+++ b/packages/google-shopping-merchant-notifications/samples/generated_samples/merchantapi_v1beta_generated_notifications_api_service_get_notification_subscription_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-notifications/samples/generated_samples/merchantapi_v1beta_generated_notifications_api_service_list_notification_subscriptions_async.py
+++ b/packages/google-shopping-merchant-notifications/samples/generated_samples/merchantapi_v1beta_generated_notifications_api_service_list_notification_subscriptions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-notifications/samples/generated_samples/merchantapi_v1beta_generated_notifications_api_service_list_notification_subscriptions_sync.py
+++ b/packages/google-shopping-merchant-notifications/samples/generated_samples/merchantapi_v1beta_generated_notifications_api_service_list_notification_subscriptions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-notifications/samples/generated_samples/merchantapi_v1beta_generated_notifications_api_service_update_notification_subscription_async.py
+++ b/packages/google-shopping-merchant-notifications/samples/generated_samples/merchantapi_v1beta_generated_notifications_api_service_update_notification_subscription_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-notifications/samples/generated_samples/merchantapi_v1beta_generated_notifications_api_service_update_notification_subscription_sync.py
+++ b/packages/google-shopping-merchant-notifications/samples/generated_samples/merchantapi_v1beta_generated_notifications_api_service_update_notification_subscription_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-notifications/tests/__init__.py
+++ b/packages/google-shopping-merchant-notifications/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-notifications/tests/unit/__init__.py
+++ b/packages/google-shopping-merchant-notifications/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-notifications/tests/unit/gapic/__init__.py
+++ b/packages/google-shopping-merchant-notifications/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-notifications/tests/unit/gapic/merchant_notifications_v1/__init__.py
+++ b/packages/google-shopping-merchant-notifications/tests/unit/gapic/merchant_notifications_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-notifications/tests/unit/gapic/merchant_notifications_v1beta/__init__.py
+++ b/packages/google-shopping-merchant-notifications/tests/unit/gapic/merchant_notifications_v1beta/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-ordertracking/.flake8
+++ b/packages/google-shopping-merchant-ordertracking/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-ordertracking/MANIFEST.in
+++ b/packages/google-shopping-merchant-ordertracking/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-ordertracking/google/shopping/merchant_ordertracking/__init__.py
+++ b/packages/google-shopping-merchant-ordertracking/google/shopping/merchant_ordertracking/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-ordertracking/google/shopping/merchant_ordertracking/gapic_version.py
+++ b/packages/google-shopping-merchant-ordertracking/google/shopping/merchant_ordertracking/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-ordertracking/google/shopping/merchant_ordertracking_v1/gapic_version.py
+++ b/packages/google-shopping-merchant-ordertracking/google/shopping/merchant_ordertracking_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-ordertracking/google/shopping/merchant_ordertracking_v1/services/__init__.py
+++ b/packages/google-shopping-merchant-ordertracking/google/shopping/merchant_ordertracking_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-ordertracking/google/shopping/merchant_ordertracking_v1/services/order_tracking_signals_service/__init__.py
+++ b/packages/google-shopping-merchant-ordertracking/google/shopping/merchant_ordertracking_v1/services/order_tracking_signals_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-ordertracking/google/shopping/merchant_ordertracking_v1/services/order_tracking_signals_service/async_client.py
+++ b/packages/google-shopping-merchant-ordertracking/google/shopping/merchant_ordertracking_v1/services/order_tracking_signals_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-ordertracking/google/shopping/merchant_ordertracking_v1/services/order_tracking_signals_service/client.py
+++ b/packages/google-shopping-merchant-ordertracking/google/shopping/merchant_ordertracking_v1/services/order_tracking_signals_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-ordertracking/google/shopping/merchant_ordertracking_v1/services/order_tracking_signals_service/transports/__init__.py
+++ b/packages/google-shopping-merchant-ordertracking/google/shopping/merchant_ordertracking_v1/services/order_tracking_signals_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-ordertracking/google/shopping/merchant_ordertracking_v1/services/order_tracking_signals_service/transports/base.py
+++ b/packages/google-shopping-merchant-ordertracking/google/shopping/merchant_ordertracking_v1/services/order_tracking_signals_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-ordertracking/google/shopping/merchant_ordertracking_v1/services/order_tracking_signals_service/transports/grpc.py
+++ b/packages/google-shopping-merchant-ordertracking/google/shopping/merchant_ordertracking_v1/services/order_tracking_signals_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-ordertracking/google/shopping/merchant_ordertracking_v1/services/order_tracking_signals_service/transports/grpc_asyncio.py
+++ b/packages/google-shopping-merchant-ordertracking/google/shopping/merchant_ordertracking_v1/services/order_tracking_signals_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-ordertracking/google/shopping/merchant_ordertracking_v1/services/order_tracking_signals_service/transports/rest.py
+++ b/packages/google-shopping-merchant-ordertracking/google/shopping/merchant_ordertracking_v1/services/order_tracking_signals_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-ordertracking/google/shopping/merchant_ordertracking_v1/services/order_tracking_signals_service/transports/rest_base.py
+++ b/packages/google-shopping-merchant-ordertracking/google/shopping/merchant_ordertracking_v1/services/order_tracking_signals_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-ordertracking/google/shopping/merchant_ordertracking_v1/types/__init__.py
+++ b/packages/google-shopping-merchant-ordertracking/google/shopping/merchant_ordertracking_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-ordertracking/google/shopping/merchant_ordertracking_v1/types/order_tracking_signals.py
+++ b/packages/google-shopping-merchant-ordertracking/google/shopping/merchant_ordertracking_v1/types/order_tracking_signals.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-ordertracking/google/shopping/merchant_ordertracking_v1beta/gapic_version.py
+++ b/packages/google-shopping-merchant-ordertracking/google/shopping/merchant_ordertracking_v1beta/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-ordertracking/google/shopping/merchant_ordertracking_v1beta/services/__init__.py
+++ b/packages/google-shopping-merchant-ordertracking/google/shopping/merchant_ordertracking_v1beta/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-ordertracking/google/shopping/merchant_ordertracking_v1beta/services/order_tracking_signals_service/__init__.py
+++ b/packages/google-shopping-merchant-ordertracking/google/shopping/merchant_ordertracking_v1beta/services/order_tracking_signals_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-ordertracking/google/shopping/merchant_ordertracking_v1beta/services/order_tracking_signals_service/async_client.py
+++ b/packages/google-shopping-merchant-ordertracking/google/shopping/merchant_ordertracking_v1beta/services/order_tracking_signals_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-ordertracking/google/shopping/merchant_ordertracking_v1beta/services/order_tracking_signals_service/client.py
+++ b/packages/google-shopping-merchant-ordertracking/google/shopping/merchant_ordertracking_v1beta/services/order_tracking_signals_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-ordertracking/google/shopping/merchant_ordertracking_v1beta/services/order_tracking_signals_service/transports/__init__.py
+++ b/packages/google-shopping-merchant-ordertracking/google/shopping/merchant_ordertracking_v1beta/services/order_tracking_signals_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-ordertracking/google/shopping/merchant_ordertracking_v1beta/services/order_tracking_signals_service/transports/base.py
+++ b/packages/google-shopping-merchant-ordertracking/google/shopping/merchant_ordertracking_v1beta/services/order_tracking_signals_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-ordertracking/google/shopping/merchant_ordertracking_v1beta/services/order_tracking_signals_service/transports/grpc.py
+++ b/packages/google-shopping-merchant-ordertracking/google/shopping/merchant_ordertracking_v1beta/services/order_tracking_signals_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-ordertracking/google/shopping/merchant_ordertracking_v1beta/services/order_tracking_signals_service/transports/grpc_asyncio.py
+++ b/packages/google-shopping-merchant-ordertracking/google/shopping/merchant_ordertracking_v1beta/services/order_tracking_signals_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-ordertracking/google/shopping/merchant_ordertracking_v1beta/services/order_tracking_signals_service/transports/rest.py
+++ b/packages/google-shopping-merchant-ordertracking/google/shopping/merchant_ordertracking_v1beta/services/order_tracking_signals_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-ordertracking/google/shopping/merchant_ordertracking_v1beta/services/order_tracking_signals_service/transports/rest_base.py
+++ b/packages/google-shopping-merchant-ordertracking/google/shopping/merchant_ordertracking_v1beta/services/order_tracking_signals_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-ordertracking/google/shopping/merchant_ordertracking_v1beta/types/__init__.py
+++ b/packages/google-shopping-merchant-ordertracking/google/shopping/merchant_ordertracking_v1beta/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-ordertracking/google/shopping/merchant_ordertracking_v1beta/types/order_tracking_signals.py
+++ b/packages/google-shopping-merchant-ordertracking/google/shopping/merchant_ordertracking_v1beta/types/order_tracking_signals.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-ordertracking/samples/generated_samples/merchantapi_v1_generated_order_tracking_signals_service_create_order_tracking_signal_async.py
+++ b/packages/google-shopping-merchant-ordertracking/samples/generated_samples/merchantapi_v1_generated_order_tracking_signals_service_create_order_tracking_signal_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-ordertracking/samples/generated_samples/merchantapi_v1_generated_order_tracking_signals_service_create_order_tracking_signal_sync.py
+++ b/packages/google-shopping-merchant-ordertracking/samples/generated_samples/merchantapi_v1_generated_order_tracking_signals_service_create_order_tracking_signal_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-ordertracking/samples/generated_samples/merchantapi_v1beta_generated_order_tracking_signals_service_create_order_tracking_signal_async.py
+++ b/packages/google-shopping-merchant-ordertracking/samples/generated_samples/merchantapi_v1beta_generated_order_tracking_signals_service_create_order_tracking_signal_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-ordertracking/samples/generated_samples/merchantapi_v1beta_generated_order_tracking_signals_service_create_order_tracking_signal_sync.py
+++ b/packages/google-shopping-merchant-ordertracking/samples/generated_samples/merchantapi_v1beta_generated_order_tracking_signals_service_create_order_tracking_signal_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-ordertracking/tests/__init__.py
+++ b/packages/google-shopping-merchant-ordertracking/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-ordertracking/tests/unit/__init__.py
+++ b/packages/google-shopping-merchant-ordertracking/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-ordertracking/tests/unit/gapic/__init__.py
+++ b/packages/google-shopping-merchant-ordertracking/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-ordertracking/tests/unit/gapic/merchant_ordertracking_v1/__init__.py
+++ b/packages/google-shopping-merchant-ordertracking/tests/unit/gapic/merchant_ordertracking_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-ordertracking/tests/unit/gapic/merchant_ordertracking_v1beta/__init__.py
+++ b/packages/google-shopping-merchant-ordertracking/tests/unit/gapic/merchant_ordertracking_v1beta/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-products/.flake8
+++ b/packages/google-shopping-merchant-products/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-products/MANIFEST.in
+++ b/packages/google-shopping-merchant-products/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-products/google/shopping/merchant_products/__init__.py
+++ b/packages/google-shopping-merchant-products/google/shopping/merchant_products/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-products/google/shopping/merchant_products/gapic_version.py
+++ b/packages/google-shopping-merchant-products/google/shopping/merchant_products/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-products/google/shopping/merchant_products_v1/gapic_version.py
+++ b/packages/google-shopping-merchant-products/google/shopping/merchant_products_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-products/google/shopping/merchant_products_v1/services/__init__.py
+++ b/packages/google-shopping-merchant-products/google/shopping/merchant_products_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-products/google/shopping/merchant_products_v1/services/product_inputs_service/__init__.py
+++ b/packages/google-shopping-merchant-products/google/shopping/merchant_products_v1/services/product_inputs_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-products/google/shopping/merchant_products_v1/services/product_inputs_service/async_client.py
+++ b/packages/google-shopping-merchant-products/google/shopping/merchant_products_v1/services/product_inputs_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-products/google/shopping/merchant_products_v1/services/product_inputs_service/client.py
+++ b/packages/google-shopping-merchant-products/google/shopping/merchant_products_v1/services/product_inputs_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-products/google/shopping/merchant_products_v1/services/product_inputs_service/transports/__init__.py
+++ b/packages/google-shopping-merchant-products/google/shopping/merchant_products_v1/services/product_inputs_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-products/google/shopping/merchant_products_v1/services/product_inputs_service/transports/base.py
+++ b/packages/google-shopping-merchant-products/google/shopping/merchant_products_v1/services/product_inputs_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-products/google/shopping/merchant_products_v1/services/product_inputs_service/transports/grpc.py
+++ b/packages/google-shopping-merchant-products/google/shopping/merchant_products_v1/services/product_inputs_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-products/google/shopping/merchant_products_v1/services/product_inputs_service/transports/grpc_asyncio.py
+++ b/packages/google-shopping-merchant-products/google/shopping/merchant_products_v1/services/product_inputs_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-products/google/shopping/merchant_products_v1/services/product_inputs_service/transports/rest.py
+++ b/packages/google-shopping-merchant-products/google/shopping/merchant_products_v1/services/product_inputs_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-products/google/shopping/merchant_products_v1/services/product_inputs_service/transports/rest_base.py
+++ b/packages/google-shopping-merchant-products/google/shopping/merchant_products_v1/services/product_inputs_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-products/google/shopping/merchant_products_v1/services/products_service/__init__.py
+++ b/packages/google-shopping-merchant-products/google/shopping/merchant_products_v1/services/products_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-products/google/shopping/merchant_products_v1/services/products_service/async_client.py
+++ b/packages/google-shopping-merchant-products/google/shopping/merchant_products_v1/services/products_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-products/google/shopping/merchant_products_v1/services/products_service/client.py
+++ b/packages/google-shopping-merchant-products/google/shopping/merchant_products_v1/services/products_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-products/google/shopping/merchant_products_v1/services/products_service/pagers.py
+++ b/packages/google-shopping-merchant-products/google/shopping/merchant_products_v1/services/products_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-products/google/shopping/merchant_products_v1/services/products_service/transports/__init__.py
+++ b/packages/google-shopping-merchant-products/google/shopping/merchant_products_v1/services/products_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-products/google/shopping/merchant_products_v1/services/products_service/transports/base.py
+++ b/packages/google-shopping-merchant-products/google/shopping/merchant_products_v1/services/products_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-products/google/shopping/merchant_products_v1/services/products_service/transports/grpc.py
+++ b/packages/google-shopping-merchant-products/google/shopping/merchant_products_v1/services/products_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-products/google/shopping/merchant_products_v1/services/products_service/transports/grpc_asyncio.py
+++ b/packages/google-shopping-merchant-products/google/shopping/merchant_products_v1/services/products_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-products/google/shopping/merchant_products_v1/services/products_service/transports/rest.py
+++ b/packages/google-shopping-merchant-products/google/shopping/merchant_products_v1/services/products_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-products/google/shopping/merchant_products_v1/services/products_service/transports/rest_base.py
+++ b/packages/google-shopping-merchant-products/google/shopping/merchant_products_v1/services/products_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-products/google/shopping/merchant_products_v1/types/__init__.py
+++ b/packages/google-shopping-merchant-products/google/shopping/merchant_products_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-products/google/shopping/merchant_products_v1/types/productinputs.py
+++ b/packages/google-shopping-merchant-products/google/shopping/merchant_products_v1/types/productinputs.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-products/google/shopping/merchant_products_v1/types/products.py
+++ b/packages/google-shopping-merchant-products/google/shopping/merchant_products_v1/types/products.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-products/google/shopping/merchant_products_v1/types/products_common.py
+++ b/packages/google-shopping-merchant-products/google/shopping/merchant_products_v1/types/products_common.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-products/google/shopping/merchant_products_v1beta/gapic_version.py
+++ b/packages/google-shopping-merchant-products/google/shopping/merchant_products_v1beta/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-products/google/shopping/merchant_products_v1beta/services/__init__.py
+++ b/packages/google-shopping-merchant-products/google/shopping/merchant_products_v1beta/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-products/google/shopping/merchant_products_v1beta/services/product_inputs_service/__init__.py
+++ b/packages/google-shopping-merchant-products/google/shopping/merchant_products_v1beta/services/product_inputs_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-products/google/shopping/merchant_products_v1beta/services/product_inputs_service/async_client.py
+++ b/packages/google-shopping-merchant-products/google/shopping/merchant_products_v1beta/services/product_inputs_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-products/google/shopping/merchant_products_v1beta/services/product_inputs_service/client.py
+++ b/packages/google-shopping-merchant-products/google/shopping/merchant_products_v1beta/services/product_inputs_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-products/google/shopping/merchant_products_v1beta/services/product_inputs_service/transports/__init__.py
+++ b/packages/google-shopping-merchant-products/google/shopping/merchant_products_v1beta/services/product_inputs_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-products/google/shopping/merchant_products_v1beta/services/product_inputs_service/transports/base.py
+++ b/packages/google-shopping-merchant-products/google/shopping/merchant_products_v1beta/services/product_inputs_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-products/google/shopping/merchant_products_v1beta/services/product_inputs_service/transports/grpc.py
+++ b/packages/google-shopping-merchant-products/google/shopping/merchant_products_v1beta/services/product_inputs_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-products/google/shopping/merchant_products_v1beta/services/product_inputs_service/transports/grpc_asyncio.py
+++ b/packages/google-shopping-merchant-products/google/shopping/merchant_products_v1beta/services/product_inputs_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-products/google/shopping/merchant_products_v1beta/services/product_inputs_service/transports/rest.py
+++ b/packages/google-shopping-merchant-products/google/shopping/merchant_products_v1beta/services/product_inputs_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-products/google/shopping/merchant_products_v1beta/services/product_inputs_service/transports/rest_base.py
+++ b/packages/google-shopping-merchant-products/google/shopping/merchant_products_v1beta/services/product_inputs_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-products/google/shopping/merchant_products_v1beta/services/products_service/__init__.py
+++ b/packages/google-shopping-merchant-products/google/shopping/merchant_products_v1beta/services/products_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-products/google/shopping/merchant_products_v1beta/services/products_service/async_client.py
+++ b/packages/google-shopping-merchant-products/google/shopping/merchant_products_v1beta/services/products_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-products/google/shopping/merchant_products_v1beta/services/products_service/client.py
+++ b/packages/google-shopping-merchant-products/google/shopping/merchant_products_v1beta/services/products_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-products/google/shopping/merchant_products_v1beta/services/products_service/pagers.py
+++ b/packages/google-shopping-merchant-products/google/shopping/merchant_products_v1beta/services/products_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-products/google/shopping/merchant_products_v1beta/services/products_service/transports/__init__.py
+++ b/packages/google-shopping-merchant-products/google/shopping/merchant_products_v1beta/services/products_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-products/google/shopping/merchant_products_v1beta/services/products_service/transports/base.py
+++ b/packages/google-shopping-merchant-products/google/shopping/merchant_products_v1beta/services/products_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-products/google/shopping/merchant_products_v1beta/services/products_service/transports/grpc.py
+++ b/packages/google-shopping-merchant-products/google/shopping/merchant_products_v1beta/services/products_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-products/google/shopping/merchant_products_v1beta/services/products_service/transports/grpc_asyncio.py
+++ b/packages/google-shopping-merchant-products/google/shopping/merchant_products_v1beta/services/products_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-products/google/shopping/merchant_products_v1beta/services/products_service/transports/rest.py
+++ b/packages/google-shopping-merchant-products/google/shopping/merchant_products_v1beta/services/products_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-products/google/shopping/merchant_products_v1beta/services/products_service/transports/rest_base.py
+++ b/packages/google-shopping-merchant-products/google/shopping/merchant_products_v1beta/services/products_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-products/google/shopping/merchant_products_v1beta/types/__init__.py
+++ b/packages/google-shopping-merchant-products/google/shopping/merchant_products_v1beta/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-products/google/shopping/merchant_products_v1beta/types/productinputs.py
+++ b/packages/google-shopping-merchant-products/google/shopping/merchant_products_v1beta/types/productinputs.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-products/google/shopping/merchant_products_v1beta/types/products.py
+++ b/packages/google-shopping-merchant-products/google/shopping/merchant_products_v1beta/types/products.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-products/google/shopping/merchant_products_v1beta/types/products_common.py
+++ b/packages/google-shopping-merchant-products/google/shopping/merchant_products_v1beta/types/products_common.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-products/samples/generated_samples/merchantapi_v1_generated_product_inputs_service_delete_product_input_async.py
+++ b/packages/google-shopping-merchant-products/samples/generated_samples/merchantapi_v1_generated_product_inputs_service_delete_product_input_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-products/samples/generated_samples/merchantapi_v1_generated_product_inputs_service_delete_product_input_sync.py
+++ b/packages/google-shopping-merchant-products/samples/generated_samples/merchantapi_v1_generated_product_inputs_service_delete_product_input_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-products/samples/generated_samples/merchantapi_v1_generated_product_inputs_service_insert_product_input_async.py
+++ b/packages/google-shopping-merchant-products/samples/generated_samples/merchantapi_v1_generated_product_inputs_service_insert_product_input_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-products/samples/generated_samples/merchantapi_v1_generated_product_inputs_service_insert_product_input_sync.py
+++ b/packages/google-shopping-merchant-products/samples/generated_samples/merchantapi_v1_generated_product_inputs_service_insert_product_input_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-products/samples/generated_samples/merchantapi_v1_generated_product_inputs_service_update_product_input_async.py
+++ b/packages/google-shopping-merchant-products/samples/generated_samples/merchantapi_v1_generated_product_inputs_service_update_product_input_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-products/samples/generated_samples/merchantapi_v1_generated_product_inputs_service_update_product_input_sync.py
+++ b/packages/google-shopping-merchant-products/samples/generated_samples/merchantapi_v1_generated_product_inputs_service_update_product_input_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-products/samples/generated_samples/merchantapi_v1_generated_products_service_get_product_async.py
+++ b/packages/google-shopping-merchant-products/samples/generated_samples/merchantapi_v1_generated_products_service_get_product_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-products/samples/generated_samples/merchantapi_v1_generated_products_service_get_product_sync.py
+++ b/packages/google-shopping-merchant-products/samples/generated_samples/merchantapi_v1_generated_products_service_get_product_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-products/samples/generated_samples/merchantapi_v1_generated_products_service_list_products_async.py
+++ b/packages/google-shopping-merchant-products/samples/generated_samples/merchantapi_v1_generated_products_service_list_products_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-products/samples/generated_samples/merchantapi_v1_generated_products_service_list_products_sync.py
+++ b/packages/google-shopping-merchant-products/samples/generated_samples/merchantapi_v1_generated_products_service_list_products_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-products/samples/generated_samples/merchantapi_v1beta_generated_product_inputs_service_delete_product_input_async.py
+++ b/packages/google-shopping-merchant-products/samples/generated_samples/merchantapi_v1beta_generated_product_inputs_service_delete_product_input_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-products/samples/generated_samples/merchantapi_v1beta_generated_product_inputs_service_delete_product_input_sync.py
+++ b/packages/google-shopping-merchant-products/samples/generated_samples/merchantapi_v1beta_generated_product_inputs_service_delete_product_input_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-products/samples/generated_samples/merchantapi_v1beta_generated_product_inputs_service_insert_product_input_async.py
+++ b/packages/google-shopping-merchant-products/samples/generated_samples/merchantapi_v1beta_generated_product_inputs_service_insert_product_input_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-products/samples/generated_samples/merchantapi_v1beta_generated_product_inputs_service_insert_product_input_sync.py
+++ b/packages/google-shopping-merchant-products/samples/generated_samples/merchantapi_v1beta_generated_product_inputs_service_insert_product_input_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-products/samples/generated_samples/merchantapi_v1beta_generated_product_inputs_service_update_product_input_async.py
+++ b/packages/google-shopping-merchant-products/samples/generated_samples/merchantapi_v1beta_generated_product_inputs_service_update_product_input_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-products/samples/generated_samples/merchantapi_v1beta_generated_product_inputs_service_update_product_input_sync.py
+++ b/packages/google-shopping-merchant-products/samples/generated_samples/merchantapi_v1beta_generated_product_inputs_service_update_product_input_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-products/samples/generated_samples/merchantapi_v1beta_generated_products_service_get_product_async.py
+++ b/packages/google-shopping-merchant-products/samples/generated_samples/merchantapi_v1beta_generated_products_service_get_product_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-products/samples/generated_samples/merchantapi_v1beta_generated_products_service_get_product_sync.py
+++ b/packages/google-shopping-merchant-products/samples/generated_samples/merchantapi_v1beta_generated_products_service_get_product_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-products/samples/generated_samples/merchantapi_v1beta_generated_products_service_list_products_async.py
+++ b/packages/google-shopping-merchant-products/samples/generated_samples/merchantapi_v1beta_generated_products_service_list_products_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-products/samples/generated_samples/merchantapi_v1beta_generated_products_service_list_products_sync.py
+++ b/packages/google-shopping-merchant-products/samples/generated_samples/merchantapi_v1beta_generated_products_service_list_products_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-products/tests/__init__.py
+++ b/packages/google-shopping-merchant-products/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-products/tests/unit/__init__.py
+++ b/packages/google-shopping-merchant-products/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-products/tests/unit/gapic/__init__.py
+++ b/packages/google-shopping-merchant-products/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-products/tests/unit/gapic/merchant_products_v1/__init__.py
+++ b/packages/google-shopping-merchant-products/tests/unit/gapic/merchant_products_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-products/tests/unit/gapic/merchant_products_v1beta/__init__.py
+++ b/packages/google-shopping-merchant-products/tests/unit/gapic/merchant_products_v1beta/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-productstudio/.flake8
+++ b/packages/google-shopping-merchant-productstudio/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-productstudio/MANIFEST.in
+++ b/packages/google-shopping-merchant-productstudio/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-productstudio/google/shopping/merchant_productstudio/__init__.py
+++ b/packages/google-shopping-merchant-productstudio/google/shopping/merchant_productstudio/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-productstudio/google/shopping/merchant_productstudio/gapic_version.py
+++ b/packages/google-shopping-merchant-productstudio/google/shopping/merchant_productstudio/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-productstudio/google/shopping/merchant_productstudio_v1alpha/gapic_version.py
+++ b/packages/google-shopping-merchant-productstudio/google/shopping/merchant_productstudio_v1alpha/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-productstudio/google/shopping/merchant_productstudio_v1alpha/services/__init__.py
+++ b/packages/google-shopping-merchant-productstudio/google/shopping/merchant_productstudio_v1alpha/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-productstudio/google/shopping/merchant_productstudio_v1alpha/services/image_service/__init__.py
+++ b/packages/google-shopping-merchant-productstudio/google/shopping/merchant_productstudio_v1alpha/services/image_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-productstudio/google/shopping/merchant_productstudio_v1alpha/services/image_service/async_client.py
+++ b/packages/google-shopping-merchant-productstudio/google/shopping/merchant_productstudio_v1alpha/services/image_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-productstudio/google/shopping/merchant_productstudio_v1alpha/services/image_service/client.py
+++ b/packages/google-shopping-merchant-productstudio/google/shopping/merchant_productstudio_v1alpha/services/image_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-productstudio/google/shopping/merchant_productstudio_v1alpha/services/image_service/transports/__init__.py
+++ b/packages/google-shopping-merchant-productstudio/google/shopping/merchant_productstudio_v1alpha/services/image_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-productstudio/google/shopping/merchant_productstudio_v1alpha/services/image_service/transports/base.py
+++ b/packages/google-shopping-merchant-productstudio/google/shopping/merchant_productstudio_v1alpha/services/image_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-productstudio/google/shopping/merchant_productstudio_v1alpha/services/image_service/transports/grpc.py
+++ b/packages/google-shopping-merchant-productstudio/google/shopping/merchant_productstudio_v1alpha/services/image_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-productstudio/google/shopping/merchant_productstudio_v1alpha/services/image_service/transports/grpc_asyncio.py
+++ b/packages/google-shopping-merchant-productstudio/google/shopping/merchant_productstudio_v1alpha/services/image_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-productstudio/google/shopping/merchant_productstudio_v1alpha/services/image_service/transports/rest.py
+++ b/packages/google-shopping-merchant-productstudio/google/shopping/merchant_productstudio_v1alpha/services/image_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-productstudio/google/shopping/merchant_productstudio_v1alpha/services/image_service/transports/rest_base.py
+++ b/packages/google-shopping-merchant-productstudio/google/shopping/merchant_productstudio_v1alpha/services/image_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-productstudio/google/shopping/merchant_productstudio_v1alpha/services/text_suggestions_service/__init__.py
+++ b/packages/google-shopping-merchant-productstudio/google/shopping/merchant_productstudio_v1alpha/services/text_suggestions_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-productstudio/google/shopping/merchant_productstudio_v1alpha/services/text_suggestions_service/async_client.py
+++ b/packages/google-shopping-merchant-productstudio/google/shopping/merchant_productstudio_v1alpha/services/text_suggestions_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-productstudio/google/shopping/merchant_productstudio_v1alpha/services/text_suggestions_service/client.py
+++ b/packages/google-shopping-merchant-productstudio/google/shopping/merchant_productstudio_v1alpha/services/text_suggestions_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-productstudio/google/shopping/merchant_productstudio_v1alpha/services/text_suggestions_service/transports/__init__.py
+++ b/packages/google-shopping-merchant-productstudio/google/shopping/merchant_productstudio_v1alpha/services/text_suggestions_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-productstudio/google/shopping/merchant_productstudio_v1alpha/services/text_suggestions_service/transports/base.py
+++ b/packages/google-shopping-merchant-productstudio/google/shopping/merchant_productstudio_v1alpha/services/text_suggestions_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-productstudio/google/shopping/merchant_productstudio_v1alpha/services/text_suggestions_service/transports/grpc.py
+++ b/packages/google-shopping-merchant-productstudio/google/shopping/merchant_productstudio_v1alpha/services/text_suggestions_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-productstudio/google/shopping/merchant_productstudio_v1alpha/services/text_suggestions_service/transports/grpc_asyncio.py
+++ b/packages/google-shopping-merchant-productstudio/google/shopping/merchant_productstudio_v1alpha/services/text_suggestions_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-productstudio/google/shopping/merchant_productstudio_v1alpha/services/text_suggestions_service/transports/rest.py
+++ b/packages/google-shopping-merchant-productstudio/google/shopping/merchant_productstudio_v1alpha/services/text_suggestions_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-productstudio/google/shopping/merchant_productstudio_v1alpha/services/text_suggestions_service/transports/rest_base.py
+++ b/packages/google-shopping-merchant-productstudio/google/shopping/merchant_productstudio_v1alpha/services/text_suggestions_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-productstudio/google/shopping/merchant_productstudio_v1alpha/types/__init__.py
+++ b/packages/google-shopping-merchant-productstudio/google/shopping/merchant_productstudio_v1alpha/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-productstudio/google/shopping/merchant_productstudio_v1alpha/types/image.py
+++ b/packages/google-shopping-merchant-productstudio/google/shopping/merchant_productstudio_v1alpha/types/image.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-productstudio/google/shopping/merchant_productstudio_v1alpha/types/productstudio_common.py
+++ b/packages/google-shopping-merchant-productstudio/google/shopping/merchant_productstudio_v1alpha/types/productstudio_common.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-productstudio/google/shopping/merchant_productstudio_v1alpha/types/textsuggestions.py
+++ b/packages/google-shopping-merchant-productstudio/google/shopping/merchant_productstudio_v1alpha/types/textsuggestions.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-productstudio/samples/generated_samples/merchantapi_v1alpha_generated_image_service_generate_product_image_background_async.py
+++ b/packages/google-shopping-merchant-productstudio/samples/generated_samples/merchantapi_v1alpha_generated_image_service_generate_product_image_background_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-productstudio/samples/generated_samples/merchantapi_v1alpha_generated_image_service_generate_product_image_background_sync.py
+++ b/packages/google-shopping-merchant-productstudio/samples/generated_samples/merchantapi_v1alpha_generated_image_service_generate_product_image_background_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-productstudio/samples/generated_samples/merchantapi_v1alpha_generated_image_service_remove_product_image_background_async.py
+++ b/packages/google-shopping-merchant-productstudio/samples/generated_samples/merchantapi_v1alpha_generated_image_service_remove_product_image_background_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-productstudio/samples/generated_samples/merchantapi_v1alpha_generated_image_service_remove_product_image_background_sync.py
+++ b/packages/google-shopping-merchant-productstudio/samples/generated_samples/merchantapi_v1alpha_generated_image_service_remove_product_image_background_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-productstudio/samples/generated_samples/merchantapi_v1alpha_generated_image_service_upscale_product_image_async.py
+++ b/packages/google-shopping-merchant-productstudio/samples/generated_samples/merchantapi_v1alpha_generated_image_service_upscale_product_image_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-productstudio/samples/generated_samples/merchantapi_v1alpha_generated_image_service_upscale_product_image_sync.py
+++ b/packages/google-shopping-merchant-productstudio/samples/generated_samples/merchantapi_v1alpha_generated_image_service_upscale_product_image_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-productstudio/samples/generated_samples/merchantapi_v1alpha_generated_text_suggestions_service_generate_product_text_suggestions_async.py
+++ b/packages/google-shopping-merchant-productstudio/samples/generated_samples/merchantapi_v1alpha_generated_text_suggestions_service_generate_product_text_suggestions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-productstudio/samples/generated_samples/merchantapi_v1alpha_generated_text_suggestions_service_generate_product_text_suggestions_sync.py
+++ b/packages/google-shopping-merchant-productstudio/samples/generated_samples/merchantapi_v1alpha_generated_text_suggestions_service_generate_product_text_suggestions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-productstudio/tests/__init__.py
+++ b/packages/google-shopping-merchant-productstudio/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-productstudio/tests/unit/__init__.py
+++ b/packages/google-shopping-merchant-productstudio/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-productstudio/tests/unit/gapic/__init__.py
+++ b/packages/google-shopping-merchant-productstudio/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-productstudio/tests/unit/gapic/merchant_productstudio_v1alpha/__init__.py
+++ b/packages/google-shopping-merchant-productstudio/tests/unit/gapic/merchant_productstudio_v1alpha/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-promotions/.flake8
+++ b/packages/google-shopping-merchant-promotions/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-promotions/MANIFEST.in
+++ b/packages/google-shopping-merchant-promotions/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-promotions/google/shopping/merchant_promotions/__init__.py
+++ b/packages/google-shopping-merchant-promotions/google/shopping/merchant_promotions/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-promotions/google/shopping/merchant_promotions/gapic_version.py
+++ b/packages/google-shopping-merchant-promotions/google/shopping/merchant_promotions/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-promotions/google/shopping/merchant_promotions_v1/gapic_version.py
+++ b/packages/google-shopping-merchant-promotions/google/shopping/merchant_promotions_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-promotions/google/shopping/merchant_promotions_v1/services/__init__.py
+++ b/packages/google-shopping-merchant-promotions/google/shopping/merchant_promotions_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-promotions/google/shopping/merchant_promotions_v1/services/promotions_service/__init__.py
+++ b/packages/google-shopping-merchant-promotions/google/shopping/merchant_promotions_v1/services/promotions_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-promotions/google/shopping/merchant_promotions_v1/services/promotions_service/async_client.py
+++ b/packages/google-shopping-merchant-promotions/google/shopping/merchant_promotions_v1/services/promotions_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-promotions/google/shopping/merchant_promotions_v1/services/promotions_service/client.py
+++ b/packages/google-shopping-merchant-promotions/google/shopping/merchant_promotions_v1/services/promotions_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-promotions/google/shopping/merchant_promotions_v1/services/promotions_service/pagers.py
+++ b/packages/google-shopping-merchant-promotions/google/shopping/merchant_promotions_v1/services/promotions_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-promotions/google/shopping/merchant_promotions_v1/services/promotions_service/transports/__init__.py
+++ b/packages/google-shopping-merchant-promotions/google/shopping/merchant_promotions_v1/services/promotions_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-promotions/google/shopping/merchant_promotions_v1/services/promotions_service/transports/base.py
+++ b/packages/google-shopping-merchant-promotions/google/shopping/merchant_promotions_v1/services/promotions_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-promotions/google/shopping/merchant_promotions_v1/services/promotions_service/transports/grpc.py
+++ b/packages/google-shopping-merchant-promotions/google/shopping/merchant_promotions_v1/services/promotions_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-promotions/google/shopping/merchant_promotions_v1/services/promotions_service/transports/grpc_asyncio.py
+++ b/packages/google-shopping-merchant-promotions/google/shopping/merchant_promotions_v1/services/promotions_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-promotions/google/shopping/merchant_promotions_v1/services/promotions_service/transports/rest.py
+++ b/packages/google-shopping-merchant-promotions/google/shopping/merchant_promotions_v1/services/promotions_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-promotions/google/shopping/merchant_promotions_v1/services/promotions_service/transports/rest_base.py
+++ b/packages/google-shopping-merchant-promotions/google/shopping/merchant_promotions_v1/services/promotions_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-promotions/google/shopping/merchant_promotions_v1/types/__init__.py
+++ b/packages/google-shopping-merchant-promotions/google/shopping/merchant_promotions_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-promotions/google/shopping/merchant_promotions_v1/types/promotions.py
+++ b/packages/google-shopping-merchant-promotions/google/shopping/merchant_promotions_v1/types/promotions.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-promotions/google/shopping/merchant_promotions_v1/types/promotions_common.py
+++ b/packages/google-shopping-merchant-promotions/google/shopping/merchant_promotions_v1/types/promotions_common.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-promotions/google/shopping/merchant_promotions_v1beta/gapic_version.py
+++ b/packages/google-shopping-merchant-promotions/google/shopping/merchant_promotions_v1beta/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-promotions/google/shopping/merchant_promotions_v1beta/services/__init__.py
+++ b/packages/google-shopping-merchant-promotions/google/shopping/merchant_promotions_v1beta/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-promotions/google/shopping/merchant_promotions_v1beta/services/promotions_service/__init__.py
+++ b/packages/google-shopping-merchant-promotions/google/shopping/merchant_promotions_v1beta/services/promotions_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-promotions/google/shopping/merchant_promotions_v1beta/services/promotions_service/async_client.py
+++ b/packages/google-shopping-merchant-promotions/google/shopping/merchant_promotions_v1beta/services/promotions_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-promotions/google/shopping/merchant_promotions_v1beta/services/promotions_service/client.py
+++ b/packages/google-shopping-merchant-promotions/google/shopping/merchant_promotions_v1beta/services/promotions_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-promotions/google/shopping/merchant_promotions_v1beta/services/promotions_service/pagers.py
+++ b/packages/google-shopping-merchant-promotions/google/shopping/merchant_promotions_v1beta/services/promotions_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-promotions/google/shopping/merchant_promotions_v1beta/services/promotions_service/transports/__init__.py
+++ b/packages/google-shopping-merchant-promotions/google/shopping/merchant_promotions_v1beta/services/promotions_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-promotions/google/shopping/merchant_promotions_v1beta/services/promotions_service/transports/base.py
+++ b/packages/google-shopping-merchant-promotions/google/shopping/merchant_promotions_v1beta/services/promotions_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-promotions/google/shopping/merchant_promotions_v1beta/services/promotions_service/transports/grpc.py
+++ b/packages/google-shopping-merchant-promotions/google/shopping/merchant_promotions_v1beta/services/promotions_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-promotions/google/shopping/merchant_promotions_v1beta/services/promotions_service/transports/grpc_asyncio.py
+++ b/packages/google-shopping-merchant-promotions/google/shopping/merchant_promotions_v1beta/services/promotions_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-promotions/google/shopping/merchant_promotions_v1beta/services/promotions_service/transports/rest.py
+++ b/packages/google-shopping-merchant-promotions/google/shopping/merchant_promotions_v1beta/services/promotions_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-promotions/google/shopping/merchant_promotions_v1beta/services/promotions_service/transports/rest_base.py
+++ b/packages/google-shopping-merchant-promotions/google/shopping/merchant_promotions_v1beta/services/promotions_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-promotions/google/shopping/merchant_promotions_v1beta/types/__init__.py
+++ b/packages/google-shopping-merchant-promotions/google/shopping/merchant_promotions_v1beta/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-promotions/google/shopping/merchant_promotions_v1beta/types/promotions.py
+++ b/packages/google-shopping-merchant-promotions/google/shopping/merchant_promotions_v1beta/types/promotions.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-promotions/google/shopping/merchant_promotions_v1beta/types/promotions_common.py
+++ b/packages/google-shopping-merchant-promotions/google/shopping/merchant_promotions_v1beta/types/promotions_common.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-promotions/samples/generated_samples/merchantapi_v1_generated_promotions_service_get_promotion_async.py
+++ b/packages/google-shopping-merchant-promotions/samples/generated_samples/merchantapi_v1_generated_promotions_service_get_promotion_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-promotions/samples/generated_samples/merchantapi_v1_generated_promotions_service_get_promotion_sync.py
+++ b/packages/google-shopping-merchant-promotions/samples/generated_samples/merchantapi_v1_generated_promotions_service_get_promotion_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-promotions/samples/generated_samples/merchantapi_v1_generated_promotions_service_insert_promotion_async.py
+++ b/packages/google-shopping-merchant-promotions/samples/generated_samples/merchantapi_v1_generated_promotions_service_insert_promotion_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-promotions/samples/generated_samples/merchantapi_v1_generated_promotions_service_insert_promotion_sync.py
+++ b/packages/google-shopping-merchant-promotions/samples/generated_samples/merchantapi_v1_generated_promotions_service_insert_promotion_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-promotions/samples/generated_samples/merchantapi_v1_generated_promotions_service_list_promotions_async.py
+++ b/packages/google-shopping-merchant-promotions/samples/generated_samples/merchantapi_v1_generated_promotions_service_list_promotions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-promotions/samples/generated_samples/merchantapi_v1_generated_promotions_service_list_promotions_sync.py
+++ b/packages/google-shopping-merchant-promotions/samples/generated_samples/merchantapi_v1_generated_promotions_service_list_promotions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-promotions/samples/generated_samples/merchantapi_v1beta_generated_promotions_service_get_promotion_async.py
+++ b/packages/google-shopping-merchant-promotions/samples/generated_samples/merchantapi_v1beta_generated_promotions_service_get_promotion_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-promotions/samples/generated_samples/merchantapi_v1beta_generated_promotions_service_get_promotion_sync.py
+++ b/packages/google-shopping-merchant-promotions/samples/generated_samples/merchantapi_v1beta_generated_promotions_service_get_promotion_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-promotions/samples/generated_samples/merchantapi_v1beta_generated_promotions_service_insert_promotion_async.py
+++ b/packages/google-shopping-merchant-promotions/samples/generated_samples/merchantapi_v1beta_generated_promotions_service_insert_promotion_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-promotions/samples/generated_samples/merchantapi_v1beta_generated_promotions_service_insert_promotion_sync.py
+++ b/packages/google-shopping-merchant-promotions/samples/generated_samples/merchantapi_v1beta_generated_promotions_service_insert_promotion_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-promotions/samples/generated_samples/merchantapi_v1beta_generated_promotions_service_list_promotions_async.py
+++ b/packages/google-shopping-merchant-promotions/samples/generated_samples/merchantapi_v1beta_generated_promotions_service_list_promotions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-promotions/samples/generated_samples/merchantapi_v1beta_generated_promotions_service_list_promotions_sync.py
+++ b/packages/google-shopping-merchant-promotions/samples/generated_samples/merchantapi_v1beta_generated_promotions_service_list_promotions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-promotions/tests/__init__.py
+++ b/packages/google-shopping-merchant-promotions/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-promotions/tests/unit/__init__.py
+++ b/packages/google-shopping-merchant-promotions/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-promotions/tests/unit/gapic/__init__.py
+++ b/packages/google-shopping-merchant-promotions/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-promotions/tests/unit/gapic/merchant_promotions_v1/__init__.py
+++ b/packages/google-shopping-merchant-promotions/tests/unit/gapic/merchant_promotions_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-promotions/tests/unit/gapic/merchant_promotions_v1beta/__init__.py
+++ b/packages/google-shopping-merchant-promotions/tests/unit/gapic/merchant_promotions_v1beta/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-quota/.flake8
+++ b/packages/google-shopping-merchant-quota/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-quota/MANIFEST.in
+++ b/packages/google-shopping-merchant-quota/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-quota/google/shopping/merchant_quota/__init__.py
+++ b/packages/google-shopping-merchant-quota/google/shopping/merchant_quota/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-quota/google/shopping/merchant_quota/gapic_version.py
+++ b/packages/google-shopping-merchant-quota/google/shopping/merchant_quota/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-quota/google/shopping/merchant_quota_v1/gapic_version.py
+++ b/packages/google-shopping-merchant-quota/google/shopping/merchant_quota_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-quota/google/shopping/merchant_quota_v1/services/__init__.py
+++ b/packages/google-shopping-merchant-quota/google/shopping/merchant_quota_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-quota/google/shopping/merchant_quota_v1/services/account_limits_service/__init__.py
+++ b/packages/google-shopping-merchant-quota/google/shopping/merchant_quota_v1/services/account_limits_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-quota/google/shopping/merchant_quota_v1/services/account_limits_service/async_client.py
+++ b/packages/google-shopping-merchant-quota/google/shopping/merchant_quota_v1/services/account_limits_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-quota/google/shopping/merchant_quota_v1/services/account_limits_service/client.py
+++ b/packages/google-shopping-merchant-quota/google/shopping/merchant_quota_v1/services/account_limits_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-quota/google/shopping/merchant_quota_v1/services/account_limits_service/pagers.py
+++ b/packages/google-shopping-merchant-quota/google/shopping/merchant_quota_v1/services/account_limits_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-quota/google/shopping/merchant_quota_v1/services/account_limits_service/transports/__init__.py
+++ b/packages/google-shopping-merchant-quota/google/shopping/merchant_quota_v1/services/account_limits_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-quota/google/shopping/merchant_quota_v1/services/account_limits_service/transports/base.py
+++ b/packages/google-shopping-merchant-quota/google/shopping/merchant_quota_v1/services/account_limits_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-quota/google/shopping/merchant_quota_v1/services/account_limits_service/transports/grpc.py
+++ b/packages/google-shopping-merchant-quota/google/shopping/merchant_quota_v1/services/account_limits_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-quota/google/shopping/merchant_quota_v1/services/account_limits_service/transports/grpc_asyncio.py
+++ b/packages/google-shopping-merchant-quota/google/shopping/merchant_quota_v1/services/account_limits_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-quota/google/shopping/merchant_quota_v1/services/account_limits_service/transports/rest.py
+++ b/packages/google-shopping-merchant-quota/google/shopping/merchant_quota_v1/services/account_limits_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-quota/google/shopping/merchant_quota_v1/services/account_limits_service/transports/rest_base.py
+++ b/packages/google-shopping-merchant-quota/google/shopping/merchant_quota_v1/services/account_limits_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-quota/google/shopping/merchant_quota_v1/services/quota_service/__init__.py
+++ b/packages/google-shopping-merchant-quota/google/shopping/merchant_quota_v1/services/quota_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-quota/google/shopping/merchant_quota_v1/services/quota_service/async_client.py
+++ b/packages/google-shopping-merchant-quota/google/shopping/merchant_quota_v1/services/quota_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-quota/google/shopping/merchant_quota_v1/services/quota_service/client.py
+++ b/packages/google-shopping-merchant-quota/google/shopping/merchant_quota_v1/services/quota_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-quota/google/shopping/merchant_quota_v1/services/quota_service/pagers.py
+++ b/packages/google-shopping-merchant-quota/google/shopping/merchant_quota_v1/services/quota_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-quota/google/shopping/merchant_quota_v1/services/quota_service/transports/__init__.py
+++ b/packages/google-shopping-merchant-quota/google/shopping/merchant_quota_v1/services/quota_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-quota/google/shopping/merchant_quota_v1/services/quota_service/transports/base.py
+++ b/packages/google-shopping-merchant-quota/google/shopping/merchant_quota_v1/services/quota_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-quota/google/shopping/merchant_quota_v1/services/quota_service/transports/grpc.py
+++ b/packages/google-shopping-merchant-quota/google/shopping/merchant_quota_v1/services/quota_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-quota/google/shopping/merchant_quota_v1/services/quota_service/transports/grpc_asyncio.py
+++ b/packages/google-shopping-merchant-quota/google/shopping/merchant_quota_v1/services/quota_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-quota/google/shopping/merchant_quota_v1/services/quota_service/transports/rest.py
+++ b/packages/google-shopping-merchant-quota/google/shopping/merchant_quota_v1/services/quota_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-quota/google/shopping/merchant_quota_v1/services/quota_service/transports/rest_base.py
+++ b/packages/google-shopping-merchant-quota/google/shopping/merchant_quota_v1/services/quota_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-quota/google/shopping/merchant_quota_v1/types/__init__.py
+++ b/packages/google-shopping-merchant-quota/google/shopping/merchant_quota_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-quota/google/shopping/merchant_quota_v1/types/accountlimits.py
+++ b/packages/google-shopping-merchant-quota/google/shopping/merchant_quota_v1/types/accountlimits.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-quota/google/shopping/merchant_quota_v1/types/quota.py
+++ b/packages/google-shopping-merchant-quota/google/shopping/merchant_quota_v1/types/quota.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-quota/google/shopping/merchant_quota_v1beta/gapic_version.py
+++ b/packages/google-shopping-merchant-quota/google/shopping/merchant_quota_v1beta/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-quota/google/shopping/merchant_quota_v1beta/services/__init__.py
+++ b/packages/google-shopping-merchant-quota/google/shopping/merchant_quota_v1beta/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-quota/google/shopping/merchant_quota_v1beta/services/quota_service/__init__.py
+++ b/packages/google-shopping-merchant-quota/google/shopping/merchant_quota_v1beta/services/quota_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-quota/google/shopping/merchant_quota_v1beta/services/quota_service/async_client.py
+++ b/packages/google-shopping-merchant-quota/google/shopping/merchant_quota_v1beta/services/quota_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-quota/google/shopping/merchant_quota_v1beta/services/quota_service/client.py
+++ b/packages/google-shopping-merchant-quota/google/shopping/merchant_quota_v1beta/services/quota_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-quota/google/shopping/merchant_quota_v1beta/services/quota_service/pagers.py
+++ b/packages/google-shopping-merchant-quota/google/shopping/merchant_quota_v1beta/services/quota_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-quota/google/shopping/merchant_quota_v1beta/services/quota_service/transports/__init__.py
+++ b/packages/google-shopping-merchant-quota/google/shopping/merchant_quota_v1beta/services/quota_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-quota/google/shopping/merchant_quota_v1beta/services/quota_service/transports/base.py
+++ b/packages/google-shopping-merchant-quota/google/shopping/merchant_quota_v1beta/services/quota_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-quota/google/shopping/merchant_quota_v1beta/services/quota_service/transports/grpc.py
+++ b/packages/google-shopping-merchant-quota/google/shopping/merchant_quota_v1beta/services/quota_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-quota/google/shopping/merchant_quota_v1beta/services/quota_service/transports/grpc_asyncio.py
+++ b/packages/google-shopping-merchant-quota/google/shopping/merchant_quota_v1beta/services/quota_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-quota/google/shopping/merchant_quota_v1beta/services/quota_service/transports/rest.py
+++ b/packages/google-shopping-merchant-quota/google/shopping/merchant_quota_v1beta/services/quota_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-quota/google/shopping/merchant_quota_v1beta/services/quota_service/transports/rest_base.py
+++ b/packages/google-shopping-merchant-quota/google/shopping/merchant_quota_v1beta/services/quota_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-quota/google/shopping/merchant_quota_v1beta/types/__init__.py
+++ b/packages/google-shopping-merchant-quota/google/shopping/merchant_quota_v1beta/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-quota/google/shopping/merchant_quota_v1beta/types/quota.py
+++ b/packages/google-shopping-merchant-quota/google/shopping/merchant_quota_v1beta/types/quota.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-quota/samples/generated_samples/merchantapi_v1_generated_account_limits_service_get_account_limit_async.py
+++ b/packages/google-shopping-merchant-quota/samples/generated_samples/merchantapi_v1_generated_account_limits_service_get_account_limit_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-quota/samples/generated_samples/merchantapi_v1_generated_account_limits_service_get_account_limit_sync.py
+++ b/packages/google-shopping-merchant-quota/samples/generated_samples/merchantapi_v1_generated_account_limits_service_get_account_limit_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-quota/samples/generated_samples/merchantapi_v1_generated_account_limits_service_list_account_limits_async.py
+++ b/packages/google-shopping-merchant-quota/samples/generated_samples/merchantapi_v1_generated_account_limits_service_list_account_limits_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-quota/samples/generated_samples/merchantapi_v1_generated_account_limits_service_list_account_limits_sync.py
+++ b/packages/google-shopping-merchant-quota/samples/generated_samples/merchantapi_v1_generated_account_limits_service_list_account_limits_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-quota/samples/generated_samples/merchantapi_v1_generated_quota_service_list_quota_groups_async.py
+++ b/packages/google-shopping-merchant-quota/samples/generated_samples/merchantapi_v1_generated_quota_service_list_quota_groups_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-quota/samples/generated_samples/merchantapi_v1_generated_quota_service_list_quota_groups_sync.py
+++ b/packages/google-shopping-merchant-quota/samples/generated_samples/merchantapi_v1_generated_quota_service_list_quota_groups_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-quota/samples/generated_samples/merchantapi_v1beta_generated_quota_service_list_quota_groups_async.py
+++ b/packages/google-shopping-merchant-quota/samples/generated_samples/merchantapi_v1beta_generated_quota_service_list_quota_groups_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-quota/samples/generated_samples/merchantapi_v1beta_generated_quota_service_list_quota_groups_sync.py
+++ b/packages/google-shopping-merchant-quota/samples/generated_samples/merchantapi_v1beta_generated_quota_service_list_quota_groups_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-quota/tests/__init__.py
+++ b/packages/google-shopping-merchant-quota/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-quota/tests/unit/__init__.py
+++ b/packages/google-shopping-merchant-quota/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-quota/tests/unit/gapic/__init__.py
+++ b/packages/google-shopping-merchant-quota/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-quota/tests/unit/gapic/merchant_quota_v1/__init__.py
+++ b/packages/google-shopping-merchant-quota/tests/unit/gapic/merchant_quota_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-quota/tests/unit/gapic/merchant_quota_v1beta/__init__.py
+++ b/packages/google-shopping-merchant-quota/tests/unit/gapic/merchant_quota_v1beta/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-reports/.flake8
+++ b/packages/google-shopping-merchant-reports/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-reports/MANIFEST.in
+++ b/packages/google-shopping-merchant-reports/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-reports/google/shopping/merchant_reports/__init__.py
+++ b/packages/google-shopping-merchant-reports/google/shopping/merchant_reports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-reports/google/shopping/merchant_reports/gapic_version.py
+++ b/packages/google-shopping-merchant-reports/google/shopping/merchant_reports/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-reports/google/shopping/merchant_reports_v1/gapic_version.py
+++ b/packages/google-shopping-merchant-reports/google/shopping/merchant_reports_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-reports/google/shopping/merchant_reports_v1/services/__init__.py
+++ b/packages/google-shopping-merchant-reports/google/shopping/merchant_reports_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-reports/google/shopping/merchant_reports_v1/services/report_service/__init__.py
+++ b/packages/google-shopping-merchant-reports/google/shopping/merchant_reports_v1/services/report_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-reports/google/shopping/merchant_reports_v1/services/report_service/async_client.py
+++ b/packages/google-shopping-merchant-reports/google/shopping/merchant_reports_v1/services/report_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-reports/google/shopping/merchant_reports_v1/services/report_service/client.py
+++ b/packages/google-shopping-merchant-reports/google/shopping/merchant_reports_v1/services/report_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-reports/google/shopping/merchant_reports_v1/services/report_service/pagers.py
+++ b/packages/google-shopping-merchant-reports/google/shopping/merchant_reports_v1/services/report_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-reports/google/shopping/merchant_reports_v1/services/report_service/transports/__init__.py
+++ b/packages/google-shopping-merchant-reports/google/shopping/merchant_reports_v1/services/report_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-reports/google/shopping/merchant_reports_v1/services/report_service/transports/base.py
+++ b/packages/google-shopping-merchant-reports/google/shopping/merchant_reports_v1/services/report_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-reports/google/shopping/merchant_reports_v1/services/report_service/transports/grpc.py
+++ b/packages/google-shopping-merchant-reports/google/shopping/merchant_reports_v1/services/report_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-reports/google/shopping/merchant_reports_v1/services/report_service/transports/grpc_asyncio.py
+++ b/packages/google-shopping-merchant-reports/google/shopping/merchant_reports_v1/services/report_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-reports/google/shopping/merchant_reports_v1/services/report_service/transports/rest.py
+++ b/packages/google-shopping-merchant-reports/google/shopping/merchant_reports_v1/services/report_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-reports/google/shopping/merchant_reports_v1/services/report_service/transports/rest_base.py
+++ b/packages/google-shopping-merchant-reports/google/shopping/merchant_reports_v1/services/report_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-reports/google/shopping/merchant_reports_v1/types/__init__.py
+++ b/packages/google-shopping-merchant-reports/google/shopping/merchant_reports_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-reports/google/shopping/merchant_reports_v1alpha/gapic_version.py
+++ b/packages/google-shopping-merchant-reports/google/shopping/merchant_reports_v1alpha/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-reports/google/shopping/merchant_reports_v1alpha/services/__init__.py
+++ b/packages/google-shopping-merchant-reports/google/shopping/merchant_reports_v1alpha/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-reports/google/shopping/merchant_reports_v1alpha/services/report_service/__init__.py
+++ b/packages/google-shopping-merchant-reports/google/shopping/merchant_reports_v1alpha/services/report_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-reports/google/shopping/merchant_reports_v1alpha/services/report_service/async_client.py
+++ b/packages/google-shopping-merchant-reports/google/shopping/merchant_reports_v1alpha/services/report_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-reports/google/shopping/merchant_reports_v1alpha/services/report_service/client.py
+++ b/packages/google-shopping-merchant-reports/google/shopping/merchant_reports_v1alpha/services/report_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-reports/google/shopping/merchant_reports_v1alpha/services/report_service/pagers.py
+++ b/packages/google-shopping-merchant-reports/google/shopping/merchant_reports_v1alpha/services/report_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-reports/google/shopping/merchant_reports_v1alpha/services/report_service/transports/__init__.py
+++ b/packages/google-shopping-merchant-reports/google/shopping/merchant_reports_v1alpha/services/report_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-reports/google/shopping/merchant_reports_v1alpha/services/report_service/transports/base.py
+++ b/packages/google-shopping-merchant-reports/google/shopping/merchant_reports_v1alpha/services/report_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-reports/google/shopping/merchant_reports_v1alpha/services/report_service/transports/grpc.py
+++ b/packages/google-shopping-merchant-reports/google/shopping/merchant_reports_v1alpha/services/report_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-reports/google/shopping/merchant_reports_v1alpha/services/report_service/transports/grpc_asyncio.py
+++ b/packages/google-shopping-merchant-reports/google/shopping/merchant_reports_v1alpha/services/report_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-reports/google/shopping/merchant_reports_v1alpha/services/report_service/transports/rest.py
+++ b/packages/google-shopping-merchant-reports/google/shopping/merchant_reports_v1alpha/services/report_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-reports/google/shopping/merchant_reports_v1alpha/services/report_service/transports/rest_base.py
+++ b/packages/google-shopping-merchant-reports/google/shopping/merchant_reports_v1alpha/services/report_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-reports/google/shopping/merchant_reports_v1alpha/types/__init__.py
+++ b/packages/google-shopping-merchant-reports/google/shopping/merchant_reports_v1alpha/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-reports/google/shopping/merchant_reports_v1beta/gapic_version.py
+++ b/packages/google-shopping-merchant-reports/google/shopping/merchant_reports_v1beta/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-reports/google/shopping/merchant_reports_v1beta/services/__init__.py
+++ b/packages/google-shopping-merchant-reports/google/shopping/merchant_reports_v1beta/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-reports/google/shopping/merchant_reports_v1beta/services/report_service/__init__.py
+++ b/packages/google-shopping-merchant-reports/google/shopping/merchant_reports_v1beta/services/report_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-reports/google/shopping/merchant_reports_v1beta/services/report_service/async_client.py
+++ b/packages/google-shopping-merchant-reports/google/shopping/merchant_reports_v1beta/services/report_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-reports/google/shopping/merchant_reports_v1beta/services/report_service/client.py
+++ b/packages/google-shopping-merchant-reports/google/shopping/merchant_reports_v1beta/services/report_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-reports/google/shopping/merchant_reports_v1beta/services/report_service/pagers.py
+++ b/packages/google-shopping-merchant-reports/google/shopping/merchant_reports_v1beta/services/report_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-reports/google/shopping/merchant_reports_v1beta/services/report_service/transports/__init__.py
+++ b/packages/google-shopping-merchant-reports/google/shopping/merchant_reports_v1beta/services/report_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-reports/google/shopping/merchant_reports_v1beta/services/report_service/transports/base.py
+++ b/packages/google-shopping-merchant-reports/google/shopping/merchant_reports_v1beta/services/report_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-reports/google/shopping/merchant_reports_v1beta/services/report_service/transports/grpc.py
+++ b/packages/google-shopping-merchant-reports/google/shopping/merchant_reports_v1beta/services/report_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-reports/google/shopping/merchant_reports_v1beta/services/report_service/transports/grpc_asyncio.py
+++ b/packages/google-shopping-merchant-reports/google/shopping/merchant_reports_v1beta/services/report_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-reports/google/shopping/merchant_reports_v1beta/services/report_service/transports/rest.py
+++ b/packages/google-shopping-merchant-reports/google/shopping/merchant_reports_v1beta/services/report_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-reports/google/shopping/merchant_reports_v1beta/services/report_service/transports/rest_base.py
+++ b/packages/google-shopping-merchant-reports/google/shopping/merchant_reports_v1beta/services/report_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-reports/google/shopping/merchant_reports_v1beta/types/__init__.py
+++ b/packages/google-shopping-merchant-reports/google/shopping/merchant_reports_v1beta/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-reports/samples/generated_samples/merchantapi_v1_generated_report_service_search_async.py
+++ b/packages/google-shopping-merchant-reports/samples/generated_samples/merchantapi_v1_generated_report_service_search_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-reports/samples/generated_samples/merchantapi_v1_generated_report_service_search_sync.py
+++ b/packages/google-shopping-merchant-reports/samples/generated_samples/merchantapi_v1_generated_report_service_search_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-reports/samples/generated_samples/merchantapi_v1alpha_generated_report_service_search_async.py
+++ b/packages/google-shopping-merchant-reports/samples/generated_samples/merchantapi_v1alpha_generated_report_service_search_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-reports/samples/generated_samples/merchantapi_v1alpha_generated_report_service_search_sync.py
+++ b/packages/google-shopping-merchant-reports/samples/generated_samples/merchantapi_v1alpha_generated_report_service_search_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-reports/samples/generated_samples/merchantapi_v1beta_generated_report_service_search_async.py
+++ b/packages/google-shopping-merchant-reports/samples/generated_samples/merchantapi_v1beta_generated_report_service_search_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-reports/samples/generated_samples/merchantapi_v1beta_generated_report_service_search_sync.py
+++ b/packages/google-shopping-merchant-reports/samples/generated_samples/merchantapi_v1beta_generated_report_service_search_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-reports/tests/__init__.py
+++ b/packages/google-shopping-merchant-reports/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-reports/tests/unit/__init__.py
+++ b/packages/google-shopping-merchant-reports/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-reports/tests/unit/gapic/__init__.py
+++ b/packages/google-shopping-merchant-reports/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-reports/tests/unit/gapic/merchant_reports_v1/__init__.py
+++ b/packages/google-shopping-merchant-reports/tests/unit/gapic/merchant_reports_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-reports/tests/unit/gapic/merchant_reports_v1alpha/__init__.py
+++ b/packages/google-shopping-merchant-reports/tests/unit/gapic/merchant_reports_v1alpha/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-reports/tests/unit/gapic/merchant_reports_v1beta/__init__.py
+++ b/packages/google-shopping-merchant-reports/tests/unit/gapic/merchant_reports_v1beta/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-reviews/.flake8
+++ b/packages/google-shopping-merchant-reviews/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-reviews/MANIFEST.in
+++ b/packages/google-shopping-merchant-reviews/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-reviews/google/shopping/merchant_reviews/__init__.py
+++ b/packages/google-shopping-merchant-reviews/google/shopping/merchant_reviews/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-reviews/google/shopping/merchant_reviews/gapic_version.py
+++ b/packages/google-shopping-merchant-reviews/google/shopping/merchant_reviews/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-reviews/google/shopping/merchant_reviews_v1beta/gapic_version.py
+++ b/packages/google-shopping-merchant-reviews/google/shopping/merchant_reviews_v1beta/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-reviews/google/shopping/merchant_reviews_v1beta/services/__init__.py
+++ b/packages/google-shopping-merchant-reviews/google/shopping/merchant_reviews_v1beta/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-reviews/google/shopping/merchant_reviews_v1beta/services/merchant_reviews_service/__init__.py
+++ b/packages/google-shopping-merchant-reviews/google/shopping/merchant_reviews_v1beta/services/merchant_reviews_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-reviews/google/shopping/merchant_reviews_v1beta/services/merchant_reviews_service/async_client.py
+++ b/packages/google-shopping-merchant-reviews/google/shopping/merchant_reviews_v1beta/services/merchant_reviews_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-reviews/google/shopping/merchant_reviews_v1beta/services/merchant_reviews_service/client.py
+++ b/packages/google-shopping-merchant-reviews/google/shopping/merchant_reviews_v1beta/services/merchant_reviews_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-reviews/google/shopping/merchant_reviews_v1beta/services/merchant_reviews_service/pagers.py
+++ b/packages/google-shopping-merchant-reviews/google/shopping/merchant_reviews_v1beta/services/merchant_reviews_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-reviews/google/shopping/merchant_reviews_v1beta/services/merchant_reviews_service/transports/__init__.py
+++ b/packages/google-shopping-merchant-reviews/google/shopping/merchant_reviews_v1beta/services/merchant_reviews_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-reviews/google/shopping/merchant_reviews_v1beta/services/merchant_reviews_service/transports/base.py
+++ b/packages/google-shopping-merchant-reviews/google/shopping/merchant_reviews_v1beta/services/merchant_reviews_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-reviews/google/shopping/merchant_reviews_v1beta/services/merchant_reviews_service/transports/grpc.py
+++ b/packages/google-shopping-merchant-reviews/google/shopping/merchant_reviews_v1beta/services/merchant_reviews_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-reviews/google/shopping/merchant_reviews_v1beta/services/merchant_reviews_service/transports/grpc_asyncio.py
+++ b/packages/google-shopping-merchant-reviews/google/shopping/merchant_reviews_v1beta/services/merchant_reviews_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-reviews/google/shopping/merchant_reviews_v1beta/services/merchant_reviews_service/transports/rest.py
+++ b/packages/google-shopping-merchant-reviews/google/shopping/merchant_reviews_v1beta/services/merchant_reviews_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-reviews/google/shopping/merchant_reviews_v1beta/services/merchant_reviews_service/transports/rest_base.py
+++ b/packages/google-shopping-merchant-reviews/google/shopping/merchant_reviews_v1beta/services/merchant_reviews_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-reviews/google/shopping/merchant_reviews_v1beta/services/product_reviews_service/__init__.py
+++ b/packages/google-shopping-merchant-reviews/google/shopping/merchant_reviews_v1beta/services/product_reviews_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-reviews/google/shopping/merchant_reviews_v1beta/services/product_reviews_service/async_client.py
+++ b/packages/google-shopping-merchant-reviews/google/shopping/merchant_reviews_v1beta/services/product_reviews_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-reviews/google/shopping/merchant_reviews_v1beta/services/product_reviews_service/client.py
+++ b/packages/google-shopping-merchant-reviews/google/shopping/merchant_reviews_v1beta/services/product_reviews_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-reviews/google/shopping/merchant_reviews_v1beta/services/product_reviews_service/pagers.py
+++ b/packages/google-shopping-merchant-reviews/google/shopping/merchant_reviews_v1beta/services/product_reviews_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-reviews/google/shopping/merchant_reviews_v1beta/services/product_reviews_service/transports/__init__.py
+++ b/packages/google-shopping-merchant-reviews/google/shopping/merchant_reviews_v1beta/services/product_reviews_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-reviews/google/shopping/merchant_reviews_v1beta/services/product_reviews_service/transports/base.py
+++ b/packages/google-shopping-merchant-reviews/google/shopping/merchant_reviews_v1beta/services/product_reviews_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-reviews/google/shopping/merchant_reviews_v1beta/services/product_reviews_service/transports/grpc.py
+++ b/packages/google-shopping-merchant-reviews/google/shopping/merchant_reviews_v1beta/services/product_reviews_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-reviews/google/shopping/merchant_reviews_v1beta/services/product_reviews_service/transports/grpc_asyncio.py
+++ b/packages/google-shopping-merchant-reviews/google/shopping/merchant_reviews_v1beta/services/product_reviews_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-reviews/google/shopping/merchant_reviews_v1beta/services/product_reviews_service/transports/rest.py
+++ b/packages/google-shopping-merchant-reviews/google/shopping/merchant_reviews_v1beta/services/product_reviews_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-reviews/google/shopping/merchant_reviews_v1beta/services/product_reviews_service/transports/rest_base.py
+++ b/packages/google-shopping-merchant-reviews/google/shopping/merchant_reviews_v1beta/services/product_reviews_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-reviews/google/shopping/merchant_reviews_v1beta/types/__init__.py
+++ b/packages/google-shopping-merchant-reviews/google/shopping/merchant_reviews_v1beta/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-reviews/google/shopping/merchant_reviews_v1beta/types/merchantreviews.py
+++ b/packages/google-shopping-merchant-reviews/google/shopping/merchant_reviews_v1beta/types/merchantreviews.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-reviews/google/shopping/merchant_reviews_v1beta/types/merchantreviews_common.py
+++ b/packages/google-shopping-merchant-reviews/google/shopping/merchant_reviews_v1beta/types/merchantreviews_common.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-reviews/google/shopping/merchant_reviews_v1beta/types/productreviews.py
+++ b/packages/google-shopping-merchant-reviews/google/shopping/merchant_reviews_v1beta/types/productreviews.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-reviews/google/shopping/merchant_reviews_v1beta/types/productreviews_common.py
+++ b/packages/google-shopping-merchant-reviews/google/shopping/merchant_reviews_v1beta/types/productreviews_common.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-reviews/samples/generated_samples/merchantapi_v1beta_generated_merchant_reviews_service_delete_merchant_review_async.py
+++ b/packages/google-shopping-merchant-reviews/samples/generated_samples/merchantapi_v1beta_generated_merchant_reviews_service_delete_merchant_review_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-reviews/samples/generated_samples/merchantapi_v1beta_generated_merchant_reviews_service_delete_merchant_review_sync.py
+++ b/packages/google-shopping-merchant-reviews/samples/generated_samples/merchantapi_v1beta_generated_merchant_reviews_service_delete_merchant_review_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-reviews/samples/generated_samples/merchantapi_v1beta_generated_merchant_reviews_service_get_merchant_review_async.py
+++ b/packages/google-shopping-merchant-reviews/samples/generated_samples/merchantapi_v1beta_generated_merchant_reviews_service_get_merchant_review_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-reviews/samples/generated_samples/merchantapi_v1beta_generated_merchant_reviews_service_get_merchant_review_sync.py
+++ b/packages/google-shopping-merchant-reviews/samples/generated_samples/merchantapi_v1beta_generated_merchant_reviews_service_get_merchant_review_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-reviews/samples/generated_samples/merchantapi_v1beta_generated_merchant_reviews_service_insert_merchant_review_async.py
+++ b/packages/google-shopping-merchant-reviews/samples/generated_samples/merchantapi_v1beta_generated_merchant_reviews_service_insert_merchant_review_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-reviews/samples/generated_samples/merchantapi_v1beta_generated_merchant_reviews_service_insert_merchant_review_sync.py
+++ b/packages/google-shopping-merchant-reviews/samples/generated_samples/merchantapi_v1beta_generated_merchant_reviews_service_insert_merchant_review_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-reviews/samples/generated_samples/merchantapi_v1beta_generated_merchant_reviews_service_list_merchant_reviews_async.py
+++ b/packages/google-shopping-merchant-reviews/samples/generated_samples/merchantapi_v1beta_generated_merchant_reviews_service_list_merchant_reviews_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-reviews/samples/generated_samples/merchantapi_v1beta_generated_merchant_reviews_service_list_merchant_reviews_sync.py
+++ b/packages/google-shopping-merchant-reviews/samples/generated_samples/merchantapi_v1beta_generated_merchant_reviews_service_list_merchant_reviews_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-reviews/samples/generated_samples/merchantapi_v1beta_generated_product_reviews_service_delete_product_review_async.py
+++ b/packages/google-shopping-merchant-reviews/samples/generated_samples/merchantapi_v1beta_generated_product_reviews_service_delete_product_review_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-reviews/samples/generated_samples/merchantapi_v1beta_generated_product_reviews_service_delete_product_review_sync.py
+++ b/packages/google-shopping-merchant-reviews/samples/generated_samples/merchantapi_v1beta_generated_product_reviews_service_delete_product_review_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-reviews/samples/generated_samples/merchantapi_v1beta_generated_product_reviews_service_get_product_review_async.py
+++ b/packages/google-shopping-merchant-reviews/samples/generated_samples/merchantapi_v1beta_generated_product_reviews_service_get_product_review_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-reviews/samples/generated_samples/merchantapi_v1beta_generated_product_reviews_service_get_product_review_sync.py
+++ b/packages/google-shopping-merchant-reviews/samples/generated_samples/merchantapi_v1beta_generated_product_reviews_service_get_product_review_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-reviews/samples/generated_samples/merchantapi_v1beta_generated_product_reviews_service_insert_product_review_async.py
+++ b/packages/google-shopping-merchant-reviews/samples/generated_samples/merchantapi_v1beta_generated_product_reviews_service_insert_product_review_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-reviews/samples/generated_samples/merchantapi_v1beta_generated_product_reviews_service_insert_product_review_sync.py
+++ b/packages/google-shopping-merchant-reviews/samples/generated_samples/merchantapi_v1beta_generated_product_reviews_service_insert_product_review_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-reviews/samples/generated_samples/merchantapi_v1beta_generated_product_reviews_service_list_product_reviews_async.py
+++ b/packages/google-shopping-merchant-reviews/samples/generated_samples/merchantapi_v1beta_generated_product_reviews_service_list_product_reviews_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-reviews/samples/generated_samples/merchantapi_v1beta_generated_product_reviews_service_list_product_reviews_sync.py
+++ b/packages/google-shopping-merchant-reviews/samples/generated_samples/merchantapi_v1beta_generated_product_reviews_service_list_product_reviews_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-reviews/tests/__init__.py
+++ b/packages/google-shopping-merchant-reviews/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-reviews/tests/unit/__init__.py
+++ b/packages/google-shopping-merchant-reviews/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-reviews/tests/unit/gapic/__init__.py
+++ b/packages/google-shopping-merchant-reviews/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-merchant-reviews/tests/unit/gapic/merchant_reviews_v1beta/__init__.py
+++ b/packages/google-shopping-merchant-reviews/tests/unit/gapic/merchant_reviews_v1beta/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-type/.flake8
+++ b/packages/google-shopping-type/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-type/MANIFEST.in
+++ b/packages/google-shopping-type/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-type/google/shopping/type/gapic_version.py
+++ b/packages/google-shopping-type/google/shopping/type/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-type/google/shopping/type/services/__init__.py
+++ b/packages/google-shopping-type/google/shopping/type/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-type/google/shopping/type/types/__init__.py
+++ b/packages/google-shopping-type/google/shopping/type/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-type/google/shopping/type/types/types.py
+++ b/packages/google-shopping-type/google/shopping/type/types/types.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-type/tests/__init__.py
+++ b/packages/google-shopping-type/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-type/tests/unit/__init__.py
+++ b/packages/google-shopping-type/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-type/tests/unit/gapic/__init__.py
+++ b/packages/google-shopping-type/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-shopping-type/tests/unit/gapic/type/__init__.py
+++ b/packages/google-shopping-type/tests/unit/gapic/type/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
This is the result of regenerating all packages, but only committing files which have only changed in a single line, and that's a copyright line.
