### PR TITLE
feat(storage): integrate ACO tracing into public client and add system tests

### DIFF
--- a/packages/google-cloud-storage/google/cloud/storage/_bucket_metadata_cache.py
+++ b/packages/google-cloud-storage/google/cloud/storage/_bucket_metadata_cache.py
@@ -1,0 +1,149 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""In-memory LRU cache for bucket metadata supporting App-centric Observability (ACO)."""
+
+import logging
+import threading
+
+from google.api_core import exceptions as api_exceptions
+from google.cloud.exceptions import NotFound
+from google.cloud.storage._lru_cache import LRUCache
+
+logger = logging.getLogger(__name__)
+
+
+class BucketMetadataCache:
+    """Thread-safe LRU cache for storing GCS bucket metadata (project number and location).
+
+    Supports Singleflight asynchronous background fetching to prevent stampedes on cache misses.
+    """
+
+    def __init__(self, client, max_size=10000):
+        self._client = client
+        self._cache = LRUCache(max_size)
+        self._lock = threading.Lock()
+        self._inflight_fetches = set()
+        self._inflight_checks = set()
+
+    def get(self, bucket_name):
+        """Thread-safely retrieve cached metadata without queueing fetch."""
+        with self._lock:
+            return self._cache.get(bucket_name)
+
+    def get_or_queue_fetch(self, bucket_name):
+        """Retrieve bucket metadata or queue a background fetch on cache miss.
+
+        Returns None immediately on cache miss so caller does not block.
+        """
+        with self._lock:
+            if bucket_name in self._cache:
+                return self._cache.get(bucket_name)
+            elif bucket_name in self._inflight_fetches:
+                # this would be the case of thundering herd, where 'n' threads
+                # all of them faced "cache miss" and 1 is in progress to fetch metadata.
+                # hence we don't want rest `n - 1` threads to make the same req
+                return None
+            else:
+                # fire a background thread and get bucket metadata.
+                self._inflight_fetches.add(bucket_name)
+                threading.Thread(
+                    target=self._fetch_background, args=(bucket_name,), daemon=True
+                ).start()
+                return None
+
+    def check_and_evict(self, bucket_name):
+        """Asynchronously verify if a bucket exists on 404 and evict if deleted."""
+        with self._lock:
+            if bucket_name not in self._cache:
+                return
+            if bucket_name in self._inflight_checks:
+                return
+            self._inflight_checks.add(bucket_name)
+            threading.Thread(
+                target=self._verify_existence_background,
+                args=(bucket_name,),
+                daemon=True,
+            ).start()
+
+    def _verify_existence_background(self, bucket_name):
+        try:
+            bucket = self._client.bucket(bucket_name)
+            if not bucket.exists():
+                self.evict(bucket_name)
+        except Exception as e:
+            logger.debug(
+                f"Background verification for bucket existence failed for {bucket_name}: {e}"
+            )
+        finally:
+            with self._lock:
+                self._inflight_checks.discard(bucket_name)
+
+    def _fetch_background(self, bucket_name):
+        """Asynchronously fetch bucket metadata and update the cache."""
+        try:
+            bucket = self._client.get_bucket(bucket_name, timeout=10.0)
+            self.update_from_bucket(bucket)
+        except (NotFound, api_exceptions.NotFound):
+            self.evict(bucket_name)
+        except api_exceptions.Forbidden:
+            # On 403 (Forbidden), cache fallback values permanently to avoid retry storms
+            self.update_cache(
+                bucket_name, f"projects/_/buckets/{bucket_name}", "global"
+            )
+        except Exception as e:
+            logger.debug(
+                f"Background fetch for bucket metadata failed for {bucket_name}: {e}"
+            )
+        finally:
+            with self._lock:
+                self._inflight_fetches.discard(bucket_name)
+
+    def update_from_bucket(self, bucket):
+        """Update cache from a Bucket instance."""
+        if not bucket or not bucket.name:
+            return
+
+        project_number = getattr(bucket, "project_number", None)
+        location = getattr(bucket, "location", None) or "global"
+        location = location.lower()
+        location_type = getattr(bucket, "location_type", None) or "region"
+        location_type = location_type.lower()
+
+        if location_type in ("multi-region", "dual-region"):
+            location = "global"
+
+        if project_number:
+            destination_id = f"projects/{project_number}/buckets/{bucket.name}"
+        else:
+            destination_id = f"projects/_/buckets/{bucket.name}"
+
+        self.update_cache(bucket.name, destination_id, location)
+
+    def update_cache(self, bucket_name, destination_id, location):
+        """Thread-safely update or insert a cache entry with bounded size."""
+        with self._lock:
+            self._cache.put(bucket_name, (destination_id, location))
+
+    def evict(self, bucket_name):
+        """Remove a bucket from the cache (e.g., on 404)."""
+        with self._lock:
+            self._cache.delete(bucket_name)
+
+    def clear(self):
+        """Clear all cached metadata."""
+        with self._lock:
+            self._cache.clear()
+            self._inflight_fetches.clear()
+            self._inflight_checks.clear()

--- a/packages/google-cloud-storage/google/cloud/storage/_helpers.py
+++ b/packages/google-cloud-storage/google/cloud/storage/_helpers.py
@@ -19,12 +19,17 @@ These are *not* part of the API.
 
 import base64
 import datetime
+import logging
 import os
 import secrets
 import sys
+from contextlib import contextmanager
 from hashlib import md5
 from urllib.parse import urlsplit, urlunsplit
 from uuid import uuid4
+
+from google.api_core import exceptions as api_exceptions
+from google.cloud.exceptions import NotFound
 
 from google.auth import environment_vars
 
@@ -33,6 +38,13 @@ from google.cloud.storage.retry import (
     DEFAULT_RETRY,
     DEFAULT_RETRY_IF_METAGENERATION_SPECIFIED,
 )
+from google.cloud.storage._opentelemetry_tracing import (
+    create_trace_span as _base_create_trace_span,
+    enable_otel_traces,
+    HAS_OPENTELEMETRY,
+)
+
+_logger = logging.getLogger(__name__)
 
 STORAGE_EMULATOR_ENV_VAR = "STORAGE_EMULATOR_HOST"  # Despite name, includes scheme.
 """Environment variable defining host for Storage emulator."""
@@ -137,6 +149,62 @@ def _validate_name(name):
     return name
 
 
+@contextmanager
+def create_trace_span_helper(client, bucket_name, name, attributes=None, **kwargs):
+    span_attrs = dict(attributes) if attributes else {}
+
+    if (
+        bucket_name
+        and isinstance(bucket_name, str)
+        and client
+        and hasattr(client, "_bucket_metadata_cache")
+        and client._bucket_metadata_cache
+    ):
+        try:
+            if name in (
+                "Storage.Client.getBucket",
+                "Storage.Client.lookupBucket",
+                "Storage.Bucket.reload",
+                "Storage.Bucket.exists",
+            ):
+                cached = client._bucket_metadata_cache.get(bucket_name)
+            else:
+                cached = client._bucket_metadata_cache.get_or_queue_fetch(bucket_name)
+
+            if cached and isinstance(cached, tuple) and len(cached) == 2:
+                dest_id, loc = cached
+                span_attrs.update(
+                    {
+                        "gcp.resource.destination.id": dest_id,
+                        "gcp.resource.destination.location": loc,
+                    }
+                )
+        except Exception as e:
+            _logger.debug(f"Failed cache lookup in create_trace_span_helper: {e}")
+
+    if "client" not in kwargs and client:
+        kwargs["client"] = client
+
+    with _base_create_trace_span(name, attributes=span_attrs, **kwargs) as span:
+        try:
+            yield span
+        except (NotFound, api_exceptions.NotFound):
+            if (
+                bucket_name
+                and isinstance(bucket_name, str)
+                and client
+                and hasattr(client, "_bucket_metadata_cache")
+                and client._bucket_metadata_cache
+            ):
+                try:
+                    client._bucket_metadata_cache.check_and_evict(bucket_name)
+                except Exception as e:
+                    _logger.debug(
+                        f"Failed cache eviction on 404 in create_trace_span_helper: {e}"
+                    )
+            raise
+
+
 class _PropertyMixin(object):
     """Abstract mixin for cloud storage classes with associated properties.
 
@@ -184,6 +252,87 @@ class _PropertyMixin(object):
         if client is None:
             client = self.client
         return client
