### PR TITLE
feat(error-reporting): drop support for Python 3.7, 3.8, and 3.9

### DIFF
--- a/.librarian/generator-input/client-post-processing/integrate-isolated-handwritten-code.yaml
+++ b/.librarian/generator-input/client-post-processing/integrate-isolated-handwritten-code.yaml
@@ -432,3 +432,76 @@ replacements:
       numpy==1.21.3
       google-auth==2.14.1
     count: 1
+  - paths: [
+      "packages/google-cloud-error-reporting/testing/constraints-3.10.txt",
+    ]
+    before: |
+      google-auth==2.14.1
+      grpcio==1.44.0
+    after: |
+      google-auth==2.14.1
+      google-cloud-logging==3.9.0
+      grpcio==1.44.0
+    count: 1
+  - paths: [
+      "packages/google-cloud-error-reporting/testing/constraints-3.13.txt",
+      "packages/google-cloud-error-reporting/testing/constraints-3.14.txt",
+    ]
+    before: |
+      google-auth>=2
+      grpcio>=1
+    after: |
+      google-auth>=2
+      google-cloud-logging>=3
+      grpcio>=1
+    count: 2
+  - paths: [
+      "packages/google-cloud-error-reporting/CONTRIBUTING.rst"
+    ]
+    before: |
+      - The feature must work fully on the following CPython versions:
+        3.7, 3.8, 3.9, 3.10, 3.11, 3.12, 3.13 and 3.14 on both UNIX and Windows.
+    after: |
+      - The feature must work fully on the following CPython versions:
+        3.10, 3.11, 3.12, 3.13 and 3.14 on both UNIX and Windows.
+    count: 1
+  - paths: [
+      "packages/google-cloud-error-reporting/CONTRIBUTING.rst"
+    ]
+    before: |
+      We support:
+
+      -  `Python 3.7`_
+      -  `Python 3.8`_
+      -  `Python 3.9`_
+      -  `Python 3.10`_
+      -  `Python 3.11`_
+      -  `Python 3.12`_
+      -  `Python 3.13`_
+      -  `Python 3.14`_
+
+      .. _Python 3.7: https://docs.python.org/3.7/
+      .. _Python 3.8: https://docs.python.org/3.8/
+      .. _Python 3.9: https://docs.python.org/3.9/
+      .. _Python 3.10: https://docs.python.org/3.10/
+    after: |
+      We support:
+
+      -  `Python 3.10`_
+      -  `Python 3.11`_
+      -  `Python 3.12`_
+      -  `Python 3.13`_
+      -  `Python 3.14`_
+
+      .. _Python 3.10: https://docs.python.org/3.10/
+    count: 1
+  - paths: [
+      "packages/google-cloud-error-reporting/CONTRIBUTING.rst"
+    ]
+    before: |
+      We also explicitly decided to support Python 3 beginning with version 3.7.
+    after: |
+      We also explicitly decided to support Python 3 beginning with version 3.10.
+    count: 1
+
+

--- a/packages/google-cloud-error-reporting/CONTRIBUTING.rst
+++ b/packages/google-cloud-error-reporting/CONTRIBUTING.rst
@@ -22,7 +22,7 @@ In order to add a feature:
   documentation.
 
 - The feature must work fully on the following CPython versions:
