### PR TITLE
chore(revert): Revert "ci: update protoc version from 25.3 to 33.2 in regenerate-all.yml"

### DIFF
--- a/.github/workflows/regenerate-all.yml
+++ b/.github/workflows/regenerate-all.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Install protoc
         uses: arduino/setup-protoc@v3
         with:
-          version: "33.2"
+          version: "25.3"
 
       - name: Install pandoc
         run: |


### PR DESCRIPTION
Reverts googleapis/google-cloud-python#17228

Protoc 25.3 is still in use here: https://github.com/googleapis/librarian/blob/3ec07bb1adbad63953dbd741427f92f00fea2646/cmd/librarian/Dockerfile#L49