### PR TITLE
test(spanner): upgrade Spanner sample instance fixtures to session scope

### DIFF
--- a/packages/google-cloud-spanner/samples/samples/archived/backup_snippet_test.py
+++ b/packages/google-cloud-spanner/samples/samples/archived/backup_snippet_test.py
@@ -18,12 +18,6 @@ import pytest
 from google.api_core.exceptions import DeadlineExceeded
 from test_utils.retry import RetryErrors
 
-
-@pytest.fixture(scope="module")
-def sample_name():
-    return "backup"
-
-
 def unique_database_id():
     """Creates a unique id for the database."""
     return f"test-db-{uuid.uuid4().hex[:10]}"

--- a/packages/google-cloud-spanner/samples/samples/archived/pg_samples_test.py
+++ b/packages/google-cloud-spanner/samples/samples/archived/pg_samples_test.py
@@ -46,11 +46,6 @@ retry_429 = RetryErrors(exceptions.ResourceExhausted, delay=15)
 
 
 @pytest.fixture(scope="module")
-def sample_name():
-    return "pg_snippets"
-
-
-@pytest.fixture(scope="module")
 def database_dialect():
     """Spanner dialect to be used for this sample.
     The dialect is used to initialize the dialect for the database.

--- a/packages/google-cloud-spanner/samples/samples/archived/samples_test.py
+++ b/packages/google-cloud-spanner/samples/samples/archived/samples_test.py
@@ -54,11 +54,6 @@ retry_429 = RetryErrors(exceptions.ResourceExhausted, delay=15)
 
 
 @pytest.fixture(scope="module")
-def sample_name():
-    return "snippets"
-
-
-@pytest.fixture(scope="module")
 def database_dialect():
     """Spanner dialect to be used for this sample.
 

--- a/packages/google-cloud-spanner/samples/samples/autocommit_test.py
+++ b/packages/google-cloud-spanner/samples/samples/autocommit_test.py
@@ -11,11 +11,6 @@ from test_utils.retry import RetryErrors
 import autocommit
 
 
-@pytest.fixture(scope="module")
-def sample_name():
-    return "autocommit"
-
-
 @RetryErrors(exception=Aborted, max_tries=2)
 def test_enable_autocommit_mode(capsys, instance_id, sample_database):
     # Delete table if it exists for retry attempts.

--- a/packages/google-cloud-spanner/samples/samples/backup_sample_test.py
+++ b/packages/google-cloud-spanner/samples/samples/backup_sample_test.py
@@ -20,11 +20,6 @@ from test_utils.retry import RetryErrors
 import backup_sample
 
 
-@pytest.fixture(scope="module")
-def sample_name():
-    return "backup"
-
-
 def unique_database_id():
     """Creates a unique id for the database."""
     return f"test-db-{uuid.uuid4().hex[:10]}"

--- a/packages/google-cloud-spanner/samples/samples/backup_schedule_samples_test.py
+++ b/packages/google-cloud-spanner/samples/samples/backup_schedule_samples_test.py
@@ -23,11 +23,6 @@ __INCREMENTAL_BACKUP_SCHEDULE_ID = "incremental-backup-schedule"
 
 
 @pytest.fixture(scope="module")
-def sample_name():
-    return "backup_schedule"
-
-
-@pytest.fixture(scope="module")
 def database_id():
     return f"test-db-{uuid.uuid4().hex[:10]}"
 

--- a/packages/google-cloud-spanner/samples/samples/conftest.py
+++ b/packages/google-cloud-spanner/samples/samples/conftest.py
@@ -33,17 +33,6 @@ retry_cleanup = retry.RetryErrors(
     (exceptions.ResourceExhausted, exceptions.FailedPrecondition), max_tries=6, delay=15
 )
 
