### PR TITLE
ci: update protoc version from 25.3 to 33.2 in regenerate-all.yml

### DIFF
--- a/.github/workflows/regenerate-all.yml
+++ b/.github/workflows/regenerate-all.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Install protoc
         uses: arduino/setup-protoc@v3
         with:
-          version: "25.3"
+          version: "33.2"
 
       - name: Install pandoc
         run: |


### PR DESCRIPTION
In our playbook we use Protoc 33.2. Let's use the version in the regenerate-all test.

For https://github.com/googleapis/google-cloud-python/issues/17164
