### PR TITLE
chore(release): enable release of google-cloud-storage

### DIFF
--- a/.librarian/config.yaml
+++ b/.librarian/config.yaml
@@ -15,10 +15,6 @@ global_files_allowlist:
 libraries:
   # libraries have "release_blocked: true" so that releases are
   # explicitly initiated.
-  # TODO(https://github.com/googleapis/google-cloud-python/issues/16487):
-  # Allow releases for google-cloud-storage once this bug is fixed.
-  - id: "google-cloud-storage"
-    release_blocked: true
   # TODO(https://github.com/googleapis/google-cloud-python/issues/16489):
   # Allow releases for bigframes once the bug above is fixed.
   - id: "bigframes"

--- a/librarian.yaml
+++ b/librarian.yaml
@@ -1934,7 +1934,6 @@ libraries:
     version: 3.10.1
     apis:
       - path: google/storage/v2
-    skip_release: true
     python:
       library_type: GAPIC_MANUAL
       opt_args_by_api:


### PR DESCRIPTION
All the steps in #16487 are complete. 
Removing the release block on `google-cloud-storage`.