### PR TITLE
test(spanner): fix IndexError in async session retry deadline unit test

### DIFF
--- a/packages/google-cloud-spanner/tests/unit/_async/test_session.py
+++ b/packages/google-cloud-spanner/tests/unit/_async/test_session.py
@@ -1802,7 +1802,9 @@ class TestSession(OpenTelemetryBase):
 
         # retry once w/ timeout_secs=1
         def _time(_results=[1, 1.5]):
-            return _results.pop(0)
+            if len(_results) > 1:
+                return _results.pop(0)
+            return _results[0]
 
         with mock.patch("time.time", _time):
             with mock.patch(


### PR DESCRIPTION
Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/google-cloud-python/issues) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)

### Root Cause
In Python 3.13 (and under recent `pytest-asyncio` / `asyncio` runtimes), the asynchronous event loop and task scheduling infrastructure makes internal calls to `time.time()` during coroutine execution and retry delay handling. 

In `test_run_in_transaction_w_abort_w_retry_metadata_deadline`, `time.time` was mocked using a helper that popped from a fixed 2-element list on every invocation (`_results.pop(0)`). The extra internal event loop calls exhausted `_results` prematurely, deterministically raising an `IndexError: pop from empty list` when `_delay_until_retry` checked the deadline.

### Solution
Updated the `_time` mock helper in `packages/google-cloud-spanner/tests/unit/_async/test_session.py` to return the last timestamp repeatedly once `_results` has reached its final element:
```python
def _time(_results=[1, 1.5]):
    if len(_results) > 1:
        return _results.pop(0)
    return _results[0]
