### PR TITLE
chore: bump gapic-generator to v1.32.0 for legacylibrarian

### DIFF
--- a/.generator/requirements.in
+++ b/.generator/requirements.in
@@ -1,5 +1,5 @@
 click
-gapic-generator==1.30.13 # https://github.com/googleapis/gapic-generator-python/releases/tag/v1.30.13
+gapic-generator==1.32.0 # https://github.com/googleapis/gapic-generator-python/releases/tag/v1.32.0
 nox
 starlark-pyo3>=2025.1
 build


### PR DESCRIPTION
bump gapic-generator to v1.32.0 for legacylibrarian