### PR TITLE
ci: pre-populate synthtool cache to avoid race condition

### DIFF
--- a/.github/workflows/regenerate-all.yml
+++ b/.github/workflows/regenerate-all.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-  pull_request:
 
 permissions:
   contents: read

--- a/.github/workflows/regenerate-all.yml
+++ b/.github/workflows/regenerate-all.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+  pull_request:
 
 permissions:
   contents: read
@@ -40,6 +41,11 @@ jobs:
         run: |
           version=$(sed -n 's/^version: *//p' librarian.yaml)
           go run "github.com/googleapis/librarian/cmd/librarian@${version}" install
+
+      - name: Pre-populate Synthtool Cache
+        run: |
+          mkdir -p ~/.cache/synthtool
+          git clone --recurse-submodules --single-branch https://github.com/googleapis/synthtool.git ~/.cache/synthtool/synthtool
 
       - name: Regenerate
         run: |

--- a/.github/workflows/regenerate-all.yml
+++ b/.github/workflows/regenerate-all.yml
@@ -15,6 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       PANDOC_VERSION: 3.8.2
+      SYNTHTOOL_TEMPLATES: /home/runner/synthtool/synthtool/gcp/templates
 
     steps:
       - name: Checkout
@@ -42,10 +43,9 @@ jobs:
           version=$(sed -n 's/^version: *//p' librarian.yaml)
           go run "github.com/googleapis/librarian/cmd/librarian@${version}" install
 
-      - name: Pre-populate Synthtool Cache
+      - name: Clone Synthtool Templates
         run: |
-          mkdir -p ~/.cache/synthtool
-          git clone --recurse-submodules --single-branch https://github.com/googleapis/synthtool.git ~/.cache/synthtool/synthtool
+          git clone --recurse-submodules --single-branch https://github.com/googleapis/synthtool.git /home/runner/synthtool
 
       - name: Regenerate
         run: |

--- a/.librarian/generator-input/client-post-processing/spanner-integration.yaml
+++ b/.librarian/generator-input/client-post-processing/spanner-integration.yaml
@@ -607,38 +607,7 @@ replacements:
       Next Steps
     count: 1
 
-  - paths: [
-      packages/google-cloud-spanner/README.rst
-    ]
-    before: |
-      Supported Python Versions
-      \^\^\^\^\^\^\^\^\^\^\^\^\^\^\^\^\^\^\^\^\^\^\^\^\^
-      Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
-      Python\.
 
-      Python >= 3\.9, including 3\.14
-
-      \.\. _active: https://devguide\.python\.org/devcycle/#in-development-main-branch
-      \.\. _maintenance: https://devguide\.python\.org/devcycle/#maintenance-branches
-
-      Unsupported Python Versions
-      \^\^\^\^\^\^\^\^\^\^\^\^\^\^\^\^\^\^\^\^\^\^\^\^\^\^\^
-      Python <= 3\.8
-    after: |
-      Supported Python Versions
-      ^^^^^^^^^^^^^^^^^^^^^^^^^
-      Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
-      Python.
-
-      Python >= 3.10, including 3.14
-
-      .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
-      .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
-
-      Unsupported Python Versions
-      ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-      Python <= 3.9
-    count: 1
 
     # Note: noxfile.py is heavily customized so we clobber the whole file. 
   - paths: [


### PR DESCRIPTION
This PR resolves a blocking parallel generation issue on GitHub Actions and updates Spanner's post-processing config to align with recent template updates.

### 1. Fix GHA parallel generation race condition
When running `librarian generate --all` in GHA, multiple libraries are generated in parallel. They concurrently invoke `synthtool`, which races to clone/update the templates repository (`googleapis/synthtool`) in the shared cache directory `~/.cache/synthtool/synthtool`. 

This results in either:
*   A **clone race**: One process starts cloning, and others see the half-created directory, assume it's valid, and fail with `fatal: failed to resolve HEAD as a valid ref` when running `git branch`.
*   An **update race**: Multiple processes try to run `git checkout` / `git pull` concurrently, failing with `fatal: Unable to create ... index.lock: File exists`.

**Fix**: 
We now clone `googleapis/synthtool` once sequentially at the beginning of the workflow (`Clone Synthtool Templates`), and configure `SYNTHTOOL_TEMPLATES` environment variable globally to point to this local directory. This completely bypasses all concurrent git clone/pull operations during parallel generation, resolving the race conditions and speeding up the build.

### 2. Fix Spanner post-processing AssertionError
We removed the obsolete `Supported Python Versions` replacement block from `.librarian/generator-input/client-post-processing/spanner-integration.yaml`.

**Why it was needed**:
*   On **May 19, 2026** (commit `2408166fec`), Python 3.7-3.9 support was dropped specifically for Spanner. Because the `synthtool` templates still generated `Python >= 3.9` in `README.rst` by default, a post-processing workaround was added to force it to `3.10`.
*   On **May 21, 2026** (commit `e643ce8` in `googleapis/synthtool`), `synthtool` templates were updated globally to drop Python 3.9 support for all mono-repo libraries.
*   As a result, the freshly generated `README.rst` for Spanner now already defaults to `Python >= 3.10`. The May 19 workaround became obsolete and failed with `AssertionError: Replaced 0 rather than 1 instances` because the "before" pattern (expecting `3.9`) no longer exists.

TAG=agy
CONV=acb0ee9b-3d87-4b9e-b3c6-0d4aa3efbd35