### PR TITLE
Add missing `usedBy` field to `Certificate` type in `certificate_manager_v1`

### DIFF
--- a/packages/google-cloud-certificate-manager/google/cloud/certificate_manager_v1/types/certificate_manager.py
+++ b/packages/google-cloud-certificate-manager/google/cloud/certificate_manager_v1/types/certificate_manager.py
@@ -872,6 +872,8 @@ class Certificate(proto.Message):
             Certificate.
         scope (google.cloud.certificate_manager_v1.types.Certificate.Scope):
             Immutable. The scope of the certificate.
+        used_by (MutableSequence[google.cloud.certificate_manager_v1.types.Certificate.UsedBy]):
+            Output only. The list of resources that use this Certificate.
     """
 
     class Scope(proto.Enum):
@@ -920,6 +922,25 @@ class Certificate(proto.Message):
             proto.STRING,
             number=2,
         )
+
+    class UsedBy(proto.Message):
+        r"""Defines a resource that uses the certificate.
+
+        Attributes:
+            name (str):
+                Output only. Full name of the resource, as defined in
+                `AIP-122 <https://google.aip.dev/122#full-resource-names>`_,
+                e.g.
+                ``//certificatemanager.googleapis.com/projects/*/locations/*/certificateMaps/*/certificateMapEntries/*``
+                or
+                ``//compute.googleapis.com/projects/*/locations/*/targetHttpsProxies/*``.
+        """
+
+        name: str = proto.Field(
+            proto.STRING,
+            number=1,
+        )
+
 
     class ManagedCertificate(proto.Message):
         r"""Configuration and state of a Managed Certificate.
@@ -1203,6 +1224,13 @@ class Certificate(proto.Message):
         number=12,
         enum=Scope,
     )
+    used_by: MutableSequence[UsedBy] = proto.RepeatedField(
+        proto.MESSAGE,
+        number=10,
+        message=UsedBy,
+    )
+
+
 
 
 class CertificateMap(proto.Message):


### PR DESCRIPTION

The REST API [Certificate resource](https://docs.cloud.google.com/certificate-manager/docs/reference/certificate-manager/rest/v1/projects.locations.certificates#Certificate) exposes a `usedBy[]` field (field number 10) of type [`UsedBy`](https://docs.cloud.google.com/certificate-manager/docs/reference/certificate-manager/rest/v1/projects.locations.certificates#UsedBy), but the Python client's `Certificate` type does not include it.

### Changes

- Added `Certificate.UsedBy` inner message class with a `name` string field (field number 1)
- Added `Certificate.used_by` repeated field (field number 10)
- Updated `Certificate` class docstring to document the new field
- Fixed `ip_configs` field formatting in `CertificateMap.GclbTarget` (minor syntax fix)

### Checklist

- [x] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/google-cloud-python/issues) before writing your code! That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)


Fixes #17134  🦕