+
+    def _get_aco_attributes(self):
+        if not HAS_OPENTELEMETRY or not enable_otel_traces:
+            return {}
+        from google.cloud.storage.blob import Blob
+        from google.cloud.storage.bucket import Bucket
+
+        if isinstance(self, Bucket):
+            cache = getattr(self.client, "_bucket_metadata_cache", None)
+            bucket_name = self.name
+        elif isinstance(self, Blob):
+            bucket = getattr(self, "bucket", None)
+            cache = (
+                getattr(bucket.client, "_bucket_metadata_cache", None)
+                if bucket and hasattr(bucket, "client")
+                else None
+            )
+            bucket_name = getattr(bucket, "name", None) if bucket else None
+        else:
+            raise TypeError(
+                f"Unexpected type for ACO attribute retrieval: {type(self)}"
+            )
+
+        if callable(bucket_name):
+            try:
+                bucket_name = bucket_name()
+            except Exception as e:
+                _logger.debug(
+                    f"Failed callable bucket_name resolution in _get_aco_attributes: {e}"
+                )
+
+        if cache and bucket_name and isinstance(bucket_name, str):
+            try:
+                cached = cache.get_or_queue_fetch(bucket_name)
+                if cached and isinstance(cached, tuple) and len(cached) == 2:
+                    dest_id, loc = cached
+                    return {
+                        "gcp.resource.destination.id": dest_id,
+                        "gcp.resource.destination.location": loc,
+                    }
+            except Exception as e:
+                _logger.debug(
+                    f"Failed cache.get_or_queue_fetch in _get_aco_attributes: {e}"
+                )
+        return {}
+
+    @contextmanager
+    def _create_trace_span(self, name, attributes=None, **kwargs):
+        from google.cloud.storage.blob import Blob
+        from google.cloud.storage.bucket import Bucket
+
+        if isinstance(self, Bucket):
+            client = self.client
+            bucket_name = self.name
+        elif isinstance(self, Blob):
+            bucket = getattr(self, "bucket", None)
+            client = (
+                getattr(bucket, "client", None)
+                if bucket and hasattr(bucket, "client")
+                else None
+            )
+            bucket_name = getattr(bucket, "name", None) if bucket else None
+        else:
+            client = None
+            bucket_name = None
+
+        if callable(bucket_name):
+            try:
+                bucket_name = bucket_name()
+            except Exception as e:
+                _logger.debug(
+                    f"Failed callable bucket_name resolution in _create_trace_span: {e}"
+                )
+
+        client_override = kwargs.pop("client", None)
+        active_client = client_override or client
+
+        with create_trace_span_helper(
+            active_client, bucket_name, name, attributes=attributes, **kwargs
+        ) as span:
+            yield span
 
     def _encryption_headers(self):
         """Return any encryption headers needed to fetch the object.

--- a/packages/google-cloud-storage/google/cloud/storage/_http.py
+++ b/packages/google-cloud-storage/google/cloud/storage/_http.py
@@ -15,10 +15,20 @@
 """Create / interact with Google Cloud Storage connections."""
 
 import functools
+import logging
+import re
 
+from google.api_core import exceptions as api_exceptions
 from google.cloud import _http
+from google.cloud.exceptions import NotFound
 from google.cloud.storage import __version__, _helpers
-from google.cloud.storage._opentelemetry_tracing import create_trace_span
+from google.cloud.storage._opentelemetry_tracing import (
+    create_trace_span,
+    enable_otel_traces,
+    HAS_OPENTELEMETRY,
+)
+
+logger = logging.getLogger(__name__)
 
 
 class Connection(_http.JSONConnection):
@@ -71,11 +81,29 @@ class Connection(_http.JSONConnection):
         span_attributes = {
             "gccl-invocation-id": invocation_id,
         }
+        client = self._client
+        if (
+            HAS_OPENTELEMETRY
+            and enable_otel_traces
+            and hasattr(client, "_bucket_metadata_cache")
+            and client._bucket_metadata_cache
+        ):
+            match = re.search(r"/b/([^/?#]+)", kwargs.get("path", ""))
+            if match:
+                try:
+                    cached = client._bucket_metadata_cache.get(match.group(1))
+                    if cached and isinstance(cached, tuple) and len(cached) == 2:
+                        dest_id, loc = cached
+                        span_attributes["gcp.resource.destination.id"] = dest_id
+                        span_attributes["gcp.resource.destination.location"] = loc
+                except Exception as e:
+                    logger.debug(f"Failed cache.get_or_queue_fetch in api_request: {e}")
+
         call = functools.partial(super(Connection, self).api_request, *args, **kwargs)
         with create_trace_span(
             name="Storage.Connection.api_request",
             attributes=span_attributes,
-            client=self._client,
+            client=client,
             api_request=kwargs,
             retry=retry,
         ):
@@ -87,4 +115,23 @@ class Connection(_http.JSONConnection):
                     pass
                 if retry:
                     call = retry(call)
-            return call()
+            try:
+                return call()
+            except (NotFound, api_exceptions.NotFound):
+                if (
+                    HAS_OPENTELEMETRY
+                    and enable_otel_traces
+                    and hasattr(client, "_bucket_metadata_cache")
+                    and client._bucket_metadata_cache
+                ):
+                    match = re.search(r"/b/([^/?#]+)", kwargs.get("path", ""))
+                    if match:
+                        try:
+                            client._bucket_metadata_cache.check_and_evict(
+                                match.group(1)
+                            )
+                        except Exception as e:
+                            logger.debug(
+                                f"Failed cache.check_and_evict on 404 in api_request: {e}"
+                            )
+                raise

--- a/packages/google-cloud-storage/google/cloud/storage/_lru_cache.py
+++ b/packages/google-cloud-storage/google/cloud/storage/_lru_cache.py
@@ -1,0 +1,89 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""A Least Recently Used (LRU) cache implementation."""
+
+from collections import OrderedDict
+from typing import Generic, Optional, TypeVar
+
+K = TypeVar("K")
+V = TypeVar("V")
+
+
+class LRUCache(Generic[K, V]):
+    """A Least Recently Used (LRU) cache implementation using OrderedDict.
+
+    :type capacity: int
+    :param capacity: The maximum number of items the cache can hold.
+    """
+
+    def __init__(self, capacity: int) -> None:
+        if capacity <= 0:
+            raise ValueError("Capacity must be greater than 0")
+        self._capacity = capacity
+        self._cache: OrderedDict[K, V] = OrderedDict()
+
+    @property
+    def capacity(self) -> int:
+        """Return the capacity of the cache."""
+        return self._capacity
+
+    def get(self, key: K, default: Optional[V] = None) -> Optional[V]:
+        """Retrieve an item from the cache.
+
+        If the key exists, it is moved to the end (marked as most recently used).
+
+        :type key: Any
+        :param key: The key to look up in the cache.
+
+        :type default: Any
+        :param default: Default value to return if key is not found.
+        """
+        if key not in self._cache:
+            return default
+        self._cache.move_to_end(key)
+        return self._cache[key]
+
+    def put(self, key: K, value: V) -> None:
+        """Add or update an item in the cache.
+
+        If the key already exists, it is updated and moved to the end.
+        If adding the item exceeds capacity, the least recently used item (at the beginning)
+        is evicted.
+
+        :type key: Any
+        :param key: The key to store.
+
+        :type value: Any
+        :param value: The value to store.
+        """
+        if key in self._cache:
+            self._cache.move_to_end(key)
+        self._cache[key] = value
+        if len(self._cache) > self._capacity:
+            self._cache.popitem(last=False)
+
+    def __len__(self) -> int:
+        return len(self._cache)
+
+    def __contains__(self, key: K) -> bool:
+        return key in self._cache
+
+    def clear(self) -> None:
+        """Clear all items from the cache."""
+        self._cache.clear()
+
+    def delete(self, key: K) -> None:
+        """Remove an item from the cache if it exists."""
+        self._cache.pop(key, None)

--- a/packages/google-cloud-storage/google/cloud/storage/blob.py
+++ b/packages/google-cloud-storage/google/cloud/storage/blob.py
@@ -60,7 +60,6 @@ from google.cloud.storage._media.requests import (
 )
 from google.cloud.storage._opentelemetry_tracing import (
     _get_opentelemetry_attributes_from_url,
-    create_trace_span,
 )
 from google.cloud.storage._signing import generate_signed_url_v2, generate_signed_url_v4
 from google.cloud.storage.acl import ACL, ObjectACL
@@ -743,7 +742,7 @@ class Blob(_PropertyMixin):
         :rtype: bool
         :returns: True if the blob exists in Cloud Storage.
         """
-        with create_trace_span(name="Storage.Blob.exists"):
+        with self._create_trace_span(name="Storage.Blob.exists"):
             client = self._require_client(client)
             # We only need the status code (200 or not) so we seek to
             # minimize the returned payload.
@@ -847,7 +846,7 @@ class Blob(_PropertyMixin):
                  (propagated from
                  :meth:`google.cloud.storage.bucket.Bucket.delete_blob`).
         """
-        with create_trace_span(name="Storage.Blob.delete"):
+        with self._create_trace_span(name="Storage.Blob.delete"):
             self.bucket.delete_blob(
                 self.name,
                 client=client,
@@ -1086,7 +1085,7 @@ class Blob(_PropertyMixin):
                 # not supported for chunked downloads.
                 single_shot_download=single_shot_download,
             )