-
-@pytest.fixture(scope="module")
-def sample_name():
-    """Sample testcase modules must define this fixture.
-
-    The name is used to label the instance created by the sample, to
-    aid in debugging leaked instances.
-    """
-    raise NotImplementedError("Define 'sample_name' fixture in sample test driver")
-
-
 @pytest.fixture(scope="module")
 def database_dialect():
     """Database dialect to be used for this sample.
@@ -99,31 +88,31 @@ def cleanup_old_instances(spanner_client):
                 scrub_instance_ignore_not_found(inst)
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture(scope="session")
 def instance_id():
     """Unique id for the instance used in samples."""
     return f"test-instance-{uuid.uuid4().hex[:10]}"
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture(scope="session")
 def multi_region_instance_id():
     """Unique id for the multi-region instance used in samples."""
     return f"multi-instance-{uuid.uuid4().hex[:10]}"
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture(scope="session")
 def instance_config(spanner_client):
     return "{}/instanceConfigs/{}".format(
         spanner_client.project_name, "regional-us-central1"
     )
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture(scope="session")
 def multi_region_instance_config(spanner_client):
     return "{}/instanceConfigs/{}".format(spanner_client.project_name, "nam3")
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture(scope="session")
 def proto_descriptor_file():
     import os
 
@@ -134,13 +123,12 @@ def proto_descriptor_file():
     file.close()
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture(scope="session")
 def sample_instance(
     spanner_client,
     cleanup_old_instances,
     instance_id,
     instance_config,
-    sample_name,
 ):
     operation = spanner_client.instance_admin_api.create_instance(
         parent=spanner_client.project_name,
@@ -151,7 +139,7 @@ def sample_instance(
             node_count=1,
             labels={
                 "cloud_spanner_samples": "true",
-                "sample_name": sample_name,
+                "sample_name": "shared-samples",
                 "created": str(int(time.time())),
             },
             edition=spanner_instance_admin.Instance.Edition.ENTERPRISE_PLUS,  # Optional
@@ -170,20 +158,19 @@ def sample_instance(
     scrub_instance_ignore_not_found(sample_instance)
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture(scope="session")
 def multi_region_instance(
     spanner_client,
     cleanup_old_instances,
     multi_region_instance_id,
     multi_region_instance_config,
-    sample_name,
 ):
     multi_region_instance = spanner_client.instance(
         multi_region_instance_id,
         multi_region_instance_config,
         labels={
             "cloud_spanner_samples": "true",
-            "sample_name": sample_name,
+            "sample_name": "shared-samples",
             "created": str(int(time.time())),
         },
     )
@@ -205,7 +192,7 @@ def database_id():
 
     Sample testcase modules can override as needed.
     """
-    return "my-database-id"
+    return f"my-db-{uuid.uuid4().hex[:10]}"
 
 
 @pytest.fixture(scope="module")

--- a/packages/google-cloud-spanner/samples/samples/graph_snippets_test.py
+++ b/packages/google-cloud-spanner/samples/samples/graph_snippets_test.py
@@ -80,12 +80,6 @@ CREATE OR REPLACE PROPERTY GRAPH FinGraph
                     LABEL Transfers)
 """
 
-
-@pytest.fixture(scope="module")
-def sample_name():
-    return "snippets"
-
-
 @pytest.fixture(scope="module")
 def database_dialect():
     """Spanner dialect to be used for this sample.

--- a/packages/google-cloud-spanner/samples/samples/pg_snippets_test.py
+++ b/packages/google-cloud-spanner/samples/samples/pg_snippets_test.py
@@ -47,11 +47,6 @@ retry_429 = RetryErrors(exceptions.ResourceExhausted, delay=15)
 
 
 @pytest.fixture(scope="module")
-def sample_name():
-    return "pg_snippets"
-
-
-@pytest.fixture(scope="module")
 def database_dialect():
     """Spanner dialect to be used for this sample.
 

--- a/packages/google-cloud-spanner/samples/samples/quickstart_test.py
+++ b/packages/google-cloud-spanner/samples/samples/quickstart_test.py
@@ -17,11 +17,6 @@ import pytest
 import quickstart
 
 
-@pytest.fixture(scope="module")
-def sample_name():
-    return "quickstart"
-
-
 def test_quickstart(capsys, instance_id, sample_database):
     quickstart.run_quickstart(instance_id, sample_database.database_id)
     out, _ = capsys.readouterr()

--- a/packages/google-cloud-spanner/samples/samples/snippets_test.py
+++ b/packages/google-cloud-spanner/samples/samples/snippets_test.py
@@ -56,11 +56,6 @@ retry_429 = RetryErrors(exceptions.ResourceExhausted, delay=15)
 
 
 @pytest.fixture(scope="module")
-def sample_name():
-    return "snippets"
-
-
-@pytest.fixture(scope="module")
 def database_dialect():
     """Spanner dialect to be used for this sample.
 


### PR DESCRIPTION
Previously, standard and multi-region Spanner instance fixtures in conftest.py were module-scoped, meaning a brand-new Spanner instance was created and destroyed for every single test file, adding massive execution time (~2 minutes per file) in CI/CD runs.

This change upgrades the instance and config fixtures to session scope. To prevent ScopeMismatch exceptions, the dependencies on module-scoped sample_name are replaced with a generic shared-samples label. This allows the test suite to reuse a single shared Spanner instance, dramatically optimizing test execution times.

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/google-cloud-python/issues) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)

Fixes #<issue_number_goes_here> 🦕