-  3.7, 3.8, 3.9, 3.10, 3.11, 3.12, 3.13 and 3.14 on both UNIX and Windows.
+  3.10, 3.11, 3.12, 3.13 and 3.14 on both UNIX and Windows.
 
 - The feature must not add unnecessary dependencies (where
   "unnecessary" is of course subjective, but new dependencies should
@@ -221,18 +221,12 @@ Supported Python Versions
 
 We support:
 
--  `Python 3.7`_
--  `Python 3.8`_
--  `Python 3.9`_
 -  `Python 3.10`_
 -  `Python 3.11`_
 -  `Python 3.12`_
 -  `Python 3.13`_
 -  `Python 3.14`_
 
-.. _Python 3.7: https://docs.python.org/3.7/
-.. _Python 3.8: https://docs.python.org/3.8/
-.. _Python 3.9: https://docs.python.org/3.9/
 .. _Python 3.10: https://docs.python.org/3.10/
 .. _Python 3.11: https://docs.python.org/3.11/
 .. _Python 3.12: https://docs.python.org/3.12/
@@ -245,7 +239,7 @@ Supported versions can be found in our ``noxfile.py`` `config`_.
 .. _config: https://github.com/googleapis/google-cloud-python/blob/main/noxfile.py
 
 
-We also explicitly decided to support Python 3 beginning with version 3.7.
+We also explicitly decided to support Python 3 beginning with version 3.10.
 Reasons for this include:
 
 -  Encouraging use of newest versions of Python 3

--- a/packages/google-cloud-error-reporting/README.rst
+++ b/packages/google-cloud-error-reporting/README.rst
@@ -63,14 +63,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-error-reporting/docs/README.rst
+++ b/packages/google-cloud-error-reporting/docs/README.rst
@@ -63,14 +63,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-error-reporting/pytest.ini
+++ b/packages/google-cloud-error-reporting/pytest.ini
@@ -15,14 +15,9 @@ filterwarnings =
     ignore:.*Create unlinked descriptors is going to go away. Please use get/find descriptors from generated code or query the descriptor_pool.*:DeprecationWarning
     # Remove tests for `credentials_file` once support for `credentials_file` is removed in `google-auth`
     ignore:The `credentials_file` argument is deprecated because of a potential security risk:DeprecationWarning
-    # Remove after support for Python 3.7 is dropped
-    ignore:You are using a non-supported Python version \(3\.7:FutureWarning
-    # Remove after support for Python 3.8 is dropped
-    ignore:You are using a non-supported Python version \(3\.8:DeprecationWarning
-    ignore:You are using a non-supported Python version \(3\.8:FutureWarning
-    # Remove after support for Python 3.9 is dropped
-    ignore:You are using a Python version \(3\.9:FutureWarning
     # Remove after support for Python 3.10 is dropped
     ignore:.*You are using a Python version \(3\.10:FutureWarning
     ignore:.*Please upgrade to the latest Python version.*:FutureWarning
+    # Remove once opentelemetry stops triggering SelectableGroups DeprecationWarning on Python 3.11+
+    ignore:.*SelectableGroups dict interface is deprecated.*:DeprecationWarning
     ignore:(?s).*using a Python version.*past its end of life.*:FutureWarning

--- a/packages/google-cloud-error-reporting/testing/constraints-3.10.txt
+++ b/packages/google-cloud-error-reporting/testing/constraints-3.10.txt
@@ -6,6 +6,7 @@
 # then this file should have google-cloud-foo==1.14.0
 google-api-core==2.17.1
 google-auth==2.14.1
+google-cloud-logging==3.9.0
 grpcio==1.44.0
 proto-plus==1.22.3
 protobuf==4.25.8

--- a/packages/google-cloud-error-reporting/testing/constraints-3.13.txt
+++ b/packages/google-cloud-error-reporting/testing/constraints-3.13.txt
@@ -7,6 +7,7 @@
 # Then this file should have google-cloud-foo>=1
 google-api-core>=2
 google-auth>=2
+google-cloud-logging>=3
 grpcio>=1
 proto-plus>=1
 protobuf>=6

--- a/packages/google-cloud-error-reporting/testing/constraints-3.14.txt
+++ b/packages/google-cloud-error-reporting/testing/constraints-3.14.txt
@@ -7,6 +7,7 @@
 # Then this file should have google-cloud-foo>=1
 google-api-core>=2
 google-auth>=2
+google-cloud-logging>=3
 grpcio>=1
 proto-plus>=1
 protobuf>=6


### PR DESCRIPTION
> [!Note]
> Waiting on changes to [synthtools](https://github.com/googleapis/synthtool/pull/2178) and [librarian](https://github.com/googleapis/librarian/pull/6111) before regenerating files in this update.

This PR updates `google-cloud-error-reporting` to establish Python 3.10 as the minimum supported version.

### Changes
* Configuration: Updated `setup.py`, `noxfile.py`, `CONTRIBUTING.rst`, and `README.rst` to remove references to Python 3.7, 3.8, and 3.9.
* Environment & Build: Standardised protobuf==4.25.8 and bumped lower-bounds for dependencies in constraints.
* Cleanup: Removed obsolete pytest.ini warning filters.

Fixes internal issue: http://b/482126936 🦕