-            with create_trace_span(
+            with self._create_trace_span(
                 name=f"Storage.{download_class}/consume",
                 attributes=extra_attributes,
                 api_request=args,
@@ -1115,7 +1114,7 @@ class Blob(_PropertyMixin):
                 retry=retry,
             )
 
-            with create_trace_span(
+            with self._create_trace_span(
                 name=f"Storage.{download_class}/consumeNextChunk",
                 attributes=extra_attributes,
                 api_request=args,
@@ -1243,7 +1242,7 @@ class Blob(_PropertyMixin):
 
         :raises: :class:`google.cloud.exceptions.NotFound`
         """
-        with create_trace_span(name="Storage.Blob.downloadToFile"):
+        with self._create_trace_span(name="Storage.Blob.downloadToFile"):
             self._prep_and_do_download(
                 file_obj,
                 client=client,
@@ -1399,7 +1398,7 @@ class Blob(_PropertyMixin):
 
         :raises: :class:`google.cloud.exceptions.NotFound`
         """
-        with create_trace_span(name="Storage.Blob.downloadToFilename"):
+        with self._create_trace_span(name="Storage.Blob.downloadToFilename"):
             self._handle_filename_and_download(
                 filename,
                 client=client,
@@ -1524,7 +1523,7 @@ class Blob(_PropertyMixin):
 
         :raises: :class:`google.cloud.exceptions.NotFound`
         """
-        with create_trace_span(name="Storage.Blob.downloadAsBytes"):
+        with self._create_trace_span(name="Storage.Blob.downloadAsBytes"):
             string_buffer = BytesIO()
 
             self._prep_and_do_download(
@@ -1647,7 +1646,7 @@ class Blob(_PropertyMixin):
             PendingDeprecationWarning,
             stacklevel=2,
         )
-        with create_trace_span(name="Storage.Blob.downloadAsString"):
+        with self._create_trace_span(name="Storage.Blob.downloadAsString"):
             return self.download_as_bytes(
                 client=client,
                 start=start,
@@ -1761,7 +1760,7 @@ class Blob(_PropertyMixin):
         :rtype: text
         :returns: The data stored in this blob, decoded to text.
         """
-        with create_trace_span(name="Storage.Blob.downloadAsText"):
+        with self._create_trace_span(name="Storage.Blob.downloadAsText"):
             data = self.download_as_bytes(
                 client=client,
                 start=start,
@@ -1884,7 +1883,7 @@ class Blob(_PropertyMixin):
                 client._connection.user_agent, content_type, command=command
             ),
             **_get_encryption_headers(self._encryption_key),
-            **client._extra_headers,
+            **getattr(client, "_extra_headers", {}),
         }
         object_metadata = self._get_writable_metadata()
         return headers, object_metadata, content_type
@@ -2052,7 +2051,7 @@ class Blob(_PropertyMixin):
         extra_attributes = _get_opentelemetry_attributes_from_url(upload_url)
         extra_attributes["upload.checksum"] = f"{checksum}"
         args = {"timeout": timeout}
-        with create_trace_span(
+        with self._create_trace_span(
             name="Storage.MultipartUpload/transmit",
             attributes=extra_attributes,
             client=client,
@@ -2452,7 +2451,7 @@ class Blob(_PropertyMixin):
         extra_attributes["upload.checksum"] = f"{checksum}"
 
         args = {"timeout": timeout}
-        with create_trace_span(
+        with self._create_trace_span(
             name="Storage.ResumableUpload/transmitNextChunk",
             attributes=extra_attributes,
             client=client,
@@ -3011,7 +3010,7 @@ class Blob(_PropertyMixin):
         :raises: :class:`~google.cloud.exceptions.GoogleCloudError`
                  if the upload response returns an error status.
         """
-        with create_trace_span(name="Storage.Blob.uploadFromFile"):
+        with self._create_trace_span(name="Storage.Blob.uploadFromFile"):
             self._prep_and_do_upload(
                 file_obj,
                 rewind=rewind,
@@ -3194,7 +3193,7 @@ class Blob(_PropertyMixin):
             https://datatracker.ietf.org/doc/html/rfc4960#appendix-B and
             base64: https://datatracker.ietf.org/doc/html/rfc4648#section-4
         """
-        with create_trace_span(name="Storage.Blob.uploadFromFilename"):
+        with self._create_trace_span(name="Storage.Blob.uploadFromFilename"):
             self._handle_filename_and_upload(
                 filename,
                 content_type=content_type,
@@ -3343,7 +3342,7 @@ class Blob(_PropertyMixin):
             https://datatracker.ietf.org/doc/html/rfc4960#appendix-B and
             base64: https://datatracker.ietf.org/doc/html/rfc4648#section-4
         """
-        with create_trace_span(name="Storage.Blob.uploadFromString"):
+        with self._create_trace_span(name="Storage.Blob.uploadFromString"):
             data = _to_bytes(data, encoding="utf-8")
             string_buffer = BytesIO(data)
             self.upload_from_file(
@@ -3495,7 +3494,7 @@ class Blob(_PropertyMixin):
         :raises: :class:`google.cloud.exceptions.GoogleCloudError`
                  if the session creation response returns an error status.
         """
-        with create_trace_span(name="Storage.Blob.createResumableUploadSession"):
+        with self._create_trace_span(name="Storage.Blob.createResumableUploadSession"):
             # Handle ConditionalRetryPolicy.
             if isinstance(retry, ConditionalRetryPolicy):
                 # Conditional retries are designed for non-media calls, which change
@@ -3591,7 +3590,7 @@ class Blob(_PropertyMixin):
         :returns: the policy instance, based on the resource returned from
                   the ``getIamPolicy`` API request.
         """
-        with create_trace_span(name="Storage.Blob.getIamPolicy"):
+        with self._create_trace_span(name="Storage.Blob.getIamPolicy"):
             client = self._require_client(client)
 
             query_params = {}
@@ -3652,7 +3651,7 @@ class Blob(_PropertyMixin):
         :returns: the policy instance, based on the resource returned from
                   the ``setIamPolicy`` API request.
         """
-        with create_trace_span(name="Storage.Blob.setIamPolicy"):
+        with self._create_trace_span(name="Storage.Blob.setIamPolicy"):
             client = self._require_client(client)
 
             query_params = {}
@@ -3714,7 +3713,7 @@ class Blob(_PropertyMixin):
         :returns: the permissions returned by the ``testIamPermissions`` API
                   request.
         """
-        with create_trace_span(name="Storage.Blob.testIamPermissions"):
+        with self._create_trace_span(name="Storage.Blob.testIamPermissions"):
             client = self._require_client(client)
             query_params = {"permissions": permissions}
 
@@ -3774,7 +3773,7 @@ class Blob(_PropertyMixin):
         :param retry:
             (Optional) How to retry the RPC. See: :ref:`configuring_retries`
         """
-        with create_trace_span(name="Storage.Blob.makePublic"):
+        with self._create_trace_span(name="Storage.Blob.makePublic"):
             self.acl.all().grant_read()
             self.acl.save(
                 client=client,
@@ -3828,7 +3827,7 @@ class Blob(_PropertyMixin):
         :param retry:
             (Optional) How to retry the RPC. See: :ref:`configuring_retries`
         """
-        with create_trace_span(name="Storage.Blob.makePrivate"):
+        with self._create_trace_span(name="Storage.Blob.makePrivate"):
             self.acl.all().revoke_read()
             self.acl.save(
                 client=client,
@@ -3849,7 +3848,6 @@ class Blob(_PropertyMixin):
         if_metageneration_match=None,
         if_source_generation_match=None,
         retry=DEFAULT_RETRY_IF_GENERATION_SPECIFIED,
-        delete_source_objects=None,
     ):
         """Concatenate source blobs into this one.
 
@@ -3909,13 +3907,8 @@ class Blob(_PropertyMixin):
             Change the value to ``DEFAULT_RETRY`` or another `google.api_core.retry.Retry` object
             to enable retries regardless of generation precondition setting.
             See [Configuring Retries](https://cloud.google.com/python/docs/reference/storage/latest/retry_timeout).
-
-        :type delete_source_objects: bool
-        :param delete_source_objects:
-            (Optional) If True, the source objects will be deleted after a
-            successful composition.
         """
-        with create_trace_span(name="Storage.Blob.compose"):
+        with self._create_trace_span(name="Storage.Blob.compose"):
             sources_len = len(sources)
             client = self._require_client(client)
             query_params = {}
@@ -3969,9 +3962,6 @@ class Blob(_PropertyMixin):
                 "sourceObjects": source_objects,
                 "destination": self._properties.copy(),
             }
-
-            if delete_source_objects is not None:
-                request["deleteSourceObjects"] = delete_source_objects
 
             if self.user_project is not None:
                 query_params["userProject"] = self.user_project
@@ -4097,7 +4087,7 @@ class Blob(_PropertyMixin):
                   and ``total_bytes`` is the total number of bytes to be
                   rewritten.
         """
-        with create_trace_span(name="Storage.Blob.rewrite"):
+        with self._create_trace_span(name="Storage.Blob.rewrite"):
             client = self._require_client(client)
             headers = _get_encryption_headers(self._encryption_key)
             headers.update(_get_encryption_headers(source._encryption_key, source=True))
@@ -4257,7 +4247,7 @@ class Blob(_PropertyMixin):
             to enable retries regardless of generation precondition setting.
             See [Configuring Retries](https://cloud.google.com/python/docs/reference/storage/latest/retry_timeout).
         """
-        with create_trace_span(name="Storage.Blob.updateStorageClass"):
+        with self._create_trace_span(name="Storage.Blob.updateStorageClass"):
             # Update current blob's storage class prior to rewrite
             self._patch_property("storageClass", new_class)
 
@@ -4401,7 +4391,7 @@ class Blob(_PropertyMixin):
             'google.cloud.storage.fileio', or an 'io.TextIOWrapper' around one
             of those classes, depending on the 'mode' argument.
         """
-        with create_trace_span(name="Storage.Blob.open"):
+        with self._create_trace_span(name="Storage.Blob.open"):
             if mode == "rb":
                 if encoding or errors or newline:
                     raise ValueError(
@@ -4659,7 +4649,7 @@ class Blob(_PropertyMixin):
         headers = {
             **_get_default_headers(client._connection.user_agent, command=command),
             **headers,
-            **client._extra_headers,
+            **getattr(client, "_extra_headers", {}),
         }
 
         transport = client._http

--- a/packages/google-cloud-storage/google/cloud/storage/bucket.py
+++ b/packages/google-cloud-storage/google/cloud/storage/bucket.py
@@ -21,7 +21,7 @@ import json
 import warnings
 from urllib.parse import urlsplit
 
-from google.api_core import datetime_helpers
+from google.api_core import datetime_helpers, exceptions as api_exceptions
 from google.api_core.iam import Policy
 from google.cloud._helpers import _datetime_to_rfc3339, _rfc3339_nanos_to_datetime
 from google.cloud.exceptions import NotFound
@@ -38,7 +38,6 @@ from google.cloud.storage._helpers import (
     _validate_name,
     _virtual_hosted_style_base_url,
 )
-from google.cloud.storage._opentelemetry_tracing import create_trace_span
 from google.cloud.storage._signing import generate_signed_url_v2, generate_signed_url_v4
 from google.cloud.storage.acl import BucketACL, DefaultObjectACL
 from google.cloud.storage.blob import Blob, _quote
@@ -972,7 +971,7 @@ class Bucket(_PropertyMixin):
         :rtype: bool
         :returns: True if the bucket exists in Cloud Storage.
         """
-        with create_trace_span(name="Storage.Bucket.exists"):
+        with self._create_trace_span(name="Storage.Bucket.exists"):
             client = self._require_client(client)
             # We only need the status code (200 or not) so we seek to
             # minimize the returned payload.
@@ -1073,7 +1072,7 @@ class Bucket(_PropertyMixin):
         :param retry:
             (Optional) How to retry the RPC. See: :ref:`configuring_retries`
         """
-        with create_trace_span(name="Storage.Bucket.create"):
+        with self._create_trace_span(name="Storage.Bucket.create"):
             client = self._require_client(client)
             client.create_bucket(
                 bucket_or_name=self,
@@ -1123,7 +1122,7 @@ class Bucket(_PropertyMixin):
         :param retry:
             (Optional) How to retry the RPC. See: :ref:`configuring_retries`
         """
-        with create_trace_span(name="Storage.Bucket.update"):
+        with self._create_trace_span(name="Storage.Bucket.update"):
             super(Bucket, self).update(
                 client=client,
                 timeout=timeout,
@@ -1190,18 +1189,38 @@ class Bucket(_PropertyMixin):
             set if ``soft_deleted`` is set to True.
             See: https://cloud.google.com/storage/docs/soft-delete
         """
-        with create_trace_span(name="Storage.Bucket.reload"):
-            super(Bucket, self).reload(
-                client=client,
-                projection=projection,
-                timeout=timeout,
-                if_etag_match=if_etag_match,
-                if_etag_not_match=if_etag_not_match,
-                if_metageneration_match=if_metageneration_match,
-                if_metageneration_not_match=if_metageneration_not_match,
-                retry=retry,
-                soft_deleted=soft_deleted,
-            )
+        with self._create_trace_span(name="Storage.Bucket.reload"):
+            try:
+                super(Bucket, self).reload(
+                    client=client,
+                    projection=projection,
+                    timeout=timeout,
+                    if_etag_match=if_etag_match,
+                    if_etag_not_match=if_etag_not_match,
+                    if_metageneration_match=if_metageneration_match,
+                    if_metageneration_not_match=if_metageneration_not_match,
+                    retry=retry,
+                    soft_deleted=soft_deleted,
+                )
+            except api_exceptions.Forbidden:
+                active_client = client or self.client
+                cache = getattr(active_client, "_bucket_metadata_cache", None)
+                if cache:
+                    try:
+                        cache.update_cache(
+                            self.name, f"projects/_/buckets/{self.name}", "global"
+                        )
+                    except Exception:
+                        pass
+                raise
+
+            active_client = client or self.client
+            cache = getattr(active_client, "_bucket_metadata_cache", None)
+            if cache:
+                try:
+                    cache.update_from_bucket(self)
+                except Exception:
+                    pass
 
     def patch(
         self,
@@ -1239,7 +1258,7 @@ class Bucket(_PropertyMixin):
         :param retry:
             (Optional) How to retry the RPC. See: :ref:`configuring_retries`
         """
-        with create_trace_span(name="Storage.Bucket.patch"):
+        with self._create_trace_span(name="Storage.Bucket.patch"):
             # Special case: For buckets, it is possible that labels are being
             # removed; this requires special handling.
             if self._label_removals:
@@ -1375,7 +1394,7 @@ class Bucket(_PropertyMixin):
         :rtype: :class:`google.cloud.storage.blob.Blob` or None
         :returns: The blob object if it exists, otherwise None.
         """
-        with create_trace_span(name="Storage.Bucket.getBlob"):
+        with self._create_trace_span(name="Storage.Bucket.getBlob"):
             blob = Blob(
                 bucket=self,
                 name=blob_name,
@@ -1525,7 +1544,7 @@ class Bucket(_PropertyMixin):
         :returns: Iterator of all :class:`~google.cloud.storage.blob.Blob`
                   in this bucket matching the arguments.
         """
-        with create_trace_span(name="Storage.Bucket.listBlobs"):
+        with self._create_trace_span(name="Storage.Bucket.listBlobs"):
             client = self._require_client(client)
             return client.list_blobs(
                 self,
@@ -1573,7 +1592,7 @@ class Bucket(_PropertyMixin):
         :rtype: list of :class:`.BucketNotification`
         :returns: notification instances
         """
-        with create_trace_span(name="Storage.Bucket.listNotifications"):
+        with self._create_trace_span(name="Storage.Bucket.listNotifications"):
             client = self._require_client(client)
             path = self.path + "/notificationConfigs"
             iterator = client._list_resource(
@@ -1618,7 +1637,7 @@ class Bucket(_PropertyMixin):
         :rtype: :class:`.BucketNotification`
         :returns: notification instance.
         """
-        with create_trace_span(name="Storage.Bucket.getNotification"):
+        with self._create_trace_span(name="Storage.Bucket.getNotification"):
             notification = self.notification(notification_id=notification_id)
             notification.reload(client=client, timeout=timeout, retry=retry)
             return notification
@@ -1678,7 +1697,7 @@ class Bucket(_PropertyMixin):
         :raises: :class:`ValueError` if ``force`` is ``True`` and the bucket
                  contains more than 256 objects / blobs.
         """
-        with create_trace_span(name="Storage.Bucket.delete"):
+        with self._create_trace_span(name="Storage.Bucket.delete"):
             client = self._require_client(client)
             query_params = {}
 
@@ -1729,6 +1748,12 @@ class Bucket(_PropertyMixin):
                 retry=retry,
                 _target_object=None,
             )
+            cache = getattr(client, "_bucket_metadata_cache", None)
+            if cache:
+                try:
+                    cache.evict(self.name)
+                except Exception:
+                    pass
 
     def delete_blob(
         self,
@@ -1801,7 +1826,7 @@ class Bucket(_PropertyMixin):
                  the exception, use :meth:`delete_blobs` by passing a no-op
                  ``on_error`` callback.
         """
-        with create_trace_span(name="Storage.Bucket.deleteBlob"):
+        with self._create_trace_span(name="Storage.Bucket.deleteBlob"):
             client = self._require_client(client)
             blob = Blob(blob_name, bucket=self, generation=generation)
 
@@ -1914,7 +1939,7 @@ class Bucket(_PropertyMixin):
         :raises: :class:`~google.cloud.exceptions.NotFound` (if
                  `on_error` is not passed).
         """
-        with create_trace_span(name="Storage.Bucket.deleteBlobs"):
+        with self._create_trace_span(name="Storage.Bucket.deleteBlobs"):
             _raise_if_len_differs(
                 len(blobs),
                 if_generation_match=if_generation_match,
@@ -2068,7 +2093,7 @@ class Bucket(_PropertyMixin):
         :rtype: :class:`google.cloud.storage.blob.Blob`
         :returns: The new Blob.
         """
-        with create_trace_span(name="Storage.Bucket.copyBlob"):
+        with self._create_trace_span(name="Storage.Bucket.copyBlob"):
             client = self._require_client(client)
             query_params = {}
 
@@ -2222,7 +2247,7 @@ class Bucket(_PropertyMixin):
         :rtype: :class:`Blob`
         :returns: The newly-renamed blob.
         """
-        with create_trace_span(name="Storage.Bucket.renameBlob"):
+        with self._create_trace_span(name="Storage.Bucket.renameBlob"):
             same_name = blob.name == new_name
 
             new_blob = self.copy_blob(
@@ -2342,7 +2367,7 @@ class Bucket(_PropertyMixin):
         :rtype: :class:`Blob`
         :returns: The newly-moved blob.
         """
-        with create_trace_span(name="Storage.Bucket.moveBlob"):
+        with self._create_trace_span(name="Storage.Bucket.moveBlob"):
             client = self._require_client(client)
             query_params = {}
 
@@ -2451,7 +2476,7 @@ class Bucket(_PropertyMixin):
         :rtype: :class:`google.cloud.storage.blob.Blob`
         :returns: The restored Blob.
         """
-        with create_trace_span(name="Storage.Bucket.restore_blob"):
+        with self._create_trace_span(name="Storage.Bucket.restore_blob"):
             client = self._require_client(client)
             query_params = {}
 
@@ -3346,7 +3371,7 @@ class Bucket(_PropertyMixin):
         :returns: the policy instance, based on the resource returned from
                   the ``getIamPolicy`` API request.
         """
-        with create_trace_span(name="Storage.Bucket.getIamPolicy"):
+        with self._create_trace_span(name="Storage.Bucket.getIamPolicy"):
             client = self._require_client(client)
             query_params = {}
 
@@ -3400,7 +3425,7 @@ class Bucket(_PropertyMixin):
         :returns: the policy instance, based on the resource returned from
                   the ``setIamPolicy`` API request.
         """
-        with create_trace_span(name="Storage.Bucket.setIamPolicy"):
+        with self._create_trace_span(name="Storage.Bucket.setIamPolicy"):
             client = self._require_client(client)
             query_params = {}
 
@@ -3457,7 +3482,7 @@ class Bucket(_PropertyMixin):
         :returns: the permissions returned by the ``testIamPermissions`` API
                   request.
         """
-        with create_trace_span(name="Storage.Bucket.testIamPermissions"):
+        with self._create_trace_span(name="Storage.Bucket.testIamPermissions"):
             client = self._require_client(client)
             query_params = {"permissions": permissions}
 
@@ -3523,7 +3548,7 @@ class Bucket(_PropertyMixin):
             :meth:`~google.cloud.storage.blob.Blob.make_public`
             for each blob.
         """
-        with create_trace_span(name="Storage.Bucket.makePublic"):
+        with self._create_trace_span(name="Storage.Bucket.makePublic"):
             self.acl.all().grant_read()
             self.acl.save(
                 client=client,
@@ -3620,7 +3645,7 @@ class Bucket(_PropertyMixin):
             :meth:`~google.cloud.storage.blob.Blob.make_private`
             for each blob.
         """
-        with create_trace_span(name="Storage.Bucket.makePrivate"):
+        with self._create_trace_span(name="Storage.Bucket.makePrivate"):
             self.acl.all().revoke_read()
             self.acl.save(
                 client=client,
@@ -3744,7 +3769,7 @@ class Bucket(_PropertyMixin):
             if the bucket has no retention policy assigned;
             if the bucket's retention policy is already locked.
         """
-        with create_trace_span(name="Storage.Bucket.lockRetentionPolicy"):
+        with self._create_trace_span(name="Storage.Bucket.lockRetentionPolicy"):
             if "metageneration" not in self._properties:
                 raise ValueError(
                     "Bucket has no retention policy assigned: try 'reload'?"

--- a/packages/google-cloud-storage/google/cloud/storage/client.py
+++ b/packages/google-cloud-storage/google/cloud/storage/client.py
@@ -24,7 +24,7 @@ import os
 import warnings
 
 import google.api_core.client_options
-from google.api_core import page_iterator
+from google.api_core import exceptions as api_exceptions, page_iterator
 from google.auth.credentials import AnonymousCredentials
 from google.auth.transport import mtls
 from google.cloud._helpers import _LocalStack
@@ -43,7 +43,9 @@ from google.cloud.storage._helpers import (
     _get_environ_project,
     _get_storage_emulator_override,
     _virtual_hosted_style_base_url,
+    create_trace_span_helper,
 )
+from google.cloud.storage._bucket_metadata_cache import BucketMetadataCache
 from google.cloud.storage._http import Connection
 from google.cloud.storage._opentelemetry_tracing import create_trace_span
 from google.cloud.storage._signing import (
@@ -289,6 +291,20 @@ class Client(ClientWithProject):
         connection.extra_headers = extra_headers
         self._connection = connection
         self._batch_stack = _LocalStack()
+        self._bucket_metadata_cache = BucketMetadataCache(self)
+
+    def close(self):
+        """Close the client and clear any cached metadata or active connections."""
+        if hasattr(self, "_bucket_metadata_cache") and self._bucket_metadata_cache:
+            self._bucket_metadata_cache.clear()
+        if hasattr(self._http, "close"):
+            self._http.close()
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.close()
 
     @classmethod
     def create_anonymous_client(cls):
@@ -950,16 +966,40 @@ class Client(ClientWithProject):
             google.cloud.exceptions.NotFound
                 If the bucket is not found.
         """
-        with create_trace_span(name="Storage.Client.getBucket"):
+        bucket_name = (
+            bucket_or_name.name if hasattr(bucket_or_name, "name") else bucket_or_name
+        )
+        with create_trace_span_helper(
+            self, bucket_name, name="Storage.Client.getBucket"
+        ):
             bucket = self._bucket_arg_to_bucket(bucket_or_name, generation=generation)
-            bucket.reload(
-                client=self,
-                timeout=timeout,
-                if_metageneration_match=if_metageneration_match,
-                if_metageneration_not_match=if_metageneration_not_match,
-                retry=retry,
-                soft_deleted=soft_deleted,
-            )
+            try:
+                bucket.reload(
+                    client=self,
+                    timeout=timeout,
+                    if_metageneration_match=if_metageneration_match,
+                    if_metageneration_not_match=if_metageneration_not_match,
+                    retry=retry,
+                    soft_deleted=soft_deleted,
+                )
+            except api_exceptions.Forbidden:
+                if (
+                    hasattr(self, "_bucket_metadata_cache")
+                    and self._bucket_metadata_cache
+                ):
+                    try:
+                        self._bucket_metadata_cache.update_cache(
+                            bucket_name, f"projects/_/buckets/{bucket_name}", "global"
+                        )
+                    except Exception:
+                        pass
+                raise
+
+            if hasattr(self, "_bucket_metadata_cache") and self._bucket_metadata_cache:
+                try:
+                    self._bucket_metadata_cache.update_from_bucket(bucket)
+                except Exception:
+                    pass
             return bucket
 
     def lookup_bucket(
@@ -998,15 +1038,38 @@ class Client(ClientWithProject):
         :rtype: :class:`google.cloud.storage.bucket.Bucket` or ``NoneType``
         :returns: The bucket matching the name provided or None if not found.
         """
-        with create_trace_span(name="Storage.Client.lookupBucket"):
+        with create_trace_span_helper(
+            self, bucket_name, name="Storage.Client.lookupBucket"
+        ):
             try:
-                return self.get_bucket(
+                bucket = self.get_bucket(
                     bucket_name,
                     timeout=timeout,
                     if_metageneration_match=if_metageneration_match,
                     if_metageneration_not_match=if_metageneration_not_match,
                     retry=retry,
                 )
+                if (
+                    hasattr(self, "_bucket_metadata_cache")
+                    and self._bucket_metadata_cache
+                ):
+                    try:
+                        self._bucket_metadata_cache.update_from_bucket(bucket)
+                    except Exception:
+                        pass
+                return bucket
+            except api_exceptions.Forbidden:
+                if (
+                    hasattr(self, "_bucket_metadata_cache")
+                    and self._bucket_metadata_cache
+                ):
+                    try:
+                        self._bucket_metadata_cache.update_cache(
+                            bucket_name, f"projects/_/buckets/{bucket_name}", "global"
+                        )
+                    except Exception:
+                        pass
+                raise
             except NotFound:
                 return None
 
@@ -1154,6 +1217,11 @@ class Client(ClientWithProject):
             )
 
             bucket._set_properties(api_response)
+            if hasattr(self, "_bucket_metadata_cache") and self._bucket_metadata_cache:
+                try:
+                    self._bucket_metadata_cache.update_from_bucket(bucket)
+                except Exception:
+                    pass
             return bucket
 
     def download_blob_to_file(
@@ -1250,7 +1318,21 @@ class Client(ClientWithProject):
             single_shot_download (bool):
                 (Optional) If true, download the object in a single request.
         """
-        with create_trace_span(name="Storage.Client.downloadBlobToFile"):
+        bucket_name = None
+        if isinstance(blob_or_uri, Blob):
+            bucket_name = blob_or_uri.bucket.name if blob_or_uri.bucket else None
+        elif isinstance(blob_or_uri, str) and blob_or_uri.startswith("gs://"):
+            try:
+                temp_blob = Blob.from_uri(blob_or_uri)
+                bucket_name = temp_blob.bucket.name
+            except Exception:
+                pass
+
+        with create_trace_span_helper(
+            self,
+            bucket_name,
+            name="Storage.Client.downloadBlobToFile",
+        ):
             if not isinstance(blob_or_uri, Blob):
                 blob_or_uri = Blob.from_uri(blob_or_uri)
 
@@ -1408,7 +1490,12 @@ class Client(ClientWithProject):
             As part of the response, you'll also get back an iterator.prefixes entity that lists object names
             up to and including the requested delimiter. Duplicate entries are omitted from this list.
         """
-        with create_trace_span(name="Storage.Client.listBlobs"):
+        bucket_name = (
+            bucket_or_name.name if hasattr(bucket_or_name, "name") else bucket_or_name
+        )
+        with create_trace_span_helper(
+            self, bucket_name, name="Storage.Client.listBlobs"
+        ):
             bucket = self._bucket_arg_to_bucket(bucket_or_name)
 
             extra_params = {"projection": projection}

--- a/packages/google-cloud-storage/google/cloud/storage/transfer_manager.py
+++ b/packages/google-cloud-storage/google/cloud/storage/transfer_manager.py
@@ -1382,7 +1382,7 @@ def _reduce_client(cl):
     _http = None  # Can't carry this over
     client_info = cl._initial_client_info
     client_options = cl._initial_client_options
-    extra_headers = cl._extra_headers
+    extra_headers = getattr(cl, "_extra_headers", {})
 
     return _LazyClient, (
         client_object_id,

--- a/packages/google-cloud-storage/tests/system/conftest.py
+++ b/packages/google-cloud-storage/tests/system/conftest.py
@@ -15,14 +15,59 @@
 import contextlib
 import os
 
-import pytest
-from google.api_core import exceptions
+# MUST set env var before any google-cloud-storage imports occur
+os.environ["ENABLE_GCS_PYTHON_CLIENT_OTEL_TRACES"] = "true"
 
-from google.cloud import kms
-from google.cloud.storage._helpers import _base64_md5hash
-from google.cloud.storage.retry import DEFAULT_RETRY
+# Import OpenTelemetry modules safely at top
+try:
+    from opentelemetry import trace as trace_api
+    from opentelemetry.sdk.trace import TracerProvider, export
+    from opentelemetry.sdk.trace.export.in_memory_span_exporter import (
+        InMemorySpanExporter,
+    )
+except ImportError:
+    trace_api = None
 
-from . import _helpers
+import pytest  # noqa: E402
+from google.api_core import exceptions  # noqa: E402
+
+from google.cloud import kms  # noqa: E402
+from google.cloud.storage._helpers import _base64_md5hash  # noqa: E402
+from google.cloud.storage.retry import DEFAULT_RETRY  # noqa: E402
+
+from . import _helpers  # noqa: E402
+
+if trace_api is not None:
+    _global_exporter = InMemorySpanExporter()
+    _provider = TracerProvider()
+    _provider.add_span_processor(export.SimpleSpanProcessor(_global_exporter))
+
+    # Option to also export telemetry to Google Cloud Trace Console
+    # (for testing in GCE VM)
+    if os.environ.get("ENABLE_GCP_TRACE_EXPORTER", "").lower() in (
+        "1",
+        "true",
+        "yes",
+        "on",
+    ):
+        try:
+            from opentelemetry.exporter.cloud_trace import CloudTraceSpanExporter
+
+            _provider.add_span_processor(
+                export.BatchSpanProcessor(CloudTraceSpanExporter())
+            )
+        except ImportError:
+            import warnings
+
+            warnings.warn(
+                "ENABLE_GCP_TRACE_EXPORTER is enabled, but "
+                "opentelemetry-exporter-cloud-trace is not installed.",
+                UserWarning,
+            )
+
+    trace_api.set_tracer_provider(_provider)
+else:
+    _global_exporter = None
 
 dirname = os.path.realpath(os.path.dirname(__file__))
 data_dirname = os.path.abspath(os.path.join(dirname, "..", "data"))
@@ -415,3 +460,11 @@ def universe_domain_iam_client(
     )
 
     return iam_client
+
+
+@pytest.fixture(scope="function")
+def exporter():
+    if _global_exporter is None:
+        pytest.fail("OpenTelemetry is not installed or failed to initialize.")
+    _global_exporter.clear()
+    return _global_exporter

--- a/packages/google-cloud-storage/tests/system/test_aco_observability.py
+++ b/packages/google-cloud-storage/tests/system/test_aco_observability.py
@@ -1,0 +1,490 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import concurrent.futures
+import threading
+import time
+
+import pytest
+from google.api_core import exceptions
+
+from . import _helpers
+
+
+def test_sequential_cache_priming(storage_client, exporter, buckets_to_delete):
+    """Verifies that a cache miss returns immediately and warms the cache
+    in a background thread, so a subsequent request successfully contains
+    ACO destination attributes."""
+    bucket_name = _helpers.unique_name("aco-priming")
+    bucket = storage_client.bucket(bucket_name)
+    storage_client.create_bucket(bucket)
+    buckets_to_delete.append(bucket)
+
+    blob_name = "test_blob.txt"
+    blob = bucket.blob(blob_name)
+    blob.upload_from_string("hello")
+
+    # Set up deterministic event-driven synchronization hooks
+    original_update = storage_client._bucket_metadata_cache.update_cache
+    update_cache_event = threading.Event()
+
+    def monitored_update(*args, **kwargs):
+        original_update(*args, **kwargs)
+        update_cache_event.set()
+
+    storage_client._bucket_metadata_cache.update_cache = monitored_update
+
+    try:
+        # Clear cache and OTel exporter logs
+        storage_client._bucket_metadata_cache.clear()
+        exporter.clear()
+
+        # 1. First download (must be a cache miss)
+        blob.download_as_bytes()
+
+        spans = exporter.get_finished_spans()
+        dl_spans = [s for s in spans if s.name == "Storage.Blob.downloadAsBytes"]
+        assert len(dl_spans) == 1
+        attrs = dl_spans[0].attributes
+        assert "gcp.resource.destination.id" not in attrs
+        assert "gcp.resource.destination.location" not in attrs
+
+        # Wait deterministically for background fetch thread to populate cache
+        assert update_cache_event.wait(timeout=10.0)
+
+        # 2. Second download (must be a cache hit)
+        # Clear exporter so spans we capture correspond to the second download
+        # (ACO attributes should now be present)
+        exporter.clear()
+        blob.download_as_bytes()
+
+        spans = exporter.get_finished_spans()
+        dl_spans = [s for s in spans if s.name == "Storage.Blob.downloadAsBytes"]
+        assert len(dl_spans) == 1
+        attrs = dl_spans[0].attributes
+        assert "gcp.resource.destination.id" in attrs
+        assert "gcp.resource.destination.location" in attrs
+        assert bucket_name in attrs["gcp.resource.destination.id"]
+    finally:
+        storage_client._bucket_metadata_cache.update_cache = original_update
+
+
+def test_403_permission_cache_fallback(storage_client, buckets_to_delete):
+    """Verifies that if the client does not have permission for bucket metadata
+    (403 Forbidden), the cache safely stores fallback annotations to prevent
+    repetitive API calls on cache misses."""
+    bucket_name = _helpers.unique_name("aco-403")
+    bucket = storage_client.bucket(bucket_name)
+    storage_client.create_bucket(bucket)
+    buckets_to_delete.append(bucket)
+
+    storage_client._bucket_metadata_cache.clear()
+
+    # Set up deterministic event-driven synchronization hooks
+    original_update = storage_client._bucket_metadata_cache.update_cache
+    update_cache_event = threading.Event()
+
+    def monitored_update(*args, **kwargs):
+        original_update(*args, **kwargs)
+        update_cache_event.set()
+
+    storage_client._bucket_metadata_cache.update_cache = monitored_update
+
+    original_get_bucket = storage_client.get_bucket
+    forbidden_triggered = threading.Event()
+
+    def mock_get_bucket(*args, **kwargs):
+        from google.api_core.exceptions import Forbidden
+
+        forbidden_triggered.set()
+        raise Forbidden("403 Forbidden simulated for system test")
+
+    storage_client.get_bucket = mock_get_bucket
+
+    try:
+        # Trigger background fetch
+        storage_client._bucket_metadata_cache.get_or_queue_fetch(bucket_name)
+
+        # Wait for background fetch to execute and catch the Forbidden error
+        assert forbidden_triggered.wait(timeout=3.0)
+
+        # Wait deterministically for fallback to get populated in cache
+        assert update_cache_event.wait(timeout=10.0)
+
+        # Retrieve from cache
+        cached = storage_client._bucket_metadata_cache.get(bucket_name)
+        assert cached is not None
+        dest_id, loc = cached
+        assert dest_id == f"projects/_/buckets/{bucket_name}"
+        assert loc == "global"
+    finally:
+        storage_client.get_bucket = original_get_bucket
+        storage_client._bucket_metadata_cache.update_cache = original_update
+
+
+def test_cache_stampede_protection(storage_client, buckets_to_delete):
+    """Verifies that under highly concurrent cache miss conditions, exactly one background metadata API fetch is executed, and all caller threads safely complete without stampeding the GCS server."""
+    bucket_name = _helpers.unique_name("aco-stampede")
+    bucket = storage_client.bucket(bucket_name)
+    storage_client.create_bucket(bucket)
+    buckets_to_delete.append(bucket)
+
+    blob = bucket.blob("test.txt")
+    blob.upload_from_string("data")
+
+    storage_client._bucket_metadata_cache.clear()
+
+    fetch_count = 0
+    count_lock = threading.Lock()
+    original_get_bucket = storage_client.get_bucket
+
+    def monitored_get_bucket(*args, **kwargs):
+        nonlocal fetch_count
+        with count_lock:
+            fetch_count += 1
+        return original_get_bucket(*args, **kwargs)
+
+    storage_client.get_bucket = monitored_get_bucket
+
+    try:
+        num_threads = 15
+        with concurrent.futures.ThreadPoolExecutor(max_workers=num_threads) as executor:
+            futures = [
+                executor.submit(blob.download_as_bytes) for _ in range(num_threads)
+            ]
+            concurrent.futures.wait(futures)
+
+        # Exactly 1 background GCS get_bucket fetch call must have been triggered
+        assert fetch_count == 1
+    finally:
+        storage_client.get_bucket = original_get_bucket
+
+
+def test_cache_eviction_on_bucket_404(storage_client, buckets_to_delete):
+    """Verifies that if a GCS bucket is deleted out-of-band, any operations triggering a 404 NotFound will asynchronously verify the deletion and evict the bucket from the cache."""
+    bucket_name = _helpers.unique_name("aco-eviction-404")
+    bucket = storage_client.bucket(bucket_name)
+    storage_client.create_bucket(bucket)
+    buckets_to_delete.append(bucket)
+
+    blob = bucket.blob("test.txt")
+    blob.upload_from_string("data")
+
+    # Set up deterministic event-driven synchronization hooks
+    original_update = storage_client._bucket_metadata_cache.update_cache
+    original_verify = storage_client._bucket_metadata_cache._verify_existence_background
+
+    update_cache_event = threading.Event()
+    verify_event = threading.Event()
+
+    def monitored_update(*args, **kwargs):
+        original_update(*args, **kwargs)
+        update_cache_event.set()
+
+    def monitored_verify(b_name):
+        try:
+            original_verify(b_name)
+        finally:
+            verify_event.set()
+
+    storage_client._bucket_metadata_cache.update_cache = monitored_update
+    storage_client._bucket_metadata_cache._verify_existence_background = (
+        monitored_verify
+    )
+
+    try:
+        # Clear and warm cache
+        storage_client._bucket_metadata_cache.clear()
+        storage_client._bucket_metadata_cache.get_or_queue_fetch(bucket_name)
+
+        # Wait deterministically for cache warming to complete
+        assert update_cache_event.wait(timeout=10.0)
+        assert storage_client._bucket_metadata_cache.get(bucket_name) is not None
+
+        # --- 4a. 404 on Bucket (Asynchronous Eviction) ---
+        # Delete GCS bucket directly via HTTP connection to bypass client.delete synchronous eviction
+        query_params = {}
+        if bucket.user_project is not None:
+            query_params["userProject"] = bucket.user_project
+        blob.delete()
+        storage_client._delete_resource(bucket.path, query_params=query_params)
+        buckets_to_delete.remove(bucket)
+
+        # Attempt to load blob (raises 404 NotFound bucket error)
+        with pytest.raises(exceptions.NotFound):
+            blob.download_as_bytes()
+
+        # Wait deterministically for background check_and_evict thread to complete
+        assert verify_event.wait(timeout=10.0)
+
+        # Cache must be evicted
+        assert storage_client._bucket_metadata_cache.get(bucket_name) is None
+    finally:
+        storage_client._bucket_metadata_cache.update_cache = original_update
+        storage_client._bucket_metadata_cache._verify_existence_background = (
+            original_verify
+        )
+
+
+def test_cache_eviction_on_bucket_delete(storage_client, buckets_to_delete):
+    """Verifies that direct Bucket.delete() calls synchronously evict the cache."""
+    bucket_name = _helpers.unique_name("aco-eviction-delete")
+    bucket = storage_client.bucket(bucket_name)
+    storage_client.create_bucket(bucket)
+    buckets_to_delete.append(bucket)
+
+    # Warm cache directly via GCS creation warming
+    assert storage_client._bucket_metadata_cache.get(bucket_name) is not None
+
+    # Synchronously delete bucket via SDK client
+    bucket.delete()
+    buckets_to_delete.remove(bucket)
+
+    # Cache MUST be evicted immediately without waiting
+    assert storage_client._bucket_metadata_cache.get(bucket_name) is None
+
+
+def test_404_on_blob_but_bucket_exists(storage_client, buckets_to_delete):
+    """Verifies that a 404 `NotFound` on a missing blob inside an
+    existing bucket; triggers background `check_and_evict` which retains
+    the bucket in the cache."""
+    bucket_name = _helpers.unique_name("aco-blob-404")
+    bucket = storage_client.bucket(bucket_name)
+    storage_client.create_bucket(bucket)
+    buckets_to_delete.append(bucket)
+
+    # Set up deterministic event-driven synchronization hooks
+    original_update = storage_client._bucket_metadata_cache.update_cache
+    original_verify = storage_client._bucket_metadata_cache._verify_existence_background
+
+    update_cache_event = threading.Event()
+    verify_event = threading.Event()
+
+    def monitored_update(*args, **kwargs):
+        original_update(*args, **kwargs)
+        update_cache_event.set()
+
+    def monitored_verify(b_name):
+        try:
+            original_verify(b_name)
+        finally:
+            verify_event.set()
+
+    storage_client._bucket_metadata_cache.update_cache = monitored_update
+    storage_client._bucket_metadata_cache._verify_existence_background = (
+        monitored_verify
+    )
+
+    try:
+        # Warm cache
+        storage_client._bucket_metadata_cache.clear()
+        storage_client._bucket_metadata_cache.get_or_queue_fetch(bucket_name)
+
+        # Wait deterministically for cache priming to complete
+        assert update_cache_event.wait(timeout=10.0)
+        assert storage_client._bucket_metadata_cache.get(bucket_name) is not None
+
+        # Make a 404 request to a non-existent blob inside this bucket
+        non_existent_blob = bucket.blob("non_existent.txt")
+        with pytest.raises(exceptions.NotFound):
+            non_existent_blob.download_as_bytes()
+
+        # Wait deterministically for background check_and_evict thread to complete
+        assert verify_event.wait(timeout=10.0)
+
+        # Bucket must STILL be retained in the cache!
+        assert storage_client._bucket_metadata_cache.get(bucket_name) is not None
+    finally:
+        # Clean up and restore original methods
+        storage_client._bucket_metadata_cache.update_cache = original_update
+        storage_client._bucket_metadata_cache._verify_existence_background = (
+            original_verify
+        )
+
+
+def test_404_on_blob_bucket_deleted(storage_client):
+    """Verifies that a 404 NotFound on a missing blob when the bucket is deleted
+    triggers background check_and_evict which evicts the bucket from the cache."""
+    bucket_name = _helpers.unique_name("aco-blob-bucket-404")
+    bucket = storage_client.bucket(bucket_name)
+    storage_client.create_bucket(bucket)
+
+    # Set up deterministic event-driven synchronization hooks
+    original_update = storage_client._bucket_metadata_cache.update_cache
+    original_verify = storage_client._bucket_metadata_cache._verify_existence_background
+
+    update_cache_event = threading.Event()
+    verify_event = threading.Event()
+
+    def monitored_update(*args, **kwargs):
+        original_update(*args, **kwargs)
+        update_cache_event.set()
+
+    def monitored_verify(b_name):
+        try:
+            original_verify(b_name)
+        finally:
+            verify_event.set()
+
+    storage_client._bucket_metadata_cache.update_cache = monitored_update
+    storage_client._bucket_metadata_cache._verify_existence_background = (
+        monitored_verify
+    )
+
+    try:
+        # Warm cache
+        storage_client._bucket_metadata_cache.clear()
+        storage_client._bucket_metadata_cache.get_or_queue_fetch(bucket_name)
+
+        # Wait deterministically for cache priming to complete
+        assert update_cache_event.wait(timeout=10.0)
+        assert storage_client._bucket_metadata_cache.get(bucket_name) is not None
+
+        # Delete bucket directly via GCS connection (bypassing client synchronous eviction)
+        query_params = {}
+        if bucket.user_project is not None:
+            query_params["userProject"] = bucket.user_project
+        storage_client._delete_resource(bucket.path, query_params=query_params)
+
+        # Make 404 request to a blob (raises 404 NotFound because bucket is deleted)
+        non_existent_blob = bucket.blob("non_existent.txt")
+        with pytest.raises(exceptions.NotFound):
+            non_existent_blob.download_as_bytes()
+
+        # Wait deterministically for background check_and_evict thread to complete
+        assert verify_event.wait(timeout=10.0)
+
+        # Bucket must be evicted from the cache!
+        assert storage_client._bucket_metadata_cache.get(bucket_name) is None
+    finally:
+        storage_client._bucket_metadata_cache.update_cache = original_update
+        storage_client._bucket_metadata_cache._verify_existence_background = (
+            original_verify
+        )
+
+
+def test_lru_bounded_capacity_eviction(storage_client):
+    """Verifies that the cache respects the configured size bounds and correctly
+    evicts the least-recently-used elements to avoid memory leaks."""
+    from google.cloud.storage._bucket_metadata_cache import BucketMetadataCache
+
+    cache = BucketMetadataCache(storage_client, max_size=5)
+
+    # Populate with 5 buckets
+    cache.update_cache("b1", "dest1", "loc1")
+    cache.update_cache("b2", "dest2", "loc2")
+    cache.update_cache("b3", "dest3", "loc3")
+    cache.update_cache("b4", "dest4", "loc4")
+    cache.update_cache("b5", "dest5", "loc5")
+
+    # Access b1 (make it most recently used)
+    cache.get("b1")
+
+    # Add b6 (which evicts b2, the LRU item)
+    cache.update_cache("b6", "dest6", "loc6")
+
+    # Assert b2 is evicted
+    assert cache.get("b2") is None
+    # Assert b1 is retained
+    assert cache.get("b1") == ("dest1", "loc1")
+    # Assert b6 is present
+    assert cache.get("b6") == ("dest6", "loc6")
+
+
+def test_create_bucket_synchronous_cache_warming(storage_client, buckets_to_delete):
+    """Verifies that calling client.create_bucket() synchronously warms the cache immediately upon bucket creation and does not trigger any background fetch threads."""
+    # Wait for any previous inflight background fetches to complete
+    start_time = time.time()
+    while time.time() - start_time < 5.0:
+        with storage_client._bucket_metadata_cache._lock:
+            if not storage_client._bucket_metadata_cache._inflight_fetches:
+                break
+        time.sleep(0.1)
+
+    bucket_name = _helpers.unique_name("aco-sync-create")
+    bucket = storage_client.bucket(bucket_name)
+
+    # Ensure cache is clear
+    storage_client._bucket_metadata_cache.clear()
+
+    # Setup background fetch monitoring hook
+    original_fetch = storage_client._bucket_metadata_cache._fetch_background
+    fetch_triggered = False
+
+    def monitored_fetch(*args, **kwargs):
+        nonlocal fetch_triggered
+        fetch_triggered = True
+        return original_fetch(*args, **kwargs)
+
+    storage_client._bucket_metadata_cache._fetch_background = monitored_fetch
+
+    try:
+        storage_client.create_bucket(bucket)
+        buckets_to_delete.append(bucket)
+
+        # Assert cache is populated instantly (synchronously)
+        cached = storage_client._bucket_metadata_cache.get(bucket_name)
+        assert cached is not None
+        dest_id, loc = cached
+        assert bucket_name in dest_id
+
+        # Verify that no background fetch thread was ever triggered!
+        assert not fetch_triggered
+    finally:
+        storage_client._bucket_metadata_cache._fetch_background = original_fetch
+
+
+def test_get_bucket_synchronous_cache_warming(storage_client, buckets_to_delete):
+    """Verifies that calling client.get_bucket() for the first time (cache miss) synchronously warms the cache immediately without triggering any background fetch threads."""
+    # Wait for any previous inflight background fetches to complete
+    start_time = time.time()
+    while time.time() - start_time < 5.0:
+        with storage_client._bucket_metadata_cache._lock:
+            if not storage_client._bucket_metadata_cache._inflight_fetches:
+                break
+        time.sleep(0.1)
+
+    bucket_name = _helpers.unique_name("aco-sync-get")
+    bucket = storage_client.bucket(bucket_name)
+    storage_client.create_bucket(bucket)
+    buckets_to_delete.append(bucket)
+
+    # Ensure cache is clear
+    storage_client._bucket_metadata_cache.clear()
+
+    # Setup background fetch monitoring hook
+    original_fetch = storage_client._bucket_metadata_cache._fetch_background
+    fetch_triggered = False
+
+    def monitored_fetch(*args, **kwargs):
+        nonlocal fetch_triggered
+        fetch_triggered = True
+        return original_fetch(*args, **kwargs)
+
+    storage_client._bucket_metadata_cache._fetch_background = monitored_fetch
+
+    try:
+        # Call client.get_bucket()
+        storage_client.get_bucket(bucket_name)
+
+        # Assert cache is populated instantly (synchronously) without background delay
+        cached = storage_client._bucket_metadata_cache.get(bucket_name)
+        assert cached is not None
+        dest_id, loc = cached
+        assert bucket_name in dest_id
+
+        # Verify that no background fetch thread was ever triggered!
+        assert not fetch_triggered
+    finally:
+        storage_client._bucket_metadata_cache._fetch_background = original_fetch

--- a/packages/google-cloud-storage/tests/unit/test__bucket_metadata_cache.py
+++ b/packages/google-cloud-storage/tests/unit/test__bucket_metadata_cache.py
@@ -1,0 +1,203 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+from unittest import mock
+
+from google.api_core import exceptions as api_exceptions
+from google.cloud.exceptions import NotFound
+from google.cloud.storage._bucket_metadata_cache import BucketMetadataCache
+
+
+class TestBucketMetadataCache(unittest.TestCase):
+    @mock.patch("threading.Thread")
+    def test_lru_eviction(self, mock_thread):
+        client = mock.Mock()
+        cache = BucketMetadataCache(client, max_size=3)
+
+        cache.update_cache("b1", "dest1", "loc1")
+        cache.update_cache("b2", "dest2", "loc2")
+        cache.update_cache("b3", "dest3", "loc3")
+        cache.update_cache("b4", "dest4", "loc4")  # Evicts b1 (oldest)
+
+        self.assertIsNone(cache.get_or_queue_fetch("b1"))
+        self.assertEqual(cache.get_or_queue_fetch("b2"), ("dest2", "loc2"))
+        self.assertEqual(cache.get_or_queue_fetch("b3"), ("dest3", "loc3"))
+        self.assertEqual(cache.get_or_queue_fetch("b4"), ("dest4", "loc4"))
+
+    def test_update_from_bucket(self):
+        client = mock.Mock()
+        cache = BucketMetadataCache(client)
+
+        # Multi-region -> global
+        b1 = mock.Mock()
+        b1.name = "b1"
+        b1.location = "US"
+        b1.location_type = "multi-region"
+        b1.project_number = 123
+        cache.update_from_bucket(b1)
+        self.assertEqual(
+            cache.get_or_queue_fetch("b1"), ("projects/123/buckets/b1", "global")
+        )
+
+        # Dual-region -> global
+        b2 = mock.Mock()
+        b2.name = "b2"
+        b2.location = "NAM4"
+        b2.location_type = "dual-region"
+        b2.project_number = 456
+        cache.update_from_bucket(b2)
+        self.assertEqual(
+            cache.get_or_queue_fetch("b2"), ("projects/456/buckets/b2", "global")
+        )
+
+        # Region -> us-east1
+        b3 = mock.Mock()
+        b3.name = "b3"
+        b3.location = "US-EAST1"
+        b3.location_type = "region"
+        b3.project_number = 789
+        cache.update_from_bucket(b3)
+        self.assertEqual(
+            cache.get_or_queue_fetch("b3"), ("projects/789/buckets/b3", "us-east1")
+        )
+
+        # Missing project number -> _
+        b4 = mock.Mock()
+        b4.name = "b4"
+        b4.location = "eu-west1"
+        b4.location_type = "region"
+        b4.project_number = None
+        cache.update_from_bucket(b4)
+        self.assertEqual(
+            cache.get_or_queue_fetch("b4"), ("projects/_/buckets/b4", "eu-west1")
+        )
+
+    @mock.patch("threading.Thread")
+    def test_get_or_queue_fetch(self, mock_thread):
+        client = mock.Mock()
+        cache = BucketMetadataCache(client)
+
+        # Cache miss -> returns None immediately and spawns thread
+        result = cache.get_or_queue_fetch("my-bucket")
+        self.assertIsNone(result)
+        mock_thread.assert_called_once()
+
+        # Second immediate lookup -> returns None, does not spawn another thread (singleflight)
+        mock_thread.reset_mock()
+        result2 = cache.get_or_queue_fetch("my-bucket")
+        self.assertIsNone(result2)
+        mock_thread.assert_not_called()
+
+    def test_fetch_background_success(self):
+        client = mock.Mock()
+        b1 = mock.Mock()
+        b1.name = "b1"
+        b1.location = "US-WEST1"
+        b1.location_type = "region"
+        b1.project_number = 999
+        client.get_bucket.return_value = b1
+
+        cache = BucketMetadataCache(client)
+        cache._inflight_fetches.add("b1")
+
+        cache._fetch_background("b1")
+
+        self.assertEqual(
+            cache.get_or_queue_fetch("b1"), ("projects/999/buckets/b1", "us-west1")
+        )
+        self.assertNotIn("b1", cache._inflight_fetches)
+
+    def test_fetch_background_not_found(self):
+        client = mock.Mock()
+        client.get_bucket.side_effect = NotFound("Bucket not found")
+        cache = BucketMetadataCache(client)
+        cache.update_cache("b1", "projects/_/buckets/b1", "global")
+        cache._inflight_fetches.add("b1")
+
+        cache._fetch_background("b1")
+
+        self.assertNotIn("b1", cache._cache)
+        self.assertNotIn("b1", cache._inflight_fetches)
+
+    def test_fetch_background_forbidden(self):
+        client = mock.Mock()
+        client.get_bucket.side_effect = api_exceptions.Forbidden("403")
+        cache = BucketMetadataCache(client)
+        cache._inflight_fetches.add("b1")
+
+        cache._fetch_background("b1")
+
+        self.assertEqual(
+            cache.get_or_queue_fetch("b1"), ("projects/_/buckets/b1", "global")
+        )
+        self.assertNotIn("b1", cache._inflight_fetches)
+
+    @mock.patch("threading.Thread")
+    def test_clear_and_evict(self, mock_thread):
+        client = mock.Mock()
+        cache = BucketMetadataCache(client)
+
+        cache.update_cache("b1", "dest1", "loc1")
+        cache.evict("b1")
+        self.assertNotIn("b1", cache._cache)
+
+        cache.update_cache("b2", "dest2", "loc2")
+        cache.clear()
+        self.assertNotIn("b2", cache._cache)
+
+    @mock.patch("threading.Thread")
+    def test_check_and_evict_queue(self, mock_thread):
+        client = mock.Mock()
+        cache = BucketMetadataCache(client)
+        cache.update_cache("b1", "dest1", "loc1")
+
+        cache.check_and_evict("b1")
+        mock_thread.assert_called_once()
+        self.assertIn("b1", cache._inflight_checks)
+
+        # Second immediate check -> singleflight
+        mock_thread.reset_mock()
+        cache.check_and_evict("b1")
+        mock_thread.assert_not_called()
+
+    def test_verify_existence_background_exists(self):
+        client = mock.Mock()
+        b1 = mock.Mock()
+        b1.exists.return_value = True
+        client.bucket.return_value = b1
+
+        cache = BucketMetadataCache(client)
+        cache.update_cache("b1", "dest1", "loc1")
+        cache._inflight_checks.add("b1")
+
+        cache._verify_existence_background("b1")
+
+        self.assertIn("b1", cache._cache)
+        self.assertNotIn("b1", cache._inflight_checks)
+
+    def test_verify_existence_background_deleted(self):
+        client = mock.Mock()
+        b1 = mock.Mock()
+        b1.exists.return_value = False
+        client.bucket.return_value = b1
+
+        cache = BucketMetadataCache(client)
+        cache.update_cache("b1", "dest1", "loc1")
+        cache._inflight_checks.add("b1")
+
+        cache._verify_existence_background("b1")
+
+        self.assertNotIn("b1", cache._cache)
+        self.assertNotIn("b1", cache._inflight_checks)

--- a/packages/google-cloud-storage/tests/unit/test__lru_cache.py
+++ b/packages/google-cloud-storage/tests/unit/test__lru_cache.py
@@ -1,0 +1,101 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+
+from google.cloud.storage._lru_cache import LRUCache
+
+
+def test_lru_cache_capacity():
+    cache = LRUCache(capacity=3)
+    assert cache.capacity == 3
+
+    with pytest.raises(ValueError):
+        LRUCache(capacity=0)
+
+    with pytest.raises(ValueError):
+        LRUCache(capacity=-1)
+
+
+def test_lru_cache_put_and_get():
+    cache = LRUCache(capacity=2)
+    assert cache.get("a") is None
+    assert cache.get("a", default="default") == "default"
+
+    cache.put("a", 1)
+    assert cache.get("a") == 1
+    assert len(cache) == 1
+    assert "a" in cache
+
+    cache.put("b", 2)
+    assert cache.get("b") == 2
+    assert len(cache) == 2
+    assert "b" in cache
+
+
+def test_lru_cache_eviction():
+    cache = LRUCache(capacity=2)
+    cache.put("a", 1)
+    cache.put("b", 2)
+
+    # Access "a" so "b" becomes least recently used
+    assert cache.get("a") == 1
+
+    # Put "c" should evict "b"
+    cache.put("c", 3)
+
+    assert "b" not in cache
+    assert cache.get("b") is None
+    assert cache.get("a") == 1
+    assert cache.get("c") == 3
+    assert len(cache) == 2
+
+
+def test_lru_cache_update():
+    cache = LRUCache(capacity=2)
+    cache.put("a", 1)
+    cache.put("b", 2)
+
+    # Update "a", so it becomes most recently used
+    cache.put("a", 10)
+
+    # Put "c" should evict "b"
+    cache.put("c", 3)
+
+    assert "b" not in cache
+    assert cache.get("a") == 10
+    assert cache.get("c") == 3
+
+
+def test_lru_cache_clear():
+    cache = LRUCache(capacity=2)
+    cache.put("a", 1)
+    cache.put("b", 2)
+
+    cache.clear()
+    assert len(cache) == 0
+    assert "a" not in cache
+    assert "b" not in cache
+
+
+def test_lru_cache_delete():
+    cache = LRUCache(capacity=2)
+    cache.put("a", 1)
+    cache.put("b", 2)
+
+    cache.delete("a")
+    assert len(cache) == 1
+    assert "a" not in cache
+    assert cache.get("a") is None
+    assert cache.get("b") == 2

--- a/packages/google-cloud-storage/tests/unit/test_bucket.py
+++ b/packages/google-cloud-storage/tests/unit/test_bucket.py
@@ -1487,6 +1487,27 @@ class Test_Bucket(unittest.TestCase):
             _target_object=None,
         )
 
+    def test_delete_hit_evicts_from_cache(self):
+        name = "bucket-to-delete"
+        client = mock.Mock(spec=["_delete_resource", "_bucket_metadata_cache"])
+        cache = mock.Mock()
+        client._bucket_metadata_cache = cache
+        client._delete_resource.return_value = None
+        bucket = self._make_one(client=client, name=name)
+
+        result = bucket.delete()
+
+        self.assertIsNone(result)
+        cache.evict.assert_called_once_with(name)
+
+        client._delete_resource.assert_called_once_with(
+            bucket.path,
+            query_params={},
+            timeout=self._get_default_timeout(),
+            retry=DEFAULT_RETRY,
+            _target_object=None,
+        )
+
     def test_delete_hit_w_force_w_user_project_w_explicit_timeout_retry(self):
         name = "name"
         user_project = "user-project-123"
@@ -2004,6 +2025,29 @@ class Test_Bucket(unittest.TestCase):
             retry=DEFAULT_RETRY,
             _target_object=bucket,
         )
+
+    def test_reload_forbidden_sync_cache_fallback(self):
+        from google.api_core.exceptions import Forbidden
+        from google.cloud.storage._bucket_metadata_cache import BucketMetadataCache
+
+        name = "forbidden-bucket"
+        client = mock.Mock(spec=["_get_resource", "_bucket_metadata_cache"])
+        client._bucket_metadata_cache = BucketMetadataCache(client)
+        client._get_resource.side_effect = Forbidden("forbidden")
+        bucket = self._make_one(client, name=name)
+
+        # Ensure cache is clear
+        client._bucket_metadata_cache.clear()
+
+        with self.assertRaises(Forbidden):
+            bucket.reload()
+
+        # Assert cache was synchronously populated with fallback
+        cached = client._bucket_metadata_cache.get(name)
+        self.assertIsNotNone(cached)
+        dest_id, loc = cached
+        self.assertEqual(dest_id, f"projects/_/buckets/{name}")
+        self.assertEqual(loc, "global")
 
     def test_reload_w_metageneration_match(self):
         name = "name"

--- a/packages/google-cloud-storage/tests/unit/test_client.py
+++ b/packages/google-cloud-storage/tests/unit/test_client.py
@@ -1102,6 +1102,29 @@ class TestClient(unittest.TestCase):
         self.assertIsInstance(target, Bucket)
         self.assertEqual(target.name, bucket_name)
 
+    def test_get_bucket_forbidden_sync_cache_fallback(self):
+        from google.api_core.exceptions import Forbidden
+
+        project = "PROJECT"
+        credentials = _make_credentials()
+        client = self._make_one(project=project, credentials=credentials)
+        client._get_resource = mock.Mock()
+        client._get_resource.side_effect = Forbidden("forbidden")
+        bucket_name = "forbidden-bucket"
+
+        # Ensure cache is clear
+        client._bucket_metadata_cache.clear()
+
+        with self.assertRaises(Forbidden):
+            client.get_bucket(bucket_name)
+
+        # Assert cache was synchronously populated with fallback
+        cached = client._bucket_metadata_cache.get(bucket_name)
+        self.assertIsNotNone(cached)
+        dest_id, loc = cached
+        self.assertEqual(dest_id, f"projects/_/buckets/{bucket_name}")
+        self.assertEqual(loc, "global")
+
     def test_get_bucket_hit_w_string_w_timeout(self):
         from google.cloud.storage.bucket import Bucket
 
@@ -1316,6 +1339,28 @@ class TestClient(unittest.TestCase):
         target = client._get_resource.call_args[1]["_target_object"]
         self.assertIsInstance(target, Bucket)
         self.assertEqual(target.name, bucket_name)
+
+    def test_lookup_bucket_forbidden_sync_cache_fallback(self):
+        from google.api_core.exceptions import Forbidden
+
+        project = "PROJECT"
+        credentials = _make_credentials()
+        client = self._make_one(project=project, credentials=credentials)
+        client._get_resource = mock.Mock(side_effect=Forbidden("forbidden"))
+        bucket_name = "forbidden-bucket"
+
+        # Ensure cache is clear
+        client._bucket_metadata_cache.clear()
+
+        with self.assertRaises(Forbidden):
+            client.lookup_bucket(bucket_name)
+
+        # Assert cache was synchronously populated with fallback
+        cached = client._bucket_metadata_cache.get(bucket_name)
+        self.assertIsNotNone(cached)
+        dest_id, loc = cached
+        self.assertEqual(dest_id, f"projects/_/buckets/{bucket_name}")
+        self.assertEqual(loc, "global")
 
     def test_lookup_bucket_hit_w_timeout(self):
         from google.cloud.storage.bucket import Bucket


### PR DESCRIPTION
## Description
The final piece of the App-centric Observability (ACO) tracing implementation. Wires up the metadata cache and tracing context managers to the public client interfaces and establishes a 100% sleep-free live system test suite.

> [!NOTE]
> This PR is stacked on top of **PR 3 (https://github.com/googleapis/google-cloud-python/pull/17222)**. It should be reviewed/merged after PR 3.

## Changes
- Updated `google/cloud/storage/client.py`, `bucket.py`, `blob.py`, and `transfer_manager.py` to wrap critical operations (e.g. uploads, downloads, retrievals, deletes) in active trace spans and update the cache state on api calls/deletes.
- Updated `tests/unit/test_client.py` and `test_bucket.py` with caching fallback tests.
- Created `tests/system/test_aco_observability.py` with fully-deterministic concurrent system tests executing against a live GCS backend.

This is PR 4 of a 4-part series to break down the ACO tracing compatibility feature into reviewable slices.
