### PR TITLE
chore: skip generation for packages we need to update individually

### DIFF
--- a/librarian.yaml
+++ b/librarian.yaml
@@ -391,6 +391,7 @@ libraries:
       - path: google/cloud/asset/v1p5beta1
       - path: google/cloud/asset/v1p2beta1
       - path: google/cloud/asset/v1p1beta1
+    skip_generate: true
     python:
       opt_args_by_api:
         google/cloud/asset/v1:
@@ -432,6 +433,7 @@ libraries:
       - google/cloud/automl_v1beta1/services/tables/__init__.py
       - google/cloud/automl_v1beta1/services/tables/gcs_client.py
       - google/cloud/automl_v1beta1/services/tables/tables_client.py
+    skip_generate: true
     python:
       library_type: GAPIC_COMBO
       metadata_name_override: automl
@@ -1426,6 +1428,7 @@ libraries:
     version: 2.30.0
     apis:
       - path: google/monitoring/v3
+    skip_generate: true
     python:
       library_type: GAPIC_COMBO
       opt_args_by_api:
@@ -1658,6 +1661,7 @@ libraries:
     version: 2.38.0
     apis:
       - path: google/pubsub/v1
+    skip_generate: true
     python:
       library_type: GAPIC_COMBO
       opt_args_by_api:
@@ -1904,6 +1908,7 @@ libraries:
       - docs/spanner_v1/table.rst
       - docs/spanner_v1/transaction.rst
       - tests/unit/gapic/conftest.py
+    skip_generate: true
     python:
       library_type: GAPIC_COMBO
       opt_args_by_api:
@@ -1932,6 +1937,7 @@ libraries:
     version: 3.10.1
     apis:
       - path: google/storage/v2
+    skip_generate: true
     skip_release: true
     python:
       library_type: GAPIC_MANUAL


### PR DESCRIPTION
These packages have not yet been updated to generator version 1.32.0. We should handle them with a separate PR per package which fixes any post-processing files, unskips generation, and includes the generated changes.

Packages skipped by this change:

- google-cloud-asset
- google-cloud-automl
- google-cloud-monitoring
- google-cloud-pubsub
- google-cloud-spanner
- google-cloud-storage
