### PR TITLE
chore: make librarian.yaml consistent with .librarian/state.yaml

### DIFF
--- a/librarian.yaml
+++ b/librarian.yaml
@@ -738,7 +738,6 @@ libraries:
     version: 1.47.0
     apis:
       - path: google/cloud/compute/v1
-    skip_release: true
     python:
       metadata_name_override: compute
       default_version: v1


### PR DESCRIPTION
(This was caused by #17044, but wasn't caught *in* that PR as the librarian version at the time wasn't checking for release consistency.)
