### PR TITLE
feat(storage): implement bounded LRU cache utility

### DIFF
--- a/packages/google-cloud-storage/google/cloud/storage/_lru_cache.py
+++ b/packages/google-cloud-storage/google/cloud/storage/_lru_cache.py
@@ -1,0 +1,89 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""A Least Recently Used (LRU) cache implementation."""
+
+from collections import OrderedDict
+from typing import Generic, Optional, TypeVar
+
+K = TypeVar("K")
+V = TypeVar("V")
+
+
+class LRUCache(Generic[K, V]):
+    """A Least Recently Used (LRU) cache implementation using OrderedDict.
+
+    :type capacity: int
+    :param capacity: The maximum number of items the cache can hold.
+    """
+
+    def __init__(self, capacity: int) -> None:
+        if capacity <= 0:
+            raise ValueError("Capacity must be greater than 0")
+        self._capacity = capacity
+        self._cache: OrderedDict[K, V] = OrderedDict()
+
+    @property
+    def capacity(self) -> int:
+        """Return the capacity of the cache."""
+        return self._capacity
+
+    def get(self, key: K, default: Optional[V] = None) -> Optional[V]:
+        """Retrieve an item from the cache.
+
+        If the key exists, it is moved to the end (marked as most recently used).
+
+        :type key: Any
+        :param key: The key to look up in the cache.
+
+        :type default: Any
+        :param default: Default value to return if key is not found.
+        """
+        if key not in self._cache:
+            return default
+        self._cache.move_to_end(key)
+        return self._cache[key]
+
+    def put(self, key: K, value: V) -> None:
+        """Add or update an item in the cache.
+
+        If the key already exists, it is updated and moved to the end.
+        If adding the item exceeds capacity, the least recently used item (at the beginning)
+        is evicted.
+
+        :type key: Any
+        :param key: The key to store.
+
+        :type value: Any
+        :param value: The value to store.
+        """
+        if key in self._cache:
+            self._cache.move_to_end(key)
+        self._cache[key] = value
+        if len(self._cache) > self._capacity:
+            self._cache.popitem(last=False)
+
+    def __len__(self) -> int:
+        return len(self._cache)
+
+    def __contains__(self, key: K) -> bool:
+        return key in self._cache
+
+    def clear(self) -> None:
+        """Clear all items from the cache."""
+        self._cache.clear()
+
+    def delete(self, key: K) -> None:
+        """Remove an item from the cache if it exists."""
+        self._cache.pop(key, None)

--- a/packages/google-cloud-storage/google/cloud/storage/_lru_cache.py
+++ b/packages/google-cloud-storage/google/cloud/storage/_lru_cache.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from __future__ import annotations
 
 """A Least Recently Used (LRU) cache implementation."""
 

--- a/packages/google-cloud-storage/tests/unit/test__lru_cache.py
+++ b/packages/google-cloud-storage/tests/unit/test__lru_cache.py
@@ -1,0 +1,101 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+
+from google.cloud.storage._lru_cache import LRUCache
+
+
+def test_lru_cache_capacity():
+    cache = LRUCache(capacity=3)
+    assert cache.capacity == 3
+
+    with pytest.raises(ValueError):
+        LRUCache(capacity=0)
+
+    with pytest.raises(ValueError):
+        LRUCache(capacity=-1)
+
+
+def test_lru_cache_put_and_get():
+    cache = LRUCache(capacity=2)
+    assert cache.get("a") is None
+    assert cache.get("a", default="default") == "default"
+
+    cache.put("a", 1)
+    assert cache.get("a") == 1
+    assert len(cache) == 1
+    assert "a" in cache
+
+    cache.put("b", 2)
+    assert cache.get("b") == 2
+    assert len(cache) == 2
+    assert "b" in cache
+
+
+def test_lru_cache_eviction():
+    cache = LRUCache(capacity=2)
+    cache.put("a", 1)
+    cache.put("b", 2)
+
+    # Access "a" so "b" becomes least recently used
+    assert cache.get("a") == 1
+
+    # Put "c" should evict "b"
+    cache.put("c", 3)
+
+    assert "b" not in cache
+    assert cache.get("b") is None
+    assert cache.get("a") == 1
+    assert cache.get("c") == 3
+    assert len(cache) == 2
+
+
+def test_lru_cache_update():
+    cache = LRUCache(capacity=2)
+    cache.put("a", 1)
+    cache.put("b", 2)
+
+    # Update "a", so it becomes most recently used
+    cache.put("a", 10)
+
+    # Put "c" should evict "b"
+    cache.put("c", 3)
+
+    assert "b" not in cache
+    assert cache.get("a") == 10
+    assert cache.get("c") == 3
+
+
+def test_lru_cache_clear():
+    cache = LRUCache(capacity=2)
+    cache.put("a", 1)
+    cache.put("b", 2)
+
+    cache.clear()
+    assert len(cache) == 0
+    assert "a" not in cache
+    assert "b" not in cache
+
+
+def test_lru_cache_delete():
+    cache = LRUCache(capacity=2)
+    cache.put("a", 1)
+    cache.put("b", 2)
+
+    cache.delete("a")
+    assert len(cache) == 1
+    assert "a" not in cache
+    assert cache.get("a") is None
+    assert cache.get("b") == 2


### PR DESCRIPTION
## Description
Implements a bounded capacity $O(1)$ `LRUCache` data structure using an `OrderedDict`. This class serves as the underlying storage mechanism for the App-centric Observability (ACO) metadata cache, with synchronization/locking handled by the cache manager layer (`BucketMetadataCache`).

## Changes
- Created `google/cloud/storage/_lru_cache.py` with bounded LRU capacity logic.
- Created `tests/unit/test__lru_cache.py` verifying correctness, cache hits/misses, and item eviction.

This is PR 1 of a 4-part series to break down the ACO tracing compatibility feature into reviewable slices.
