### PR TITLE
chore: librarian release pull request: 20260515T192321Z

### DIFF
--- a/.librarian/state.yaml
+++ b/.librarian/state.yaml
@@ -387,7 +387,7 @@ libraries:
       - packages/google-area120-tables/docs/
     tag_format: '{id}-v{version}'
   - id: google-auth
-    version: 2.52.0
+    version: 2.53.0
     last_generated_commit: ""
     apis: []
     source_roots:

--- a/librarian.yaml
+++ b/librarian.yaml
@@ -220,7 +220,7 @@ libraries:
       metadata_name_override: area120tables
       default_version: v1alpha1
   - name: google-auth
-    version: 2.52.0
+    version: 2.53.0
     python:
       library_type: AUTH
   - name: google-auth-httplib2

--- a/packages/google-auth/CHANGELOG.md
+++ b/packages/google-auth/CHANGELOG.md
@@ -4,6 +4,14 @@
 
 [1]: https://pypi.org/project/google-auth/#history
 
+## [2.53.0](https://github.com/googleapis/google-cloud-python/compare/google-auth-v2.52.0...google-auth-v2.53.0) (2026-05-15)
+
+
+### Bug Fixes
+
+* allowlist agents-nonprod trust domains for agent identity (#17155) ([44c93d2e3012d7c7850dacda587dcb34819738ed](https://github.com/googleapis/google-cloud-python/commit/44c93d2e3012d7c7850dacda587dcb34819738ed))
+* fail-fast on invalid or non-workload certificate configs in agent identity discovery (#17116) ([f27a546127cbbae3459fda8417f86a302fa0bbae](https://github.com/googleapis/google-cloud-python/commit/f27a546127cbbae3459fda8417f86a302fa0bbae))
+
 ## [2.52.0](https://github.com/googleapis/google-cloud-python/compare/google-auth-v2.51.0...google-auth-v2.52.0) (2026-05-07)
 
 

--- a/packages/google-auth/google/auth/version.py
+++ b/packages/google-auth/google/auth/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "2.52.0"
+__version__ = "2.53.0"


### PR DESCRIPTION
PR created by the Librarian CLI to initialize a release. Merging this PR will auto trigger a release.

Librarian Version: v0.13.0
Language Image: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/python-librarian-generator@sha256:234b9d1f2ddb057ed7ac6a38db0bf8163d839c65c6cf88ade52530cddebce59e
<details><summary>google-auth: v2.53.0</summary>

## [v2.53.0](https://github.com/suztomo/google-cloud-python/compare/google-auth-v2.52.0...google-auth-v2.53.0) (2026-05-15)

### Bug Fixes

* allowlist agents-nonprod trust domains for agent identity (#17155) ([44c93d2e](https://github.com/suztomo/google-cloud-python/commit/44c93d2e))

* fail-fast on invalid or non-workload certificate configs in agent identity discovery (#17116) ([f27a5461](https://github.com/suztomo/google-cloud-python/commit/f27a5461))

</details>

b/513591686