### PR TITLE
chore: regenerate remaining packages, copyright changes only

### DIFF
--- a/packages/google-ads-admanager/.flake8
+++ b/packages/google-ads-admanager/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/MANIFEST.in
+++ b/packages/google-ads-admanager/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager/__init__.py
+++ b/packages/google-ads-admanager/google/ads/admanager/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager/gapic_version.py
+++ b/packages/google-ads-admanager/google/ads/admanager/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/gapic_version.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/__init__.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/ad_break_service/__init__.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/ad_break_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/ad_break_service/client.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/ad_break_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/ad_break_service/pagers.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/ad_break_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/ad_break_service/transports/__init__.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/ad_break_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/ad_break_service/transports/base.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/ad_break_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/ad_break_service/transports/rest.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/ad_break_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/ad_break_service/transports/rest_base.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/ad_break_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/ad_review_center_ad_service/__init__.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/ad_review_center_ad_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/ad_review_center_ad_service/client.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/ad_review_center_ad_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/ad_review_center_ad_service/pagers.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/ad_review_center_ad_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/ad_review_center_ad_service/transports/__init__.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/ad_review_center_ad_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/ad_review_center_ad_service/transports/base.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/ad_review_center_ad_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/ad_review_center_ad_service/transports/rest.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/ad_review_center_ad_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/ad_review_center_ad_service/transports/rest_base.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/ad_review_center_ad_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/ad_unit_service/__init__.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/ad_unit_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/ad_unit_service/client.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/ad_unit_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/ad_unit_service/pagers.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/ad_unit_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/ad_unit_service/transports/__init__.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/ad_unit_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/ad_unit_service/transports/base.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/ad_unit_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/ad_unit_service/transports/rest.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/ad_unit_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/ad_unit_service/transports/rest_base.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/ad_unit_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/application_service/__init__.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/application_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/application_service/client.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/application_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/application_service/pagers.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/application_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/application_service/transports/__init__.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/application_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/application_service/transports/base.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/application_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/application_service/transports/rest.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/application_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/application_service/transports/rest_base.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/application_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/audience_segment_service/__init__.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/audience_segment_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/audience_segment_service/client.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/audience_segment_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/audience_segment_service/pagers.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/audience_segment_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/audience_segment_service/transports/__init__.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/audience_segment_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/audience_segment_service/transports/base.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/audience_segment_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/audience_segment_service/transports/rest.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/audience_segment_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/audience_segment_service/transports/rest_base.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/audience_segment_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/bandwidth_group_service/__init__.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/bandwidth_group_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/bandwidth_group_service/client.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/bandwidth_group_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/bandwidth_group_service/pagers.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/bandwidth_group_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/bandwidth_group_service/transports/__init__.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/bandwidth_group_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/bandwidth_group_service/transports/base.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/bandwidth_group_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/bandwidth_group_service/transports/rest.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/bandwidth_group_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/bandwidth_group_service/transports/rest_base.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/bandwidth_group_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/browser_language_service/__init__.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/browser_language_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/browser_language_service/client.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/browser_language_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/browser_language_service/pagers.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/browser_language_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/browser_language_service/transports/__init__.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/browser_language_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/browser_language_service/transports/base.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/browser_language_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/browser_language_service/transports/rest.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/browser_language_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/browser_language_service/transports/rest_base.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/browser_language_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/browser_service/__init__.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/browser_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/browser_service/client.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/browser_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/browser_service/pagers.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/browser_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/browser_service/transports/__init__.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/browser_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/browser_service/transports/base.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/browser_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/browser_service/transports/rest.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/browser_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/browser_service/transports/rest_base.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/browser_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/cms_metadata_key_service/__init__.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/cms_metadata_key_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/cms_metadata_key_service/client.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/cms_metadata_key_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/cms_metadata_key_service/pagers.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/cms_metadata_key_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/cms_metadata_key_service/transports/__init__.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/cms_metadata_key_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/cms_metadata_key_service/transports/base.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/cms_metadata_key_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/cms_metadata_key_service/transports/rest.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/cms_metadata_key_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/cms_metadata_key_service/transports/rest_base.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/cms_metadata_key_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/cms_metadata_value_service/__init__.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/cms_metadata_value_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/cms_metadata_value_service/client.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/cms_metadata_value_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/cms_metadata_value_service/pagers.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/cms_metadata_value_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/cms_metadata_value_service/transports/__init__.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/cms_metadata_value_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/cms_metadata_value_service/transports/base.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/cms_metadata_value_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/cms_metadata_value_service/transports/rest.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/cms_metadata_value_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/cms_metadata_value_service/transports/rest_base.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/cms_metadata_value_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/company_service/__init__.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/company_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/company_service/client.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/company_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/company_service/pagers.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/company_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/company_service/transports/__init__.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/company_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/company_service/transports/base.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/company_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/company_service/transports/rest.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/company_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/company_service/transports/rest_base.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/company_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/contact_service/__init__.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/contact_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/contact_service/client.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/contact_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/contact_service/pagers.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/contact_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/contact_service/transports/__init__.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/contact_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/contact_service/transports/base.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/contact_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/contact_service/transports/rest.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/contact_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/contact_service/transports/rest_base.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/contact_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/content_bundle_service/__init__.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/content_bundle_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/content_bundle_service/client.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/content_bundle_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/content_bundle_service/pagers.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/content_bundle_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/content_bundle_service/transports/__init__.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/content_bundle_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/content_bundle_service/transports/base.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/content_bundle_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/content_bundle_service/transports/rest.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/content_bundle_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/content_bundle_service/transports/rest_base.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/content_bundle_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/content_label_service/__init__.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/content_label_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/content_label_service/client.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/content_label_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/content_label_service/pagers.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/content_label_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/content_label_service/transports/__init__.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/content_label_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/content_label_service/transports/base.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/content_label_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/content_label_service/transports/rest.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/content_label_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/content_label_service/transports/rest_base.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/content_label_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/content_service/__init__.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/content_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/content_service/client.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/content_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/content_service/pagers.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/content_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/content_service/transports/__init__.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/content_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/content_service/transports/base.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/content_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/content_service/transports/rest.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/content_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/content_service/transports/rest_base.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/content_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/creative_template_service/__init__.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/creative_template_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/creative_template_service/client.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/creative_template_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/creative_template_service/pagers.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/creative_template_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/creative_template_service/transports/__init__.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/creative_template_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/creative_template_service/transports/base.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/creative_template_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/creative_template_service/transports/rest.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/creative_template_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/creative_template_service/transports/rest_base.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/creative_template_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/custom_field_service/__init__.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/custom_field_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/custom_field_service/client.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/custom_field_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/custom_field_service/pagers.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/custom_field_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/custom_field_service/transports/__init__.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/custom_field_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/custom_field_service/transports/base.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/custom_field_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/custom_field_service/transports/rest.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/custom_field_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/custom_field_service/transports/rest_base.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/custom_field_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/custom_targeting_key_service/__init__.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/custom_targeting_key_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/custom_targeting_key_service/client.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/custom_targeting_key_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/custom_targeting_key_service/pagers.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/custom_targeting_key_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/custom_targeting_key_service/transports/__init__.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/custom_targeting_key_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/custom_targeting_key_service/transports/base.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/custom_targeting_key_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/custom_targeting_key_service/transports/rest.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/custom_targeting_key_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/custom_targeting_key_service/transports/rest_base.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/custom_targeting_key_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/custom_targeting_value_service/__init__.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/custom_targeting_value_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/custom_targeting_value_service/client.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/custom_targeting_value_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/custom_targeting_value_service/pagers.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/custom_targeting_value_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/custom_targeting_value_service/transports/__init__.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/custom_targeting_value_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/custom_targeting_value_service/transports/base.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/custom_targeting_value_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/custom_targeting_value_service/transports/rest.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/custom_targeting_value_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/custom_targeting_value_service/transports/rest_base.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/custom_targeting_value_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/device_capability_service/__init__.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/device_capability_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/device_capability_service/client.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/device_capability_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/device_capability_service/pagers.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/device_capability_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/device_capability_service/transports/__init__.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/device_capability_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/device_capability_service/transports/base.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/device_capability_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/device_capability_service/transports/rest.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/device_capability_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/device_capability_service/transports/rest_base.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/device_capability_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/device_category_service/__init__.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/device_category_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/device_category_service/client.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/device_category_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/device_category_service/pagers.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/device_category_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/device_category_service/transports/__init__.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/device_category_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/device_category_service/transports/base.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/device_category_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/device_category_service/transports/rest.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/device_category_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/device_category_service/transports/rest_base.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/device_category_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/device_manufacturer_service/__init__.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/device_manufacturer_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/device_manufacturer_service/client.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/device_manufacturer_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/device_manufacturer_service/pagers.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/device_manufacturer_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/device_manufacturer_service/transports/__init__.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/device_manufacturer_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/device_manufacturer_service/transports/base.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/device_manufacturer_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/device_manufacturer_service/transports/rest.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/device_manufacturer_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/device_manufacturer_service/transports/rest_base.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/device_manufacturer_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/entity_signals_mapping_service/__init__.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/entity_signals_mapping_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/entity_signals_mapping_service/client.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/entity_signals_mapping_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/entity_signals_mapping_service/pagers.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/entity_signals_mapping_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/entity_signals_mapping_service/transports/__init__.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/entity_signals_mapping_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/entity_signals_mapping_service/transports/base.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/entity_signals_mapping_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/entity_signals_mapping_service/transports/rest.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/entity_signals_mapping_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/entity_signals_mapping_service/transports/rest_base.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/entity_signals_mapping_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/geo_target_service/__init__.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/geo_target_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/geo_target_service/client.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/geo_target_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/geo_target_service/pagers.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/geo_target_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/geo_target_service/transports/__init__.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/geo_target_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/geo_target_service/transports/base.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/geo_target_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/geo_target_service/transports/rest.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/geo_target_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/geo_target_service/transports/rest_base.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/geo_target_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/label_service/__init__.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/label_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/label_service/client.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/label_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/label_service/pagers.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/label_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/label_service/transports/__init__.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/label_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/label_service/transports/base.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/label_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/label_service/transports/rest.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/label_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/label_service/transports/rest_base.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/label_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/line_item_service/__init__.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/line_item_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/line_item_service/client.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/line_item_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/line_item_service/pagers.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/line_item_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/line_item_service/transports/__init__.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/line_item_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/line_item_service/transports/base.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/line_item_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/line_item_service/transports/rest.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/line_item_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/line_item_service/transports/rest_base.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/line_item_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/linked_device_service/__init__.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/linked_device_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/linked_device_service/client.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/linked_device_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/linked_device_service/pagers.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/linked_device_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/linked_device_service/transports/__init__.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/linked_device_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/linked_device_service/transports/base.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/linked_device_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/linked_device_service/transports/rest.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/linked_device_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/linked_device_service/transports/rest_base.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/linked_device_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/mcm_earnings_service/__init__.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/mcm_earnings_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/mcm_earnings_service/client.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/mcm_earnings_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/mcm_earnings_service/pagers.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/mcm_earnings_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/mcm_earnings_service/transports/__init__.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/mcm_earnings_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/mcm_earnings_service/transports/base.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/mcm_earnings_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/mcm_earnings_service/transports/rest.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/mcm_earnings_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/mcm_earnings_service/transports/rest_base.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/mcm_earnings_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/mobile_carrier_service/__init__.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/mobile_carrier_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/mobile_carrier_service/client.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/mobile_carrier_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/mobile_carrier_service/pagers.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/mobile_carrier_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/mobile_carrier_service/transports/__init__.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/mobile_carrier_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/mobile_carrier_service/transports/base.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/mobile_carrier_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/mobile_carrier_service/transports/rest.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/mobile_carrier_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/mobile_carrier_service/transports/rest_base.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/mobile_carrier_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/mobile_device_service/__init__.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/mobile_device_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/mobile_device_service/client.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/mobile_device_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/mobile_device_service/pagers.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/mobile_device_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/mobile_device_service/transports/__init__.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/mobile_device_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/mobile_device_service/transports/base.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/mobile_device_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/mobile_device_service/transports/rest.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/mobile_device_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/mobile_device_service/transports/rest_base.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/mobile_device_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/mobile_device_submodel_service/__init__.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/mobile_device_submodel_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/mobile_device_submodel_service/client.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/mobile_device_submodel_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/mobile_device_submodel_service/pagers.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/mobile_device_submodel_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/mobile_device_submodel_service/transports/__init__.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/mobile_device_submodel_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/mobile_device_submodel_service/transports/base.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/mobile_device_submodel_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/mobile_device_submodel_service/transports/rest.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/mobile_device_submodel_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/mobile_device_submodel_service/transports/rest_base.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/mobile_device_submodel_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/network_service/__init__.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/network_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/network_service/client.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/network_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/network_service/pagers.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/network_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/network_service/transports/__init__.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/network_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/network_service/transports/base.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/network_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/network_service/transports/rest.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/network_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/network_service/transports/rest_base.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/network_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/operating_system_service/__init__.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/operating_system_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/operating_system_service/client.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/operating_system_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/operating_system_service/pagers.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/operating_system_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/operating_system_service/transports/__init__.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/operating_system_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/operating_system_service/transports/base.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/operating_system_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/operating_system_service/transports/rest.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/operating_system_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/operating_system_service/transports/rest_base.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/operating_system_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/operating_system_version_service/__init__.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/operating_system_version_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/operating_system_version_service/client.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/operating_system_version_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/operating_system_version_service/pagers.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/operating_system_version_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/operating_system_version_service/transports/__init__.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/operating_system_version_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/operating_system_version_service/transports/base.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/operating_system_version_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/operating_system_version_service/transports/rest.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/operating_system_version_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/operating_system_version_service/transports/rest_base.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/operating_system_version_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/order_service/__init__.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/order_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/order_service/client.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/order_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/order_service/pagers.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/order_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/order_service/transports/__init__.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/order_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/order_service/transports/base.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/order_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/order_service/transports/rest.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/order_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/order_service/transports/rest_base.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/order_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/placement_service/__init__.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/placement_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/placement_service/client.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/placement_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/placement_service/pagers.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/placement_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/placement_service/transports/__init__.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/placement_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/placement_service/transports/base.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/placement_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/placement_service/transports/rest.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/placement_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/placement_service/transports/rest_base.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/placement_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/private_auction_deal_service/__init__.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/private_auction_deal_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/private_auction_deal_service/client.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/private_auction_deal_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/private_auction_deal_service/pagers.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/private_auction_deal_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/private_auction_deal_service/transports/__init__.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/private_auction_deal_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/private_auction_deal_service/transports/base.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/private_auction_deal_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/private_auction_deal_service/transports/rest.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/private_auction_deal_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/private_auction_deal_service/transports/rest_base.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/private_auction_deal_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/private_auction_service/__init__.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/private_auction_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/private_auction_service/client.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/private_auction_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/private_auction_service/pagers.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/private_auction_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/private_auction_service/transports/__init__.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/private_auction_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/private_auction_service/transports/base.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/private_auction_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/private_auction_service/transports/rest.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/private_auction_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/private_auction_service/transports/rest_base.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/private_auction_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/programmatic_buyer_service/__init__.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/programmatic_buyer_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/programmatic_buyer_service/client.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/programmatic_buyer_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/programmatic_buyer_service/pagers.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/programmatic_buyer_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/programmatic_buyer_service/transports/__init__.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/programmatic_buyer_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/programmatic_buyer_service/transports/base.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/programmatic_buyer_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/programmatic_buyer_service/transports/rest.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/programmatic_buyer_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/programmatic_buyer_service/transports/rest_base.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/programmatic_buyer_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/report_service/__init__.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/report_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/report_service/client.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/report_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/report_service/pagers.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/report_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/report_service/transports/__init__.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/report_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/report_service/transports/base.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/report_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/report_service/transports/rest.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/report_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/report_service/transports/rest_base.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/report_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/rich_media_ads_company_service/__init__.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/rich_media_ads_company_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/rich_media_ads_company_service/client.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/rich_media_ads_company_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/rich_media_ads_company_service/pagers.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/rich_media_ads_company_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/rich_media_ads_company_service/transports/__init__.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/rich_media_ads_company_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/rich_media_ads_company_service/transports/base.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/rich_media_ads_company_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/rich_media_ads_company_service/transports/rest.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/rich_media_ads_company_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/rich_media_ads_company_service/transports/rest_base.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/rich_media_ads_company_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/role_service/__init__.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/role_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/role_service/client.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/role_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/role_service/pagers.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/role_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/role_service/transports/__init__.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/role_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/role_service/transports/base.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/role_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/role_service/transports/rest.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/role_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/role_service/transports/rest_base.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/role_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/site_service/__init__.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/site_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/site_service/client.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/site_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/site_service/pagers.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/site_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/site_service/transports/__init__.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/site_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/site_service/transports/base.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/site_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/site_service/transports/rest.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/site_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/site_service/transports/rest_base.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/site_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/taxonomy_category_service/__init__.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/taxonomy_category_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/taxonomy_category_service/client.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/taxonomy_category_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/taxonomy_category_service/pagers.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/taxonomy_category_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/taxonomy_category_service/transports/__init__.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/taxonomy_category_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/taxonomy_category_service/transports/base.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/taxonomy_category_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/taxonomy_category_service/transports/rest.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/taxonomy_category_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/taxonomy_category_service/transports/rest_base.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/taxonomy_category_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/team_service/__init__.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/team_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/team_service/client.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/team_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/team_service/pagers.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/team_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/team_service/transports/__init__.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/team_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/team_service/transports/base.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/team_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/team_service/transports/rest.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/team_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/team_service/transports/rest_base.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/team_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/user_service/__init__.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/user_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/user_service/client.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/user_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/user_service/transports/__init__.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/user_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/user_service/transports/base.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/user_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/user_service/transports/rest.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/user_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/services/user_service/transports/rest_base.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/services/user_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/__init__.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/ad_break_messages.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/ad_break_messages.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/ad_break_service.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/ad_break_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/ad_review_center_ad_enums.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/ad_review_center_ad_enums.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/ad_review_center_ad_messages.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/ad_review_center_ad_messages.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/ad_review_center_ad_service.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/ad_review_center_ad_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/ad_unit_enums.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/ad_unit_enums.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/ad_unit_messages.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/ad_unit_messages.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/ad_unit_service.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/ad_unit_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/admanager_error.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/admanager_error.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/application_enums.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/application_enums.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/application_messages.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/application_messages.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/application_service.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/application_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/applied_label.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/applied_label.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/audience_segment_messages.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/audience_segment_messages.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/audience_segment_service.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/audience_segment_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/bandwidth_group_messages.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/bandwidth_group_messages.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/bandwidth_group_service.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/bandwidth_group_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/browser_language_messages.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/browser_language_messages.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/browser_language_service.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/browser_language_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/browser_messages.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/browser_messages.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/browser_service.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/browser_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/child_publisher_messages.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/child_publisher_messages.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/cms_metadata_key_enums.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/cms_metadata_key_enums.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/cms_metadata_key_messages.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/cms_metadata_key_messages.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/cms_metadata_key_service.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/cms_metadata_key_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/cms_metadata_value_enums.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/cms_metadata_value_enums.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/cms_metadata_value_messages.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/cms_metadata_value_messages.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/cms_metadata_value_service.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/cms_metadata_value_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/company_enums.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/company_enums.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/company_messages.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/company_messages.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/company_service.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/company_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/contact_enums.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/contact_enums.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/contact_messages.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/contact_messages.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/contact_service.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/contact_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/content_bundle_messages.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/content_bundle_messages.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/content_bundle_service.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/content_bundle_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/content_label_messages.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/content_label_messages.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/content_label_service.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/content_label_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/content_messages.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/content_messages.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/content_service.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/content_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/creative_template_enums.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/creative_template_enums.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/creative_template_messages.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/creative_template_messages.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/creative_template_service.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/creative_template_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/creative_template_variable_url_type_enum.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/creative_template_variable_url_type_enum.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/custom_field_enums.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/custom_field_enums.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/custom_field_messages.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/custom_field_messages.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/custom_field_service.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/custom_field_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/custom_field_value.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/custom_field_value.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/custom_targeting_key_enums.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/custom_targeting_key_enums.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/custom_targeting_key_messages.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/custom_targeting_key_messages.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/custom_targeting_key_service.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/custom_targeting_key_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/custom_targeting_value_enums.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/custom_targeting_value_enums.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/custom_targeting_value_messages.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/custom_targeting_value_messages.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/custom_targeting_value_service.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/custom_targeting_value_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/deal_buyer_permission_type_enum.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/deal_buyer_permission_type_enum.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/device_capability_messages.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/device_capability_messages.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/device_capability_service.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/device_capability_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/device_category_messages.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/device_category_messages.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/device_category_service.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/device_category_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/device_manufacturer_messages.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/device_manufacturer_messages.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/device_manufacturer_service.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/device_manufacturer_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/early_ad_break_notification_enums.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/early_ad_break_notification_enums.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/entity_signals_mapping_messages.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/entity_signals_mapping_messages.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/entity_signals_mapping_service.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/entity_signals_mapping_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/environment_type_enum.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/environment_type_enum.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/exchange_syndication_product_enum.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/exchange_syndication_product_enum.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/frequency_cap.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/frequency_cap.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/geo_target_messages.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/geo_target_messages.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/geo_target_service.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/geo_target_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/goal.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/goal.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/goal_enums.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/goal_enums.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/label_enums.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/label_enums.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/label_messages.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/label_messages.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/label_service.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/label_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/line_item_enums.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/line_item_enums.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/line_item_messages.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/line_item_messages.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/line_item_service.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/line_item_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/linked_device_enums.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/linked_device_enums.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/linked_device_messages.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/linked_device_messages.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/linked_device_service.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/linked_device_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/live_stream_event_messages.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/live_stream_event_messages.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/mcm_earnings_messages.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/mcm_earnings_messages.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/mcm_earnings_service.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/mcm_earnings_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/mcm_enums.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/mcm_enums.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/mobile_carrier_messages.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/mobile_carrier_messages.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/mobile_carrier_service.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/mobile_carrier_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/mobile_device_messages.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/mobile_device_messages.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/mobile_device_service.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/mobile_device_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/mobile_device_submodel_messages.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/mobile_device_submodel_messages.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/mobile_device_submodel_service.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/mobile_device_submodel_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/network_messages.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/network_messages.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/network_service.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/network_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/operating_system_messages.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/operating_system_messages.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/operating_system_service.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/operating_system_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/operating_system_version_messages.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/operating_system_version_messages.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/operating_system_version_service.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/operating_system_version_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/order_enums.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/order_enums.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/order_messages.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/order_messages.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/order_service.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/order_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/placement_enums.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/placement_enums.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/placement_messages.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/placement_messages.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/placement_service.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/placement_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/private_auction_deal_messages.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/private_auction_deal_messages.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/private_auction_deal_service.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/private_auction_deal_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/private_auction_messages.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/private_auction_messages.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/private_auction_service.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/private_auction_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/private_marketplace_enums.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/private_marketplace_enums.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/programmatic_buyer_messages.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/programmatic_buyer_messages.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/programmatic_buyer_service.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/programmatic_buyer_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/report_definition.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/report_definition.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/report_messages.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/report_messages.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/report_service.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/report_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/report_value.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/report_value.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/request_platform_enum.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/request_platform_enum.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/rich_media_ads_company_enums.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/rich_media_ads_company_enums.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/rich_media_ads_company_messages.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/rich_media_ads_company_messages.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/rich_media_ads_company_service.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/rich_media_ads_company_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/role_enums.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/role_enums.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/role_messages.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/role_messages.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/role_service.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/role_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/site_enums.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/site_enums.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/site_messages.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/site_messages.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/site_service.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/site_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/size.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/size.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/size_type_enum.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/size_type_enum.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/targeted_video_bumper_type_enum.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/targeted_video_bumper_type_enum.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/targeting.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/targeting.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/taxonomy_category_messages.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/taxonomy_category_messages.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/taxonomy_category_service.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/taxonomy_category_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/taxonomy_type_enum.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/taxonomy_type_enum.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/team_enums.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/team_enums.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/team_messages.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/team_messages.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/team_service.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/team_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/time_unit_enum.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/time_unit_enum.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/user_messages.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/user_messages.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/user_service.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/user_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/video_position_enum.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/video_position_enum.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/google/ads/admanager_v1/types/web_property.py
+++ b/packages/google-ads-admanager/google/ads/admanager_v1/types/web_property.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_ad_break_service_create_ad_break_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_ad_break_service_create_ad_break_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_ad_break_service_delete_ad_break_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_ad_break_service_delete_ad_break_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_ad_break_service_get_ad_break_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_ad_break_service_get_ad_break_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_ad_break_service_list_ad_breaks_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_ad_break_service_list_ad_breaks_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_ad_break_service_update_ad_break_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_ad_break_service_update_ad_break_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_ad_review_center_ad_service_batch_allow_ad_review_center_ads_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_ad_review_center_ad_service_batch_allow_ad_review_center_ads_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_ad_review_center_ad_service_batch_block_ad_review_center_ads_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_ad_review_center_ad_service_batch_block_ad_review_center_ads_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_ad_review_center_ad_service_search_ad_review_center_ads_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_ad_review_center_ad_service_search_ad_review_center_ads_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_ad_unit_service_batch_activate_ad_units_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_ad_unit_service_batch_activate_ad_units_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_ad_unit_service_batch_archive_ad_units_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_ad_unit_service_batch_archive_ad_units_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_ad_unit_service_batch_create_ad_units_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_ad_unit_service_batch_create_ad_units_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_ad_unit_service_batch_deactivate_ad_units_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_ad_unit_service_batch_deactivate_ad_units_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_ad_unit_service_batch_update_ad_units_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_ad_unit_service_batch_update_ad_units_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_ad_unit_service_create_ad_unit_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_ad_unit_service_create_ad_unit_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_ad_unit_service_get_ad_unit_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_ad_unit_service_get_ad_unit_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_ad_unit_service_list_ad_unit_sizes_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_ad_unit_service_list_ad_unit_sizes_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_ad_unit_service_list_ad_units_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_ad_unit_service_list_ad_units_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_ad_unit_service_update_ad_unit_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_ad_unit_service_update_ad_unit_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_application_service_batch_archive_applications_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_application_service_batch_archive_applications_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_application_service_batch_create_applications_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_application_service_batch_create_applications_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_application_service_batch_unarchive_applications_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_application_service_batch_unarchive_applications_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_application_service_batch_update_applications_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_application_service_batch_update_applications_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_application_service_create_application_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_application_service_create_application_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_application_service_get_application_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_application_service_get_application_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_application_service_list_applications_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_application_service_list_applications_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_application_service_update_application_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_application_service_update_application_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_audience_segment_service_get_audience_segment_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_audience_segment_service_get_audience_segment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_audience_segment_service_list_audience_segments_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_audience_segment_service_list_audience_segments_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_bandwidth_group_service_get_bandwidth_group_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_bandwidth_group_service_get_bandwidth_group_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_bandwidth_group_service_list_bandwidth_groups_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_bandwidth_group_service_list_bandwidth_groups_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_browser_language_service_get_browser_language_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_browser_language_service_get_browser_language_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_browser_language_service_list_browser_languages_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_browser_language_service_list_browser_languages_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_browser_service_get_browser_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_browser_service_get_browser_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_browser_service_list_browsers_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_browser_service_list_browsers_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_cms_metadata_key_service_batch_activate_cms_metadata_keys_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_cms_metadata_key_service_batch_activate_cms_metadata_keys_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_cms_metadata_key_service_batch_deactivate_cms_metadata_keys_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_cms_metadata_key_service_batch_deactivate_cms_metadata_keys_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_cms_metadata_key_service_get_cms_metadata_key_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_cms_metadata_key_service_get_cms_metadata_key_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_cms_metadata_key_service_list_cms_metadata_keys_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_cms_metadata_key_service_list_cms_metadata_keys_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_cms_metadata_value_service_batch_activate_cms_metadata_values_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_cms_metadata_value_service_batch_activate_cms_metadata_values_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_cms_metadata_value_service_batch_deactivate_cms_metadata_values_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_cms_metadata_value_service_batch_deactivate_cms_metadata_values_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_cms_metadata_value_service_get_cms_metadata_value_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_cms_metadata_value_service_get_cms_metadata_value_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_cms_metadata_value_service_list_cms_metadata_values_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_cms_metadata_value_service_list_cms_metadata_values_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_company_service_get_company_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_company_service_get_company_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_company_service_list_companies_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_company_service_list_companies_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_contact_service_batch_create_contacts_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_contact_service_batch_create_contacts_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_contact_service_batch_update_contacts_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_contact_service_batch_update_contacts_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_contact_service_create_contact_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_contact_service_create_contact_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_contact_service_get_contact_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_contact_service_get_contact_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_contact_service_list_contacts_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_contact_service_list_contacts_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_contact_service_update_contact_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_contact_service_update_contact_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_content_bundle_service_get_content_bundle_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_content_bundle_service_get_content_bundle_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_content_bundle_service_list_content_bundles_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_content_bundle_service_list_content_bundles_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_content_label_service_get_content_label_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_content_label_service_get_content_label_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_content_label_service_list_content_labels_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_content_label_service_list_content_labels_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_content_service_get_content_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_content_service_get_content_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_content_service_list_content_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_content_service_list_content_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_creative_template_service_get_creative_template_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_creative_template_service_get_creative_template_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_creative_template_service_list_creative_templates_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_creative_template_service_list_creative_templates_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_custom_field_service_batch_activate_custom_fields_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_custom_field_service_batch_activate_custom_fields_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_custom_field_service_batch_create_custom_fields_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_custom_field_service_batch_create_custom_fields_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_custom_field_service_batch_deactivate_custom_fields_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_custom_field_service_batch_deactivate_custom_fields_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_custom_field_service_batch_update_custom_fields_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_custom_field_service_batch_update_custom_fields_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_custom_field_service_create_custom_field_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_custom_field_service_create_custom_field_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_custom_field_service_get_custom_field_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_custom_field_service_get_custom_field_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_custom_field_service_list_custom_fields_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_custom_field_service_list_custom_fields_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_custom_field_service_update_custom_field_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_custom_field_service_update_custom_field_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_custom_targeting_key_service_batch_activate_custom_targeting_keys_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_custom_targeting_key_service_batch_activate_custom_targeting_keys_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_custom_targeting_key_service_batch_create_custom_targeting_keys_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_custom_targeting_key_service_batch_create_custom_targeting_keys_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_custom_targeting_key_service_batch_deactivate_custom_targeting_keys_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_custom_targeting_key_service_batch_deactivate_custom_targeting_keys_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_custom_targeting_key_service_batch_update_custom_targeting_keys_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_custom_targeting_key_service_batch_update_custom_targeting_keys_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_custom_targeting_key_service_create_custom_targeting_key_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_custom_targeting_key_service_create_custom_targeting_key_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_custom_targeting_key_service_get_custom_targeting_key_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_custom_targeting_key_service_get_custom_targeting_key_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_custom_targeting_key_service_list_custom_targeting_keys_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_custom_targeting_key_service_list_custom_targeting_keys_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_custom_targeting_key_service_update_custom_targeting_key_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_custom_targeting_key_service_update_custom_targeting_key_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_custom_targeting_value_service_get_custom_targeting_value_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_custom_targeting_value_service_get_custom_targeting_value_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_custom_targeting_value_service_list_custom_targeting_values_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_custom_targeting_value_service_list_custom_targeting_values_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_device_capability_service_get_device_capability_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_device_capability_service_get_device_capability_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_device_capability_service_list_device_capabilities_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_device_capability_service_list_device_capabilities_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_device_category_service_get_device_category_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_device_category_service_get_device_category_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_device_category_service_list_device_categories_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_device_category_service_list_device_categories_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_device_manufacturer_service_get_device_manufacturer_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_device_manufacturer_service_get_device_manufacturer_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_device_manufacturer_service_list_device_manufacturers_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_device_manufacturer_service_list_device_manufacturers_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_entity_signals_mapping_service_batch_create_entity_signals_mappings_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_entity_signals_mapping_service_batch_create_entity_signals_mappings_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_entity_signals_mapping_service_batch_update_entity_signals_mappings_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_entity_signals_mapping_service_batch_update_entity_signals_mappings_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_entity_signals_mapping_service_create_entity_signals_mapping_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_entity_signals_mapping_service_create_entity_signals_mapping_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_entity_signals_mapping_service_get_entity_signals_mapping_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_entity_signals_mapping_service_get_entity_signals_mapping_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_entity_signals_mapping_service_list_entity_signals_mappings_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_entity_signals_mapping_service_list_entity_signals_mappings_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_entity_signals_mapping_service_update_entity_signals_mapping_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_entity_signals_mapping_service_update_entity_signals_mapping_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_geo_target_service_get_geo_target_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_geo_target_service_get_geo_target_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_geo_target_service_list_geo_targets_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_geo_target_service_list_geo_targets_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_label_service_batch_activate_labels_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_label_service_batch_activate_labels_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_label_service_batch_create_labels_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_label_service_batch_create_labels_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_label_service_batch_deactivate_labels_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_label_service_batch_deactivate_labels_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_label_service_batch_update_labels_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_label_service_batch_update_labels_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_label_service_create_label_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_label_service_create_label_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_label_service_get_label_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_label_service_get_label_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_label_service_list_labels_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_label_service_list_labels_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_label_service_update_label_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_label_service_update_label_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_line_item_service_get_line_item_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_line_item_service_get_line_item_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_line_item_service_list_line_items_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_line_item_service_list_line_items_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_linked_device_service_get_linked_device_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_linked_device_service_get_linked_device_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_linked_device_service_list_linked_devices_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_linked_device_service_list_linked_devices_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_mcm_earnings_service_fetch_mcm_earnings_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_mcm_earnings_service_fetch_mcm_earnings_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_mobile_carrier_service_get_mobile_carrier_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_mobile_carrier_service_get_mobile_carrier_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_mobile_carrier_service_list_mobile_carriers_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_mobile_carrier_service_list_mobile_carriers_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_mobile_device_service_get_mobile_device_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_mobile_device_service_get_mobile_device_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_mobile_device_service_list_mobile_devices_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_mobile_device_service_list_mobile_devices_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_mobile_device_submodel_service_get_mobile_device_submodel_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_mobile_device_submodel_service_get_mobile_device_submodel_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_mobile_device_submodel_service_list_mobile_device_submodels_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_mobile_device_submodel_service_list_mobile_device_submodels_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_network_service_get_network_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_network_service_get_network_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_network_service_list_networks_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_network_service_list_networks_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_operating_system_service_get_operating_system_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_operating_system_service_get_operating_system_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_operating_system_service_list_operating_systems_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_operating_system_service_list_operating_systems_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_operating_system_version_service_get_operating_system_version_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_operating_system_version_service_get_operating_system_version_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_operating_system_version_service_list_operating_system_versions_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_operating_system_version_service_list_operating_system_versions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_order_service_get_order_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_order_service_get_order_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_order_service_list_orders_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_order_service_list_orders_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_placement_service_batch_activate_placements_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_placement_service_batch_activate_placements_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_placement_service_batch_archive_placements_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_placement_service_batch_archive_placements_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_placement_service_batch_create_placements_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_placement_service_batch_create_placements_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_placement_service_batch_deactivate_placements_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_placement_service_batch_deactivate_placements_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_placement_service_batch_update_placements_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_placement_service_batch_update_placements_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_placement_service_create_placement_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_placement_service_create_placement_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_placement_service_get_placement_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_placement_service_get_placement_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_placement_service_list_placements_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_placement_service_list_placements_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_placement_service_update_placement_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_placement_service_update_placement_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_private_auction_deal_service_create_private_auction_deal_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_private_auction_deal_service_create_private_auction_deal_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_private_auction_deal_service_get_private_auction_deal_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_private_auction_deal_service_get_private_auction_deal_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_private_auction_deal_service_list_private_auction_deals_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_private_auction_deal_service_list_private_auction_deals_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_private_auction_deal_service_update_private_auction_deal_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_private_auction_deal_service_update_private_auction_deal_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_private_auction_service_create_private_auction_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_private_auction_service_create_private_auction_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_private_auction_service_get_private_auction_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_private_auction_service_get_private_auction_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_private_auction_service_list_private_auctions_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_private_auction_service_list_private_auctions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_private_auction_service_update_private_auction_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_private_auction_service_update_private_auction_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_programmatic_buyer_service_get_programmatic_buyer_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_programmatic_buyer_service_get_programmatic_buyer_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_programmatic_buyer_service_list_programmatic_buyers_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_programmatic_buyer_service_list_programmatic_buyers_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_report_service_create_report_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_report_service_create_report_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_report_service_fetch_report_result_rows_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_report_service_fetch_report_result_rows_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_report_service_get_report_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_report_service_get_report_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_report_service_list_reports_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_report_service_list_reports_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_report_service_run_report_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_report_service_run_report_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_report_service_update_report_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_report_service_update_report_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_rich_media_ads_company_service_get_rich_media_ads_company_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_rich_media_ads_company_service_get_rich_media_ads_company_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_rich_media_ads_company_service_list_rich_media_ads_companies_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_rich_media_ads_company_service_list_rich_media_ads_companies_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_role_service_get_role_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_role_service_get_role_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_role_service_list_roles_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_role_service_list_roles_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_site_service_batch_create_sites_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_site_service_batch_create_sites_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_site_service_batch_deactivate_sites_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_site_service_batch_deactivate_sites_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_site_service_batch_submit_sites_for_approval_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_site_service_batch_submit_sites_for_approval_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_site_service_batch_update_sites_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_site_service_batch_update_sites_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_site_service_create_site_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_site_service_create_site_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_site_service_get_site_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_site_service_get_site_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_site_service_list_sites_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_site_service_list_sites_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_site_service_update_site_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_site_service_update_site_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_taxonomy_category_service_get_taxonomy_category_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_taxonomy_category_service_get_taxonomy_category_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_taxonomy_category_service_list_taxonomy_categories_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_taxonomy_category_service_list_taxonomy_categories_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_team_service_batch_activate_teams_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_team_service_batch_activate_teams_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_team_service_batch_create_teams_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_team_service_batch_create_teams_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_team_service_batch_deactivate_teams_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_team_service_batch_deactivate_teams_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_team_service_batch_update_teams_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_team_service_batch_update_teams_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_team_service_create_team_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_team_service_create_team_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_team_service_get_team_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_team_service_get_team_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_team_service_list_teams_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_team_service_list_teams_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_team_service_update_team_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_team_service_update_team_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_user_service_get_user_sync.py
+++ b/packages/google-ads-admanager/samples/generated_samples/admanager_v1_generated_user_service_get_user_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/tests/__init__.py
+++ b/packages/google-ads-admanager/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/tests/unit/__init__.py
+++ b/packages/google-ads-admanager/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/tests/unit/gapic/__init__.py
+++ b/packages/google-ads-admanager/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-admanager/tests/unit/gapic/admanager_v1/__init__.py
+++ b/packages/google-ads-admanager/tests/unit/gapic/admanager_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/.flake8
+++ b/packages/google-ads-datamanager/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/MANIFEST.in
+++ b/packages/google-ads-datamanager/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/google/ads/datamanager/__init__.py
+++ b/packages/google-ads-datamanager/google/ads/datamanager/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/google/ads/datamanager/gapic_version.py
+++ b/packages/google-ads-datamanager/google/ads/datamanager/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/google/ads/datamanager_v1/gapic_version.py
+++ b/packages/google-ads-datamanager/google/ads/datamanager_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/google/ads/datamanager_v1/services/__init__.py
+++ b/packages/google-ads-datamanager/google/ads/datamanager_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/google/ads/datamanager_v1/services/ingestion_service/__init__.py
+++ b/packages/google-ads-datamanager/google/ads/datamanager_v1/services/ingestion_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/google/ads/datamanager_v1/services/ingestion_service/async_client.py
+++ b/packages/google-ads-datamanager/google/ads/datamanager_v1/services/ingestion_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/google/ads/datamanager_v1/services/ingestion_service/client.py
+++ b/packages/google-ads-datamanager/google/ads/datamanager_v1/services/ingestion_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/google/ads/datamanager_v1/services/ingestion_service/transports/__init__.py
+++ b/packages/google-ads-datamanager/google/ads/datamanager_v1/services/ingestion_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/google/ads/datamanager_v1/services/ingestion_service/transports/base.py
+++ b/packages/google-ads-datamanager/google/ads/datamanager_v1/services/ingestion_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/google/ads/datamanager_v1/services/ingestion_service/transports/grpc.py
+++ b/packages/google-ads-datamanager/google/ads/datamanager_v1/services/ingestion_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/google/ads/datamanager_v1/services/ingestion_service/transports/grpc_asyncio.py
+++ b/packages/google-ads-datamanager/google/ads/datamanager_v1/services/ingestion_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/google/ads/datamanager_v1/services/ingestion_service/transports/rest.py
+++ b/packages/google-ads-datamanager/google/ads/datamanager_v1/services/ingestion_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/google/ads/datamanager_v1/services/ingestion_service/transports/rest_base.py
+++ b/packages/google-ads-datamanager/google/ads/datamanager_v1/services/ingestion_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/google/ads/datamanager_v1/services/marketing_data_insights_service/__init__.py
+++ b/packages/google-ads-datamanager/google/ads/datamanager_v1/services/marketing_data_insights_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/google/ads/datamanager_v1/services/marketing_data_insights_service/async_client.py
+++ b/packages/google-ads-datamanager/google/ads/datamanager_v1/services/marketing_data_insights_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/google/ads/datamanager_v1/services/marketing_data_insights_service/client.py
+++ b/packages/google-ads-datamanager/google/ads/datamanager_v1/services/marketing_data_insights_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/google/ads/datamanager_v1/services/marketing_data_insights_service/transports/__init__.py
+++ b/packages/google-ads-datamanager/google/ads/datamanager_v1/services/marketing_data_insights_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/google/ads/datamanager_v1/services/marketing_data_insights_service/transports/base.py
+++ b/packages/google-ads-datamanager/google/ads/datamanager_v1/services/marketing_data_insights_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/google/ads/datamanager_v1/services/marketing_data_insights_service/transports/grpc.py
+++ b/packages/google-ads-datamanager/google/ads/datamanager_v1/services/marketing_data_insights_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/google/ads/datamanager_v1/services/marketing_data_insights_service/transports/grpc_asyncio.py
+++ b/packages/google-ads-datamanager/google/ads/datamanager_v1/services/marketing_data_insights_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/google/ads/datamanager_v1/services/marketing_data_insights_service/transports/rest.py
+++ b/packages/google-ads-datamanager/google/ads/datamanager_v1/services/marketing_data_insights_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/google/ads/datamanager_v1/services/marketing_data_insights_service/transports/rest_base.py
+++ b/packages/google-ads-datamanager/google/ads/datamanager_v1/services/marketing_data_insights_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/google/ads/datamanager_v1/services/partner_link_service/__init__.py
+++ b/packages/google-ads-datamanager/google/ads/datamanager_v1/services/partner_link_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/google/ads/datamanager_v1/services/partner_link_service/async_client.py
+++ b/packages/google-ads-datamanager/google/ads/datamanager_v1/services/partner_link_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/google/ads/datamanager_v1/services/partner_link_service/client.py
+++ b/packages/google-ads-datamanager/google/ads/datamanager_v1/services/partner_link_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/google/ads/datamanager_v1/services/partner_link_service/pagers.py
+++ b/packages/google-ads-datamanager/google/ads/datamanager_v1/services/partner_link_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/google/ads/datamanager_v1/services/partner_link_service/transports/__init__.py
+++ b/packages/google-ads-datamanager/google/ads/datamanager_v1/services/partner_link_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/google/ads/datamanager_v1/services/partner_link_service/transports/base.py
+++ b/packages/google-ads-datamanager/google/ads/datamanager_v1/services/partner_link_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/google/ads/datamanager_v1/services/partner_link_service/transports/grpc.py
+++ b/packages/google-ads-datamanager/google/ads/datamanager_v1/services/partner_link_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/google/ads/datamanager_v1/services/partner_link_service/transports/grpc_asyncio.py
+++ b/packages/google-ads-datamanager/google/ads/datamanager_v1/services/partner_link_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/google/ads/datamanager_v1/services/partner_link_service/transports/rest.py
+++ b/packages/google-ads-datamanager/google/ads/datamanager_v1/services/partner_link_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/google/ads/datamanager_v1/services/partner_link_service/transports/rest_base.py
+++ b/packages/google-ads-datamanager/google/ads/datamanager_v1/services/partner_link_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/google/ads/datamanager_v1/services/user_list_direct_license_service/__init__.py
+++ b/packages/google-ads-datamanager/google/ads/datamanager_v1/services/user_list_direct_license_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/google/ads/datamanager_v1/services/user_list_direct_license_service/async_client.py
+++ b/packages/google-ads-datamanager/google/ads/datamanager_v1/services/user_list_direct_license_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/google/ads/datamanager_v1/services/user_list_direct_license_service/client.py
+++ b/packages/google-ads-datamanager/google/ads/datamanager_v1/services/user_list_direct_license_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/google/ads/datamanager_v1/services/user_list_direct_license_service/pagers.py
+++ b/packages/google-ads-datamanager/google/ads/datamanager_v1/services/user_list_direct_license_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/google/ads/datamanager_v1/services/user_list_direct_license_service/transports/__init__.py
+++ b/packages/google-ads-datamanager/google/ads/datamanager_v1/services/user_list_direct_license_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/google/ads/datamanager_v1/services/user_list_direct_license_service/transports/base.py
+++ b/packages/google-ads-datamanager/google/ads/datamanager_v1/services/user_list_direct_license_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/google/ads/datamanager_v1/services/user_list_direct_license_service/transports/grpc.py
+++ b/packages/google-ads-datamanager/google/ads/datamanager_v1/services/user_list_direct_license_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/google/ads/datamanager_v1/services/user_list_direct_license_service/transports/grpc_asyncio.py
+++ b/packages/google-ads-datamanager/google/ads/datamanager_v1/services/user_list_direct_license_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/google/ads/datamanager_v1/services/user_list_direct_license_service/transports/rest.py
+++ b/packages/google-ads-datamanager/google/ads/datamanager_v1/services/user_list_direct_license_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/google/ads/datamanager_v1/services/user_list_direct_license_service/transports/rest_base.py
+++ b/packages/google-ads-datamanager/google/ads/datamanager_v1/services/user_list_direct_license_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/google/ads/datamanager_v1/services/user_list_global_license_service/__init__.py
+++ b/packages/google-ads-datamanager/google/ads/datamanager_v1/services/user_list_global_license_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/google/ads/datamanager_v1/services/user_list_global_license_service/async_client.py
+++ b/packages/google-ads-datamanager/google/ads/datamanager_v1/services/user_list_global_license_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/google/ads/datamanager_v1/services/user_list_global_license_service/client.py
+++ b/packages/google-ads-datamanager/google/ads/datamanager_v1/services/user_list_global_license_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/google/ads/datamanager_v1/services/user_list_global_license_service/pagers.py
+++ b/packages/google-ads-datamanager/google/ads/datamanager_v1/services/user_list_global_license_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/google/ads/datamanager_v1/services/user_list_global_license_service/transports/__init__.py
+++ b/packages/google-ads-datamanager/google/ads/datamanager_v1/services/user_list_global_license_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/google/ads/datamanager_v1/services/user_list_global_license_service/transports/base.py
+++ b/packages/google-ads-datamanager/google/ads/datamanager_v1/services/user_list_global_license_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/google/ads/datamanager_v1/services/user_list_global_license_service/transports/grpc.py
+++ b/packages/google-ads-datamanager/google/ads/datamanager_v1/services/user_list_global_license_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/google/ads/datamanager_v1/services/user_list_global_license_service/transports/grpc_asyncio.py
+++ b/packages/google-ads-datamanager/google/ads/datamanager_v1/services/user_list_global_license_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/google/ads/datamanager_v1/services/user_list_global_license_service/transports/rest.py
+++ b/packages/google-ads-datamanager/google/ads/datamanager_v1/services/user_list_global_license_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/google/ads/datamanager_v1/services/user_list_global_license_service/transports/rest_base.py
+++ b/packages/google-ads-datamanager/google/ads/datamanager_v1/services/user_list_global_license_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/google/ads/datamanager_v1/services/user_list_service/__init__.py
+++ b/packages/google-ads-datamanager/google/ads/datamanager_v1/services/user_list_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/google/ads/datamanager_v1/services/user_list_service/async_client.py
+++ b/packages/google-ads-datamanager/google/ads/datamanager_v1/services/user_list_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/google/ads/datamanager_v1/services/user_list_service/client.py
+++ b/packages/google-ads-datamanager/google/ads/datamanager_v1/services/user_list_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/google/ads/datamanager_v1/services/user_list_service/pagers.py
+++ b/packages/google-ads-datamanager/google/ads/datamanager_v1/services/user_list_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/google/ads/datamanager_v1/services/user_list_service/transports/__init__.py
+++ b/packages/google-ads-datamanager/google/ads/datamanager_v1/services/user_list_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/google/ads/datamanager_v1/services/user_list_service/transports/base.py
+++ b/packages/google-ads-datamanager/google/ads/datamanager_v1/services/user_list_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/google/ads/datamanager_v1/services/user_list_service/transports/grpc.py
+++ b/packages/google-ads-datamanager/google/ads/datamanager_v1/services/user_list_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/google/ads/datamanager_v1/services/user_list_service/transports/grpc_asyncio.py
+++ b/packages/google-ads-datamanager/google/ads/datamanager_v1/services/user_list_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/google/ads/datamanager_v1/services/user_list_service/transports/rest.py
+++ b/packages/google-ads-datamanager/google/ads/datamanager_v1/services/user_list_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/google/ads/datamanager_v1/services/user_list_service/transports/rest_base.py
+++ b/packages/google-ads-datamanager/google/ads/datamanager_v1/services/user_list_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/google/ads/datamanager_v1/types/__init__.py
+++ b/packages/google-ads-datamanager/google/ads/datamanager_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/google/ads/datamanager_v1/types/age_range.py
+++ b/packages/google-ads-datamanager/google/ads/datamanager_v1/types/age_range.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/google/ads/datamanager_v1/types/audience.py
+++ b/packages/google-ads-datamanager/google/ads/datamanager_v1/types/audience.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/google/ads/datamanager_v1/types/cart_data.py
+++ b/packages/google-ads-datamanager/google/ads/datamanager_v1/types/cart_data.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/google/ads/datamanager_v1/types/consent.py
+++ b/packages/google-ads-datamanager/google/ads/datamanager_v1/types/consent.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/google/ads/datamanager_v1/types/destination.py
+++ b/packages/google-ads-datamanager/google/ads/datamanager_v1/types/destination.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/google/ads/datamanager_v1/types/device_info.py
+++ b/packages/google-ads-datamanager/google/ads/datamanager_v1/types/device_info.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/google/ads/datamanager_v1/types/encryption_info.py
+++ b/packages/google-ads-datamanager/google/ads/datamanager_v1/types/encryption_info.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/google/ads/datamanager_v1/types/error.py
+++ b/packages/google-ads-datamanager/google/ads/datamanager_v1/types/error.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/google/ads/datamanager_v1/types/event.py
+++ b/packages/google-ads-datamanager/google/ads/datamanager_v1/types/event.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/google/ads/datamanager_v1/types/experimental_field.py
+++ b/packages/google-ads-datamanager/google/ads/datamanager_v1/types/experimental_field.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/google/ads/datamanager_v1/types/gender.py
+++ b/packages/google-ads-datamanager/google/ads/datamanager_v1/types/gender.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/google/ads/datamanager_v1/types/ingestion_service.py
+++ b/packages/google-ads-datamanager/google/ads/datamanager_v1/types/ingestion_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/google/ads/datamanager_v1/types/insights_service.py
+++ b/packages/google-ads-datamanager/google/ads/datamanager_v1/types/insights_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/google/ads/datamanager_v1/types/item_parameter.py
+++ b/packages/google-ads-datamanager/google/ads/datamanager_v1/types/item_parameter.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/google/ads/datamanager_v1/types/match_rate.py
+++ b/packages/google-ads-datamanager/google/ads/datamanager_v1/types/match_rate.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/google/ads/datamanager_v1/types/partner_link_service.py
+++ b/packages/google-ads-datamanager/google/ads/datamanager_v1/types/partner_link_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/google/ads/datamanager_v1/types/processing_errors.py
+++ b/packages/google-ads-datamanager/google/ads/datamanager_v1/types/processing_errors.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/google/ads/datamanager_v1/types/request_status_per_destination.py
+++ b/packages/google-ads-datamanager/google/ads/datamanager_v1/types/request_status_per_destination.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/google/ads/datamanager_v1/types/terms_of_service.py
+++ b/packages/google-ads-datamanager/google/ads/datamanager_v1/types/terms_of_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/google/ads/datamanager_v1/types/user_data.py
+++ b/packages/google-ads-datamanager/google/ads/datamanager_v1/types/user_data.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/google/ads/datamanager_v1/types/user_list.py
+++ b/packages/google-ads-datamanager/google/ads/datamanager_v1/types/user_list.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/google/ads/datamanager_v1/types/user_list_direct_license.py
+++ b/packages/google-ads-datamanager/google/ads/datamanager_v1/types/user_list_direct_license.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/google/ads/datamanager_v1/types/user_list_direct_license_service.py
+++ b/packages/google-ads-datamanager/google/ads/datamanager_v1/types/user_list_direct_license_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/google/ads/datamanager_v1/types/user_list_global_license.py
+++ b/packages/google-ads-datamanager/google/ads/datamanager_v1/types/user_list_global_license.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/google/ads/datamanager_v1/types/user_list_global_license_service.py
+++ b/packages/google-ads-datamanager/google/ads/datamanager_v1/types/user_list_global_license_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/google/ads/datamanager_v1/types/user_list_global_license_type.py
+++ b/packages/google-ads-datamanager/google/ads/datamanager_v1/types/user_list_global_license_type.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/google/ads/datamanager_v1/types/user_list_license_client_account_type.py
+++ b/packages/google-ads-datamanager/google/ads/datamanager_v1/types/user_list_license_client_account_type.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/google/ads/datamanager_v1/types/user_list_license_metrics.py
+++ b/packages/google-ads-datamanager/google/ads/datamanager_v1/types/user_list_license_metrics.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/google/ads/datamanager_v1/types/user_list_license_pricing.py
+++ b/packages/google-ads-datamanager/google/ads/datamanager_v1/types/user_list_license_pricing.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/google/ads/datamanager_v1/types/user_list_license_status.py
+++ b/packages/google-ads-datamanager/google/ads/datamanager_v1/types/user_list_license_status.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/google/ads/datamanager_v1/types/user_list_service.py
+++ b/packages/google-ads-datamanager/google/ads/datamanager_v1/types/user_list_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/google/ads/datamanager_v1/types/user_properties.py
+++ b/packages/google-ads-datamanager/google/ads/datamanager_v1/types/user_properties.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/samples/generated_samples/datamanager_v1_generated_ingestion_service_ingest_audience_members_async.py
+++ b/packages/google-ads-datamanager/samples/generated_samples/datamanager_v1_generated_ingestion_service_ingest_audience_members_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/samples/generated_samples/datamanager_v1_generated_ingestion_service_ingest_audience_members_sync.py
+++ b/packages/google-ads-datamanager/samples/generated_samples/datamanager_v1_generated_ingestion_service_ingest_audience_members_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/samples/generated_samples/datamanager_v1_generated_ingestion_service_ingest_events_async.py
+++ b/packages/google-ads-datamanager/samples/generated_samples/datamanager_v1_generated_ingestion_service_ingest_events_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/samples/generated_samples/datamanager_v1_generated_ingestion_service_ingest_events_sync.py
+++ b/packages/google-ads-datamanager/samples/generated_samples/datamanager_v1_generated_ingestion_service_ingest_events_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/samples/generated_samples/datamanager_v1_generated_ingestion_service_remove_audience_members_async.py
+++ b/packages/google-ads-datamanager/samples/generated_samples/datamanager_v1_generated_ingestion_service_remove_audience_members_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/samples/generated_samples/datamanager_v1_generated_ingestion_service_remove_audience_members_sync.py
+++ b/packages/google-ads-datamanager/samples/generated_samples/datamanager_v1_generated_ingestion_service_remove_audience_members_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/samples/generated_samples/datamanager_v1_generated_ingestion_service_retrieve_request_status_async.py
+++ b/packages/google-ads-datamanager/samples/generated_samples/datamanager_v1_generated_ingestion_service_retrieve_request_status_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/samples/generated_samples/datamanager_v1_generated_ingestion_service_retrieve_request_status_sync.py
+++ b/packages/google-ads-datamanager/samples/generated_samples/datamanager_v1_generated_ingestion_service_retrieve_request_status_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/samples/generated_samples/datamanager_v1_generated_marketing_data_insights_service_retrieve_insights_async.py
+++ b/packages/google-ads-datamanager/samples/generated_samples/datamanager_v1_generated_marketing_data_insights_service_retrieve_insights_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/samples/generated_samples/datamanager_v1_generated_marketing_data_insights_service_retrieve_insights_sync.py
+++ b/packages/google-ads-datamanager/samples/generated_samples/datamanager_v1_generated_marketing_data_insights_service_retrieve_insights_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/samples/generated_samples/datamanager_v1_generated_partner_link_service_create_partner_link_async.py
+++ b/packages/google-ads-datamanager/samples/generated_samples/datamanager_v1_generated_partner_link_service_create_partner_link_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/samples/generated_samples/datamanager_v1_generated_partner_link_service_create_partner_link_sync.py
+++ b/packages/google-ads-datamanager/samples/generated_samples/datamanager_v1_generated_partner_link_service_create_partner_link_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/samples/generated_samples/datamanager_v1_generated_partner_link_service_delete_partner_link_async.py
+++ b/packages/google-ads-datamanager/samples/generated_samples/datamanager_v1_generated_partner_link_service_delete_partner_link_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/samples/generated_samples/datamanager_v1_generated_partner_link_service_delete_partner_link_sync.py
+++ b/packages/google-ads-datamanager/samples/generated_samples/datamanager_v1_generated_partner_link_service_delete_partner_link_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/samples/generated_samples/datamanager_v1_generated_partner_link_service_search_partner_links_async.py
+++ b/packages/google-ads-datamanager/samples/generated_samples/datamanager_v1_generated_partner_link_service_search_partner_links_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/samples/generated_samples/datamanager_v1_generated_partner_link_service_search_partner_links_sync.py
+++ b/packages/google-ads-datamanager/samples/generated_samples/datamanager_v1_generated_partner_link_service_search_partner_links_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/samples/generated_samples/datamanager_v1_generated_user_list_direct_license_service_create_user_list_direct_license_async.py
+++ b/packages/google-ads-datamanager/samples/generated_samples/datamanager_v1_generated_user_list_direct_license_service_create_user_list_direct_license_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/samples/generated_samples/datamanager_v1_generated_user_list_direct_license_service_create_user_list_direct_license_sync.py
+++ b/packages/google-ads-datamanager/samples/generated_samples/datamanager_v1_generated_user_list_direct_license_service_create_user_list_direct_license_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/samples/generated_samples/datamanager_v1_generated_user_list_direct_license_service_get_user_list_direct_license_async.py
+++ b/packages/google-ads-datamanager/samples/generated_samples/datamanager_v1_generated_user_list_direct_license_service_get_user_list_direct_license_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/samples/generated_samples/datamanager_v1_generated_user_list_direct_license_service_get_user_list_direct_license_sync.py
+++ b/packages/google-ads-datamanager/samples/generated_samples/datamanager_v1_generated_user_list_direct_license_service_get_user_list_direct_license_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/samples/generated_samples/datamanager_v1_generated_user_list_direct_license_service_list_user_list_direct_licenses_async.py
+++ b/packages/google-ads-datamanager/samples/generated_samples/datamanager_v1_generated_user_list_direct_license_service_list_user_list_direct_licenses_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/samples/generated_samples/datamanager_v1_generated_user_list_direct_license_service_list_user_list_direct_licenses_sync.py
+++ b/packages/google-ads-datamanager/samples/generated_samples/datamanager_v1_generated_user_list_direct_license_service_list_user_list_direct_licenses_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/samples/generated_samples/datamanager_v1_generated_user_list_direct_license_service_update_user_list_direct_license_async.py
+++ b/packages/google-ads-datamanager/samples/generated_samples/datamanager_v1_generated_user_list_direct_license_service_update_user_list_direct_license_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/samples/generated_samples/datamanager_v1_generated_user_list_direct_license_service_update_user_list_direct_license_sync.py
+++ b/packages/google-ads-datamanager/samples/generated_samples/datamanager_v1_generated_user_list_direct_license_service_update_user_list_direct_license_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/samples/generated_samples/datamanager_v1_generated_user_list_global_license_service_create_user_list_global_license_async.py
+++ b/packages/google-ads-datamanager/samples/generated_samples/datamanager_v1_generated_user_list_global_license_service_create_user_list_global_license_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/samples/generated_samples/datamanager_v1_generated_user_list_global_license_service_create_user_list_global_license_sync.py
+++ b/packages/google-ads-datamanager/samples/generated_samples/datamanager_v1_generated_user_list_global_license_service_create_user_list_global_license_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/samples/generated_samples/datamanager_v1_generated_user_list_global_license_service_get_user_list_global_license_async.py
+++ b/packages/google-ads-datamanager/samples/generated_samples/datamanager_v1_generated_user_list_global_license_service_get_user_list_global_license_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/samples/generated_samples/datamanager_v1_generated_user_list_global_license_service_get_user_list_global_license_sync.py
+++ b/packages/google-ads-datamanager/samples/generated_samples/datamanager_v1_generated_user_list_global_license_service_get_user_list_global_license_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/samples/generated_samples/datamanager_v1_generated_user_list_global_license_service_list_user_list_global_license_customer_infos_async.py
+++ b/packages/google-ads-datamanager/samples/generated_samples/datamanager_v1_generated_user_list_global_license_service_list_user_list_global_license_customer_infos_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/samples/generated_samples/datamanager_v1_generated_user_list_global_license_service_list_user_list_global_license_customer_infos_sync.py
+++ b/packages/google-ads-datamanager/samples/generated_samples/datamanager_v1_generated_user_list_global_license_service_list_user_list_global_license_customer_infos_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/samples/generated_samples/datamanager_v1_generated_user_list_global_license_service_list_user_list_global_licenses_async.py
+++ b/packages/google-ads-datamanager/samples/generated_samples/datamanager_v1_generated_user_list_global_license_service_list_user_list_global_licenses_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/samples/generated_samples/datamanager_v1_generated_user_list_global_license_service_list_user_list_global_licenses_sync.py
+++ b/packages/google-ads-datamanager/samples/generated_samples/datamanager_v1_generated_user_list_global_license_service_list_user_list_global_licenses_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/samples/generated_samples/datamanager_v1_generated_user_list_global_license_service_update_user_list_global_license_async.py
+++ b/packages/google-ads-datamanager/samples/generated_samples/datamanager_v1_generated_user_list_global_license_service_update_user_list_global_license_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/samples/generated_samples/datamanager_v1_generated_user_list_global_license_service_update_user_list_global_license_sync.py
+++ b/packages/google-ads-datamanager/samples/generated_samples/datamanager_v1_generated_user_list_global_license_service_update_user_list_global_license_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/samples/generated_samples/datamanager_v1_generated_user_list_service_create_user_list_async.py
+++ b/packages/google-ads-datamanager/samples/generated_samples/datamanager_v1_generated_user_list_service_create_user_list_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/samples/generated_samples/datamanager_v1_generated_user_list_service_create_user_list_sync.py
+++ b/packages/google-ads-datamanager/samples/generated_samples/datamanager_v1_generated_user_list_service_create_user_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/samples/generated_samples/datamanager_v1_generated_user_list_service_delete_user_list_async.py
+++ b/packages/google-ads-datamanager/samples/generated_samples/datamanager_v1_generated_user_list_service_delete_user_list_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/samples/generated_samples/datamanager_v1_generated_user_list_service_delete_user_list_sync.py
+++ b/packages/google-ads-datamanager/samples/generated_samples/datamanager_v1_generated_user_list_service_delete_user_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/samples/generated_samples/datamanager_v1_generated_user_list_service_get_user_list_async.py
+++ b/packages/google-ads-datamanager/samples/generated_samples/datamanager_v1_generated_user_list_service_get_user_list_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/samples/generated_samples/datamanager_v1_generated_user_list_service_get_user_list_sync.py
+++ b/packages/google-ads-datamanager/samples/generated_samples/datamanager_v1_generated_user_list_service_get_user_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/samples/generated_samples/datamanager_v1_generated_user_list_service_list_user_lists_async.py
+++ b/packages/google-ads-datamanager/samples/generated_samples/datamanager_v1_generated_user_list_service_list_user_lists_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/samples/generated_samples/datamanager_v1_generated_user_list_service_list_user_lists_sync.py
+++ b/packages/google-ads-datamanager/samples/generated_samples/datamanager_v1_generated_user_list_service_list_user_lists_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/samples/generated_samples/datamanager_v1_generated_user_list_service_update_user_list_async.py
+++ b/packages/google-ads-datamanager/samples/generated_samples/datamanager_v1_generated_user_list_service_update_user_list_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/samples/generated_samples/datamanager_v1_generated_user_list_service_update_user_list_sync.py
+++ b/packages/google-ads-datamanager/samples/generated_samples/datamanager_v1_generated_user_list_service_update_user_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/tests/__init__.py
+++ b/packages/google-ads-datamanager/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/tests/unit/__init__.py
+++ b/packages/google-ads-datamanager/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/tests/unit/gapic/__init__.py
+++ b/packages/google-ads-datamanager/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-datamanager/tests/unit/gapic/datamanager_v1/__init__.py
+++ b/packages/google-ads-datamanager/tests/unit/gapic/datamanager_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-marketingplatform-admin/.flake8
+++ b/packages/google-ads-marketingplatform-admin/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-marketingplatform-admin/MANIFEST.in
+++ b/packages/google-ads-marketingplatform-admin/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-marketingplatform-admin/google/ads/marketingplatform_admin/__init__.py
+++ b/packages/google-ads-marketingplatform-admin/google/ads/marketingplatform_admin/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-marketingplatform-admin/google/ads/marketingplatform_admin/gapic_version.py
+++ b/packages/google-ads-marketingplatform-admin/google/ads/marketingplatform_admin/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-marketingplatform-admin/google/ads/marketingplatform_admin_v1alpha/gapic_version.py
+++ b/packages/google-ads-marketingplatform-admin/google/ads/marketingplatform_admin_v1alpha/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-marketingplatform-admin/google/ads/marketingplatform_admin_v1alpha/services/__init__.py
+++ b/packages/google-ads-marketingplatform-admin/google/ads/marketingplatform_admin_v1alpha/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-marketingplatform-admin/google/ads/marketingplatform_admin_v1alpha/services/marketingplatform_admin_service/__init__.py
+++ b/packages/google-ads-marketingplatform-admin/google/ads/marketingplatform_admin_v1alpha/services/marketingplatform_admin_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-marketingplatform-admin/google/ads/marketingplatform_admin_v1alpha/services/marketingplatform_admin_service/async_client.py
+++ b/packages/google-ads-marketingplatform-admin/google/ads/marketingplatform_admin_v1alpha/services/marketingplatform_admin_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-marketingplatform-admin/google/ads/marketingplatform_admin_v1alpha/services/marketingplatform_admin_service/client.py
+++ b/packages/google-ads-marketingplatform-admin/google/ads/marketingplatform_admin_v1alpha/services/marketingplatform_admin_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-marketingplatform-admin/google/ads/marketingplatform_admin_v1alpha/services/marketingplatform_admin_service/pagers.py
+++ b/packages/google-ads-marketingplatform-admin/google/ads/marketingplatform_admin_v1alpha/services/marketingplatform_admin_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-marketingplatform-admin/google/ads/marketingplatform_admin_v1alpha/services/marketingplatform_admin_service/transports/__init__.py
+++ b/packages/google-ads-marketingplatform-admin/google/ads/marketingplatform_admin_v1alpha/services/marketingplatform_admin_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-marketingplatform-admin/google/ads/marketingplatform_admin_v1alpha/services/marketingplatform_admin_service/transports/base.py
+++ b/packages/google-ads-marketingplatform-admin/google/ads/marketingplatform_admin_v1alpha/services/marketingplatform_admin_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-marketingplatform-admin/google/ads/marketingplatform_admin_v1alpha/services/marketingplatform_admin_service/transports/grpc.py
+++ b/packages/google-ads-marketingplatform-admin/google/ads/marketingplatform_admin_v1alpha/services/marketingplatform_admin_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-marketingplatform-admin/google/ads/marketingplatform_admin_v1alpha/services/marketingplatform_admin_service/transports/grpc_asyncio.py
+++ b/packages/google-ads-marketingplatform-admin/google/ads/marketingplatform_admin_v1alpha/services/marketingplatform_admin_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-marketingplatform-admin/google/ads/marketingplatform_admin_v1alpha/services/marketingplatform_admin_service/transports/rest.py
+++ b/packages/google-ads-marketingplatform-admin/google/ads/marketingplatform_admin_v1alpha/services/marketingplatform_admin_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-marketingplatform-admin/google/ads/marketingplatform_admin_v1alpha/services/marketingplatform_admin_service/transports/rest_base.py
+++ b/packages/google-ads-marketingplatform-admin/google/ads/marketingplatform_admin_v1alpha/services/marketingplatform_admin_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-marketingplatform-admin/google/ads/marketingplatform_admin_v1alpha/types/__init__.py
+++ b/packages/google-ads-marketingplatform-admin/google/ads/marketingplatform_admin_v1alpha/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-marketingplatform-admin/google/ads/marketingplatform_admin_v1alpha/types/marketingplatform_admin.py
+++ b/packages/google-ads-marketingplatform-admin/google/ads/marketingplatform_admin_v1alpha/types/marketingplatform_admin.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-marketingplatform-admin/google/ads/marketingplatform_admin_v1alpha/types/resources.py
+++ b/packages/google-ads-marketingplatform-admin/google/ads/marketingplatform_admin_v1alpha/types/resources.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-marketingplatform-admin/samples/generated_samples/marketingplatformadmin_v1alpha_generated_marketingplatform_admin_service_create_analytics_account_link_async.py
+++ b/packages/google-ads-marketingplatform-admin/samples/generated_samples/marketingplatformadmin_v1alpha_generated_marketingplatform_admin_service_create_analytics_account_link_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-marketingplatform-admin/samples/generated_samples/marketingplatformadmin_v1alpha_generated_marketingplatform_admin_service_create_analytics_account_link_sync.py
+++ b/packages/google-ads-marketingplatform-admin/samples/generated_samples/marketingplatformadmin_v1alpha_generated_marketingplatform_admin_service_create_analytics_account_link_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-marketingplatform-admin/samples/generated_samples/marketingplatformadmin_v1alpha_generated_marketingplatform_admin_service_delete_analytics_account_link_async.py
+++ b/packages/google-ads-marketingplatform-admin/samples/generated_samples/marketingplatformadmin_v1alpha_generated_marketingplatform_admin_service_delete_analytics_account_link_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-marketingplatform-admin/samples/generated_samples/marketingplatformadmin_v1alpha_generated_marketingplatform_admin_service_delete_analytics_account_link_sync.py
+++ b/packages/google-ads-marketingplatform-admin/samples/generated_samples/marketingplatformadmin_v1alpha_generated_marketingplatform_admin_service_delete_analytics_account_link_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-marketingplatform-admin/samples/generated_samples/marketingplatformadmin_v1alpha_generated_marketingplatform_admin_service_find_sales_partner_managed_clients_async.py
+++ b/packages/google-ads-marketingplatform-admin/samples/generated_samples/marketingplatformadmin_v1alpha_generated_marketingplatform_admin_service_find_sales_partner_managed_clients_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-marketingplatform-admin/samples/generated_samples/marketingplatformadmin_v1alpha_generated_marketingplatform_admin_service_find_sales_partner_managed_clients_sync.py
+++ b/packages/google-ads-marketingplatform-admin/samples/generated_samples/marketingplatformadmin_v1alpha_generated_marketingplatform_admin_service_find_sales_partner_managed_clients_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-marketingplatform-admin/samples/generated_samples/marketingplatformadmin_v1alpha_generated_marketingplatform_admin_service_get_organization_async.py
+++ b/packages/google-ads-marketingplatform-admin/samples/generated_samples/marketingplatformadmin_v1alpha_generated_marketingplatform_admin_service_get_organization_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-marketingplatform-admin/samples/generated_samples/marketingplatformadmin_v1alpha_generated_marketingplatform_admin_service_get_organization_sync.py
+++ b/packages/google-ads-marketingplatform-admin/samples/generated_samples/marketingplatformadmin_v1alpha_generated_marketingplatform_admin_service_get_organization_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-marketingplatform-admin/samples/generated_samples/marketingplatformadmin_v1alpha_generated_marketingplatform_admin_service_list_analytics_account_links_async.py
+++ b/packages/google-ads-marketingplatform-admin/samples/generated_samples/marketingplatformadmin_v1alpha_generated_marketingplatform_admin_service_list_analytics_account_links_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-marketingplatform-admin/samples/generated_samples/marketingplatformadmin_v1alpha_generated_marketingplatform_admin_service_list_analytics_account_links_sync.py
+++ b/packages/google-ads-marketingplatform-admin/samples/generated_samples/marketingplatformadmin_v1alpha_generated_marketingplatform_admin_service_list_analytics_account_links_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-marketingplatform-admin/samples/generated_samples/marketingplatformadmin_v1alpha_generated_marketingplatform_admin_service_list_organizations_async.py
+++ b/packages/google-ads-marketingplatform-admin/samples/generated_samples/marketingplatformadmin_v1alpha_generated_marketingplatform_admin_service_list_organizations_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-marketingplatform-admin/samples/generated_samples/marketingplatformadmin_v1alpha_generated_marketingplatform_admin_service_list_organizations_sync.py
+++ b/packages/google-ads-marketingplatform-admin/samples/generated_samples/marketingplatformadmin_v1alpha_generated_marketingplatform_admin_service_list_organizations_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-marketingplatform-admin/samples/generated_samples/marketingplatformadmin_v1alpha_generated_marketingplatform_admin_service_report_property_usage_async.py
+++ b/packages/google-ads-marketingplatform-admin/samples/generated_samples/marketingplatformadmin_v1alpha_generated_marketingplatform_admin_service_report_property_usage_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-marketingplatform-admin/samples/generated_samples/marketingplatformadmin_v1alpha_generated_marketingplatform_admin_service_report_property_usage_sync.py
+++ b/packages/google-ads-marketingplatform-admin/samples/generated_samples/marketingplatformadmin_v1alpha_generated_marketingplatform_admin_service_report_property_usage_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-marketingplatform-admin/samples/generated_samples/marketingplatformadmin_v1alpha_generated_marketingplatform_admin_service_set_property_service_level_async.py
+++ b/packages/google-ads-marketingplatform-admin/samples/generated_samples/marketingplatformadmin_v1alpha_generated_marketingplatform_admin_service_set_property_service_level_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-marketingplatform-admin/samples/generated_samples/marketingplatformadmin_v1alpha_generated_marketingplatform_admin_service_set_property_service_level_sync.py
+++ b/packages/google-ads-marketingplatform-admin/samples/generated_samples/marketingplatformadmin_v1alpha_generated_marketingplatform_admin_service_set_property_service_level_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-marketingplatform-admin/tests/__init__.py
+++ b/packages/google-ads-marketingplatform-admin/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-marketingplatform-admin/tests/unit/__init__.py
+++ b/packages/google-ads-marketingplatform-admin/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-marketingplatform-admin/tests/unit/gapic/__init__.py
+++ b/packages/google-ads-marketingplatform-admin/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ads-marketingplatform-admin/tests/unit/gapic/marketingplatform_admin_v1alpha/__init__.py
+++ b/packages/google-ads-marketingplatform-admin/tests/unit/gapic/marketingplatform_admin_v1alpha/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/.flake8
+++ b/packages/google-ai-generativelanguage/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/MANIFEST.in
+++ b/packages/google-ai-generativelanguage/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage/__init__.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage/gapic_version.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1/gapic_version.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1/services/__init__.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1/services/generative_service/__init__.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1/services/generative_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1/services/generative_service/async_client.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1/services/generative_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1/services/generative_service/client.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1/services/generative_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1/services/generative_service/transports/__init__.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1/services/generative_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1/services/generative_service/transports/base.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1/services/generative_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1/services/generative_service/transports/grpc.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1/services/generative_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1/services/generative_service/transports/grpc_asyncio.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1/services/generative_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1/services/generative_service/transports/rest.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1/services/generative_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1/services/generative_service/transports/rest_base.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1/services/generative_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1/services/model_service/__init__.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1/services/model_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1/services/model_service/async_client.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1/services/model_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1/services/model_service/client.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1/services/model_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1/services/model_service/pagers.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1/services/model_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1/services/model_service/transports/__init__.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1/services/model_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1/services/model_service/transports/base.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1/services/model_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1/services/model_service/transports/grpc.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1/services/model_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1/services/model_service/transports/grpc_asyncio.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1/services/model_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1/services/model_service/transports/rest.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1/services/model_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1/services/model_service/transports/rest_base.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1/services/model_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1/types/__init__.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1/types/citation.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1/types/citation.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1/types/content.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1/types/content.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1/types/generative_service.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1/types/generative_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1/types/model.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1/types/model.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1/types/model_service.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1/types/model_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1/types/safety.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1/types/safety.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/gapic_version.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/__init__.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/cache_service/__init__.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/cache_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/cache_service/async_client.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/cache_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/cache_service/client.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/cache_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/cache_service/pagers.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/cache_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/cache_service/transports/__init__.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/cache_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/cache_service/transports/base.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/cache_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/cache_service/transports/grpc.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/cache_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/cache_service/transports/grpc_asyncio.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/cache_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/cache_service/transports/rest.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/cache_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/cache_service/transports/rest_base.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/cache_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/discuss_service/__init__.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/discuss_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/discuss_service/async_client.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/discuss_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/discuss_service/client.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/discuss_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/discuss_service/transports/__init__.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/discuss_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/discuss_service/transports/base.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/discuss_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/discuss_service/transports/grpc.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/discuss_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/discuss_service/transports/grpc_asyncio.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/discuss_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/discuss_service/transports/rest.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/discuss_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/discuss_service/transports/rest_base.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/discuss_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/file_service/__init__.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/file_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/file_service/async_client.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/file_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/file_service/client.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/file_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/file_service/pagers.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/file_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/file_service/transports/__init__.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/file_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/file_service/transports/base.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/file_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/file_service/transports/grpc.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/file_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/file_service/transports/grpc_asyncio.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/file_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/file_service/transports/rest.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/file_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/file_service/transports/rest_base.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/file_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/generative_service/__init__.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/generative_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/generative_service/async_client.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/generative_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/generative_service/client.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/generative_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/generative_service/transports/__init__.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/generative_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/generative_service/transports/base.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/generative_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/generative_service/transports/grpc.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/generative_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/generative_service/transports/grpc_asyncio.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/generative_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/generative_service/transports/rest.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/generative_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/generative_service/transports/rest_base.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/generative_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/model_service/__init__.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/model_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/model_service/client.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/model_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/model_service/pagers.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/model_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/model_service/transports/__init__.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/model_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/model_service/transports/base.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/model_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/model_service/transports/grpc.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/model_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/model_service/transports/grpc_asyncio.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/model_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/model_service/transports/rest.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/model_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/model_service/transports/rest_base.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/model_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/permission_service/__init__.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/permission_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/permission_service/async_client.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/permission_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/permission_service/client.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/permission_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/permission_service/pagers.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/permission_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/permission_service/transports/__init__.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/permission_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/permission_service/transports/base.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/permission_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/permission_service/transports/grpc.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/permission_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/permission_service/transports/grpc_asyncio.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/permission_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/permission_service/transports/rest.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/permission_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/permission_service/transports/rest_base.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/permission_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/prediction_service/__init__.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/prediction_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/prediction_service/async_client.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/prediction_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/prediction_service/client.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/prediction_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/prediction_service/transports/__init__.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/prediction_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/prediction_service/transports/base.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/prediction_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/prediction_service/transports/grpc.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/prediction_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/prediction_service/transports/grpc_asyncio.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/prediction_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/prediction_service/transports/rest.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/prediction_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/prediction_service/transports/rest_base.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/prediction_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/retriever_service/__init__.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/retriever_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/retriever_service/async_client.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/retriever_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/retriever_service/client.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/retriever_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/retriever_service/pagers.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/retriever_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/retriever_service/transports/__init__.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/retriever_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/retriever_service/transports/base.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/retriever_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/retriever_service/transports/grpc.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/retriever_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/retriever_service/transports/grpc_asyncio.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/retriever_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/retriever_service/transports/rest.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/retriever_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/retriever_service/transports/rest_base.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/retriever_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/text_service/__init__.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/text_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/text_service/async_client.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/text_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/text_service/client.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/text_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/text_service/transports/__init__.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/text_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/text_service/transports/base.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/text_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/text_service/transports/grpc.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/text_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/text_service/transports/grpc_asyncio.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/text_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/text_service/transports/rest.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/text_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/text_service/transports/rest_base.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/services/text_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/types/__init__.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/types/cache_service.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/types/cache_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/types/cached_content.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/types/cached_content.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/types/citation.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/types/citation.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/types/content.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/types/content.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/types/discuss_service.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/types/discuss_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/types/file.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/types/file.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/types/file_service.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/types/file_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/types/generative_service.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/types/generative_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/types/model.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/types/model.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/types/model_service.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/types/model_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/types/permission.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/types/permission.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/types/permission_service.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/types/permission_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/types/prediction_service.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/types/prediction_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/types/retriever.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/types/retriever.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/types/retriever_service.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/types/retriever_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/types/safety.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/types/safety.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/types/text_service.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/types/text_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/types/tuned_model.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1alpha/types/tuned_model.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/gapic_version.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/__init__.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/cache_service/__init__.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/cache_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/cache_service/async_client.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/cache_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/cache_service/client.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/cache_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/cache_service/pagers.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/cache_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/cache_service/transports/__init__.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/cache_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/cache_service/transports/base.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/cache_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/cache_service/transports/grpc.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/cache_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/cache_service/transports/grpc_asyncio.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/cache_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/cache_service/transports/rest.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/cache_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/cache_service/transports/rest_base.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/cache_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/discuss_service/__init__.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/discuss_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/discuss_service/async_client.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/discuss_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/discuss_service/client.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/discuss_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/discuss_service/transports/__init__.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/discuss_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/discuss_service/transports/base.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/discuss_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/discuss_service/transports/grpc.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/discuss_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/discuss_service/transports/grpc_asyncio.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/discuss_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/discuss_service/transports/rest.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/discuss_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/discuss_service/transports/rest_base.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/discuss_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/file_service/__init__.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/file_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/file_service/async_client.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/file_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/file_service/client.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/file_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/file_service/pagers.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/file_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/file_service/transports/__init__.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/file_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/file_service/transports/base.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/file_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/file_service/transports/grpc.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/file_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/file_service/transports/grpc_asyncio.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/file_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/file_service/transports/rest.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/file_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/file_service/transports/rest_base.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/file_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/generative_service/__init__.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/generative_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/generative_service/async_client.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/generative_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/generative_service/client.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/generative_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/generative_service/transports/__init__.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/generative_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/generative_service/transports/base.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/generative_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/generative_service/transports/grpc.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/generative_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/generative_service/transports/grpc_asyncio.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/generative_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/generative_service/transports/rest.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/generative_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/generative_service/transports/rest_base.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/generative_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/model_service/__init__.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/model_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/model_service/client.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/model_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/model_service/pagers.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/model_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/model_service/transports/__init__.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/model_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/model_service/transports/base.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/model_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/model_service/transports/grpc.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/model_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/model_service/transports/grpc_asyncio.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/model_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/model_service/transports/rest.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/model_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/model_service/transports/rest_base.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/model_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/permission_service/__init__.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/permission_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/permission_service/async_client.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/permission_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/permission_service/client.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/permission_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/permission_service/pagers.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/permission_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/permission_service/transports/__init__.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/permission_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/permission_service/transports/base.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/permission_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/permission_service/transports/grpc.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/permission_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/permission_service/transports/grpc_asyncio.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/permission_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/permission_service/transports/rest.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/permission_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/permission_service/transports/rest_base.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/permission_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/prediction_service/__init__.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/prediction_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/prediction_service/client.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/prediction_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/prediction_service/transports/__init__.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/prediction_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/prediction_service/transports/base.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/prediction_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/prediction_service/transports/grpc.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/prediction_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/prediction_service/transports/grpc_asyncio.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/prediction_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/prediction_service/transports/rest.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/prediction_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/prediction_service/transports/rest_base.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/prediction_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/retriever_service/__init__.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/retriever_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/retriever_service/async_client.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/retriever_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/retriever_service/client.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/retriever_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/retriever_service/pagers.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/retriever_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/retriever_service/transports/__init__.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/retriever_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/retriever_service/transports/base.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/retriever_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/retriever_service/transports/grpc.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/retriever_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/retriever_service/transports/grpc_asyncio.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/retriever_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/retriever_service/transports/rest.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/retriever_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/retriever_service/transports/rest_base.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/retriever_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/text_service/__init__.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/text_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/text_service/async_client.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/text_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/text_service/client.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/text_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/text_service/transports/__init__.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/text_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/text_service/transports/base.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/text_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/text_service/transports/grpc.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/text_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/text_service/transports/grpc_asyncio.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/text_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/text_service/transports/rest.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/text_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/text_service/transports/rest_base.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/services/text_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/types/__init__.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/types/cache_service.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/types/cache_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/types/cached_content.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/types/cached_content.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/types/citation.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/types/citation.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/types/content.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/types/content.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/types/discuss_service.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/types/discuss_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/types/file.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/types/file.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/types/file_service.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/types/file_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/types/generative_service.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/types/generative_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/types/model.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/types/model.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/types/model_service.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/types/model_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/types/permission.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/types/permission.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/types/permission_service.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/types/permission_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/types/prediction_service.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/types/prediction_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/types/retriever.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/types/retriever.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/types/retriever_service.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/types/retriever_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/types/safety.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/types/safety.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/types/text_service.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/types/text_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/types/tuned_model.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta/types/tuned_model.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta2/gapic_version.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta2/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta2/services/__init__.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta2/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta2/services/discuss_service/__init__.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta2/services/discuss_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta2/services/discuss_service/async_client.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta2/services/discuss_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta2/services/discuss_service/client.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta2/services/discuss_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta2/services/discuss_service/transports/__init__.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta2/services/discuss_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta2/services/discuss_service/transports/base.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta2/services/discuss_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta2/services/discuss_service/transports/grpc.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta2/services/discuss_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta2/services/discuss_service/transports/grpc_asyncio.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta2/services/discuss_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta2/services/discuss_service/transports/rest.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta2/services/discuss_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta2/services/discuss_service/transports/rest_base.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta2/services/discuss_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta2/services/model_service/__init__.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta2/services/model_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta2/services/model_service/async_client.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta2/services/model_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta2/services/model_service/client.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta2/services/model_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta2/services/model_service/pagers.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta2/services/model_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta2/services/model_service/transports/__init__.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta2/services/model_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta2/services/model_service/transports/base.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta2/services/model_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta2/services/model_service/transports/grpc.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta2/services/model_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta2/services/model_service/transports/grpc_asyncio.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta2/services/model_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta2/services/model_service/transports/rest.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta2/services/model_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta2/services/model_service/transports/rest_base.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta2/services/model_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta2/services/text_service/__init__.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta2/services/text_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta2/services/text_service/async_client.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta2/services/text_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta2/services/text_service/client.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta2/services/text_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta2/services/text_service/transports/__init__.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta2/services/text_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta2/services/text_service/transports/base.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta2/services/text_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta2/services/text_service/transports/grpc.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta2/services/text_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta2/services/text_service/transports/grpc_asyncio.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta2/services/text_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta2/services/text_service/transports/rest.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta2/services/text_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta2/services/text_service/transports/rest_base.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta2/services/text_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta2/types/__init__.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta2/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta2/types/citation.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta2/types/citation.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta2/types/discuss_service.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta2/types/discuss_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta2/types/model.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta2/types/model.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta2/types/model_service.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta2/types/model_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta2/types/safety.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta2/types/safety.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta2/types/text_service.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta2/types/text_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta3/gapic_version.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta3/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta3/services/__init__.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta3/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta3/services/discuss_service/__init__.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta3/services/discuss_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta3/services/discuss_service/async_client.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta3/services/discuss_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta3/services/discuss_service/client.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta3/services/discuss_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta3/services/discuss_service/transports/__init__.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta3/services/discuss_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta3/services/discuss_service/transports/base.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta3/services/discuss_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta3/services/discuss_service/transports/grpc.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta3/services/discuss_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta3/services/discuss_service/transports/grpc_asyncio.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta3/services/discuss_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta3/services/discuss_service/transports/rest.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta3/services/discuss_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta3/services/discuss_service/transports/rest_base.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta3/services/discuss_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta3/services/model_service/__init__.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta3/services/model_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta3/services/model_service/client.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta3/services/model_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta3/services/model_service/pagers.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta3/services/model_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta3/services/model_service/transports/__init__.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta3/services/model_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta3/services/model_service/transports/base.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta3/services/model_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta3/services/model_service/transports/grpc.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta3/services/model_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta3/services/model_service/transports/grpc_asyncio.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta3/services/model_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta3/services/model_service/transports/rest.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta3/services/model_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta3/services/model_service/transports/rest_base.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta3/services/model_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta3/services/permission_service/__init__.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta3/services/permission_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta3/services/permission_service/pagers.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta3/services/permission_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta3/services/permission_service/transports/__init__.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta3/services/permission_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta3/services/permission_service/transports/base.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta3/services/permission_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta3/services/permission_service/transports/grpc.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta3/services/permission_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta3/services/permission_service/transports/grpc_asyncio.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta3/services/permission_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta3/services/permission_service/transports/rest.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta3/services/permission_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta3/services/permission_service/transports/rest_base.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta3/services/permission_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta3/services/text_service/__init__.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta3/services/text_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta3/services/text_service/async_client.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta3/services/text_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta3/services/text_service/client.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta3/services/text_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta3/services/text_service/transports/__init__.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta3/services/text_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta3/services/text_service/transports/base.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta3/services/text_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta3/services/text_service/transports/grpc.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta3/services/text_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta3/services/text_service/transports/grpc_asyncio.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta3/services/text_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta3/services/text_service/transports/rest.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta3/services/text_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta3/services/text_service/transports/rest_base.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta3/services/text_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta3/types/__init__.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta3/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta3/types/citation.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta3/types/citation.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta3/types/discuss_service.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta3/types/discuss_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta3/types/model.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta3/types/model.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta3/types/model_service.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta3/types/model_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta3/types/permission_service.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta3/types/permission_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta3/types/safety.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta3/types/safety.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta3/types/text_service.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta3/types/text_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta3/types/tuned_model.py
+++ b/packages/google-ai-generativelanguage/google/ai/generativelanguage_v1beta3/types/tuned_model.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1_generated_generative_service_batch_embed_contents_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1_generated_generative_service_batch_embed_contents_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1_generated_generative_service_batch_embed_contents_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1_generated_generative_service_batch_embed_contents_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1_generated_generative_service_count_tokens_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1_generated_generative_service_count_tokens_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1_generated_generative_service_count_tokens_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1_generated_generative_service_count_tokens_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1_generated_generative_service_embed_content_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1_generated_generative_service_embed_content_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1_generated_generative_service_embed_content_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1_generated_generative_service_embed_content_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1_generated_generative_service_generate_content_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1_generated_generative_service_generate_content_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1_generated_generative_service_generate_content_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1_generated_generative_service_generate_content_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1_generated_generative_service_stream_generate_content_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1_generated_generative_service_stream_generate_content_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1_generated_generative_service_stream_generate_content_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1_generated_generative_service_stream_generate_content_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1_generated_model_service_get_model_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1_generated_model_service_get_model_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1_generated_model_service_get_model_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1_generated_model_service_get_model_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1_generated_model_service_list_models_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1_generated_model_service_list_models_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1_generated_model_service_list_models_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1_generated_model_service_list_models_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_cache_service_create_cached_content_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_cache_service_create_cached_content_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_cache_service_create_cached_content_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_cache_service_create_cached_content_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_cache_service_delete_cached_content_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_cache_service_delete_cached_content_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_cache_service_delete_cached_content_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_cache_service_delete_cached_content_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_cache_service_get_cached_content_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_cache_service_get_cached_content_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_cache_service_get_cached_content_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_cache_service_get_cached_content_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_cache_service_list_cached_contents_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_cache_service_list_cached_contents_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_cache_service_list_cached_contents_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_cache_service_list_cached_contents_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_cache_service_update_cached_content_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_cache_service_update_cached_content_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_cache_service_update_cached_content_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_cache_service_update_cached_content_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_discuss_service_count_message_tokens_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_discuss_service_count_message_tokens_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_discuss_service_count_message_tokens_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_discuss_service_count_message_tokens_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_discuss_service_generate_message_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_discuss_service_generate_message_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_discuss_service_generate_message_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_discuss_service_generate_message_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_file_service_create_file_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_file_service_create_file_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_file_service_create_file_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_file_service_create_file_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_file_service_delete_file_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_file_service_delete_file_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_file_service_delete_file_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_file_service_delete_file_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_file_service_get_file_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_file_service_get_file_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_file_service_get_file_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_file_service_get_file_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_file_service_list_files_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_file_service_list_files_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_file_service_list_files_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_file_service_list_files_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_generative_service_batch_embed_contents_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_generative_service_batch_embed_contents_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_generative_service_batch_embed_contents_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_generative_service_batch_embed_contents_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_generative_service_bidi_generate_content_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_generative_service_bidi_generate_content_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_generative_service_bidi_generate_content_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_generative_service_bidi_generate_content_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_generative_service_count_tokens_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_generative_service_count_tokens_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_generative_service_count_tokens_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_generative_service_count_tokens_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_generative_service_embed_content_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_generative_service_embed_content_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_generative_service_embed_content_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_generative_service_embed_content_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_generative_service_generate_answer_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_generative_service_generate_answer_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_generative_service_generate_answer_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_generative_service_generate_answer_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_generative_service_generate_content_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_generative_service_generate_content_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_generative_service_generate_content_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_generative_service_generate_content_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_generative_service_stream_generate_content_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_generative_service_stream_generate_content_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_generative_service_stream_generate_content_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_generative_service_stream_generate_content_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_model_service_create_tuned_model_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_model_service_create_tuned_model_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_model_service_delete_tuned_model_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_model_service_delete_tuned_model_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_model_service_delete_tuned_model_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_model_service_delete_tuned_model_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_model_service_get_model_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_model_service_get_model_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_model_service_get_model_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_model_service_get_model_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_model_service_get_tuned_model_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_model_service_get_tuned_model_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_model_service_get_tuned_model_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_model_service_get_tuned_model_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_model_service_list_models_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_model_service_list_models_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_model_service_list_models_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_model_service_list_models_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_model_service_list_tuned_models_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_model_service_list_tuned_models_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_model_service_list_tuned_models_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_model_service_list_tuned_models_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_model_service_update_tuned_model_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_model_service_update_tuned_model_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_model_service_update_tuned_model_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_model_service_update_tuned_model_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_permission_service_create_permission_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_permission_service_create_permission_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_permission_service_create_permission_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_permission_service_create_permission_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_permission_service_delete_permission_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_permission_service_delete_permission_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_permission_service_delete_permission_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_permission_service_delete_permission_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_permission_service_get_permission_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_permission_service_get_permission_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_permission_service_get_permission_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_permission_service_get_permission_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_permission_service_list_permissions_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_permission_service_list_permissions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_permission_service_list_permissions_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_permission_service_list_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_permission_service_transfer_ownership_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_permission_service_transfer_ownership_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_permission_service_transfer_ownership_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_permission_service_transfer_ownership_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_permission_service_update_permission_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_permission_service_update_permission_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_permission_service_update_permission_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_permission_service_update_permission_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_prediction_service_predict_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_prediction_service_predict_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_prediction_service_predict_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_prediction_service_predict_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_retriever_service_batch_create_chunks_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_retriever_service_batch_create_chunks_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_retriever_service_batch_create_chunks_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_retriever_service_batch_create_chunks_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_retriever_service_batch_delete_chunks_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_retriever_service_batch_delete_chunks_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_retriever_service_batch_delete_chunks_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_retriever_service_batch_delete_chunks_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_retriever_service_batch_update_chunks_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_retriever_service_batch_update_chunks_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_retriever_service_batch_update_chunks_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_retriever_service_batch_update_chunks_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_retriever_service_create_chunk_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_retriever_service_create_chunk_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_retriever_service_create_chunk_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_retriever_service_create_chunk_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_retriever_service_create_corpus_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_retriever_service_create_corpus_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_retriever_service_create_corpus_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_retriever_service_create_corpus_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_retriever_service_create_document_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_retriever_service_create_document_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_retriever_service_create_document_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_retriever_service_create_document_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_retriever_service_delete_chunk_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_retriever_service_delete_chunk_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_retriever_service_delete_chunk_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_retriever_service_delete_chunk_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_retriever_service_delete_corpus_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_retriever_service_delete_corpus_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_retriever_service_delete_corpus_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_retriever_service_delete_corpus_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_retriever_service_delete_document_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_retriever_service_delete_document_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_retriever_service_delete_document_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_retriever_service_delete_document_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_retriever_service_get_chunk_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_retriever_service_get_chunk_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_retriever_service_get_chunk_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_retriever_service_get_chunk_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_retriever_service_get_corpus_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_retriever_service_get_corpus_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_retriever_service_get_corpus_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_retriever_service_get_corpus_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_retriever_service_get_document_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_retriever_service_get_document_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_retriever_service_get_document_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_retriever_service_get_document_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_retriever_service_list_chunks_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_retriever_service_list_chunks_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_retriever_service_list_chunks_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_retriever_service_list_chunks_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_retriever_service_list_corpora_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_retriever_service_list_corpora_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_retriever_service_list_corpora_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_retriever_service_list_corpora_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_retriever_service_list_documents_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_retriever_service_list_documents_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_retriever_service_list_documents_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_retriever_service_list_documents_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_retriever_service_query_corpus_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_retriever_service_query_corpus_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_retriever_service_query_corpus_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_retriever_service_query_corpus_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_retriever_service_query_document_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_retriever_service_query_document_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_retriever_service_query_document_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_retriever_service_query_document_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_retriever_service_update_chunk_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_retriever_service_update_chunk_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_retriever_service_update_chunk_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_retriever_service_update_chunk_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_retriever_service_update_corpus_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_retriever_service_update_corpus_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_retriever_service_update_corpus_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_retriever_service_update_corpus_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_retriever_service_update_document_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_retriever_service_update_document_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_retriever_service_update_document_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_retriever_service_update_document_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_text_service_batch_embed_text_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_text_service_batch_embed_text_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_text_service_batch_embed_text_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_text_service_batch_embed_text_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_text_service_count_text_tokens_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_text_service_count_text_tokens_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_text_service_count_text_tokens_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_text_service_count_text_tokens_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_text_service_embed_text_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_text_service_embed_text_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_text_service_embed_text_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_text_service_embed_text_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_text_service_generate_text_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_text_service_generate_text_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_text_service_generate_text_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1alpha_generated_text_service_generate_text_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta2_generated_discuss_service_count_message_tokens_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta2_generated_discuss_service_count_message_tokens_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta2_generated_discuss_service_count_message_tokens_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta2_generated_discuss_service_count_message_tokens_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta2_generated_discuss_service_generate_message_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta2_generated_discuss_service_generate_message_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta2_generated_discuss_service_generate_message_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta2_generated_discuss_service_generate_message_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta2_generated_model_service_get_model_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta2_generated_model_service_get_model_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta2_generated_model_service_get_model_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta2_generated_model_service_get_model_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta2_generated_model_service_list_models_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta2_generated_model_service_list_models_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta2_generated_model_service_list_models_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta2_generated_model_service_list_models_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta2_generated_text_service_embed_text_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta2_generated_text_service_embed_text_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta2_generated_text_service_embed_text_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta2_generated_text_service_embed_text_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta2_generated_text_service_generate_text_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta2_generated_text_service_generate_text_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta2_generated_text_service_generate_text_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta2_generated_text_service_generate_text_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta3_generated_discuss_service_count_message_tokens_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta3_generated_discuss_service_count_message_tokens_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta3_generated_discuss_service_count_message_tokens_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta3_generated_discuss_service_count_message_tokens_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta3_generated_discuss_service_generate_message_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta3_generated_discuss_service_generate_message_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta3_generated_discuss_service_generate_message_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta3_generated_discuss_service_generate_message_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta3_generated_model_service_create_tuned_model_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta3_generated_model_service_create_tuned_model_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta3_generated_model_service_delete_tuned_model_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta3_generated_model_service_delete_tuned_model_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta3_generated_model_service_delete_tuned_model_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta3_generated_model_service_delete_tuned_model_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta3_generated_model_service_get_model_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta3_generated_model_service_get_model_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta3_generated_model_service_get_model_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta3_generated_model_service_get_model_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta3_generated_model_service_get_tuned_model_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta3_generated_model_service_get_tuned_model_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta3_generated_model_service_get_tuned_model_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta3_generated_model_service_get_tuned_model_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta3_generated_model_service_list_models_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta3_generated_model_service_list_models_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta3_generated_model_service_list_models_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta3_generated_model_service_list_models_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta3_generated_model_service_list_tuned_models_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta3_generated_model_service_list_tuned_models_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta3_generated_model_service_list_tuned_models_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta3_generated_model_service_list_tuned_models_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta3_generated_model_service_update_tuned_model_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta3_generated_model_service_update_tuned_model_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta3_generated_model_service_update_tuned_model_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta3_generated_model_service_update_tuned_model_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta3_generated_permission_service_create_permission_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta3_generated_permission_service_create_permission_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta3_generated_permission_service_create_permission_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta3_generated_permission_service_create_permission_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta3_generated_permission_service_delete_permission_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta3_generated_permission_service_delete_permission_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta3_generated_permission_service_delete_permission_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta3_generated_permission_service_delete_permission_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta3_generated_permission_service_get_permission_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta3_generated_permission_service_get_permission_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta3_generated_permission_service_get_permission_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta3_generated_permission_service_get_permission_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta3_generated_permission_service_list_permissions_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta3_generated_permission_service_list_permissions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta3_generated_permission_service_list_permissions_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta3_generated_permission_service_list_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta3_generated_permission_service_transfer_ownership_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta3_generated_permission_service_transfer_ownership_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta3_generated_permission_service_transfer_ownership_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta3_generated_permission_service_transfer_ownership_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta3_generated_permission_service_update_permission_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta3_generated_permission_service_update_permission_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta3_generated_permission_service_update_permission_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta3_generated_permission_service_update_permission_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta3_generated_text_service_batch_embed_text_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta3_generated_text_service_batch_embed_text_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta3_generated_text_service_batch_embed_text_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta3_generated_text_service_batch_embed_text_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta3_generated_text_service_count_text_tokens_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta3_generated_text_service_count_text_tokens_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta3_generated_text_service_count_text_tokens_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta3_generated_text_service_count_text_tokens_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta3_generated_text_service_embed_text_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta3_generated_text_service_embed_text_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta3_generated_text_service_embed_text_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta3_generated_text_service_embed_text_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta3_generated_text_service_generate_text_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta3_generated_text_service_generate_text_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta3_generated_text_service_generate_text_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta3_generated_text_service_generate_text_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_cache_service_create_cached_content_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_cache_service_create_cached_content_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_cache_service_create_cached_content_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_cache_service_create_cached_content_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_cache_service_delete_cached_content_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_cache_service_delete_cached_content_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_cache_service_delete_cached_content_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_cache_service_delete_cached_content_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_cache_service_get_cached_content_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_cache_service_get_cached_content_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_cache_service_get_cached_content_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_cache_service_get_cached_content_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_cache_service_list_cached_contents_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_cache_service_list_cached_contents_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_cache_service_list_cached_contents_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_cache_service_list_cached_contents_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_cache_service_update_cached_content_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_cache_service_update_cached_content_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_cache_service_update_cached_content_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_cache_service_update_cached_content_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_discuss_service_count_message_tokens_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_discuss_service_count_message_tokens_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_discuss_service_count_message_tokens_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_discuss_service_count_message_tokens_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_discuss_service_generate_message_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_discuss_service_generate_message_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_discuss_service_generate_message_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_discuss_service_generate_message_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_file_service_create_file_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_file_service_create_file_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_file_service_create_file_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_file_service_create_file_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_file_service_delete_file_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_file_service_delete_file_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_file_service_delete_file_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_file_service_delete_file_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_file_service_download_file_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_file_service_download_file_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_file_service_download_file_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_file_service_download_file_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_file_service_get_file_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_file_service_get_file_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_file_service_get_file_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_file_service_get_file_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_file_service_list_files_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_file_service_list_files_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_file_service_list_files_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_file_service_list_files_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_generative_service_batch_embed_contents_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_generative_service_batch_embed_contents_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_generative_service_batch_embed_contents_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_generative_service_batch_embed_contents_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_generative_service_bidi_generate_content_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_generative_service_bidi_generate_content_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_generative_service_bidi_generate_content_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_generative_service_bidi_generate_content_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_generative_service_count_tokens_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_generative_service_count_tokens_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_generative_service_count_tokens_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_generative_service_count_tokens_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_generative_service_embed_content_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_generative_service_embed_content_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_generative_service_embed_content_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_generative_service_embed_content_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_generative_service_generate_answer_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_generative_service_generate_answer_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_generative_service_generate_answer_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_generative_service_generate_answer_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_generative_service_generate_content_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_generative_service_generate_content_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_generative_service_generate_content_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_generative_service_generate_content_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_generative_service_stream_generate_content_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_generative_service_stream_generate_content_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_generative_service_stream_generate_content_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_generative_service_stream_generate_content_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_model_service_create_tuned_model_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_model_service_create_tuned_model_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_model_service_delete_tuned_model_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_model_service_delete_tuned_model_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_model_service_delete_tuned_model_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_model_service_delete_tuned_model_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_model_service_get_model_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_model_service_get_model_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_model_service_get_model_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_model_service_get_model_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_model_service_get_tuned_model_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_model_service_get_tuned_model_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_model_service_get_tuned_model_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_model_service_get_tuned_model_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_model_service_list_models_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_model_service_list_models_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_model_service_list_models_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_model_service_list_models_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_model_service_list_tuned_models_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_model_service_list_tuned_models_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_model_service_list_tuned_models_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_model_service_list_tuned_models_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_model_service_update_tuned_model_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_model_service_update_tuned_model_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_model_service_update_tuned_model_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_model_service_update_tuned_model_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_permission_service_create_permission_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_permission_service_create_permission_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_permission_service_create_permission_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_permission_service_create_permission_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_permission_service_delete_permission_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_permission_service_delete_permission_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_permission_service_delete_permission_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_permission_service_delete_permission_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_permission_service_get_permission_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_permission_service_get_permission_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_permission_service_get_permission_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_permission_service_get_permission_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_permission_service_list_permissions_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_permission_service_list_permissions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_permission_service_list_permissions_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_permission_service_list_permissions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_permission_service_transfer_ownership_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_permission_service_transfer_ownership_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_permission_service_transfer_ownership_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_permission_service_transfer_ownership_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_permission_service_update_permission_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_permission_service_update_permission_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_permission_service_update_permission_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_permission_service_update_permission_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_prediction_service_predict_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_prediction_service_predict_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_prediction_service_predict_long_running_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_prediction_service_predict_long_running_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_prediction_service_predict_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_prediction_service_predict_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_retriever_service_batch_create_chunks_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_retriever_service_batch_create_chunks_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_retriever_service_batch_create_chunks_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_retriever_service_batch_create_chunks_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_retriever_service_batch_delete_chunks_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_retriever_service_batch_delete_chunks_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_retriever_service_batch_delete_chunks_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_retriever_service_batch_delete_chunks_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_retriever_service_batch_update_chunks_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_retriever_service_batch_update_chunks_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_retriever_service_batch_update_chunks_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_retriever_service_batch_update_chunks_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_retriever_service_create_chunk_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_retriever_service_create_chunk_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_retriever_service_create_chunk_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_retriever_service_create_chunk_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_retriever_service_create_corpus_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_retriever_service_create_corpus_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_retriever_service_create_corpus_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_retriever_service_create_corpus_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_retriever_service_create_document_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_retriever_service_create_document_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_retriever_service_create_document_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_retriever_service_create_document_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_retriever_service_delete_chunk_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_retriever_service_delete_chunk_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_retriever_service_delete_chunk_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_retriever_service_delete_chunk_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_retriever_service_delete_corpus_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_retriever_service_delete_corpus_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_retriever_service_delete_corpus_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_retriever_service_delete_corpus_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_retriever_service_delete_document_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_retriever_service_delete_document_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_retriever_service_delete_document_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_retriever_service_delete_document_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_retriever_service_get_chunk_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_retriever_service_get_chunk_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_retriever_service_get_chunk_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_retriever_service_get_chunk_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_retriever_service_get_corpus_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_retriever_service_get_corpus_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_retriever_service_get_corpus_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_retriever_service_get_corpus_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_retriever_service_get_document_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_retriever_service_get_document_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_retriever_service_get_document_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_retriever_service_get_document_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_retriever_service_list_chunks_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_retriever_service_list_chunks_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_retriever_service_list_chunks_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_retriever_service_list_chunks_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_retriever_service_list_corpora_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_retriever_service_list_corpora_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_retriever_service_list_corpora_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_retriever_service_list_corpora_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_retriever_service_list_documents_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_retriever_service_list_documents_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_retriever_service_list_documents_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_retriever_service_list_documents_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_retriever_service_query_corpus_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_retriever_service_query_corpus_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_retriever_service_query_corpus_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_retriever_service_query_corpus_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_retriever_service_query_document_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_retriever_service_query_document_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_retriever_service_query_document_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_retriever_service_query_document_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_retriever_service_update_chunk_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_retriever_service_update_chunk_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_retriever_service_update_chunk_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_retriever_service_update_chunk_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_retriever_service_update_corpus_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_retriever_service_update_corpus_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_retriever_service_update_corpus_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_retriever_service_update_corpus_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_retriever_service_update_document_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_retriever_service_update_document_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_retriever_service_update_document_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_retriever_service_update_document_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_text_service_batch_embed_text_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_text_service_batch_embed_text_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_text_service_batch_embed_text_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_text_service_batch_embed_text_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_text_service_count_text_tokens_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_text_service_count_text_tokens_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_text_service_count_text_tokens_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_text_service_count_text_tokens_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_text_service_embed_text_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_text_service_embed_text_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_text_service_embed_text_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_text_service_embed_text_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_text_service_generate_text_async.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_text_service_generate_text_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_text_service_generate_text_sync.py
+++ b/packages/google-ai-generativelanguage/samples/generated_samples/generativelanguage_v1beta_generated_text_service_generate_text_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/tests/__init__.py
+++ b/packages/google-ai-generativelanguage/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/tests/unit/__init__.py
+++ b/packages/google-ai-generativelanguage/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/tests/unit/gapic/__init__.py
+++ b/packages/google-ai-generativelanguage/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/tests/unit/gapic/generativelanguage_v1/__init__.py
+++ b/packages/google-ai-generativelanguage/tests/unit/gapic/generativelanguage_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/tests/unit/gapic/generativelanguage_v1alpha/__init__.py
+++ b/packages/google-ai-generativelanguage/tests/unit/gapic/generativelanguage_v1alpha/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/tests/unit/gapic/generativelanguage_v1beta/__init__.py
+++ b/packages/google-ai-generativelanguage/tests/unit/gapic/generativelanguage_v1beta/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/tests/unit/gapic/generativelanguage_v1beta2/__init__.py
+++ b/packages/google-ai-generativelanguage/tests/unit/gapic/generativelanguage_v1beta2/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-ai-generativelanguage/tests/unit/gapic/generativelanguage_v1beta3/__init__.py
+++ b/packages/google-ai-generativelanguage/tests/unit/gapic/generativelanguage_v1beta3/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/.flake8
+++ b/packages/google-analytics-admin/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/MANIFEST.in
+++ b/packages/google-analytics-admin/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/google/analytics/admin/__init__.py
+++ b/packages/google-analytics-admin/google/analytics/admin/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/google/analytics/admin/gapic_version.py
+++ b/packages/google-analytics-admin/google/analytics/admin/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/google/analytics/admin_v1alpha/gapic_version.py
+++ b/packages/google-analytics-admin/google/analytics/admin_v1alpha/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/google/analytics/admin_v1alpha/services/__init__.py
+++ b/packages/google-analytics-admin/google/analytics/admin_v1alpha/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/google/analytics/admin_v1alpha/services/analytics_admin_service/__init__.py
+++ b/packages/google-analytics-admin/google/analytics/admin_v1alpha/services/analytics_admin_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/google/analytics/admin_v1alpha/services/analytics_admin_service/async_client.py
+++ b/packages/google-analytics-admin/google/analytics/admin_v1alpha/services/analytics_admin_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/google/analytics/admin_v1alpha/services/analytics_admin_service/client.py
+++ b/packages/google-analytics-admin/google/analytics/admin_v1alpha/services/analytics_admin_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/google/analytics/admin_v1alpha/services/analytics_admin_service/pagers.py
+++ b/packages/google-analytics-admin/google/analytics/admin_v1alpha/services/analytics_admin_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/google/analytics/admin_v1alpha/services/analytics_admin_service/transports/__init__.py
+++ b/packages/google-analytics-admin/google/analytics/admin_v1alpha/services/analytics_admin_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/google/analytics/admin_v1alpha/services/analytics_admin_service/transports/base.py
+++ b/packages/google-analytics-admin/google/analytics/admin_v1alpha/services/analytics_admin_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/google/analytics/admin_v1alpha/services/analytics_admin_service/transports/grpc.py
+++ b/packages/google-analytics-admin/google/analytics/admin_v1alpha/services/analytics_admin_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/google/analytics/admin_v1alpha/services/analytics_admin_service/transports/grpc_asyncio.py
+++ b/packages/google-analytics-admin/google/analytics/admin_v1alpha/services/analytics_admin_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/google/analytics/admin_v1alpha/services/analytics_admin_service/transports/rest.py
+++ b/packages/google-analytics-admin/google/analytics/admin_v1alpha/services/analytics_admin_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/google/analytics/admin_v1alpha/services/analytics_admin_service/transports/rest_base.py
+++ b/packages/google-analytics-admin/google/analytics/admin_v1alpha/services/analytics_admin_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/google/analytics/admin_v1alpha/types/__init__.py
+++ b/packages/google-analytics-admin/google/analytics/admin_v1alpha/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/google/analytics/admin_v1alpha/types/access_report.py
+++ b/packages/google-analytics-admin/google/analytics/admin_v1alpha/types/access_report.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/google/analytics/admin_v1alpha/types/analytics_admin.py
+++ b/packages/google-analytics-admin/google/analytics/admin_v1alpha/types/analytics_admin.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/google/analytics/admin_v1alpha/types/audience.py
+++ b/packages/google-analytics-admin/google/analytics/admin_v1alpha/types/audience.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/google/analytics/admin_v1alpha/types/channel_group.py
+++ b/packages/google-analytics-admin/google/analytics/admin_v1alpha/types/channel_group.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/google/analytics/admin_v1alpha/types/event_create_and_edit.py
+++ b/packages/google-analytics-admin/google/analytics/admin_v1alpha/types/event_create_and_edit.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/google/analytics/admin_v1alpha/types/expanded_data_set.py
+++ b/packages/google-analytics-admin/google/analytics/admin_v1alpha/types/expanded_data_set.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/google/analytics/admin_v1alpha/types/resources.py
+++ b/packages/google-analytics-admin/google/analytics/admin_v1alpha/types/resources.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/google/analytics/admin_v1alpha/types/subproperty_event_filter.py
+++ b/packages/google-analytics-admin/google/analytics/admin_v1alpha/types/subproperty_event_filter.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/google/analytics/admin_v1beta/gapic_version.py
+++ b/packages/google-analytics-admin/google/analytics/admin_v1beta/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/google/analytics/admin_v1beta/services/__init__.py
+++ b/packages/google-analytics-admin/google/analytics/admin_v1beta/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/google/analytics/admin_v1beta/services/analytics_admin_service/__init__.py
+++ b/packages/google-analytics-admin/google/analytics/admin_v1beta/services/analytics_admin_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/google/analytics/admin_v1beta/services/analytics_admin_service/async_client.py
+++ b/packages/google-analytics-admin/google/analytics/admin_v1beta/services/analytics_admin_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/google/analytics/admin_v1beta/services/analytics_admin_service/client.py
+++ b/packages/google-analytics-admin/google/analytics/admin_v1beta/services/analytics_admin_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/google/analytics/admin_v1beta/services/analytics_admin_service/pagers.py
+++ b/packages/google-analytics-admin/google/analytics/admin_v1beta/services/analytics_admin_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/google/analytics/admin_v1beta/services/analytics_admin_service/transports/__init__.py
+++ b/packages/google-analytics-admin/google/analytics/admin_v1beta/services/analytics_admin_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/google/analytics/admin_v1beta/services/analytics_admin_service/transports/base.py
+++ b/packages/google-analytics-admin/google/analytics/admin_v1beta/services/analytics_admin_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/google/analytics/admin_v1beta/services/analytics_admin_service/transports/grpc.py
+++ b/packages/google-analytics-admin/google/analytics/admin_v1beta/services/analytics_admin_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/google/analytics/admin_v1beta/services/analytics_admin_service/transports/grpc_asyncio.py
+++ b/packages/google-analytics-admin/google/analytics/admin_v1beta/services/analytics_admin_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/google/analytics/admin_v1beta/services/analytics_admin_service/transports/rest.py
+++ b/packages/google-analytics-admin/google/analytics/admin_v1beta/services/analytics_admin_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/google/analytics/admin_v1beta/services/analytics_admin_service/transports/rest_base.py
+++ b/packages/google-analytics-admin/google/analytics/admin_v1beta/services/analytics_admin_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/google/analytics/admin_v1beta/types/__init__.py
+++ b/packages/google-analytics-admin/google/analytics/admin_v1beta/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/google/analytics/admin_v1beta/types/access_report.py
+++ b/packages/google-analytics-admin/google/analytics/admin_v1beta/types/access_report.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/google/analytics/admin_v1beta/types/analytics_admin.py
+++ b/packages/google-analytics-admin/google/analytics/admin_v1beta/types/analytics_admin.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/google/analytics/admin_v1beta/types/resources.py
+++ b/packages/google-analytics-admin/google/analytics/admin_v1beta/types/resources.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_acknowledge_user_data_collection_async.py
+++ b/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_acknowledge_user_data_collection_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_acknowledge_user_data_collection_sync.py
+++ b/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_acknowledge_user_data_collection_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_archive_custom_dimension_async.py
+++ b/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_archive_custom_dimension_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_archive_custom_dimension_sync.py
+++ b/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_archive_custom_dimension_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_archive_custom_metric_async.py
+++ b/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_archive_custom_metric_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_archive_custom_metric_sync.py
+++ b/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_archive_custom_metric_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_create_conversion_event_async.py
+++ b/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_create_conversion_event_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_create_conversion_event_sync.py
+++ b/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_create_conversion_event_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_create_custom_dimension_async.py
+++ b/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_create_custom_dimension_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_create_custom_dimension_sync.py
+++ b/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_create_custom_dimension_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_create_custom_metric_async.py
+++ b/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_create_custom_metric_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_create_custom_metric_sync.py
+++ b/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_create_custom_metric_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_create_data_stream_async.py
+++ b/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_create_data_stream_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_create_data_stream_sync.py
+++ b/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_create_data_stream_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_create_firebase_link_async.py
+++ b/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_create_firebase_link_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_create_firebase_link_sync.py
+++ b/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_create_firebase_link_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_create_google_ads_link_async.py
+++ b/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_create_google_ads_link_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_create_google_ads_link_sync.py
+++ b/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_create_google_ads_link_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_create_key_event_async.py
+++ b/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_create_key_event_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_create_key_event_sync.py
+++ b/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_create_key_event_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_create_measurement_protocol_secret_async.py
+++ b/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_create_measurement_protocol_secret_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_create_measurement_protocol_secret_sync.py
+++ b/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_create_measurement_protocol_secret_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_create_property_async.py
+++ b/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_create_property_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_create_property_sync.py
+++ b/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_create_property_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_delete_account_async.py
+++ b/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_delete_account_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_delete_account_sync.py
+++ b/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_delete_account_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_delete_conversion_event_async.py
+++ b/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_delete_conversion_event_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_delete_conversion_event_sync.py
+++ b/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_delete_conversion_event_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_delete_data_stream_async.py
+++ b/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_delete_data_stream_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_delete_data_stream_sync.py
+++ b/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_delete_data_stream_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_delete_firebase_link_async.py
+++ b/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_delete_firebase_link_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_delete_firebase_link_sync.py
+++ b/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_delete_firebase_link_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_delete_google_ads_link_async.py
+++ b/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_delete_google_ads_link_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_delete_google_ads_link_sync.py
+++ b/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_delete_google_ads_link_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_delete_key_event_async.py
+++ b/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_delete_key_event_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_delete_key_event_sync.py
+++ b/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_delete_key_event_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_delete_measurement_protocol_secret_async.py
+++ b/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_delete_measurement_protocol_secret_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_delete_measurement_protocol_secret_sync.py
+++ b/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_delete_measurement_protocol_secret_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_delete_property_async.py
+++ b/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_delete_property_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_delete_property_sync.py
+++ b/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_delete_property_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_get_account_async.py
+++ b/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_get_account_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_get_account_sync.py
+++ b/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_get_account_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_get_conversion_event_async.py
+++ b/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_get_conversion_event_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_get_conversion_event_sync.py
+++ b/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_get_conversion_event_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_get_custom_dimension_async.py
+++ b/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_get_custom_dimension_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_get_custom_dimension_sync.py
+++ b/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_get_custom_dimension_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_get_custom_metric_async.py
+++ b/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_get_custom_metric_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_get_custom_metric_sync.py
+++ b/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_get_custom_metric_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_get_data_retention_settings_async.py
+++ b/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_get_data_retention_settings_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_get_data_retention_settings_sync.py
+++ b/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_get_data_retention_settings_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_get_data_sharing_settings_async.py
+++ b/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_get_data_sharing_settings_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_get_data_sharing_settings_sync.py
+++ b/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_get_data_sharing_settings_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_get_data_stream_async.py
+++ b/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_get_data_stream_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_get_data_stream_sync.py
+++ b/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_get_data_stream_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_get_key_event_async.py
+++ b/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_get_key_event_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_get_key_event_sync.py
+++ b/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_get_key_event_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_get_measurement_protocol_secret_async.py
+++ b/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_get_measurement_protocol_secret_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_get_measurement_protocol_secret_sync.py
+++ b/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_get_measurement_protocol_secret_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_get_property_async.py
+++ b/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_get_property_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_get_property_sync.py
+++ b/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_get_property_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_list_account_summaries_async.py
+++ b/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_list_account_summaries_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_list_account_summaries_sync.py
+++ b/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_list_account_summaries_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_list_accounts_async.py
+++ b/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_list_accounts_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_list_accounts_sync.py
+++ b/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_list_accounts_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_list_conversion_events_async.py
+++ b/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_list_conversion_events_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_list_conversion_events_sync.py
+++ b/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_list_conversion_events_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_list_custom_dimensions_async.py
+++ b/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_list_custom_dimensions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_list_custom_dimensions_sync.py
+++ b/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_list_custom_dimensions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_list_custom_metrics_async.py
+++ b/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_list_custom_metrics_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_list_custom_metrics_sync.py
+++ b/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_list_custom_metrics_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_list_data_streams_async.py
+++ b/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_list_data_streams_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_list_data_streams_sync.py
+++ b/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_list_data_streams_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_list_firebase_links_async.py
+++ b/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_list_firebase_links_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_list_firebase_links_sync.py
+++ b/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_list_firebase_links_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_list_google_ads_links_async.py
+++ b/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_list_google_ads_links_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_list_google_ads_links_sync.py
+++ b/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_list_google_ads_links_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_list_key_events_async.py
+++ b/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_list_key_events_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_list_key_events_sync.py
+++ b/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_list_key_events_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_list_measurement_protocol_secrets_async.py
+++ b/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_list_measurement_protocol_secrets_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_list_measurement_protocol_secrets_sync.py
+++ b/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_list_measurement_protocol_secrets_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_list_properties_async.py
+++ b/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_list_properties_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_list_properties_sync.py
+++ b/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_list_properties_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_provision_account_ticket_async.py
+++ b/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_provision_account_ticket_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_provision_account_ticket_sync.py
+++ b/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_provision_account_ticket_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_run_access_report_async.py
+++ b/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_run_access_report_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_run_access_report_sync.py
+++ b/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_run_access_report_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_search_change_history_events_async.py
+++ b/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_search_change_history_events_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_search_change_history_events_sync.py
+++ b/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_search_change_history_events_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_update_account_async.py
+++ b/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_update_account_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_update_account_sync.py
+++ b/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_update_account_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_update_conversion_event_async.py
+++ b/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_update_conversion_event_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_update_conversion_event_sync.py
+++ b/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_update_conversion_event_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_update_custom_dimension_async.py
+++ b/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_update_custom_dimension_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_update_custom_dimension_sync.py
+++ b/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_update_custom_dimension_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_update_custom_metric_async.py
+++ b/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_update_custom_metric_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_update_custom_metric_sync.py
+++ b/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_update_custom_metric_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_update_data_retention_settings_async.py
+++ b/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_update_data_retention_settings_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_update_data_retention_settings_sync.py
+++ b/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_update_data_retention_settings_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_update_data_stream_async.py
+++ b/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_update_data_stream_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_update_data_stream_sync.py
+++ b/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_update_data_stream_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_update_google_ads_link_async.py
+++ b/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_update_google_ads_link_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_update_google_ads_link_sync.py
+++ b/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_update_google_ads_link_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_update_key_event_async.py
+++ b/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_update_key_event_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_update_key_event_sync.py
+++ b/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_update_key_event_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_update_measurement_protocol_secret_async.py
+++ b/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_update_measurement_protocol_secret_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_update_measurement_protocol_secret_sync.py
+++ b/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_update_measurement_protocol_secret_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_update_property_async.py
+++ b/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_update_property_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_update_property_sync.py
+++ b/packages/google-analytics-admin/samples/generated_samples/analyticsadmin_v1beta_generated_analytics_admin_service_update_property_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/tests/__init__.py
+++ b/packages/google-analytics-admin/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/tests/unit/__init__.py
+++ b/packages/google-analytics-admin/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/tests/unit/gapic/__init__.py
+++ b/packages/google-analytics-admin/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/tests/unit/gapic/admin_v1alpha/__init__.py
+++ b/packages/google-analytics-admin/tests/unit/gapic/admin_v1alpha/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-admin/tests/unit/gapic/admin_v1beta/__init__.py
+++ b/packages/google-analytics-admin/tests/unit/gapic/admin_v1beta/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-data/.flake8
+++ b/packages/google-analytics-data/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-data/MANIFEST.in
+++ b/packages/google-analytics-data/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-data/google/analytics/data/__init__.py
+++ b/packages/google-analytics-data/google/analytics/data/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-data/google/analytics/data/gapic_version.py
+++ b/packages/google-analytics-data/google/analytics/data/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-data/google/analytics/data_v1alpha/gapic_version.py
+++ b/packages/google-analytics-data/google/analytics/data_v1alpha/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-data/google/analytics/data_v1alpha/services/__init__.py
+++ b/packages/google-analytics-data/google/analytics/data_v1alpha/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-data/google/analytics/data_v1alpha/services/alpha_analytics_data/__init__.py
+++ b/packages/google-analytics-data/google/analytics/data_v1alpha/services/alpha_analytics_data/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-data/google/analytics/data_v1alpha/services/alpha_analytics_data/client.py
+++ b/packages/google-analytics-data/google/analytics/data_v1alpha/services/alpha_analytics_data/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-data/google/analytics/data_v1alpha/services/alpha_analytics_data/pagers.py
+++ b/packages/google-analytics-data/google/analytics/data_v1alpha/services/alpha_analytics_data/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-data/google/analytics/data_v1alpha/services/alpha_analytics_data/transports/__init__.py
+++ b/packages/google-analytics-data/google/analytics/data_v1alpha/services/alpha_analytics_data/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-data/google/analytics/data_v1alpha/services/alpha_analytics_data/transports/base.py
+++ b/packages/google-analytics-data/google/analytics/data_v1alpha/services/alpha_analytics_data/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-data/google/analytics/data_v1alpha/services/alpha_analytics_data/transports/grpc.py
+++ b/packages/google-analytics-data/google/analytics/data_v1alpha/services/alpha_analytics_data/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-data/google/analytics/data_v1alpha/services/alpha_analytics_data/transports/grpc_asyncio.py
+++ b/packages/google-analytics-data/google/analytics/data_v1alpha/services/alpha_analytics_data/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-data/google/analytics/data_v1alpha/services/alpha_analytics_data/transports/rest.py
+++ b/packages/google-analytics-data/google/analytics/data_v1alpha/services/alpha_analytics_data/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-data/google/analytics/data_v1alpha/services/alpha_analytics_data/transports/rest_base.py
+++ b/packages/google-analytics-data/google/analytics/data_v1alpha/services/alpha_analytics_data/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-data/google/analytics/data_v1alpha/types/__init__.py
+++ b/packages/google-analytics-data/google/analytics/data_v1alpha/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-data/google/analytics/data_v1alpha/types/analytics_data_api.py
+++ b/packages/google-analytics-data/google/analytics/data_v1alpha/types/analytics_data_api.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-data/google/analytics/data_v1alpha/types/data.py
+++ b/packages/google-analytics-data/google/analytics/data_v1alpha/types/data.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-data/google/analytics/data_v1beta/gapic_version.py
+++ b/packages/google-analytics-data/google/analytics/data_v1beta/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-data/google/analytics/data_v1beta/services/__init__.py
+++ b/packages/google-analytics-data/google/analytics/data_v1beta/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-data/google/analytics/data_v1beta/services/beta_analytics_data/__init__.py
+++ b/packages/google-analytics-data/google/analytics/data_v1beta/services/beta_analytics_data/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-data/google/analytics/data_v1beta/services/beta_analytics_data/client.py
+++ b/packages/google-analytics-data/google/analytics/data_v1beta/services/beta_analytics_data/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-data/google/analytics/data_v1beta/services/beta_analytics_data/pagers.py
+++ b/packages/google-analytics-data/google/analytics/data_v1beta/services/beta_analytics_data/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-data/google/analytics/data_v1beta/services/beta_analytics_data/transports/__init__.py
+++ b/packages/google-analytics-data/google/analytics/data_v1beta/services/beta_analytics_data/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-data/google/analytics/data_v1beta/services/beta_analytics_data/transports/base.py
+++ b/packages/google-analytics-data/google/analytics/data_v1beta/services/beta_analytics_data/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-data/google/analytics/data_v1beta/services/beta_analytics_data/transports/grpc.py
+++ b/packages/google-analytics-data/google/analytics/data_v1beta/services/beta_analytics_data/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-data/google/analytics/data_v1beta/services/beta_analytics_data/transports/grpc_asyncio.py
+++ b/packages/google-analytics-data/google/analytics/data_v1beta/services/beta_analytics_data/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-data/google/analytics/data_v1beta/services/beta_analytics_data/transports/rest.py
+++ b/packages/google-analytics-data/google/analytics/data_v1beta/services/beta_analytics_data/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-data/google/analytics/data_v1beta/services/beta_analytics_data/transports/rest_base.py
+++ b/packages/google-analytics-data/google/analytics/data_v1beta/services/beta_analytics_data/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-data/google/analytics/data_v1beta/types/__init__.py
+++ b/packages/google-analytics-data/google/analytics/data_v1beta/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-data/google/analytics/data_v1beta/types/analytics_data_api.py
+++ b/packages/google-analytics-data/google/analytics/data_v1beta/types/analytics_data_api.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-data/google/analytics/data_v1beta/types/data.py
+++ b/packages/google-analytics-data/google/analytics/data_v1beta/types/data.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-data/samples/generated_samples/analyticsdata_v1alpha_generated_alpha_analytics_data_create_audience_list_sync.py
+++ b/packages/google-analytics-data/samples/generated_samples/analyticsdata_v1alpha_generated_alpha_analytics_data_create_audience_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-data/samples/generated_samples/analyticsdata_v1alpha_generated_alpha_analytics_data_create_recurring_audience_list_async.py
+++ b/packages/google-analytics-data/samples/generated_samples/analyticsdata_v1alpha_generated_alpha_analytics_data_create_recurring_audience_list_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-data/samples/generated_samples/analyticsdata_v1alpha_generated_alpha_analytics_data_create_recurring_audience_list_sync.py
+++ b/packages/google-analytics-data/samples/generated_samples/analyticsdata_v1alpha_generated_alpha_analytics_data_create_recurring_audience_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-data/samples/generated_samples/analyticsdata_v1alpha_generated_alpha_analytics_data_create_report_task_sync.py
+++ b/packages/google-analytics-data/samples/generated_samples/analyticsdata_v1alpha_generated_alpha_analytics_data_create_report_task_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-data/samples/generated_samples/analyticsdata_v1alpha_generated_alpha_analytics_data_get_audience_list_async.py
+++ b/packages/google-analytics-data/samples/generated_samples/analyticsdata_v1alpha_generated_alpha_analytics_data_get_audience_list_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-data/samples/generated_samples/analyticsdata_v1alpha_generated_alpha_analytics_data_get_audience_list_sync.py
+++ b/packages/google-analytics-data/samples/generated_samples/analyticsdata_v1alpha_generated_alpha_analytics_data_get_audience_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-data/samples/generated_samples/analyticsdata_v1alpha_generated_alpha_analytics_data_get_metadata_async.py
+++ b/packages/google-analytics-data/samples/generated_samples/analyticsdata_v1alpha_generated_alpha_analytics_data_get_metadata_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-data/samples/generated_samples/analyticsdata_v1alpha_generated_alpha_analytics_data_get_metadata_sync.py
+++ b/packages/google-analytics-data/samples/generated_samples/analyticsdata_v1alpha_generated_alpha_analytics_data_get_metadata_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-data/samples/generated_samples/analyticsdata_v1alpha_generated_alpha_analytics_data_get_property_quotas_snapshot_async.py
+++ b/packages/google-analytics-data/samples/generated_samples/analyticsdata_v1alpha_generated_alpha_analytics_data_get_property_quotas_snapshot_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-data/samples/generated_samples/analyticsdata_v1alpha_generated_alpha_analytics_data_get_property_quotas_snapshot_sync.py
+++ b/packages/google-analytics-data/samples/generated_samples/analyticsdata_v1alpha_generated_alpha_analytics_data_get_property_quotas_snapshot_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-data/samples/generated_samples/analyticsdata_v1alpha_generated_alpha_analytics_data_get_recurring_audience_list_async.py
+++ b/packages/google-analytics-data/samples/generated_samples/analyticsdata_v1alpha_generated_alpha_analytics_data_get_recurring_audience_list_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-data/samples/generated_samples/analyticsdata_v1alpha_generated_alpha_analytics_data_get_recurring_audience_list_sync.py
+++ b/packages/google-analytics-data/samples/generated_samples/analyticsdata_v1alpha_generated_alpha_analytics_data_get_recurring_audience_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-data/samples/generated_samples/analyticsdata_v1alpha_generated_alpha_analytics_data_get_report_task_async.py
+++ b/packages/google-analytics-data/samples/generated_samples/analyticsdata_v1alpha_generated_alpha_analytics_data_get_report_task_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-data/samples/generated_samples/analyticsdata_v1alpha_generated_alpha_analytics_data_get_report_task_sync.py
+++ b/packages/google-analytics-data/samples/generated_samples/analyticsdata_v1alpha_generated_alpha_analytics_data_get_report_task_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-data/samples/generated_samples/analyticsdata_v1alpha_generated_alpha_analytics_data_list_audience_lists_async.py
+++ b/packages/google-analytics-data/samples/generated_samples/analyticsdata_v1alpha_generated_alpha_analytics_data_list_audience_lists_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-data/samples/generated_samples/analyticsdata_v1alpha_generated_alpha_analytics_data_list_audience_lists_sync.py
+++ b/packages/google-analytics-data/samples/generated_samples/analyticsdata_v1alpha_generated_alpha_analytics_data_list_audience_lists_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-data/samples/generated_samples/analyticsdata_v1alpha_generated_alpha_analytics_data_list_recurring_audience_lists_async.py
+++ b/packages/google-analytics-data/samples/generated_samples/analyticsdata_v1alpha_generated_alpha_analytics_data_list_recurring_audience_lists_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-data/samples/generated_samples/analyticsdata_v1alpha_generated_alpha_analytics_data_list_recurring_audience_lists_sync.py
+++ b/packages/google-analytics-data/samples/generated_samples/analyticsdata_v1alpha_generated_alpha_analytics_data_list_recurring_audience_lists_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-data/samples/generated_samples/analyticsdata_v1alpha_generated_alpha_analytics_data_list_report_tasks_async.py
+++ b/packages/google-analytics-data/samples/generated_samples/analyticsdata_v1alpha_generated_alpha_analytics_data_list_report_tasks_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-data/samples/generated_samples/analyticsdata_v1alpha_generated_alpha_analytics_data_list_report_tasks_sync.py
+++ b/packages/google-analytics-data/samples/generated_samples/analyticsdata_v1alpha_generated_alpha_analytics_data_list_report_tasks_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-data/samples/generated_samples/analyticsdata_v1alpha_generated_alpha_analytics_data_query_audience_list_async.py
+++ b/packages/google-analytics-data/samples/generated_samples/analyticsdata_v1alpha_generated_alpha_analytics_data_query_audience_list_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-data/samples/generated_samples/analyticsdata_v1alpha_generated_alpha_analytics_data_query_audience_list_sync.py
+++ b/packages/google-analytics-data/samples/generated_samples/analyticsdata_v1alpha_generated_alpha_analytics_data_query_audience_list_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-data/samples/generated_samples/analyticsdata_v1alpha_generated_alpha_analytics_data_query_report_task_async.py
+++ b/packages/google-analytics-data/samples/generated_samples/analyticsdata_v1alpha_generated_alpha_analytics_data_query_report_task_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-data/samples/generated_samples/analyticsdata_v1alpha_generated_alpha_analytics_data_query_report_task_sync.py
+++ b/packages/google-analytics-data/samples/generated_samples/analyticsdata_v1alpha_generated_alpha_analytics_data_query_report_task_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-data/samples/generated_samples/analyticsdata_v1alpha_generated_alpha_analytics_data_run_funnel_report_async.py
+++ b/packages/google-analytics-data/samples/generated_samples/analyticsdata_v1alpha_generated_alpha_analytics_data_run_funnel_report_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-data/samples/generated_samples/analyticsdata_v1alpha_generated_alpha_analytics_data_run_funnel_report_sync.py
+++ b/packages/google-analytics-data/samples/generated_samples/analyticsdata_v1alpha_generated_alpha_analytics_data_run_funnel_report_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-data/samples/generated_samples/analyticsdata_v1alpha_generated_alpha_analytics_data_run_report_async.py
+++ b/packages/google-analytics-data/samples/generated_samples/analyticsdata_v1alpha_generated_alpha_analytics_data_run_report_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-data/samples/generated_samples/analyticsdata_v1alpha_generated_alpha_analytics_data_run_report_sync.py
+++ b/packages/google-analytics-data/samples/generated_samples/analyticsdata_v1alpha_generated_alpha_analytics_data_run_report_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-data/samples/generated_samples/analyticsdata_v1beta_generated_beta_analytics_data_batch_run_pivot_reports_async.py
+++ b/packages/google-analytics-data/samples/generated_samples/analyticsdata_v1beta_generated_beta_analytics_data_batch_run_pivot_reports_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-data/samples/generated_samples/analyticsdata_v1beta_generated_beta_analytics_data_batch_run_pivot_reports_sync.py
+++ b/packages/google-analytics-data/samples/generated_samples/analyticsdata_v1beta_generated_beta_analytics_data_batch_run_pivot_reports_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-data/samples/generated_samples/analyticsdata_v1beta_generated_beta_analytics_data_batch_run_reports_async.py
+++ b/packages/google-analytics-data/samples/generated_samples/analyticsdata_v1beta_generated_beta_analytics_data_batch_run_reports_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-data/samples/generated_samples/analyticsdata_v1beta_generated_beta_analytics_data_batch_run_reports_sync.py
+++ b/packages/google-analytics-data/samples/generated_samples/analyticsdata_v1beta_generated_beta_analytics_data_batch_run_reports_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-data/samples/generated_samples/analyticsdata_v1beta_generated_beta_analytics_data_check_compatibility_async.py
+++ b/packages/google-analytics-data/samples/generated_samples/analyticsdata_v1beta_generated_beta_analytics_data_check_compatibility_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-data/samples/generated_samples/analyticsdata_v1beta_generated_beta_analytics_data_check_compatibility_sync.py
+++ b/packages/google-analytics-data/samples/generated_samples/analyticsdata_v1beta_generated_beta_analytics_data_check_compatibility_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-data/samples/generated_samples/analyticsdata_v1beta_generated_beta_analytics_data_create_audience_export_sync.py
+++ b/packages/google-analytics-data/samples/generated_samples/analyticsdata_v1beta_generated_beta_analytics_data_create_audience_export_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-data/samples/generated_samples/analyticsdata_v1beta_generated_beta_analytics_data_get_audience_export_async.py
+++ b/packages/google-analytics-data/samples/generated_samples/analyticsdata_v1beta_generated_beta_analytics_data_get_audience_export_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-data/samples/generated_samples/analyticsdata_v1beta_generated_beta_analytics_data_get_audience_export_sync.py
+++ b/packages/google-analytics-data/samples/generated_samples/analyticsdata_v1beta_generated_beta_analytics_data_get_audience_export_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-data/samples/generated_samples/analyticsdata_v1beta_generated_beta_analytics_data_get_metadata_async.py
+++ b/packages/google-analytics-data/samples/generated_samples/analyticsdata_v1beta_generated_beta_analytics_data_get_metadata_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-data/samples/generated_samples/analyticsdata_v1beta_generated_beta_analytics_data_get_metadata_sync.py
+++ b/packages/google-analytics-data/samples/generated_samples/analyticsdata_v1beta_generated_beta_analytics_data_get_metadata_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-data/samples/generated_samples/analyticsdata_v1beta_generated_beta_analytics_data_list_audience_exports_async.py
+++ b/packages/google-analytics-data/samples/generated_samples/analyticsdata_v1beta_generated_beta_analytics_data_list_audience_exports_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-data/samples/generated_samples/analyticsdata_v1beta_generated_beta_analytics_data_list_audience_exports_sync.py
+++ b/packages/google-analytics-data/samples/generated_samples/analyticsdata_v1beta_generated_beta_analytics_data_list_audience_exports_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-data/samples/generated_samples/analyticsdata_v1beta_generated_beta_analytics_data_query_audience_export_async.py
+++ b/packages/google-analytics-data/samples/generated_samples/analyticsdata_v1beta_generated_beta_analytics_data_query_audience_export_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-data/samples/generated_samples/analyticsdata_v1beta_generated_beta_analytics_data_query_audience_export_sync.py
+++ b/packages/google-analytics-data/samples/generated_samples/analyticsdata_v1beta_generated_beta_analytics_data_query_audience_export_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-data/samples/generated_samples/analyticsdata_v1beta_generated_beta_analytics_data_run_pivot_report_async.py
+++ b/packages/google-analytics-data/samples/generated_samples/analyticsdata_v1beta_generated_beta_analytics_data_run_pivot_report_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-data/samples/generated_samples/analyticsdata_v1beta_generated_beta_analytics_data_run_pivot_report_sync.py
+++ b/packages/google-analytics-data/samples/generated_samples/analyticsdata_v1beta_generated_beta_analytics_data_run_pivot_report_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-data/samples/generated_samples/analyticsdata_v1beta_generated_beta_analytics_data_run_realtime_report_async.py
+++ b/packages/google-analytics-data/samples/generated_samples/analyticsdata_v1beta_generated_beta_analytics_data_run_realtime_report_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-data/samples/generated_samples/analyticsdata_v1beta_generated_beta_analytics_data_run_realtime_report_sync.py
+++ b/packages/google-analytics-data/samples/generated_samples/analyticsdata_v1beta_generated_beta_analytics_data_run_realtime_report_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-data/samples/generated_samples/analyticsdata_v1beta_generated_beta_analytics_data_run_report_async.py
+++ b/packages/google-analytics-data/samples/generated_samples/analyticsdata_v1beta_generated_beta_analytics_data_run_report_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-data/samples/generated_samples/analyticsdata_v1beta_generated_beta_analytics_data_run_report_sync.py
+++ b/packages/google-analytics-data/samples/generated_samples/analyticsdata_v1beta_generated_beta_analytics_data_run_report_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-data/tests/__init__.py
+++ b/packages/google-analytics-data/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-data/tests/unit/__init__.py
+++ b/packages/google-analytics-data/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-data/tests/unit/gapic/__init__.py
+++ b/packages/google-analytics-data/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-data/tests/unit/gapic/data_v1alpha/__init__.py
+++ b/packages/google-analytics-data/tests/unit/gapic/data_v1alpha/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-analytics-data/tests/unit/gapic/data_v1beta/__init__.py
+++ b/packages/google-analytics-data/tests/unit/gapic/data_v1beta/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-card/.flake8
+++ b/packages/google-apps-card/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-card/MANIFEST.in
+++ b/packages/google-apps-card/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-card/google/apps/card/__init__.py
+++ b/packages/google-apps-card/google/apps/card/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-card/google/apps/card/gapic_version.py
+++ b/packages/google-apps-card/google/apps/card/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-card/google/apps/card_v1/gapic_version.py
+++ b/packages/google-apps-card/google/apps/card_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-card/google/apps/card_v1/services/__init__.py
+++ b/packages/google-apps-card/google/apps/card_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-card/google/apps/card_v1/types/__init__.py
+++ b/packages/google-apps-card/google/apps/card_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-card/google/apps/card_v1/types/card.py
+++ b/packages/google-apps-card/google/apps/card_v1/types/card.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-card/tests/__init__.py
+++ b/packages/google-apps-card/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-card/tests/unit/__init__.py
+++ b/packages/google-apps-card/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-card/tests/unit/gapic/__init__.py
+++ b/packages/google-apps-card/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-card/tests/unit/gapic/card_v1/__init__.py
+++ b/packages/google-apps-card/tests/unit/gapic/card_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/.flake8
+++ b/packages/google-apps-chat/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/MANIFEST.in
+++ b/packages/google-apps-chat/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/google/apps/chat/__init__.py
+++ b/packages/google-apps-chat/google/apps/chat/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/google/apps/chat/gapic_version.py
+++ b/packages/google-apps-chat/google/apps/chat/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/google/apps/chat_v1/gapic_version.py
+++ b/packages/google-apps-chat/google/apps/chat_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/google/apps/chat_v1/services/__init__.py
+++ b/packages/google-apps-chat/google/apps/chat_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/google/apps/chat_v1/services/chat_service/__init__.py
+++ b/packages/google-apps-chat/google/apps/chat_v1/services/chat_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/google/apps/chat_v1/services/chat_service/client.py
+++ b/packages/google-apps-chat/google/apps/chat_v1/services/chat_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/google/apps/chat_v1/services/chat_service/pagers.py
+++ b/packages/google-apps-chat/google/apps/chat_v1/services/chat_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/google/apps/chat_v1/services/chat_service/transports/__init__.py
+++ b/packages/google-apps-chat/google/apps/chat_v1/services/chat_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/google/apps/chat_v1/services/chat_service/transports/base.py
+++ b/packages/google-apps-chat/google/apps/chat_v1/services/chat_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/google/apps/chat_v1/services/chat_service/transports/rest.py
+++ b/packages/google-apps-chat/google/apps/chat_v1/services/chat_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/google/apps/chat_v1/services/chat_service/transports/rest_base.py
+++ b/packages/google-apps-chat/google/apps/chat_v1/services/chat_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/google/apps/chat_v1/types/__init__.py
+++ b/packages/google-apps-chat/google/apps/chat_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/google/apps/chat_v1/types/action_status.py
+++ b/packages/google-apps-chat/google/apps/chat_v1/types/action_status.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/google/apps/chat_v1/types/annotation.py
+++ b/packages/google-apps-chat/google/apps/chat_v1/types/annotation.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/google/apps/chat_v1/types/attachment.py
+++ b/packages/google-apps-chat/google/apps/chat_v1/types/attachment.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/google/apps/chat_v1/types/chat_service.py
+++ b/packages/google-apps-chat/google/apps/chat_v1/types/chat_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/google/apps/chat_v1/types/contextual_addon.py
+++ b/packages/google-apps-chat/google/apps/chat_v1/types/contextual_addon.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/google/apps/chat_v1/types/deletion_metadata.py
+++ b/packages/google-apps-chat/google/apps/chat_v1/types/deletion_metadata.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/google/apps/chat_v1/types/event_payload.py
+++ b/packages/google-apps-chat/google/apps/chat_v1/types/event_payload.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/google/apps/chat_v1/types/group.py
+++ b/packages/google-apps-chat/google/apps/chat_v1/types/group.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/google/apps/chat_v1/types/history_state.py
+++ b/packages/google-apps-chat/google/apps/chat_v1/types/history_state.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/google/apps/chat_v1/types/matched_url.py
+++ b/packages/google-apps-chat/google/apps/chat_v1/types/matched_url.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/google/apps/chat_v1/types/membership.py
+++ b/packages/google-apps-chat/google/apps/chat_v1/types/membership.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/google/apps/chat_v1/types/message.py
+++ b/packages/google-apps-chat/google/apps/chat_v1/types/message.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/google/apps/chat_v1/types/reaction.py
+++ b/packages/google-apps-chat/google/apps/chat_v1/types/reaction.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/google/apps/chat_v1/types/section.py
+++ b/packages/google-apps-chat/google/apps/chat_v1/types/section.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/google/apps/chat_v1/types/slash_command.py
+++ b/packages/google-apps-chat/google/apps/chat_v1/types/slash_command.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/google/apps/chat_v1/types/space.py
+++ b/packages/google-apps-chat/google/apps/chat_v1/types/space.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/google/apps/chat_v1/types/space_event.py
+++ b/packages/google-apps-chat/google/apps/chat_v1/types/space_event.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/google/apps/chat_v1/types/space_notification_setting.py
+++ b/packages/google-apps-chat/google/apps/chat_v1/types/space_notification_setting.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/google/apps/chat_v1/types/space_read_state.py
+++ b/packages/google-apps-chat/google/apps/chat_v1/types/space_read_state.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/google/apps/chat_v1/types/space_setup.py
+++ b/packages/google-apps-chat/google/apps/chat_v1/types/space_setup.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/google/apps/chat_v1/types/thread_read_state.py
+++ b/packages/google-apps-chat/google/apps/chat_v1/types/thread_read_state.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/google/apps/chat_v1/types/user.py
+++ b/packages/google-apps-chat/google/apps/chat_v1/types/user.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/google/apps/chat_v1/types/widgets.py
+++ b/packages/google-apps-chat/google/apps/chat_v1/types/widgets.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_complete_import_space_async.py
+++ b/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_complete_import_space_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_complete_import_space_sync.py
+++ b/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_complete_import_space_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_create_custom_emoji_async.py
+++ b/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_create_custom_emoji_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_create_custom_emoji_sync.py
+++ b/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_create_custom_emoji_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_create_membership_async.py
+++ b/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_create_membership_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_create_membership_sync.py
+++ b/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_create_membership_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_create_message_async.py
+++ b/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_create_message_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_create_message_sync.py
+++ b/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_create_message_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_create_reaction_async.py
+++ b/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_create_reaction_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_create_reaction_sync.py
+++ b/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_create_reaction_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_create_section_async.py
+++ b/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_create_section_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_create_section_sync.py
+++ b/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_create_section_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_create_space_async.py
+++ b/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_create_space_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_create_space_sync.py
+++ b/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_create_space_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_delete_custom_emoji_async.py
+++ b/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_delete_custom_emoji_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_delete_custom_emoji_sync.py
+++ b/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_delete_custom_emoji_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_delete_membership_async.py
+++ b/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_delete_membership_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_delete_membership_sync.py
+++ b/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_delete_membership_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_delete_message_async.py
+++ b/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_delete_message_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_delete_message_sync.py
+++ b/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_delete_message_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_delete_reaction_async.py
+++ b/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_delete_reaction_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_delete_reaction_sync.py
+++ b/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_delete_reaction_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_delete_section_async.py
+++ b/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_delete_section_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_delete_section_sync.py
+++ b/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_delete_section_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_delete_space_async.py
+++ b/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_delete_space_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_delete_space_sync.py
+++ b/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_delete_space_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_find_direct_message_async.py
+++ b/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_find_direct_message_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_find_direct_message_sync.py
+++ b/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_find_direct_message_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_find_group_chats_async.py
+++ b/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_find_group_chats_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_find_group_chats_sync.py
+++ b/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_find_group_chats_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_get_attachment_async.py
+++ b/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_get_attachment_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_get_attachment_sync.py
+++ b/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_get_attachment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_get_custom_emoji_async.py
+++ b/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_get_custom_emoji_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_get_custom_emoji_sync.py
+++ b/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_get_custom_emoji_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_get_membership_async.py
+++ b/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_get_membership_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_get_membership_sync.py
+++ b/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_get_membership_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_get_message_async.py
+++ b/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_get_message_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_get_message_sync.py
+++ b/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_get_message_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_get_space_async.py
+++ b/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_get_space_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_get_space_event_async.py
+++ b/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_get_space_event_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_get_space_event_sync.py
+++ b/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_get_space_event_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_get_space_notification_setting_async.py
+++ b/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_get_space_notification_setting_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_get_space_notification_setting_sync.py
+++ b/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_get_space_notification_setting_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_get_space_read_state_async.py
+++ b/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_get_space_read_state_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_get_space_read_state_sync.py
+++ b/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_get_space_read_state_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_get_space_sync.py
+++ b/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_get_space_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_get_thread_read_state_async.py
+++ b/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_get_thread_read_state_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_get_thread_read_state_sync.py
+++ b/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_get_thread_read_state_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_list_custom_emojis_async.py
+++ b/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_list_custom_emojis_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_list_custom_emojis_sync.py
+++ b/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_list_custom_emojis_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_list_memberships_async.py
+++ b/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_list_memberships_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_list_memberships_sync.py
+++ b/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_list_memberships_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_list_messages_async.py
+++ b/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_list_messages_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_list_messages_sync.py
+++ b/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_list_messages_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_list_reactions_async.py
+++ b/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_list_reactions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_list_reactions_sync.py
+++ b/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_list_reactions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_list_section_items_async.py
+++ b/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_list_section_items_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_list_section_items_sync.py
+++ b/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_list_section_items_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_list_sections_async.py
+++ b/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_list_sections_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_list_sections_sync.py
+++ b/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_list_sections_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_list_space_events_async.py
+++ b/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_list_space_events_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_list_space_events_sync.py
+++ b/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_list_space_events_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_list_spaces_async.py
+++ b/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_list_spaces_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_list_spaces_sync.py
+++ b/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_list_spaces_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_move_section_item_async.py
+++ b/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_move_section_item_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_move_section_item_sync.py
+++ b/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_move_section_item_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_position_section_async.py
+++ b/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_position_section_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_position_section_sync.py
+++ b/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_position_section_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_search_spaces_async.py
+++ b/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_search_spaces_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_search_spaces_sync.py
+++ b/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_search_spaces_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_set_up_space_async.py
+++ b/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_set_up_space_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_set_up_space_sync.py
+++ b/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_set_up_space_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_update_membership_async.py
+++ b/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_update_membership_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_update_membership_sync.py
+++ b/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_update_membership_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_update_message_async.py
+++ b/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_update_message_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_update_message_sync.py
+++ b/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_update_message_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_update_section_async.py
+++ b/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_update_section_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_update_section_sync.py
+++ b/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_update_section_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_update_space_async.py
+++ b/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_update_space_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_update_space_notification_setting_async.py
+++ b/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_update_space_notification_setting_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_update_space_notification_setting_sync.py
+++ b/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_update_space_notification_setting_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_update_space_read_state_async.py
+++ b/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_update_space_read_state_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_update_space_read_state_sync.py
+++ b/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_update_space_read_state_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_update_space_sync.py
+++ b/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_update_space_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_upload_attachment_async.py
+++ b/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_upload_attachment_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_upload_attachment_sync.py
+++ b/packages/google-apps-chat/samples/generated_samples/chat_v1_generated_chat_service_upload_attachment_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/tests/__init__.py
+++ b/packages/google-apps-chat/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/tests/unit/__init__.py
+++ b/packages/google-apps-chat/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/tests/unit/gapic/__init__.py
+++ b/packages/google-apps-chat/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-chat/tests/unit/gapic/chat_v1/__init__.py
+++ b/packages/google-apps-chat/tests/unit/gapic/chat_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-events-subscriptions/.flake8
+++ b/packages/google-apps-events-subscriptions/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-events-subscriptions/MANIFEST.in
+++ b/packages/google-apps-events-subscriptions/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-events-subscriptions/google/apps/events_subscriptions/__init__.py
+++ b/packages/google-apps-events-subscriptions/google/apps/events_subscriptions/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-events-subscriptions/google/apps/events_subscriptions/gapic_version.py
+++ b/packages/google-apps-events-subscriptions/google/apps/events_subscriptions/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-events-subscriptions/google/apps/events_subscriptions_v1/gapic_version.py
+++ b/packages/google-apps-events-subscriptions/google/apps/events_subscriptions_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-events-subscriptions/google/apps/events_subscriptions_v1/services/__init__.py
+++ b/packages/google-apps-events-subscriptions/google/apps/events_subscriptions_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-events-subscriptions/google/apps/events_subscriptions_v1/services/subscriptions_service/__init__.py
+++ b/packages/google-apps-events-subscriptions/google/apps/events_subscriptions_v1/services/subscriptions_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-events-subscriptions/google/apps/events_subscriptions_v1/services/subscriptions_service/client.py
+++ b/packages/google-apps-events-subscriptions/google/apps/events_subscriptions_v1/services/subscriptions_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-events-subscriptions/google/apps/events_subscriptions_v1/services/subscriptions_service/pagers.py
+++ b/packages/google-apps-events-subscriptions/google/apps/events_subscriptions_v1/services/subscriptions_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-events-subscriptions/google/apps/events_subscriptions_v1/services/subscriptions_service/transports/__init__.py
+++ b/packages/google-apps-events-subscriptions/google/apps/events_subscriptions_v1/services/subscriptions_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-events-subscriptions/google/apps/events_subscriptions_v1/services/subscriptions_service/transports/base.py
+++ b/packages/google-apps-events-subscriptions/google/apps/events_subscriptions_v1/services/subscriptions_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-events-subscriptions/google/apps/events_subscriptions_v1/services/subscriptions_service/transports/grpc.py
+++ b/packages/google-apps-events-subscriptions/google/apps/events_subscriptions_v1/services/subscriptions_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-events-subscriptions/google/apps/events_subscriptions_v1/services/subscriptions_service/transports/grpc_asyncio.py
+++ b/packages/google-apps-events-subscriptions/google/apps/events_subscriptions_v1/services/subscriptions_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-events-subscriptions/google/apps/events_subscriptions_v1/services/subscriptions_service/transports/rest.py
+++ b/packages/google-apps-events-subscriptions/google/apps/events_subscriptions_v1/services/subscriptions_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-events-subscriptions/google/apps/events_subscriptions_v1/services/subscriptions_service/transports/rest_base.py
+++ b/packages/google-apps-events-subscriptions/google/apps/events_subscriptions_v1/services/subscriptions_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-events-subscriptions/google/apps/events_subscriptions_v1/types/__init__.py
+++ b/packages/google-apps-events-subscriptions/google/apps/events_subscriptions_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-events-subscriptions/google/apps/events_subscriptions_v1/types/subscription_resource.py
+++ b/packages/google-apps-events-subscriptions/google/apps/events_subscriptions_v1/types/subscription_resource.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-events-subscriptions/google/apps/events_subscriptions_v1/types/subscriptions_service.py
+++ b/packages/google-apps-events-subscriptions/google/apps/events_subscriptions_v1/types/subscriptions_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-events-subscriptions/google/apps/events_subscriptions_v1beta/gapic_version.py
+++ b/packages/google-apps-events-subscriptions/google/apps/events_subscriptions_v1beta/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-events-subscriptions/google/apps/events_subscriptions_v1beta/services/__init__.py
+++ b/packages/google-apps-events-subscriptions/google/apps/events_subscriptions_v1beta/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-events-subscriptions/google/apps/events_subscriptions_v1beta/services/subscriptions_service/__init__.py
+++ b/packages/google-apps-events-subscriptions/google/apps/events_subscriptions_v1beta/services/subscriptions_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-events-subscriptions/google/apps/events_subscriptions_v1beta/services/subscriptions_service/client.py
+++ b/packages/google-apps-events-subscriptions/google/apps/events_subscriptions_v1beta/services/subscriptions_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-events-subscriptions/google/apps/events_subscriptions_v1beta/services/subscriptions_service/pagers.py
+++ b/packages/google-apps-events-subscriptions/google/apps/events_subscriptions_v1beta/services/subscriptions_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-events-subscriptions/google/apps/events_subscriptions_v1beta/services/subscriptions_service/transports/__init__.py
+++ b/packages/google-apps-events-subscriptions/google/apps/events_subscriptions_v1beta/services/subscriptions_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-events-subscriptions/google/apps/events_subscriptions_v1beta/services/subscriptions_service/transports/base.py
+++ b/packages/google-apps-events-subscriptions/google/apps/events_subscriptions_v1beta/services/subscriptions_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-events-subscriptions/google/apps/events_subscriptions_v1beta/services/subscriptions_service/transports/grpc.py
+++ b/packages/google-apps-events-subscriptions/google/apps/events_subscriptions_v1beta/services/subscriptions_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-events-subscriptions/google/apps/events_subscriptions_v1beta/services/subscriptions_service/transports/grpc_asyncio.py
+++ b/packages/google-apps-events-subscriptions/google/apps/events_subscriptions_v1beta/services/subscriptions_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-events-subscriptions/google/apps/events_subscriptions_v1beta/services/subscriptions_service/transports/rest.py
+++ b/packages/google-apps-events-subscriptions/google/apps/events_subscriptions_v1beta/services/subscriptions_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-events-subscriptions/google/apps/events_subscriptions_v1beta/services/subscriptions_service/transports/rest_base.py
+++ b/packages/google-apps-events-subscriptions/google/apps/events_subscriptions_v1beta/services/subscriptions_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-events-subscriptions/google/apps/events_subscriptions_v1beta/types/__init__.py
+++ b/packages/google-apps-events-subscriptions/google/apps/events_subscriptions_v1beta/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-events-subscriptions/google/apps/events_subscriptions_v1beta/types/subscription_resource.py
+++ b/packages/google-apps-events-subscriptions/google/apps/events_subscriptions_v1beta/types/subscription_resource.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-events-subscriptions/google/apps/events_subscriptions_v1beta/types/subscriptions_service.py
+++ b/packages/google-apps-events-subscriptions/google/apps/events_subscriptions_v1beta/types/subscriptions_service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-events-subscriptions/samples/generated_samples/workspaceevents_v1_generated_subscriptions_service_create_subscription_sync.py
+++ b/packages/google-apps-events-subscriptions/samples/generated_samples/workspaceevents_v1_generated_subscriptions_service_create_subscription_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-events-subscriptions/samples/generated_samples/workspaceevents_v1_generated_subscriptions_service_delete_subscription_sync.py
+++ b/packages/google-apps-events-subscriptions/samples/generated_samples/workspaceevents_v1_generated_subscriptions_service_delete_subscription_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-events-subscriptions/samples/generated_samples/workspaceevents_v1_generated_subscriptions_service_get_subscription_async.py
+++ b/packages/google-apps-events-subscriptions/samples/generated_samples/workspaceevents_v1_generated_subscriptions_service_get_subscription_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-events-subscriptions/samples/generated_samples/workspaceevents_v1_generated_subscriptions_service_get_subscription_sync.py
+++ b/packages/google-apps-events-subscriptions/samples/generated_samples/workspaceevents_v1_generated_subscriptions_service_get_subscription_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-events-subscriptions/samples/generated_samples/workspaceevents_v1_generated_subscriptions_service_list_subscriptions_async.py
+++ b/packages/google-apps-events-subscriptions/samples/generated_samples/workspaceevents_v1_generated_subscriptions_service_list_subscriptions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-events-subscriptions/samples/generated_samples/workspaceevents_v1_generated_subscriptions_service_list_subscriptions_sync.py
+++ b/packages/google-apps-events-subscriptions/samples/generated_samples/workspaceevents_v1_generated_subscriptions_service_list_subscriptions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-events-subscriptions/samples/generated_samples/workspaceevents_v1_generated_subscriptions_service_reactivate_subscription_sync.py
+++ b/packages/google-apps-events-subscriptions/samples/generated_samples/workspaceevents_v1_generated_subscriptions_service_reactivate_subscription_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-events-subscriptions/samples/generated_samples/workspaceevents_v1_generated_subscriptions_service_update_subscription_sync.py
+++ b/packages/google-apps-events-subscriptions/samples/generated_samples/workspaceevents_v1_generated_subscriptions_service_update_subscription_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-events-subscriptions/samples/generated_samples/workspaceevents_v1beta_generated_subscriptions_service_create_subscription_sync.py
+++ b/packages/google-apps-events-subscriptions/samples/generated_samples/workspaceevents_v1beta_generated_subscriptions_service_create_subscription_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-events-subscriptions/samples/generated_samples/workspaceevents_v1beta_generated_subscriptions_service_delete_subscription_sync.py
+++ b/packages/google-apps-events-subscriptions/samples/generated_samples/workspaceevents_v1beta_generated_subscriptions_service_delete_subscription_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-events-subscriptions/samples/generated_samples/workspaceevents_v1beta_generated_subscriptions_service_get_subscription_async.py
+++ b/packages/google-apps-events-subscriptions/samples/generated_samples/workspaceevents_v1beta_generated_subscriptions_service_get_subscription_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-events-subscriptions/samples/generated_samples/workspaceevents_v1beta_generated_subscriptions_service_get_subscription_sync.py
+++ b/packages/google-apps-events-subscriptions/samples/generated_samples/workspaceevents_v1beta_generated_subscriptions_service_get_subscription_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-events-subscriptions/samples/generated_samples/workspaceevents_v1beta_generated_subscriptions_service_list_subscriptions_async.py
+++ b/packages/google-apps-events-subscriptions/samples/generated_samples/workspaceevents_v1beta_generated_subscriptions_service_list_subscriptions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-events-subscriptions/samples/generated_samples/workspaceevents_v1beta_generated_subscriptions_service_list_subscriptions_sync.py
+++ b/packages/google-apps-events-subscriptions/samples/generated_samples/workspaceevents_v1beta_generated_subscriptions_service_list_subscriptions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-events-subscriptions/samples/generated_samples/workspaceevents_v1beta_generated_subscriptions_service_reactivate_subscription_sync.py
+++ b/packages/google-apps-events-subscriptions/samples/generated_samples/workspaceevents_v1beta_generated_subscriptions_service_reactivate_subscription_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-events-subscriptions/samples/generated_samples/workspaceevents_v1beta_generated_subscriptions_service_update_subscription_sync.py
+++ b/packages/google-apps-events-subscriptions/samples/generated_samples/workspaceevents_v1beta_generated_subscriptions_service_update_subscription_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-events-subscriptions/tests/__init__.py
+++ b/packages/google-apps-events-subscriptions/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-events-subscriptions/tests/unit/__init__.py
+++ b/packages/google-apps-events-subscriptions/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-events-subscriptions/tests/unit/gapic/__init__.py
+++ b/packages/google-apps-events-subscriptions/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-events-subscriptions/tests/unit/gapic/events_subscriptions_v1/__init__.py
+++ b/packages/google-apps-events-subscriptions/tests/unit/gapic/events_subscriptions_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-events-subscriptions/tests/unit/gapic/events_subscriptions_v1beta/__init__.py
+++ b/packages/google-apps-events-subscriptions/tests/unit/gapic/events_subscriptions_v1beta/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/.flake8
+++ b/packages/google-apps-meet/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/MANIFEST.in
+++ b/packages/google-apps-meet/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/google/apps/meet/__init__.py
+++ b/packages/google-apps-meet/google/apps/meet/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/google/apps/meet/gapic_version.py
+++ b/packages/google-apps-meet/google/apps/meet/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/google/apps/meet_v2/gapic_version.py
+++ b/packages/google-apps-meet/google/apps/meet_v2/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/google/apps/meet_v2/services/__init__.py
+++ b/packages/google-apps-meet/google/apps/meet_v2/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/google/apps/meet_v2/services/conference_records_service/__init__.py
+++ b/packages/google-apps-meet/google/apps/meet_v2/services/conference_records_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/google/apps/meet_v2/services/conference_records_service/async_client.py
+++ b/packages/google-apps-meet/google/apps/meet_v2/services/conference_records_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/google/apps/meet_v2/services/conference_records_service/client.py
+++ b/packages/google-apps-meet/google/apps/meet_v2/services/conference_records_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/google/apps/meet_v2/services/conference_records_service/pagers.py
+++ b/packages/google-apps-meet/google/apps/meet_v2/services/conference_records_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/google/apps/meet_v2/services/conference_records_service/transports/__init__.py
+++ b/packages/google-apps-meet/google/apps/meet_v2/services/conference_records_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/google/apps/meet_v2/services/conference_records_service/transports/base.py
+++ b/packages/google-apps-meet/google/apps/meet_v2/services/conference_records_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/google/apps/meet_v2/services/conference_records_service/transports/grpc.py
+++ b/packages/google-apps-meet/google/apps/meet_v2/services/conference_records_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/google/apps/meet_v2/services/conference_records_service/transports/grpc_asyncio.py
+++ b/packages/google-apps-meet/google/apps/meet_v2/services/conference_records_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/google/apps/meet_v2/services/conference_records_service/transports/rest.py
+++ b/packages/google-apps-meet/google/apps/meet_v2/services/conference_records_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/google/apps/meet_v2/services/conference_records_service/transports/rest_base.py
+++ b/packages/google-apps-meet/google/apps/meet_v2/services/conference_records_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/google/apps/meet_v2/services/spaces_service/__init__.py
+++ b/packages/google-apps-meet/google/apps/meet_v2/services/spaces_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/google/apps/meet_v2/services/spaces_service/async_client.py
+++ b/packages/google-apps-meet/google/apps/meet_v2/services/spaces_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/google/apps/meet_v2/services/spaces_service/client.py
+++ b/packages/google-apps-meet/google/apps/meet_v2/services/spaces_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/google/apps/meet_v2/services/spaces_service/transports/__init__.py
+++ b/packages/google-apps-meet/google/apps/meet_v2/services/spaces_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/google/apps/meet_v2/services/spaces_service/transports/base.py
+++ b/packages/google-apps-meet/google/apps/meet_v2/services/spaces_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/google/apps/meet_v2/services/spaces_service/transports/grpc.py
+++ b/packages/google-apps-meet/google/apps/meet_v2/services/spaces_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/google/apps/meet_v2/services/spaces_service/transports/grpc_asyncio.py
+++ b/packages/google-apps-meet/google/apps/meet_v2/services/spaces_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/google/apps/meet_v2/services/spaces_service/transports/rest.py
+++ b/packages/google-apps-meet/google/apps/meet_v2/services/spaces_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/google/apps/meet_v2/services/spaces_service/transports/rest_base.py
+++ b/packages/google-apps-meet/google/apps/meet_v2/services/spaces_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/google/apps/meet_v2/types/__init__.py
+++ b/packages/google-apps-meet/google/apps/meet_v2/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/google/apps/meet_v2/types/resource.py
+++ b/packages/google-apps-meet/google/apps/meet_v2/types/resource.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/google/apps/meet_v2/types/service.py
+++ b/packages/google-apps-meet/google/apps/meet_v2/types/service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/google/apps/meet_v2beta/gapic_version.py
+++ b/packages/google-apps-meet/google/apps/meet_v2beta/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/google/apps/meet_v2beta/services/__init__.py
+++ b/packages/google-apps-meet/google/apps/meet_v2beta/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/google/apps/meet_v2beta/services/conference_records_service/__init__.py
+++ b/packages/google-apps-meet/google/apps/meet_v2beta/services/conference_records_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/google/apps/meet_v2beta/services/conference_records_service/async_client.py
+++ b/packages/google-apps-meet/google/apps/meet_v2beta/services/conference_records_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/google/apps/meet_v2beta/services/conference_records_service/client.py
+++ b/packages/google-apps-meet/google/apps/meet_v2beta/services/conference_records_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/google/apps/meet_v2beta/services/conference_records_service/pagers.py
+++ b/packages/google-apps-meet/google/apps/meet_v2beta/services/conference_records_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/google/apps/meet_v2beta/services/conference_records_service/transports/__init__.py
+++ b/packages/google-apps-meet/google/apps/meet_v2beta/services/conference_records_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/google/apps/meet_v2beta/services/conference_records_service/transports/base.py
+++ b/packages/google-apps-meet/google/apps/meet_v2beta/services/conference_records_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/google/apps/meet_v2beta/services/conference_records_service/transports/grpc.py
+++ b/packages/google-apps-meet/google/apps/meet_v2beta/services/conference_records_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/google/apps/meet_v2beta/services/conference_records_service/transports/grpc_asyncio.py
+++ b/packages/google-apps-meet/google/apps/meet_v2beta/services/conference_records_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/google/apps/meet_v2beta/services/conference_records_service/transports/rest.py
+++ b/packages/google-apps-meet/google/apps/meet_v2beta/services/conference_records_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/google/apps/meet_v2beta/services/conference_records_service/transports/rest_base.py
+++ b/packages/google-apps-meet/google/apps/meet_v2beta/services/conference_records_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/google/apps/meet_v2beta/services/spaces_service/__init__.py
+++ b/packages/google-apps-meet/google/apps/meet_v2beta/services/spaces_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/google/apps/meet_v2beta/services/spaces_service/async_client.py
+++ b/packages/google-apps-meet/google/apps/meet_v2beta/services/spaces_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/google/apps/meet_v2beta/services/spaces_service/client.py
+++ b/packages/google-apps-meet/google/apps/meet_v2beta/services/spaces_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/google/apps/meet_v2beta/services/spaces_service/pagers.py
+++ b/packages/google-apps-meet/google/apps/meet_v2beta/services/spaces_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/google/apps/meet_v2beta/services/spaces_service/transports/__init__.py
+++ b/packages/google-apps-meet/google/apps/meet_v2beta/services/spaces_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/google/apps/meet_v2beta/services/spaces_service/transports/base.py
+++ b/packages/google-apps-meet/google/apps/meet_v2beta/services/spaces_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/google/apps/meet_v2beta/services/spaces_service/transports/grpc.py
+++ b/packages/google-apps-meet/google/apps/meet_v2beta/services/spaces_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/google/apps/meet_v2beta/services/spaces_service/transports/grpc_asyncio.py
+++ b/packages/google-apps-meet/google/apps/meet_v2beta/services/spaces_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/google/apps/meet_v2beta/services/spaces_service/transports/rest.py
+++ b/packages/google-apps-meet/google/apps/meet_v2beta/services/spaces_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/google/apps/meet_v2beta/services/spaces_service/transports/rest_base.py
+++ b/packages/google-apps-meet/google/apps/meet_v2beta/services/spaces_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/google/apps/meet_v2beta/types/__init__.py
+++ b/packages/google-apps-meet/google/apps/meet_v2beta/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/google/apps/meet_v2beta/types/resource.py
+++ b/packages/google-apps-meet/google/apps/meet_v2beta/types/resource.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/google/apps/meet_v2beta/types/service.py
+++ b/packages/google-apps-meet/google/apps/meet_v2beta/types/service.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/samples/generated_samples/meet_v2_generated_conference_records_service_get_conference_record_async.py
+++ b/packages/google-apps-meet/samples/generated_samples/meet_v2_generated_conference_records_service_get_conference_record_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/samples/generated_samples/meet_v2_generated_conference_records_service_get_conference_record_sync.py
+++ b/packages/google-apps-meet/samples/generated_samples/meet_v2_generated_conference_records_service_get_conference_record_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/samples/generated_samples/meet_v2_generated_conference_records_service_get_participant_async.py
+++ b/packages/google-apps-meet/samples/generated_samples/meet_v2_generated_conference_records_service_get_participant_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/samples/generated_samples/meet_v2_generated_conference_records_service_get_participant_session_async.py
+++ b/packages/google-apps-meet/samples/generated_samples/meet_v2_generated_conference_records_service_get_participant_session_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/samples/generated_samples/meet_v2_generated_conference_records_service_get_participant_session_sync.py
+++ b/packages/google-apps-meet/samples/generated_samples/meet_v2_generated_conference_records_service_get_participant_session_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/samples/generated_samples/meet_v2_generated_conference_records_service_get_participant_sync.py
+++ b/packages/google-apps-meet/samples/generated_samples/meet_v2_generated_conference_records_service_get_participant_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/samples/generated_samples/meet_v2_generated_conference_records_service_get_recording_async.py
+++ b/packages/google-apps-meet/samples/generated_samples/meet_v2_generated_conference_records_service_get_recording_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/samples/generated_samples/meet_v2_generated_conference_records_service_get_recording_sync.py
+++ b/packages/google-apps-meet/samples/generated_samples/meet_v2_generated_conference_records_service_get_recording_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/samples/generated_samples/meet_v2_generated_conference_records_service_get_transcript_async.py
+++ b/packages/google-apps-meet/samples/generated_samples/meet_v2_generated_conference_records_service_get_transcript_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/samples/generated_samples/meet_v2_generated_conference_records_service_get_transcript_entry_async.py
+++ b/packages/google-apps-meet/samples/generated_samples/meet_v2_generated_conference_records_service_get_transcript_entry_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/samples/generated_samples/meet_v2_generated_conference_records_service_get_transcript_entry_sync.py
+++ b/packages/google-apps-meet/samples/generated_samples/meet_v2_generated_conference_records_service_get_transcript_entry_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/samples/generated_samples/meet_v2_generated_conference_records_service_get_transcript_sync.py
+++ b/packages/google-apps-meet/samples/generated_samples/meet_v2_generated_conference_records_service_get_transcript_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/samples/generated_samples/meet_v2_generated_conference_records_service_list_conference_records_async.py
+++ b/packages/google-apps-meet/samples/generated_samples/meet_v2_generated_conference_records_service_list_conference_records_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/samples/generated_samples/meet_v2_generated_conference_records_service_list_conference_records_sync.py
+++ b/packages/google-apps-meet/samples/generated_samples/meet_v2_generated_conference_records_service_list_conference_records_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/samples/generated_samples/meet_v2_generated_conference_records_service_list_participant_sessions_async.py
+++ b/packages/google-apps-meet/samples/generated_samples/meet_v2_generated_conference_records_service_list_participant_sessions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/samples/generated_samples/meet_v2_generated_conference_records_service_list_participant_sessions_sync.py
+++ b/packages/google-apps-meet/samples/generated_samples/meet_v2_generated_conference_records_service_list_participant_sessions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/samples/generated_samples/meet_v2_generated_conference_records_service_list_participants_async.py
+++ b/packages/google-apps-meet/samples/generated_samples/meet_v2_generated_conference_records_service_list_participants_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/samples/generated_samples/meet_v2_generated_conference_records_service_list_participants_sync.py
+++ b/packages/google-apps-meet/samples/generated_samples/meet_v2_generated_conference_records_service_list_participants_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/samples/generated_samples/meet_v2_generated_conference_records_service_list_recordings_async.py
+++ b/packages/google-apps-meet/samples/generated_samples/meet_v2_generated_conference_records_service_list_recordings_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/samples/generated_samples/meet_v2_generated_conference_records_service_list_recordings_sync.py
+++ b/packages/google-apps-meet/samples/generated_samples/meet_v2_generated_conference_records_service_list_recordings_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/samples/generated_samples/meet_v2_generated_conference_records_service_list_transcript_entries_async.py
+++ b/packages/google-apps-meet/samples/generated_samples/meet_v2_generated_conference_records_service_list_transcript_entries_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/samples/generated_samples/meet_v2_generated_conference_records_service_list_transcript_entries_sync.py
+++ b/packages/google-apps-meet/samples/generated_samples/meet_v2_generated_conference_records_service_list_transcript_entries_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/samples/generated_samples/meet_v2_generated_conference_records_service_list_transcripts_async.py
+++ b/packages/google-apps-meet/samples/generated_samples/meet_v2_generated_conference_records_service_list_transcripts_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/samples/generated_samples/meet_v2_generated_conference_records_service_list_transcripts_sync.py
+++ b/packages/google-apps-meet/samples/generated_samples/meet_v2_generated_conference_records_service_list_transcripts_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/samples/generated_samples/meet_v2_generated_spaces_service_create_space_async.py
+++ b/packages/google-apps-meet/samples/generated_samples/meet_v2_generated_spaces_service_create_space_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/samples/generated_samples/meet_v2_generated_spaces_service_create_space_sync.py
+++ b/packages/google-apps-meet/samples/generated_samples/meet_v2_generated_spaces_service_create_space_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/samples/generated_samples/meet_v2_generated_spaces_service_end_active_conference_async.py
+++ b/packages/google-apps-meet/samples/generated_samples/meet_v2_generated_spaces_service_end_active_conference_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/samples/generated_samples/meet_v2_generated_spaces_service_end_active_conference_sync.py
+++ b/packages/google-apps-meet/samples/generated_samples/meet_v2_generated_spaces_service_end_active_conference_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/samples/generated_samples/meet_v2_generated_spaces_service_get_space_async.py
+++ b/packages/google-apps-meet/samples/generated_samples/meet_v2_generated_spaces_service_get_space_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/samples/generated_samples/meet_v2_generated_spaces_service_get_space_sync.py
+++ b/packages/google-apps-meet/samples/generated_samples/meet_v2_generated_spaces_service_get_space_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/samples/generated_samples/meet_v2_generated_spaces_service_update_space_async.py
+++ b/packages/google-apps-meet/samples/generated_samples/meet_v2_generated_spaces_service_update_space_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/samples/generated_samples/meet_v2_generated_spaces_service_update_space_sync.py
+++ b/packages/google-apps-meet/samples/generated_samples/meet_v2_generated_spaces_service_update_space_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/samples/generated_samples/meet_v2beta_generated_conference_records_service_get_conference_record_async.py
+++ b/packages/google-apps-meet/samples/generated_samples/meet_v2beta_generated_conference_records_service_get_conference_record_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/samples/generated_samples/meet_v2beta_generated_conference_records_service_get_conference_record_sync.py
+++ b/packages/google-apps-meet/samples/generated_samples/meet_v2beta_generated_conference_records_service_get_conference_record_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/samples/generated_samples/meet_v2beta_generated_conference_records_service_get_participant_async.py
+++ b/packages/google-apps-meet/samples/generated_samples/meet_v2beta_generated_conference_records_service_get_participant_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/samples/generated_samples/meet_v2beta_generated_conference_records_service_get_participant_session_async.py
+++ b/packages/google-apps-meet/samples/generated_samples/meet_v2beta_generated_conference_records_service_get_participant_session_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/samples/generated_samples/meet_v2beta_generated_conference_records_service_get_participant_session_sync.py
+++ b/packages/google-apps-meet/samples/generated_samples/meet_v2beta_generated_conference_records_service_get_participant_session_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/samples/generated_samples/meet_v2beta_generated_conference_records_service_get_participant_sync.py
+++ b/packages/google-apps-meet/samples/generated_samples/meet_v2beta_generated_conference_records_service_get_participant_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/samples/generated_samples/meet_v2beta_generated_conference_records_service_get_recording_async.py
+++ b/packages/google-apps-meet/samples/generated_samples/meet_v2beta_generated_conference_records_service_get_recording_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/samples/generated_samples/meet_v2beta_generated_conference_records_service_get_recording_sync.py
+++ b/packages/google-apps-meet/samples/generated_samples/meet_v2beta_generated_conference_records_service_get_recording_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/samples/generated_samples/meet_v2beta_generated_conference_records_service_get_transcript_async.py
+++ b/packages/google-apps-meet/samples/generated_samples/meet_v2beta_generated_conference_records_service_get_transcript_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/samples/generated_samples/meet_v2beta_generated_conference_records_service_get_transcript_entry_async.py
+++ b/packages/google-apps-meet/samples/generated_samples/meet_v2beta_generated_conference_records_service_get_transcript_entry_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/samples/generated_samples/meet_v2beta_generated_conference_records_service_get_transcript_entry_sync.py
+++ b/packages/google-apps-meet/samples/generated_samples/meet_v2beta_generated_conference_records_service_get_transcript_entry_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/samples/generated_samples/meet_v2beta_generated_conference_records_service_get_transcript_sync.py
+++ b/packages/google-apps-meet/samples/generated_samples/meet_v2beta_generated_conference_records_service_get_transcript_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/samples/generated_samples/meet_v2beta_generated_conference_records_service_list_conference_records_async.py
+++ b/packages/google-apps-meet/samples/generated_samples/meet_v2beta_generated_conference_records_service_list_conference_records_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/samples/generated_samples/meet_v2beta_generated_conference_records_service_list_conference_records_sync.py
+++ b/packages/google-apps-meet/samples/generated_samples/meet_v2beta_generated_conference_records_service_list_conference_records_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/samples/generated_samples/meet_v2beta_generated_conference_records_service_list_participant_sessions_async.py
+++ b/packages/google-apps-meet/samples/generated_samples/meet_v2beta_generated_conference_records_service_list_participant_sessions_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/samples/generated_samples/meet_v2beta_generated_conference_records_service_list_participant_sessions_sync.py
+++ b/packages/google-apps-meet/samples/generated_samples/meet_v2beta_generated_conference_records_service_list_participant_sessions_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/samples/generated_samples/meet_v2beta_generated_conference_records_service_list_participants_async.py
+++ b/packages/google-apps-meet/samples/generated_samples/meet_v2beta_generated_conference_records_service_list_participants_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/samples/generated_samples/meet_v2beta_generated_conference_records_service_list_participants_sync.py
+++ b/packages/google-apps-meet/samples/generated_samples/meet_v2beta_generated_conference_records_service_list_participants_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/samples/generated_samples/meet_v2beta_generated_conference_records_service_list_recordings_async.py
+++ b/packages/google-apps-meet/samples/generated_samples/meet_v2beta_generated_conference_records_service_list_recordings_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/samples/generated_samples/meet_v2beta_generated_conference_records_service_list_recordings_sync.py
+++ b/packages/google-apps-meet/samples/generated_samples/meet_v2beta_generated_conference_records_service_list_recordings_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/samples/generated_samples/meet_v2beta_generated_conference_records_service_list_transcript_entries_async.py
+++ b/packages/google-apps-meet/samples/generated_samples/meet_v2beta_generated_conference_records_service_list_transcript_entries_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/samples/generated_samples/meet_v2beta_generated_conference_records_service_list_transcript_entries_sync.py
+++ b/packages/google-apps-meet/samples/generated_samples/meet_v2beta_generated_conference_records_service_list_transcript_entries_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/samples/generated_samples/meet_v2beta_generated_conference_records_service_list_transcripts_async.py
+++ b/packages/google-apps-meet/samples/generated_samples/meet_v2beta_generated_conference_records_service_list_transcripts_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/samples/generated_samples/meet_v2beta_generated_conference_records_service_list_transcripts_sync.py
+++ b/packages/google-apps-meet/samples/generated_samples/meet_v2beta_generated_conference_records_service_list_transcripts_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/samples/generated_samples/meet_v2beta_generated_spaces_service_connect_active_conference_async.py
+++ b/packages/google-apps-meet/samples/generated_samples/meet_v2beta_generated_spaces_service_connect_active_conference_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/samples/generated_samples/meet_v2beta_generated_spaces_service_connect_active_conference_sync.py
+++ b/packages/google-apps-meet/samples/generated_samples/meet_v2beta_generated_spaces_service_connect_active_conference_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/samples/generated_samples/meet_v2beta_generated_spaces_service_create_member_async.py
+++ b/packages/google-apps-meet/samples/generated_samples/meet_v2beta_generated_spaces_service_create_member_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/samples/generated_samples/meet_v2beta_generated_spaces_service_create_member_sync.py
+++ b/packages/google-apps-meet/samples/generated_samples/meet_v2beta_generated_spaces_service_create_member_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/samples/generated_samples/meet_v2beta_generated_spaces_service_create_space_async.py
+++ b/packages/google-apps-meet/samples/generated_samples/meet_v2beta_generated_spaces_service_create_space_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/samples/generated_samples/meet_v2beta_generated_spaces_service_create_space_sync.py
+++ b/packages/google-apps-meet/samples/generated_samples/meet_v2beta_generated_spaces_service_create_space_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/samples/generated_samples/meet_v2beta_generated_spaces_service_delete_member_async.py
+++ b/packages/google-apps-meet/samples/generated_samples/meet_v2beta_generated_spaces_service_delete_member_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/samples/generated_samples/meet_v2beta_generated_spaces_service_delete_member_sync.py
+++ b/packages/google-apps-meet/samples/generated_samples/meet_v2beta_generated_spaces_service_delete_member_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/samples/generated_samples/meet_v2beta_generated_spaces_service_end_active_conference_async.py
+++ b/packages/google-apps-meet/samples/generated_samples/meet_v2beta_generated_spaces_service_end_active_conference_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/samples/generated_samples/meet_v2beta_generated_spaces_service_end_active_conference_sync.py
+++ b/packages/google-apps-meet/samples/generated_samples/meet_v2beta_generated_spaces_service_end_active_conference_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/samples/generated_samples/meet_v2beta_generated_spaces_service_get_member_async.py
+++ b/packages/google-apps-meet/samples/generated_samples/meet_v2beta_generated_spaces_service_get_member_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/samples/generated_samples/meet_v2beta_generated_spaces_service_get_member_sync.py
+++ b/packages/google-apps-meet/samples/generated_samples/meet_v2beta_generated_spaces_service_get_member_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/samples/generated_samples/meet_v2beta_generated_spaces_service_get_space_async.py
+++ b/packages/google-apps-meet/samples/generated_samples/meet_v2beta_generated_spaces_service_get_space_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/samples/generated_samples/meet_v2beta_generated_spaces_service_get_space_sync.py
+++ b/packages/google-apps-meet/samples/generated_samples/meet_v2beta_generated_spaces_service_get_space_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/samples/generated_samples/meet_v2beta_generated_spaces_service_list_members_async.py
+++ b/packages/google-apps-meet/samples/generated_samples/meet_v2beta_generated_spaces_service_list_members_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/samples/generated_samples/meet_v2beta_generated_spaces_service_list_members_sync.py
+++ b/packages/google-apps-meet/samples/generated_samples/meet_v2beta_generated_spaces_service_list_members_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/samples/generated_samples/meet_v2beta_generated_spaces_service_update_space_async.py
+++ b/packages/google-apps-meet/samples/generated_samples/meet_v2beta_generated_spaces_service_update_space_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/samples/generated_samples/meet_v2beta_generated_spaces_service_update_space_sync.py
+++ b/packages/google-apps-meet/samples/generated_samples/meet_v2beta_generated_spaces_service_update_space_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/tests/__init__.py
+++ b/packages/google-apps-meet/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/tests/unit/__init__.py
+++ b/packages/google-apps-meet/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/tests/unit/gapic/__init__.py
+++ b/packages/google-apps-meet/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/tests/unit/gapic/meet_v2/__init__.py
+++ b/packages/google-apps-meet/tests/unit/gapic/meet_v2/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-meet/tests/unit/gapic/meet_v2beta/__init__.py
+++ b/packages/google-apps-meet/tests/unit/gapic/meet_v2beta/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-script-type/.flake8
+++ b/packages/google-apps-script-type/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-script-type/MANIFEST.in
+++ b/packages/google-apps-script-type/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-script-type/google/apps/script/type/calendar/gapic_version.py
+++ b/packages/google-apps-script-type/google/apps/script/type/calendar/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-script-type/google/apps/script/type/calendar/services/__init__.py
+++ b/packages/google-apps-script-type/google/apps/script/type/calendar/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-script-type/google/apps/script/type/calendar/types/__init__.py
+++ b/packages/google-apps-script-type/google/apps/script/type/calendar/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-script-type/google/apps/script/type/calendar/types/calendar_addon_manifest.py
+++ b/packages/google-apps-script-type/google/apps/script/type/calendar/types/calendar_addon_manifest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-script-type/google/apps/script/type/docs/gapic_version.py
+++ b/packages/google-apps-script-type/google/apps/script/type/docs/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-script-type/google/apps/script/type/docs/services/__init__.py
+++ b/packages/google-apps-script-type/google/apps/script/type/docs/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-script-type/google/apps/script/type/docs/types/__init__.py
+++ b/packages/google-apps-script-type/google/apps/script/type/docs/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-script-type/google/apps/script/type/docs/types/docs_addon_manifest.py
+++ b/packages/google-apps-script-type/google/apps/script/type/docs/types/docs_addon_manifest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-script-type/google/apps/script/type/drive/gapic_version.py
+++ b/packages/google-apps-script-type/google/apps/script/type/drive/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-script-type/google/apps/script/type/drive/services/__init__.py
+++ b/packages/google-apps-script-type/google/apps/script/type/drive/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-script-type/google/apps/script/type/drive/types/__init__.py
+++ b/packages/google-apps-script-type/google/apps/script/type/drive/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-script-type/google/apps/script/type/drive/types/drive_addon_manifest.py
+++ b/packages/google-apps-script-type/google/apps/script/type/drive/types/drive_addon_manifest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-script-type/google/apps/script/type/gapic_version.py
+++ b/packages/google-apps-script-type/google/apps/script/type/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-script-type/google/apps/script/type/gmail/gapic_version.py
+++ b/packages/google-apps-script-type/google/apps/script/type/gmail/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-script-type/google/apps/script/type/gmail/services/__init__.py
+++ b/packages/google-apps-script-type/google/apps/script/type/gmail/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-script-type/google/apps/script/type/gmail/types/__init__.py
+++ b/packages/google-apps-script-type/google/apps/script/type/gmail/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-script-type/google/apps/script/type/gmail/types/gmail_addon_manifest.py
+++ b/packages/google-apps-script-type/google/apps/script/type/gmail/types/gmail_addon_manifest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-script-type/google/apps/script/type/services/__init__.py
+++ b/packages/google-apps-script-type/google/apps/script/type/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-script-type/google/apps/script/type/sheets/gapic_version.py
+++ b/packages/google-apps-script-type/google/apps/script/type/sheets/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-script-type/google/apps/script/type/sheets/services/__init__.py
+++ b/packages/google-apps-script-type/google/apps/script/type/sheets/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-script-type/google/apps/script/type/sheets/types/__init__.py
+++ b/packages/google-apps-script-type/google/apps/script/type/sheets/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-script-type/google/apps/script/type/sheets/types/sheets_addon_manifest.py
+++ b/packages/google-apps-script-type/google/apps/script/type/sheets/types/sheets_addon_manifest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-script-type/google/apps/script/type/slides/gapic_version.py
+++ b/packages/google-apps-script-type/google/apps/script/type/slides/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-script-type/google/apps/script/type/slides/services/__init__.py
+++ b/packages/google-apps-script-type/google/apps/script/type/slides/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-script-type/google/apps/script/type/slides/types/__init__.py
+++ b/packages/google-apps-script-type/google/apps/script/type/slides/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-script-type/google/apps/script/type/slides/types/slides_addon_manifest.py
+++ b/packages/google-apps-script-type/google/apps/script/type/slides/types/slides_addon_manifest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-script-type/google/apps/script/type/types/__init__.py
+++ b/packages/google-apps-script-type/google/apps/script/type/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-script-type/google/apps/script/type/types/addon_widget_set.py
+++ b/packages/google-apps-script-type/google/apps/script/type/types/addon_widget_set.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-script-type/google/apps/script/type/types/extension_point.py
+++ b/packages/google-apps-script-type/google/apps/script/type/types/extension_point.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-script-type/google/apps/script/type/types/script_manifest.py
+++ b/packages/google-apps-script-type/google/apps/script/type/types/script_manifest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-script-type/tests/__init__.py
+++ b/packages/google-apps-script-type/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-script-type/tests/unit/__init__.py
+++ b/packages/google-apps-script-type/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-script-type/tests/unit/gapic/__init__.py
+++ b/packages/google-apps-script-type/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-script-type/tests/unit/gapic/calendar/__init__.py
+++ b/packages/google-apps-script-type/tests/unit/gapic/calendar/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-script-type/tests/unit/gapic/docs/__init__.py
+++ b/packages/google-apps-script-type/tests/unit/gapic/docs/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-script-type/tests/unit/gapic/drive/__init__.py
+++ b/packages/google-apps-script-type/tests/unit/gapic/drive/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-script-type/tests/unit/gapic/gmail/__init__.py
+++ b/packages/google-apps-script-type/tests/unit/gapic/gmail/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-script-type/tests/unit/gapic/sheets/__init__.py
+++ b/packages/google-apps-script-type/tests/unit/gapic/sheets/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-script-type/tests/unit/gapic/slides/__init__.py
+++ b/packages/google-apps-script-type/tests/unit/gapic/slides/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-apps-script-type/tests/unit/gapic/type/__init__.py
+++ b/packages/google-apps-script-type/tests/unit/gapic/type/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-area120-tables/.flake8
+++ b/packages/google-area120-tables/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-area120-tables/MANIFEST.in
+++ b/packages/google-area120-tables/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-area120-tables/google/area120/tables/__init__.py
+++ b/packages/google-area120-tables/google/area120/tables/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-area120-tables/google/area120/tables/gapic_version.py
+++ b/packages/google-area120-tables/google/area120/tables/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-area120-tables/google/area120/tables_v1alpha1/gapic_version.py
+++ b/packages/google-area120-tables/google/area120/tables_v1alpha1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-area120-tables/google/area120/tables_v1alpha1/services/__init__.py
+++ b/packages/google-area120-tables/google/area120/tables_v1alpha1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-area120-tables/google/area120/tables_v1alpha1/services/tables_service/__init__.py
+++ b/packages/google-area120-tables/google/area120/tables_v1alpha1/services/tables_service/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-area120-tables/google/area120/tables_v1alpha1/services/tables_service/async_client.py
+++ b/packages/google-area120-tables/google/area120/tables_v1alpha1/services/tables_service/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-area120-tables/google/area120/tables_v1alpha1/services/tables_service/client.py
+++ b/packages/google-area120-tables/google/area120/tables_v1alpha1/services/tables_service/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-area120-tables/google/area120/tables_v1alpha1/services/tables_service/pagers.py
+++ b/packages/google-area120-tables/google/area120/tables_v1alpha1/services/tables_service/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-area120-tables/google/area120/tables_v1alpha1/services/tables_service/transports/__init__.py
+++ b/packages/google-area120-tables/google/area120/tables_v1alpha1/services/tables_service/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-area120-tables/google/area120/tables_v1alpha1/services/tables_service/transports/base.py
+++ b/packages/google-area120-tables/google/area120/tables_v1alpha1/services/tables_service/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-area120-tables/google/area120/tables_v1alpha1/services/tables_service/transports/grpc.py
+++ b/packages/google-area120-tables/google/area120/tables_v1alpha1/services/tables_service/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-area120-tables/google/area120/tables_v1alpha1/services/tables_service/transports/grpc_asyncio.py
+++ b/packages/google-area120-tables/google/area120/tables_v1alpha1/services/tables_service/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-area120-tables/google/area120/tables_v1alpha1/services/tables_service/transports/rest.py
+++ b/packages/google-area120-tables/google/area120/tables_v1alpha1/services/tables_service/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-area120-tables/google/area120/tables_v1alpha1/services/tables_service/transports/rest_base.py
+++ b/packages/google-area120-tables/google/area120/tables_v1alpha1/services/tables_service/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-area120-tables/google/area120/tables_v1alpha1/types/__init__.py
+++ b/packages/google-area120-tables/google/area120/tables_v1alpha1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-area120-tables/google/area120/tables_v1alpha1/types/tables.py
+++ b/packages/google-area120-tables/google/area120/tables_v1alpha1/types/tables.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-area120-tables/samples/generated_samples/area120tables_v1alpha1_generated_tables_service_batch_create_rows_async.py
+++ b/packages/google-area120-tables/samples/generated_samples/area120tables_v1alpha1_generated_tables_service_batch_create_rows_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-area120-tables/samples/generated_samples/area120tables_v1alpha1_generated_tables_service_batch_create_rows_sync.py
+++ b/packages/google-area120-tables/samples/generated_samples/area120tables_v1alpha1_generated_tables_service_batch_create_rows_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-area120-tables/samples/generated_samples/area120tables_v1alpha1_generated_tables_service_batch_delete_rows_async.py
+++ b/packages/google-area120-tables/samples/generated_samples/area120tables_v1alpha1_generated_tables_service_batch_delete_rows_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-area120-tables/samples/generated_samples/area120tables_v1alpha1_generated_tables_service_batch_delete_rows_sync.py
+++ b/packages/google-area120-tables/samples/generated_samples/area120tables_v1alpha1_generated_tables_service_batch_delete_rows_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-area120-tables/samples/generated_samples/area120tables_v1alpha1_generated_tables_service_batch_update_rows_async.py
+++ b/packages/google-area120-tables/samples/generated_samples/area120tables_v1alpha1_generated_tables_service_batch_update_rows_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-area120-tables/samples/generated_samples/area120tables_v1alpha1_generated_tables_service_batch_update_rows_sync.py
+++ b/packages/google-area120-tables/samples/generated_samples/area120tables_v1alpha1_generated_tables_service_batch_update_rows_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-area120-tables/samples/generated_samples/area120tables_v1alpha1_generated_tables_service_create_row_async.py
+++ b/packages/google-area120-tables/samples/generated_samples/area120tables_v1alpha1_generated_tables_service_create_row_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-area120-tables/samples/generated_samples/area120tables_v1alpha1_generated_tables_service_create_row_sync.py
+++ b/packages/google-area120-tables/samples/generated_samples/area120tables_v1alpha1_generated_tables_service_create_row_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-area120-tables/samples/generated_samples/area120tables_v1alpha1_generated_tables_service_delete_row_async.py
+++ b/packages/google-area120-tables/samples/generated_samples/area120tables_v1alpha1_generated_tables_service_delete_row_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-area120-tables/samples/generated_samples/area120tables_v1alpha1_generated_tables_service_delete_row_sync.py
+++ b/packages/google-area120-tables/samples/generated_samples/area120tables_v1alpha1_generated_tables_service_delete_row_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-area120-tables/samples/generated_samples/area120tables_v1alpha1_generated_tables_service_get_row_async.py
+++ b/packages/google-area120-tables/samples/generated_samples/area120tables_v1alpha1_generated_tables_service_get_row_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-area120-tables/samples/generated_samples/area120tables_v1alpha1_generated_tables_service_get_row_sync.py
+++ b/packages/google-area120-tables/samples/generated_samples/area120tables_v1alpha1_generated_tables_service_get_row_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-area120-tables/samples/generated_samples/area120tables_v1alpha1_generated_tables_service_get_table_async.py
+++ b/packages/google-area120-tables/samples/generated_samples/area120tables_v1alpha1_generated_tables_service_get_table_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-area120-tables/samples/generated_samples/area120tables_v1alpha1_generated_tables_service_get_table_sync.py
+++ b/packages/google-area120-tables/samples/generated_samples/area120tables_v1alpha1_generated_tables_service_get_table_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-area120-tables/samples/generated_samples/area120tables_v1alpha1_generated_tables_service_get_workspace_async.py
+++ b/packages/google-area120-tables/samples/generated_samples/area120tables_v1alpha1_generated_tables_service_get_workspace_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-area120-tables/samples/generated_samples/area120tables_v1alpha1_generated_tables_service_get_workspace_sync.py
+++ b/packages/google-area120-tables/samples/generated_samples/area120tables_v1alpha1_generated_tables_service_get_workspace_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-area120-tables/samples/generated_samples/area120tables_v1alpha1_generated_tables_service_list_rows_async.py
+++ b/packages/google-area120-tables/samples/generated_samples/area120tables_v1alpha1_generated_tables_service_list_rows_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-area120-tables/samples/generated_samples/area120tables_v1alpha1_generated_tables_service_list_rows_sync.py
+++ b/packages/google-area120-tables/samples/generated_samples/area120tables_v1alpha1_generated_tables_service_list_rows_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-area120-tables/samples/generated_samples/area120tables_v1alpha1_generated_tables_service_list_tables_async.py
+++ b/packages/google-area120-tables/samples/generated_samples/area120tables_v1alpha1_generated_tables_service_list_tables_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-area120-tables/samples/generated_samples/area120tables_v1alpha1_generated_tables_service_list_tables_sync.py
+++ b/packages/google-area120-tables/samples/generated_samples/area120tables_v1alpha1_generated_tables_service_list_tables_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-area120-tables/samples/generated_samples/area120tables_v1alpha1_generated_tables_service_list_workspaces_async.py
+++ b/packages/google-area120-tables/samples/generated_samples/area120tables_v1alpha1_generated_tables_service_list_workspaces_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-area120-tables/samples/generated_samples/area120tables_v1alpha1_generated_tables_service_list_workspaces_sync.py
+++ b/packages/google-area120-tables/samples/generated_samples/area120tables_v1alpha1_generated_tables_service_list_workspaces_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-area120-tables/samples/generated_samples/area120tables_v1alpha1_generated_tables_service_update_row_async.py
+++ b/packages/google-area120-tables/samples/generated_samples/area120tables_v1alpha1_generated_tables_service_update_row_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-area120-tables/samples/generated_samples/area120tables_v1alpha1_generated_tables_service_update_row_sync.py
+++ b/packages/google-area120-tables/samples/generated_samples/area120tables_v1alpha1_generated_tables_service_update_row_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-area120-tables/tests/__init__.py
+++ b/packages/google-area120-tables/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-area120-tables/tests/unit/__init__.py
+++ b/packages/google-area120-tables/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-area120-tables/tests/unit/gapic/__init__.py
+++ b/packages/google-area120-tables/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-area120-tables/tests/unit/gapic/tables_v1alpha1/__init__.py
+++ b/packages/google-area120-tables/tests/unit/gapic/tables_v1alpha1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-geo-type/.flake8
+++ b/packages/google-geo-type/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-geo-type/MANIFEST.in
+++ b/packages/google-geo-type/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-geo-type/google/geo/type/gapic_version.py
+++ b/packages/google-geo-type/google/geo/type/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-geo-type/google/geo/type/services/__init__.py
+++ b/packages/google-geo-type/google/geo/type/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-geo-type/google/geo/type/types/__init__.py
+++ b/packages/google-geo-type/google/geo/type/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-geo-type/google/geo/type/types/viewport.py
+++ b/packages/google-geo-type/google/geo/type/types/viewport.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-geo-type/tests/__init__.py
+++ b/packages/google-geo-type/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-geo-type/tests/unit/__init__.py
+++ b/packages/google-geo-type/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-geo-type/tests/unit/gapic/__init__.py
+++ b/packages/google-geo-type/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/google-geo-type/tests/unit/gapic/type/__init__.py
+++ b/packages/google-geo-type/tests/unit/gapic/type/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/grafeas/.flake8
+++ b/packages/grafeas/.flake8
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/grafeas/MANIFEST.in
+++ b/packages/grafeas/MANIFEST.in
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/grafeas/grafeas/grafeas/__init__.py
+++ b/packages/grafeas/grafeas/grafeas/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/grafeas/grafeas/grafeas/gapic_version.py
+++ b/packages/grafeas/grafeas/grafeas/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/grafeas/grafeas/grafeas_v1/gapic_version.py
+++ b/packages/grafeas/grafeas/grafeas_v1/gapic_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/grafeas/grafeas/grafeas_v1/services/__init__.py
+++ b/packages/grafeas/grafeas/grafeas_v1/services/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/grafeas/grafeas/grafeas_v1/services/grafeas/__init__.py
+++ b/packages/grafeas/grafeas/grafeas_v1/services/grafeas/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/grafeas/grafeas/grafeas_v1/services/grafeas/async_client.py
+++ b/packages/grafeas/grafeas/grafeas_v1/services/grafeas/async_client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/grafeas/grafeas/grafeas_v1/services/grafeas/client.py
+++ b/packages/grafeas/grafeas/grafeas_v1/services/grafeas/client.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/grafeas/grafeas/grafeas_v1/services/grafeas/pagers.py
+++ b/packages/grafeas/grafeas/grafeas_v1/services/grafeas/pagers.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/grafeas/grafeas/grafeas_v1/services/grafeas/transports/__init__.py
+++ b/packages/grafeas/grafeas/grafeas_v1/services/grafeas/transports/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/grafeas/grafeas/grafeas_v1/services/grafeas/transports/base.py
+++ b/packages/grafeas/grafeas/grafeas_v1/services/grafeas/transports/base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/grafeas/grafeas/grafeas_v1/services/grafeas/transports/grpc.py
+++ b/packages/grafeas/grafeas/grafeas_v1/services/grafeas/transports/grpc.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/grafeas/grafeas/grafeas_v1/services/grafeas/transports/grpc_asyncio.py
+++ b/packages/grafeas/grafeas/grafeas_v1/services/grafeas/transports/grpc_asyncio.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/grafeas/grafeas/grafeas_v1/services/grafeas/transports/rest.py
+++ b/packages/grafeas/grafeas/grafeas_v1/services/grafeas/transports/rest.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/grafeas/grafeas/grafeas_v1/services/grafeas/transports/rest_base.py
+++ b/packages/grafeas/grafeas/grafeas_v1/services/grafeas/transports/rest_base.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/grafeas/grafeas/grafeas_v1/types/__init__.py
+++ b/packages/grafeas/grafeas/grafeas_v1/types/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/grafeas/grafeas/grafeas_v1/types/attestation.py
+++ b/packages/grafeas/grafeas/grafeas_v1/types/attestation.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/grafeas/grafeas/grafeas_v1/types/build.py
+++ b/packages/grafeas/grafeas/grafeas_v1/types/build.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/grafeas/grafeas/grafeas_v1/types/common.py
+++ b/packages/grafeas/grafeas/grafeas_v1/types/common.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/grafeas/grafeas/grafeas_v1/types/compliance.py
+++ b/packages/grafeas/grafeas/grafeas_v1/types/compliance.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/grafeas/grafeas/grafeas_v1/types/cvss.py
+++ b/packages/grafeas/grafeas/grafeas_v1/types/cvss.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/grafeas/grafeas/grafeas_v1/types/deployment.py
+++ b/packages/grafeas/grafeas/grafeas_v1/types/deployment.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/grafeas/grafeas/grafeas_v1/types/discovery.py
+++ b/packages/grafeas/grafeas/grafeas_v1/types/discovery.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/grafeas/grafeas/grafeas_v1/types/dsse_attestation.py
+++ b/packages/grafeas/grafeas/grafeas_v1/types/dsse_attestation.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/grafeas/grafeas/grafeas_v1/types/grafeas.py
+++ b/packages/grafeas/grafeas/grafeas_v1/types/grafeas.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/grafeas/grafeas/grafeas_v1/types/image.py
+++ b/packages/grafeas/grafeas/grafeas_v1/types/image.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/grafeas/grafeas/grafeas_v1/types/intoto_provenance.py
+++ b/packages/grafeas/grafeas/grafeas_v1/types/intoto_provenance.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/grafeas/grafeas/grafeas_v1/types/intoto_statement.py
+++ b/packages/grafeas/grafeas/grafeas_v1/types/intoto_statement.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/grafeas/grafeas/grafeas_v1/types/package.py
+++ b/packages/grafeas/grafeas/grafeas_v1/types/package.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/grafeas/grafeas/grafeas_v1/types/provenance.py
+++ b/packages/grafeas/grafeas/grafeas_v1/types/provenance.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/grafeas/grafeas/grafeas_v1/types/risk.py
+++ b/packages/grafeas/grafeas/grafeas_v1/types/risk.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/grafeas/grafeas/grafeas_v1/types/sbom.py
+++ b/packages/grafeas/grafeas/grafeas_v1/types/sbom.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/grafeas/grafeas/grafeas_v1/types/secret.py
+++ b/packages/grafeas/grafeas/grafeas_v1/types/secret.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/grafeas/grafeas/grafeas_v1/types/severity.py
+++ b/packages/grafeas/grafeas/grafeas_v1/types/severity.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/grafeas/grafeas/grafeas_v1/types/slsa_provenance.py
+++ b/packages/grafeas/grafeas/grafeas_v1/types/slsa_provenance.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/grafeas/grafeas/grafeas_v1/types/slsa_provenance_zero_two.py
+++ b/packages/grafeas/grafeas/grafeas_v1/types/slsa_provenance_zero_two.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/grafeas/grafeas/grafeas_v1/types/upgrade.py
+++ b/packages/grafeas/grafeas/grafeas_v1/types/upgrade.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/grafeas/grafeas/grafeas_v1/types/vex.py
+++ b/packages/grafeas/grafeas/grafeas_v1/types/vex.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/grafeas/grafeas/grafeas_v1/types/vulnerability.py
+++ b/packages/grafeas/grafeas/grafeas_v1/types/vulnerability.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/grafeas/samples/generated_samples/containeranalysis_v1_generated_grafeas_batch_create_notes_async.py
+++ b/packages/grafeas/samples/generated_samples/containeranalysis_v1_generated_grafeas_batch_create_notes_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/grafeas/samples/generated_samples/containeranalysis_v1_generated_grafeas_batch_create_notes_sync.py
+++ b/packages/grafeas/samples/generated_samples/containeranalysis_v1_generated_grafeas_batch_create_notes_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/grafeas/samples/generated_samples/containeranalysis_v1_generated_grafeas_batch_create_occurrences_async.py
+++ b/packages/grafeas/samples/generated_samples/containeranalysis_v1_generated_grafeas_batch_create_occurrences_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/grafeas/samples/generated_samples/containeranalysis_v1_generated_grafeas_batch_create_occurrences_sync.py
+++ b/packages/grafeas/samples/generated_samples/containeranalysis_v1_generated_grafeas_batch_create_occurrences_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/grafeas/samples/generated_samples/containeranalysis_v1_generated_grafeas_create_note_async.py
+++ b/packages/grafeas/samples/generated_samples/containeranalysis_v1_generated_grafeas_create_note_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/grafeas/samples/generated_samples/containeranalysis_v1_generated_grafeas_create_note_sync.py
+++ b/packages/grafeas/samples/generated_samples/containeranalysis_v1_generated_grafeas_create_note_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/grafeas/samples/generated_samples/containeranalysis_v1_generated_grafeas_create_occurrence_async.py
+++ b/packages/grafeas/samples/generated_samples/containeranalysis_v1_generated_grafeas_create_occurrence_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/grafeas/samples/generated_samples/containeranalysis_v1_generated_grafeas_create_occurrence_sync.py
+++ b/packages/grafeas/samples/generated_samples/containeranalysis_v1_generated_grafeas_create_occurrence_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/grafeas/samples/generated_samples/containeranalysis_v1_generated_grafeas_delete_note_async.py
+++ b/packages/grafeas/samples/generated_samples/containeranalysis_v1_generated_grafeas_delete_note_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/grafeas/samples/generated_samples/containeranalysis_v1_generated_grafeas_delete_note_sync.py
+++ b/packages/grafeas/samples/generated_samples/containeranalysis_v1_generated_grafeas_delete_note_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/grafeas/samples/generated_samples/containeranalysis_v1_generated_grafeas_delete_occurrence_async.py
+++ b/packages/grafeas/samples/generated_samples/containeranalysis_v1_generated_grafeas_delete_occurrence_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/grafeas/samples/generated_samples/containeranalysis_v1_generated_grafeas_delete_occurrence_sync.py
+++ b/packages/grafeas/samples/generated_samples/containeranalysis_v1_generated_grafeas_delete_occurrence_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/grafeas/samples/generated_samples/containeranalysis_v1_generated_grafeas_get_note_async.py
+++ b/packages/grafeas/samples/generated_samples/containeranalysis_v1_generated_grafeas_get_note_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/grafeas/samples/generated_samples/containeranalysis_v1_generated_grafeas_get_note_sync.py
+++ b/packages/grafeas/samples/generated_samples/containeranalysis_v1_generated_grafeas_get_note_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/grafeas/samples/generated_samples/containeranalysis_v1_generated_grafeas_get_occurrence_async.py
+++ b/packages/grafeas/samples/generated_samples/containeranalysis_v1_generated_grafeas_get_occurrence_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/grafeas/samples/generated_samples/containeranalysis_v1_generated_grafeas_get_occurrence_note_async.py
+++ b/packages/grafeas/samples/generated_samples/containeranalysis_v1_generated_grafeas_get_occurrence_note_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/grafeas/samples/generated_samples/containeranalysis_v1_generated_grafeas_get_occurrence_note_sync.py
+++ b/packages/grafeas/samples/generated_samples/containeranalysis_v1_generated_grafeas_get_occurrence_note_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/grafeas/samples/generated_samples/containeranalysis_v1_generated_grafeas_get_occurrence_sync.py
+++ b/packages/grafeas/samples/generated_samples/containeranalysis_v1_generated_grafeas_get_occurrence_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/grafeas/samples/generated_samples/containeranalysis_v1_generated_grafeas_list_note_occurrences_async.py
+++ b/packages/grafeas/samples/generated_samples/containeranalysis_v1_generated_grafeas_list_note_occurrences_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/grafeas/samples/generated_samples/containeranalysis_v1_generated_grafeas_list_note_occurrences_sync.py
+++ b/packages/grafeas/samples/generated_samples/containeranalysis_v1_generated_grafeas_list_note_occurrences_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/grafeas/samples/generated_samples/containeranalysis_v1_generated_grafeas_list_notes_async.py
+++ b/packages/grafeas/samples/generated_samples/containeranalysis_v1_generated_grafeas_list_notes_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/grafeas/samples/generated_samples/containeranalysis_v1_generated_grafeas_list_notes_sync.py
+++ b/packages/grafeas/samples/generated_samples/containeranalysis_v1_generated_grafeas_list_notes_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/grafeas/samples/generated_samples/containeranalysis_v1_generated_grafeas_list_occurrences_async.py
+++ b/packages/grafeas/samples/generated_samples/containeranalysis_v1_generated_grafeas_list_occurrences_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/grafeas/samples/generated_samples/containeranalysis_v1_generated_grafeas_list_occurrences_sync.py
+++ b/packages/grafeas/samples/generated_samples/containeranalysis_v1_generated_grafeas_list_occurrences_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/grafeas/samples/generated_samples/containeranalysis_v1_generated_grafeas_update_note_async.py
+++ b/packages/grafeas/samples/generated_samples/containeranalysis_v1_generated_grafeas_update_note_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/grafeas/samples/generated_samples/containeranalysis_v1_generated_grafeas_update_note_sync.py
+++ b/packages/grafeas/samples/generated_samples/containeranalysis_v1_generated_grafeas_update_note_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/grafeas/samples/generated_samples/containeranalysis_v1_generated_grafeas_update_occurrence_async.py
+++ b/packages/grafeas/samples/generated_samples/containeranalysis_v1_generated_grafeas_update_occurrence_async.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/grafeas/samples/generated_samples/containeranalysis_v1_generated_grafeas_update_occurrence_sync.py
+++ b/packages/grafeas/samples/generated_samples/containeranalysis_v1_generated_grafeas_update_occurrence_sync.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/grafeas/tests/__init__.py
+++ b/packages/grafeas/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/grafeas/tests/unit/__init__.py
+++ b/packages/grafeas/tests/unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/grafeas/tests/unit/gapic/__init__.py
+++ b/packages/grafeas/tests/unit/gapic/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/packages/grafeas/tests/unit/gapic/grafeas_v1/__init__.py
+++ b/packages/grafeas/tests/unit/gapic/grafeas_v1/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
This is the result of regenerating all packages, but only committing files which have only changed in a single line, and that's a copyright line.