### PR TITLE
Revert "fix: bump opentelemetry-instrumentation from 0.37b0 to 0.41b0 in /packages/google-cloud-bigquery"

### DIFF
--- a/packages/google-cloud-bigquery/testing/constraints-3.10.txt
+++ b/packages/google-cloud-bigquery/testing/constraints-3.10.txt
@@ -22,6 +22,6 @@ matplotlib==3.10.3
 tqdm==4.23.4
 opentelemetry-api==1.16.0
 opentelemetry-sdk==1.16.0
-opentelemetry-instrumentation==0.41b0
+opentelemetry-instrumentation==0.37b0
 proto-plus==1.22.3
 protobuf==4.25.8


### PR DESCRIPTION
Reverts googleapis/google-cloud-python#17195