### PR TITLE
fix(pubsub) : resolve issue with pubsub generation

### DIFF
--- a/.librarian/generator-input/client-post-processing/pubsub-integration.yaml
+++ b/.librarian/generator-input/client-post-processing/pubsub-integration.yaml
@@ -369,14 +369,6 @@ replacements:
     count: 1
 
 
-  # --- FIX: Restore pubsub-specific grpcio bound ---
-  - paths:
-      - "packages/google-cloud-pubsub/setup.py"
-    before: '([ \t]+)"grpcio >= [0-9\.]+, < 2\.0\.0",\n'
-    after: |-
-      \g<1>"grpcio >= 1.51.3, < 2.0.0; python_version < '3.14'",  # https://github.com/googleapis/python-pubsub/issues/609
-    count: 1
-
   # --- FIX: Restore missing dependencies, extras, and url dynamically ---
   - paths:
       - "packages/google-cloud-pubsub/setup.py"
@@ -530,8 +522,8 @@ replacements:
 
   - paths:
       - "packages/google-cloud-pubsub/setup.py"
-    before: '"grpcio-status >= 1\.44\.0",'
-    after: '"grpcio-status >= 1.51.3",'
+    before: '([ \t]+)"grpcio >= [0-9\.]+, < 2\.0\.0",\n(?:[ \t]*)"grpcio >= 1\.75\.1, < 2\.0\.0; python_version >= ''3\.14''",\n'
+    after: |-
+      \g<1>"grpcio >= 1.51.3, < 2.0.0; python_version < '3.14'",
+      \g<1>"grpcio >= 1.75.1, < 2.0.0; python_version >= '3.14'",
     count: 1
-
-

--- a/librarian.yaml
+++ b/librarian.yaml
@@ -1659,7 +1659,6 @@ libraries:
     version: 2.38.0
     apis:
       - path: google/pubsub/v1
-    skip_generate: false
     python:
       library_type: GAPIC_COMBO
       opt_args_by_api:

--- a/librarian.yaml
+++ b/librarian.yaml
@@ -1659,7 +1659,7 @@ libraries:
     version: 2.38.0
     apis:
       - path: google/pubsub/v1
-    skip_generate: true
+    skip_generate: false
     python:
       library_type: GAPIC_COMBO
       opt_args_by_api:

--- a/packages/google-cloud-pubsub/README.rst
+++ b/packages/google-cloud-pubsub/README.rst
@@ -62,14 +62,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-pubsub/docs/README.rst
+++ b/packages/google-cloud-pubsub/docs/README.rst
@@ -62,14 +62,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-pubsub/pytest.ini
+++ b/packages/google-cloud-pubsub/pytest.ini
@@ -26,3 +26,6 @@ filterwarnings =
     ignore:You are using a non-supported Python version \(([\d\.]+)\)\. Google will not post any further updates to google\.api_core.*:FutureWarning
     # These google library EOL warnings for Python versions don't matter for the purposes of a test.
     ignore::FutureWarning:google.*:
+    # Suppress SelectableGroups deprecation warning from older dependencies under Python 3.11+
+    ignore:.*SelectableGroups dict interface is deprecated:DeprecationWarning
+

--- a/packages/google-cloud-pubsub/setup.py
+++ b/packages/google-cloud-pubsub/setup.py
@@ -43,7 +43,8 @@ dependencies = [
     # Exclude incompatible versions of `google-auth`
     # See https://github.com/googleapis/google-cloud-python/issues/12364
     "google-auth >= 2.14.1, <3.0.0,!=2.24.0,!=2.25.0",
-    "grpcio >= 1.51.3, < 2.0.0; python_version < '3.14'",  # https://github.com/googleapis/python-pubsub/issues/609    "grpcio >= 1.75.1, < 2.0.0; python_version >= '3.14'",
+    "grpcio >= 1.51.3, < 2.0.0; python_version < '3.14'",
+    "grpcio >= 1.75.1, < 2.0.0; python_version >= '3.14'",
     "proto-plus >= 1.22.3, <2.0.0",
     "proto-plus >= 1.25.0, <2.0.0; python_version >= '3.13'",
     "protobuf >= 4.25.8, < 8.0.0",


### PR DESCRIPTION
Corrects issue with package generation.

### Changes

#### librarian.yaml:
* Enabled client library generation for `google-cloud-pubsub` by removing `skip_generate`.

#### .librarian/generator-input/client-post-processing/pubsub-integration.yaml:
* Removed obsolete `grpcio-status` post-processing rules that are no longer necessary.
* Added a unified post-processing rule to correctly split an unintentionally merged/concatenated `grpcio` dependency constraint back into two separate, version-constrained lines for use in `setup.py`.

#### packages/google-cloud-pubsub/pytest.ini:
* Added a selective warning ignore rule `(ignore:.*SelectableGroups dict interface is deprecated:DeprecationWarning)` to prevent `pytest` from failing on third-party dependency deprecation warnings under Python 3.11+.


#### packages/google-cloud-pubsub/README.rst & packages/google-cloud-pubsub/docs/README.rst:
* `README` files updated due to changes in synthtool template now reflect the dropped support for Python 3.9 (minimum version bounds bumped from >= 3.9 to >= 3.10).