### PR TITLE
chore: remove references to Python 3.7-3.9

### DIFF
--- a/.librarian/generator-input/client-post-processing/datastore-integration.yaml
+++ b/.librarian/generator-input/client-post-processing/datastore-integration.yaml
@@ -240,3 +240,39 @@ replacements:
                   *session.posargs,
               )
     count: 1
+  - paths: [
+      "packages/google-cloud-datastore/CONTRIBUTING.rst"
+    ]
+    before: "- The feature must work fully on the following CPython versions:\n  3.7, 3.8, 3.9, 3.10, 3.11, 3.12, 3.13 and 3.14 on both UNIX and Windows."
+    after: "- The feature must work fully on the following CPython versions:\n  3.10, 3.11, 3.12, 3.13 and 3.14 on both UNIX and Windows."
+    count: 1
+  - paths: [
+      "packages/google-cloud-datastore/CONTRIBUTING.rst"
+    ]
+    before: "We support:\n\n-  `Python 3.7`_\n-  `Python 3.8`_\n-  `Python 3.9`_\n-  `Python 3.10`_\n-  `Python 3.11`_\n-  `Python 3.12`_\n-  `Python 3.13`_\n-  `Python 3.14`_\n\n.. _Python 3.7: https://docs.python.org/3.7/\n.. _Python 3.8: https://docs.python.org/3.8/\n.. _Python 3.9: https://docs.python.org/3.9/\n.. _Python 3.10: https://docs.python.org/3.10/"
+    after: "We support:\n\n-  `Python 3.10`_\n-  `Python 3.11`_\n-  `Python 3.12`_\n-  `Python 3.13`_\n-  `Python 3.14`_\n\n.. _Python 3.10: https://docs.python.org/3.10/"
+    count: 1
+  - paths: [
+      "packages/google-cloud-datastore/CONTRIBUTING.rst"
+    ]
+    before: "We also explicitly decided to support Python 3 beginning with version 3.7."
+    after: "We also explicitly decided to support Python 3 beginning with version 3.10."
+    count: 1
+  - paths: [
+      "packages/google-cloud-datastore/CONTRIBUTING.rst"
+    ]
+    before: "system-3.8"
+    after: "system-3.10"
+    count: 1
+  - paths: [
+      "packages/google-cloud-datastore/CONTRIBUTING.rst"
+    ]
+    before: "System tests are only configured to run under Python 3.8."
+    after: "System tests are only configured to run under Python 3.10."
+    count: 1
+  - paths: [
+      "packages/google-cloud-datastore/CONTRIBUTING.rst"
+    ]
+    before: "py-3.8"
+    after: "py-3.10"
+    count: 2

--- a/.librarian/generator-input/client-post-processing/datastore-integration.yaml
+++ b/.librarian/generator-input/client-post-processing/datastore-integration.yaml
@@ -240,39 +240,3 @@ replacements:
                   *session.posargs,
               )
     count: 1
-  - paths: [
-      "packages/google-cloud-datastore/CONTRIBUTING.rst"
-    ]
-    before: "- The feature must work fully on the following CPython versions:\n  3.7, 3.8, 3.9, 3.10, 3.11, 3.12, 3.13 and 3.14 on both UNIX and Windows."
-    after: "- The feature must work fully on the following CPython versions:\n  3.10, 3.11, 3.12, 3.13 and 3.14 on both UNIX and Windows."
-    count: 1
-  - paths: [
-      "packages/google-cloud-datastore/CONTRIBUTING.rst"
-    ]
-    before: "We support:\n\n-  `Python 3.7`_\n-  `Python 3.8`_\n-  `Python 3.9`_\n-  `Python 3.10`_\n-  `Python 3.11`_\n-  `Python 3.12`_\n-  `Python 3.13`_\n-  `Python 3.14`_\n\n.. _Python 3.7: https://docs.python.org/3.7/\n.. _Python 3.8: https://docs.python.org/3.8/\n.. _Python 3.9: https://docs.python.org/3.9/\n.. _Python 3.10: https://docs.python.org/3.10/"
-    after: "We support:\n\n-  `Python 3.10`_\n-  `Python 3.11`_\n-  `Python 3.12`_\n-  `Python 3.13`_\n-  `Python 3.14`_\n\n.. _Python 3.10: https://docs.python.org/3.10/"
-    count: 1
-  - paths: [
-      "packages/google-cloud-datastore/CONTRIBUTING.rst"
-    ]
-    before: "We also explicitly decided to support Python 3 beginning with version 3.7."
-    after: "We also explicitly decided to support Python 3 beginning with version 3.10."
-    count: 1
-  - paths: [
-      "packages/google-cloud-datastore/CONTRIBUTING.rst"
-    ]
-    before: "system-3.8"
-    after: "system-3.10"
-    count: 1
-  - paths: [
-      "packages/google-cloud-datastore/CONTRIBUTING.rst"
-    ]
-    before: "System tests are only configured to run under Python 3.8."
-    after: "System tests are only configured to run under Python 3.10."
-    count: 1
-  - paths: [
-      "packages/google-cloud-datastore/CONTRIBUTING.rst"
-    ]
-    before: "py-3.8"
-    after: "py-3.10"
-    count: 2

