### PR TITLE
docs: fix RouteMatrixElement duration return types

### DIFF
--- a/packages/google-maps-routing/google/maps/routing_v2/types/routes_service.py
+++ b/packages/google-maps-routing/google/maps/routing_v2/types/routes_service.py
@@ -630,7 +630,7 @@ class RouteMatrixElement(proto.Message):
             Independent of status.
         distance_meters (int):
             The travel distance of the route, in meters.
-        duration (google.protobuf.duration_pb2.Duration):
+        duration (datetime.timedelta):
             The length of time needed to navigate the route. If you set
             the
             [routing_preference][google.maps.routing.v2.ComputeRouteMatrixRequest.routing_preference]
@@ -639,7 +639,7 @@ class RouteMatrixElement(proto.Message):
             to either ``TRAFFIC_AWARE`` or ``TRAFFIC_AWARE_OPTIMAL``,
             then this value is calculated taking traffic conditions into
             account.
-        static_duration (google.protobuf.duration_pb2.Duration):
+        static_duration (datetime.timedelta):
             The duration of traveling through the route
             without taking traffic conditions into
             consideration.


### PR DESCRIPTION
I have read the CONTRIBUTING.md file.
YES

**What kind of change does this PR introduce?**
docs update

**What is the current behavior?**
Closes #16522

The Prisma Quickstart Guide documents `RouteMatrixElement.duration` 
and `static_duration` as `google.protobuf.duration_pb2.Duration`, 
but at runtime both fields return `datetime.timedelta` objects.

This mismatch occurs because proto-plus automatically marshals 
protobuf `Duration` types into Python's native `datetime.timedelta`.

**What is the new behavior?**
Updated type annotations in `routes_service.py`:

- `duration (google.protobuf.duration_pb2.Duration)` → `duration (datetime.timedelta)`
- `static_duration (google.protobuf.duration_pb2.Duration)` → `static_duration (datetime.timedelta)`

**Additional context**
This is consistent with how proto-plus handles Duration marshalling 
across the googleapis Python client libraries. The fix ensures the 
documentation matches the actual runtime behavior users observe.