### PR TITLE
chore: librarian release pull request: 20260521T194308Z

### DIFF
--- a/.librarian/state.yaml
+++ b/.librarian/state.yaml
@@ -74,7 +74,7 @@ libraries:
       - packages/django-google-spanner/docs/
     tag_format: '{id}-v{version}'
   - id: gapic-generator
-    version: 1.32.0
+    version: 1.33.0
     last_generated_commit: ""
     apis: []
     source_roots:

--- a/librarian.yaml
+++ b/librarian.yaml
@@ -67,7 +67,7 @@ libraries:
     python:
       library_type: INTEGRATION
   - name: gapic-generator
-    version: 1.32.0
+    version: 1.33.0
     python:
       library_type: CORE
   - name: gcp-sphinx-docfx-yaml

--- a/packages/gapic-generator/CHANGELOG.md
+++ b/packages/gapic-generator/CHANGELOG.md
@@ -4,6 +4,16 @@
 
 [1]: https://pypi.org/project/gapic-generator/#history
 
+## [1.33.0](https://github.com/googleapis/google-cloud-python/compare/gapic-generator-v1.32.0...gapic-generator-v1.33.0) (2026-05-21)
+
+
+### Bug Fixes
+
+* restore messages not attached to rpc in selective_gapic_generation (#16951) ([3ef95d61995869318097e414e439da1d6c214d1f](https://github.com/googleapis/google-cloud-python/commit/3ef95d61995869318097e414e439da1d6c214d1f))
+* bump idna from 3.14 to 3.15 in /packages/gapic-generator (#17179) ([0f7c68bfd437e7f366dacd4080f31e219d7c7090](https://github.com/googleapis/google-cloud-python/commit/0f7c68bfd437e7f366dacd4080f31e219d7c7090))
+* resolve core dependencies locally and batch pip installs (#17032) ([5ca88030476fd6be7a2eceef9c94c4fc76820f40](https://github.com/googleapis/google-cloud-python/commit/5ca88030476fd6be7a2eceef9c94c4fc76820f40))
+* resolve core dependencies locally and batch pip installs ([5ca88030476fd6be7a2eceef9c94c4fc76820f40](https://github.com/googleapis/google-cloud-python/commit/5ca88030476fd6be7a2eceef9c94c4fc76820f40))
+
 ## [1.32.0](https://github.com/googleapis/google-cloud-python/compare/gapic-generator-v1.31.0...gapic-generator-v1.32.0) (2026-05-11)
 
 ## [1.31.0](https://github.com/googleapis/google-cloud-python/compare/gapic-generator-v1.30.14...gapic-generator-v1.31.0) (2026-05-06)

--- a/packages/gapic-generator/setup.py
+++ b/packages/gapic-generator/setup.py
@@ -22,7 +22,7 @@ import setuptools
 name = "gapic-generator"
 description = "Google API Client Generator for Python"
 url = "https://github.com/googleapis/gapic-generator-python"
-version = "1.32.0"
+version = "1.33.0"
 release_status = "Development Status :: 5 - Production/Stable"
 dependencies = [
     # Ensure that the lower bounds of these dependencies match what we have in the


### PR DESCRIPTION
PR created by the Librarian CLI to initialize a release. Merging this PR will auto trigger a release.

Librarian Version: v0.14.0
Language Image: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/python-librarian-generator@sha256:234b9d1f2ddb057ed7ac6a38db0bf8163d839c65c6cf88ade52530cddebce59e
<details><summary>gapic-generator: v1.33.0</summary>

## [v1.33.0](https://github.com/googleapis/google-cloud-python/compare/gapic-generator-v1.32.0...gapic-generator-v1.33.0) (2026-05-21)

### Bug Fixes

* bump idna from 3.14 to 3.15 in /packages/gapic-generator (#17179) ([0f7c68bf](https://github.com/googleapis/google-cloud-python/commit/0f7c68bf))

* restore messages not attached to rpc in selective_gapic_generation (#16951) ([3ef95d61](https://github.com/googleapis/google-cloud-python/commit/3ef95d61))

* resolve core dependencies locally and batch pip installs (#17032) ([5ca88030](https://github.com/googleapis/google-cloud-python/commit/5ca88030))

* resolve core dependencies locally and batch pip installs ([5ca88030](https://github.com/googleapis/google-cloud-python/commit/5ca88030))

</details>

b/515393379