### PR TITLE
chore: cleanup ObjectContexts and ObjectCustomContextPayload

### DIFF
--- a/packages/google-cloud-storage/google/cloud/storage/blob.py
+++ b/packages/google-cloud-storage/google/cloud/storage/blob.py
@@ -5368,20 +5368,10 @@ class ObjectCustomContextPayload(dict):
 
     :type value: str or ``NoneType``
     :param value: (Optional) The value of the custom context.
-
-    :type create_time: :class:`datetime.datetime` or ``NoneType``
-    :param create_time: (Optional) Creation time of the custom context.
-
-    :type update_time: :class:`datetime.datetime` or ``NoneType``
-    :param update_time: (Optional) Last update time of the custom context.
     """
 
-    def __init__(self, value=None, create_time=None, update_time=None):
+    def __init__(self, value=None):
         data = {"value": value}
-        if create_time is not None:
-            data["createTime"] = _datetime_to_rfc3339(create_time)
-        if update_time is not None:
-            data["updateTime"] = _datetime_to_rfc3339(update_time)
         super(ObjectCustomContextPayload, self).__init__(data)
         self._contexts = None
 
@@ -5426,6 +5416,8 @@ class ObjectCustomContextPayload(dict):
 class ObjectContexts(dict):
     """Container for an object's contexts.
 
+    See: https://docs.cloud.google.com/storage/docs/object-contexts
+
     :type blob: :class:`Blob`
     :param blob: blob for which these contexts apply to.
 
@@ -5445,12 +5437,10 @@ class ObjectContexts(dict):
                     raise ValueError(
                         "All values in custom must be ObjectCustomContextPayload instances"
                     )
+                payload._contexts = self
             data["custom"] = custom
         super(ObjectContexts, self).__init__(data)
         self._blob = blob
-        if custom is not None:
-            for payload in custom.values():
-                payload._contexts = self
 
     @classmethod
     def from_api_repr(cls, resource, blob):
@@ -5497,9 +5487,14 @@ class ObjectContexts(dict):
 
     @custom.setter
     def custom(self, value):
+        if value is None:
+            value = {}
         if not isinstance(value, dict):
             raise ValueError(
                 "custom must be a dictionary mapping keys to ObjectCustomContextPayload instances"
             )
+        for payload in value.values():
+            if isinstance(payload, ObjectCustomContextPayload):
+                payload._contexts = self
         self["custom"] = value
         self.blob._patch_property("contexts", self)

--- a/packages/google-cloud-storage/google/cloud/storage/bucket.py
+++ b/packages/google-cloud-storage/google/cloud/storage/bucket.py
@@ -1518,7 +1518,7 @@ class Bucket(_PropertyMixin):
             Note ``soft_deleted`` and ``versions`` cannot be set to True simultaneously. See:
             https://cloud.google.com/storage/docs/soft-delete
 
-        :type filter_: str
+        :type filter_: str or None
         :param filter_:
             (Optional) Filter string used to filter objects. See:
             https://docs.cloud.google.com/storage/docs/listing-objects#filter-by-object-contexts-syntax

--- a/packages/google-cloud-storage/tests/system/test_blob.py
+++ b/packages/google-cloud-storage/tests/system/test_blob.py
@@ -1308,7 +1308,7 @@ def test_blob_contexts(shared_bucket, blobs_to_delete):
 
     blob.reload()
     assert blob.contexts.custom["k1"].value == "v1-updated"
-    assert "k2" not in blob.contexts.custom or blob.contexts.custom["k2"].value is None
+    assert "k2" not in blob.contexts.custom
 
     # 3. Clear all
     blob.contexts = None
@@ -1344,3 +1344,4 @@ def test_blob_contexts_custom_setter(shared_bucket, blobs_to_delete):
 
     blob.reload()
     assert blob.contexts.custom["k1"].value == "v1-updated"
+    assert blob.contexts.custom["k2"].value == "v2"

--- a/packages/google-cloud-storage/tests/system/test_bucket.py
+++ b/packages/google-cloud-storage/tests/system/test_bucket.py
@@ -775,12 +775,16 @@ def test_bucket_list_blobs_w_filter(
     buckets_to_delete.append(bucket)
 
     payload = b"helloworld"
-    blob_names = ["foo", "bar", "baz"]
+    blob_names = ["foo", "bar", "baz", "qux"]
     for name in blob_names:
         blob = bucket.blob(name)
         blob.upload_from_string(payload)
         if name == "bar":
             custom = {"target": ObjectCustomContextPayload(value="match")}
+            blob.contexts = ObjectContexts(blob, custom=custom)
+            blob.patch()
+        if name == "qux":
+            custom = {"target": ObjectCustomContextPayload(value="nomatch")}
             blob.contexts = ObjectContexts(blob, custom=custom)
             blob.patch()
         blobs_to_delete.append(blob)
@@ -789,6 +793,21 @@ def test_bucket_list_blobs_w_filter(
     blob_iter = bucket.list_blobs(filter_='contexts."target"="match"')
     blobs = list(blob_iter)
     assert [blob.name for blob in blobs] == ["bar"]
+
+    # List with filter matching bar and qux
+    blob_iter = bucket.list_blobs(filter_='contexts."target":*')
+    blobs = list(blob_iter)
+    assert sorted([blob.name for blob in blobs]) == ["bar", "qux"]
+
+    # List with filter matching all except 'bar'
+    blob_iter = bucket.list_blobs(filter_='-contexts."target"="match"')
+    blobs = list(blob_iter)
+    assert sorted([blob.name for blob in blobs]) == ["baz", "foo", "qux"]
+
+    # List with filter matching 'foo' and 'baz' (those without target context)
+    blob_iter = bucket.list_blobs(filter_='-contexts."target":*')
+    blobs = list(blob_iter)
+    assert sorted([blob.name for blob in blobs]) == ["baz", "foo"]
 
 
 def test_bucket_list_blobs_include_managed_folders(

--- a/packages/google-cloud-storage/tests/unit/test__grpc_conversions.py
+++ b/packages/google-cloud-storage/tests/unit/test__grpc_conversions.py
@@ -145,8 +145,7 @@ def test_blob_to_proto_contexts():
 
     from google.cloud.storage.blob import ObjectContexts, ObjectCustomContextPayload
 
-    create_time = datetime.datetime(2025, 1, 1, tzinfo=datetime.timezone.utc)
-    payload = ObjectCustomContextPayload(value="val", create_time=create_time)
+    payload = ObjectCustomContextPayload(value="val")
     blob.contexts = ObjectContexts(blob, custom={"key": payload})
 
     blob.custom_time = None


### PR DESCRIPTION
This PR addresses remaining comments on PR #17039 by cleaning up constructors for ObjectContexts and ObjectCustomContextPayload, improving back-reference management, updating documentation, and expanding test coverage.

Key changes:
- `ObjectCustomContextPayload`: Removed `create_time` and `update_time` from `__init__` as they are output-only. Updated docstring.
- `ObjectContexts`:
    - Moved back-reference logic into the initialization loop.
    - Updated `custom` setter to handle `None` and establish back-references for new elements.
- Documentation: Added link to public docs for Object Contexts and fixed type annotation for `filter_` in `Bucket.list_blobs`.
- Testing:
    - Updated unit tests in `test__grpc_conversions.py` for constructor changes.
    - Expanded system tests in `test_blob.py` and `test_bucket.py` to verify back-references and all context filter syntaxes.

---
*PR created automatically by Jules for task [746690522954199067](https://jules.google.com/task/746690522954199067) started by @nidhiii-27*