--- a/packages/google-cloud-datastore/CONTRIBUTING.rst
+++ b/packages/google-cloud-datastore/CONTRIBUTING.rst
@@ -22,7 +22,7 @@ In order to add a feature:
   documentation.
 
 - The feature must work fully on the following CPython versions:
-  3.7, 3.8, 3.9, 3.10, 3.11, 3.12, 3.13 and 3.14 on both UNIX and Windows.
+  3.10, 3.11, 3.12, 3.13 and 3.14 on both UNIX and Windows.
 
 - The feature must not add unnecessary dependencies (where
   "unnecessary" is of course subjective, but new dependencies should
@@ -143,12 +143,12 @@ Running System Tests
    $ nox -s system
 
    # Run a single system test
-   $ nox -s system-3.8 -- -k <name of test>
+   $ nox -s system-3.10 -- -k <name of test>
 
 
   .. note::
 
-      System tests are only configured to run under Python 3.8.
+      System tests are only configured to run under Python 3.10.
       For expediency, we do not run them in older versions of Python 3.
 
   This alone will not run the tests. You'll need to change some local
@@ -220,11 +220,11 @@ configure them just like the System Tests.
 
    # Run all tests in a folder
    $ cd samples/snippets
-   $ nox -s py-3.8
+   $ nox -s py-3.10
 
    # Run a single sample test
    $ cd samples/snippets
-   $ nox -s py-3.8 -- -k <name of test>
+   $ nox -s py-3.10 -- -k <name of test>
 
 ********************************************
 Note About ``README`` as it pertains to PyPI
@@ -246,18 +246,12 @@ Supported Python Versions
 
 We support:
 
--  `Python 3.7`_
--  `Python 3.8`_
--  `Python 3.9`_
 -  `Python 3.10`_
 -  `Python 3.11`_
 -  `Python 3.12`_
 -  `Python 3.13`_
 -  `Python 3.14`_
 
-.. _Python 3.7: https://docs.python.org/3.7/
-.. _Python 3.8: https://docs.python.org/3.8/
-.. _Python 3.9: https://docs.python.org/3.9/
 .. _Python 3.10: https://docs.python.org/3.10/
 .. _Python 3.11: https://docs.python.org/3.11/
 .. _Python 3.12: https://docs.python.org/3.12/
@@ -270,7 +264,7 @@ Supported versions can be found in our ``noxfile.py`` `config`_.
 .. _config: https://github.com/googleapis/google-cloud-python/blob/main/noxfile.py
 
 
-We also explicitly decided to support Python 3 beginning with version 3.7.
+We also explicitly decided to support Python 3 beginning with version 3.10.
 Reasons for this include:
 
 -  Encouraging use of newest versions of Python 3

--- a/packages/google-cloud-datastore/README.rst
+++ b/packages/google-cloud-datastore/README.rst
@@ -62,14 +62,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-datastore/docs/README.rst
+++ b/packages/google-cloud-datastore/docs/README.rst
@@ -62,14 +62,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.


### PR DESCRIPTION
Drops support for Python 3.7, 3.8, and 3.9 and aligns EOL documentation versions accordingly.

### Changes
* **Corrected EOL Documentation**:
  * `README.rst` updated based on synthtool revisions to declare Supported Python Versions as `>= 3.10, including 3.14` and Unsupported Python Versions as `<= 3.9`.
  * Cleaned up `CONTRIBUTING.rst` to remove EOL references, update standard CPython support ranges, align system/sample test run commands to `3.14` (e.g., `system-3.14`), and update the global Python 3 baseline statement to `3.10`.