### PR TITLE
chore: update librarian to v0.14.1-0.20260522151051-433d9e6211ad

### DIFF
--- a/librarian.yaml
+++ b/librarian.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 language: python
-version: v0.14.0
+version: v0.14.1-0.20260522151051-433d9e6211ad
 repo: googleapis/google-cloud-python
 sources:
   googleapis:

--- a/packages/google-ads-admanager/README.rst
+++ b/packages/google-ads-admanager/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-ads-admanager/docs/README.rst
+++ b/packages/google-ads-admanager/docs/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-ads-admanager/noxfile.py
+++ b/packages/google-ads-admanager/noxfile.py
@@ -509,24 +509,50 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1) for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -596,16 +622,24 @@ def core_deps_from_source(session, protobuf_implementation):
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
+
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(
+        f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}"
+    )
 
     session.run(
         "py.test",

--- a/packages/google-ads-datamanager/README.rst
+++ b/packages/google-ads-datamanager/README.rst
@@ -62,14 +62,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-ads-datamanager/docs/README.rst
+++ b/packages/google-ads-datamanager/docs/README.rst
@@ -62,14 +62,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-ads-datamanager/noxfile.py
+++ b/packages/google-ads-datamanager/noxfile.py
@@ -509,24 +509,50 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1) for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -596,16 +622,24 @@ def core_deps_from_source(session, protobuf_implementation):
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
+
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(
+        f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}"
+    )
 
     session.run(
         "py.test",

--- a/packages/google-ads-marketingplatform-admin/README.rst
+++ b/packages/google-ads-marketingplatform-admin/README.rst
@@ -65,14 +65,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-ads-marketingplatform-admin/docs/README.rst
+++ b/packages/google-ads-marketingplatform-admin/docs/README.rst
@@ -65,14 +65,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-ads-marketingplatform-admin/noxfile.py
+++ b/packages/google-ads-marketingplatform-admin/noxfile.py
@@ -509,24 +509,50 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1) for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -596,16 +622,24 @@ def core_deps_from_source(session, protobuf_implementation):
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
+
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(
+        f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}"
+    )
 
     session.run(
         "py.test",

--- a/packages/google-ai-generativelanguage/README.rst
+++ b/packages/google-ai-generativelanguage/README.rst
@@ -67,14 +67,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-ai-generativelanguage/docs/README.rst
+++ b/packages/google-ai-generativelanguage/docs/README.rst
@@ -67,14 +67,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-ai-generativelanguage/noxfile.py
+++ b/packages/google-ai-generativelanguage/noxfile.py
@@ -509,24 +509,50 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1) for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -596,16 +622,24 @@ def core_deps_from_source(session, protobuf_implementation):
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
+
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(
+        f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}"
+    )
 
     session.run(
         "py.test",

--- a/packages/google-analytics-admin/README.rst
+++ b/packages/google-analytics-admin/README.rst
@@ -67,14 +67,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-analytics-admin/docs/README.rst
+++ b/packages/google-analytics-admin/docs/README.rst
@@ -67,14 +67,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-analytics-admin/noxfile.py
+++ b/packages/google-analytics-admin/noxfile.py
@@ -509,24 +509,50 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1) for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -596,16 +622,24 @@ def core_deps_from_source(session, protobuf_implementation):
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
+
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(
+        f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}"
+    )
 
     session.run(
         "py.test",

--- a/packages/google-analytics-data/README.rst
+++ b/packages/google-analytics-data/README.rst
@@ -67,14 +67,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-analytics-data/docs/README.rst
+++ b/packages/google-analytics-data/docs/README.rst
@@ -67,14 +67,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-analytics-data/noxfile.py
+++ b/packages/google-analytics-data/noxfile.py
@@ -509,24 +509,50 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1) for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -596,16 +622,24 @@ def core_deps_from_source(session, protobuf_implementation):
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
+
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(
+        f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}"
+    )
 
     session.run(
         "py.test",

--- a/packages/google-apps-card/README.rst
+++ b/packages/google-apps-card/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-apps-card/docs/README.rst
+++ b/packages/google-apps-card/docs/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-apps-card/noxfile.py
+++ b/packages/google-apps-card/noxfile.py
@@ -509,24 +509,50 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1) for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -596,16 +622,24 @@ def core_deps_from_source(session, protobuf_implementation):
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
+
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(
+        f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}"
+    )
 
     session.run(
         "py.test",

--- a/packages/google-apps-chat/README.rst
+++ b/packages/google-apps-chat/README.rst
@@ -63,14 +63,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-apps-chat/docs/README.rst
+++ b/packages/google-apps-chat/docs/README.rst
@@ -63,14 +63,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-apps-chat/noxfile.py
+++ b/packages/google-apps-chat/noxfile.py
@@ -509,24 +509,50 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1) for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -596,16 +622,24 @@ def core_deps_from_source(session, protobuf_implementation):
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
+
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(
+        f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}"
+    )
 
     session.run(
         "py.test",

--- a/packages/google-apps-events-subscriptions/README.rst
+++ b/packages/google-apps-events-subscriptions/README.rst
@@ -62,14 +62,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-apps-events-subscriptions/docs/README.rst
+++ b/packages/google-apps-events-subscriptions/docs/README.rst
@@ -62,14 +62,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-apps-events-subscriptions/noxfile.py
+++ b/packages/google-apps-events-subscriptions/noxfile.py
@@ -509,24 +509,50 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1) for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -596,16 +622,24 @@ def core_deps_from_source(session, protobuf_implementation):
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
+
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(
+        f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}"
+    )
 
     session.run(
         "py.test",

--- a/packages/google-apps-meet/README.rst
+++ b/packages/google-apps-meet/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-apps-meet/docs/README.rst
+++ b/packages/google-apps-meet/docs/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-apps-meet/noxfile.py
+++ b/packages/google-apps-meet/noxfile.py
@@ -509,24 +509,50 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1) for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -596,16 +622,24 @@ def core_deps_from_source(session, protobuf_implementation):
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
+
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(
+        f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}"
+    )
 
     session.run(
         "py.test",

--- a/packages/google-apps-script-type/README.rst
+++ b/packages/google-apps-script-type/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-apps-script-type/docs/README.rst
+++ b/packages/google-apps-script-type/docs/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-apps-script-type/noxfile.py
+++ b/packages/google-apps-script-type/noxfile.py
@@ -509,24 +509,50 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1) for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -596,16 +622,24 @@ def core_deps_from_source(session, protobuf_implementation):
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
+
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(
+        f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}"
+    )
 
     session.run(
         "py.test",

--- a/packages/google-area120-tables/README.rst
+++ b/packages/google-area120-tables/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-area120-tables/docs/README.rst
+++ b/packages/google-area120-tables/docs/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-area120-tables/noxfile.py
+++ b/packages/google-area120-tables/noxfile.py
@@ -509,24 +509,50 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1) for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -596,16 +622,24 @@ def core_deps_from_source(session, protobuf_implementation):
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
+
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(
+        f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}"
+    )
 
     session.run(
         "py.test",

--- a/packages/google-cloud-access-approval/README.rst
+++ b/packages/google-cloud-access-approval/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-access-approval/docs/README.rst
+++ b/packages/google-cloud-access-approval/docs/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-access-approval/noxfile.py
+++ b/packages/google-cloud-access-approval/noxfile.py
@@ -509,24 +509,50 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1) for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -596,16 +622,24 @@ def core_deps_from_source(session, protobuf_implementation):
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
+
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(
+        f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}"
+    )
 
     session.run(
         "py.test",

--- a/packages/google-cloud-access-context-manager/README.rst
+++ b/packages/google-cloud-access-context-manager/README.rst
@@ -62,14 +62,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-access-context-manager/docs/README.rst
+++ b/packages/google-cloud-access-context-manager/docs/README.rst
@@ -62,14 +62,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-advisorynotifications/README.rst
+++ b/packages/google-cloud-advisorynotifications/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-advisorynotifications/docs/README.rst
+++ b/packages/google-cloud-advisorynotifications/docs/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-advisorynotifications/noxfile.py
+++ b/packages/google-cloud-advisorynotifications/noxfile.py
@@ -509,24 +509,50 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1) for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -596,16 +622,24 @@ def core_deps_from_source(session, protobuf_implementation):
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
+
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(
+        f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}"
+    )
 
     session.run(
         "py.test",

--- a/packages/google-cloud-alloydb-connectors/README.rst
+++ b/packages/google-cloud-alloydb-connectors/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-alloydb-connectors/docs/README.rst
+++ b/packages/google-cloud-alloydb-connectors/docs/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-alloydb-connectors/noxfile.py
+++ b/packages/google-cloud-alloydb-connectors/noxfile.py
@@ -509,24 +509,50 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1) for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -596,16 +622,24 @@ def core_deps_from_source(session, protobuf_implementation):
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
+
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(
+        f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}"
+    )
 
     session.run(
         "py.test",

--- a/packages/google-cloud-alloydb/README.rst
+++ b/packages/google-cloud-alloydb/README.rst
@@ -71,14 +71,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-alloydb/docs/README.rst
+++ b/packages/google-cloud-alloydb/docs/README.rst
@@ -71,14 +71,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-alloydb/noxfile.py
+++ b/packages/google-cloud-alloydb/noxfile.py
@@ -509,24 +509,50 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1) for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -596,16 +622,24 @@ def core_deps_from_source(session, protobuf_implementation):
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
+
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(
+        f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}"
+    )
 
     session.run(
         "py.test",

--- a/packages/google-cloud-api-gateway/README.rst
+++ b/packages/google-cloud-api-gateway/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-api-gateway/docs/README.rst
+++ b/packages/google-cloud-api-gateway/docs/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-api-gateway/noxfile.py
+++ b/packages/google-cloud-api-gateway/noxfile.py
@@ -509,24 +509,50 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1) for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -596,16 +622,24 @@ def core_deps_from_source(session, protobuf_implementation):
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
+
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(
+        f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}"
+    )
 
     session.run(
         "py.test",

--- a/packages/google-cloud-api-keys/README.rst
+++ b/packages/google-cloud-api-keys/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-api-keys/docs/README.rst
+++ b/packages/google-cloud-api-keys/docs/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-api-keys/noxfile.py
+++ b/packages/google-cloud-api-keys/noxfile.py
@@ -509,24 +509,50 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1) for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -596,16 +622,24 @@ def core_deps_from_source(session, protobuf_implementation):
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
+
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(
+        f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}"
+    )
 
     session.run(
         "py.test",

--- a/packages/google-cloud-apigee-connect/README.rst
+++ b/packages/google-cloud-apigee-connect/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-apigee-connect/docs/README.rst
+++ b/packages/google-cloud-apigee-connect/docs/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-apigee-connect/noxfile.py
+++ b/packages/google-cloud-apigee-connect/noxfile.py
@@ -509,24 +509,50 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1) for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -596,16 +622,24 @@ def core_deps_from_source(session, protobuf_implementation):
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
+
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(
+        f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}"
+    )
 
     session.run(
         "py.test",

--- a/packages/google-cloud-apigee-registry/README.rst
+++ b/packages/google-cloud-apigee-registry/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-apigee-registry/docs/README.rst
+++ b/packages/google-cloud-apigee-registry/docs/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-apigee-registry/noxfile.py
+++ b/packages/google-cloud-apigee-registry/noxfile.py
@@ -509,24 +509,50 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1) for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -596,16 +622,24 @@ def core_deps_from_source(session, protobuf_implementation):
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
+
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(
+        f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}"
+    )
 
     session.run(
         "py.test",

--- a/packages/google-cloud-apihub/README.rst
+++ b/packages/google-cloud-apihub/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-apihub/docs/README.rst
+++ b/packages/google-cloud-apihub/docs/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-apihub/noxfile.py
+++ b/packages/google-cloud-apihub/noxfile.py
@@ -509,24 +509,50 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1) for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -596,16 +622,24 @@ def core_deps_from_source(session, protobuf_implementation):
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
+
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(
+        f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}"
+    )
 
     session.run(
         "py.test",

--- a/packages/google-cloud-apiregistry/README.rst
+++ b/packages/google-cloud-apiregistry/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-apiregistry/docs/README.rst
+++ b/packages/google-cloud-apiregistry/docs/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-apiregistry/noxfile.py
+++ b/packages/google-cloud-apiregistry/noxfile.py
@@ -509,24 +509,50 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1) for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -596,16 +622,24 @@ def core_deps_from_source(session, protobuf_implementation):
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
+
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(
+        f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}"
+    )
 
     session.run(
         "py.test",

--- a/packages/google-cloud-appengine-admin/README.rst
+++ b/packages/google-cloud-appengine-admin/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-appengine-admin/docs/README.rst
+++ b/packages/google-cloud-appengine-admin/docs/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-appengine-admin/noxfile.py
+++ b/packages/google-cloud-appengine-admin/noxfile.py
@@ -509,24 +509,50 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1) for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -596,16 +622,24 @@ def core_deps_from_source(session, protobuf_implementation):
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
+
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(
+        f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}"
+    )
 
     session.run(
         "py.test",

--- a/packages/google-cloud-appengine-logging/README.rst
+++ b/packages/google-cloud-appengine-logging/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-appengine-logging/docs/README.rst
+++ b/packages/google-cloud-appengine-logging/docs/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-appengine-logging/noxfile.py
+++ b/packages/google-cloud-appengine-logging/noxfile.py
@@ -509,24 +509,50 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1) for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -596,16 +622,24 @@ def core_deps_from_source(session, protobuf_implementation):
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
+
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(
+        f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}"
+    )
 
     session.run(
         "py.test",

--- a/packages/google-cloud-apphub/README.rst
+++ b/packages/google-cloud-apphub/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-apphub/docs/README.rst
+++ b/packages/google-cloud-apphub/docs/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-apphub/noxfile.py
+++ b/packages/google-cloud-apphub/noxfile.py
@@ -509,24 +509,50 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1) for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -596,16 +622,24 @@ def core_deps_from_source(session, protobuf_implementation):
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
+
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(
+        f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}"
+    )
 
     session.run(
         "py.test",

--- a/packages/google-cloud-appoptimize/README.rst
+++ b/packages/google-cloud-appoptimize/README.rst
@@ -63,14 +63,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-appoptimize/docs/README.rst
+++ b/packages/google-cloud-appoptimize/docs/README.rst
@@ -63,14 +63,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-appoptimize/noxfile.py
+++ b/packages/google-cloud-appoptimize/noxfile.py
@@ -509,24 +509,50 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1) for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -596,16 +622,24 @@ def core_deps_from_source(session, protobuf_implementation):
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
+
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(
+        f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}"
+    )
 
     session.run(
         "py.test",

--- a/packages/google-cloud-artifact-registry/README.rst
+++ b/packages/google-cloud-artifact-registry/README.rst
@@ -62,14 +62,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-artifact-registry/docs/README.rst
+++ b/packages/google-cloud-artifact-registry/docs/README.rst
@@ -62,14 +62,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-artifact-registry/noxfile.py
+++ b/packages/google-cloud-artifact-registry/noxfile.py
@@ -509,24 +509,50 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1) for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -596,16 +622,24 @@ def core_deps_from_source(session, protobuf_implementation):
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
+
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(
+        f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}"
+    )
 
     session.run(
         "py.test",

--- a/packages/google-cloud-asset/README.rst
+++ b/packages/google-cloud-asset/README.rst
@@ -62,14 +62,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-asset/docs/README.rst
+++ b/packages/google-cloud-asset/docs/README.rst
@@ -62,14 +62,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-asset/noxfile.py
+++ b/packages/google-cloud-asset/noxfile.py
@@ -509,24 +509,50 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1) for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -596,16 +622,24 @@ def core_deps_from_source(session, protobuf_implementation):
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
+
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(
+        f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}"
+    )
 
     session.run(
         "py.test",

--- a/packages/google-cloud-assured-workloads/README.rst
+++ b/packages/google-cloud-assured-workloads/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-assured-workloads/docs/README.rst
+++ b/packages/google-cloud-assured-workloads/docs/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-assured-workloads/noxfile.py
+++ b/packages/google-cloud-assured-workloads/noxfile.py
@@ -509,24 +509,50 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1) for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -596,16 +622,24 @@ def core_deps_from_source(session, protobuf_implementation):
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
+
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(
+        f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}"
+    )
 
     session.run(
         "py.test",

--- a/packages/google-cloud-audit-log/README.rst
+++ b/packages/google-cloud-audit-log/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-audit-log/docs/README.rst
+++ b/packages/google-cloud-audit-log/docs/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-auditmanager/README.rst
+++ b/packages/google-cloud-auditmanager/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-auditmanager/docs/README.rst
+++ b/packages/google-cloud-auditmanager/docs/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-auditmanager/noxfile.py
+++ b/packages/google-cloud-auditmanager/noxfile.py
@@ -509,24 +509,50 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1) for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -596,16 +622,24 @@ def core_deps_from_source(session, protobuf_implementation):
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
+
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(
+        f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}"
+    )
 
     session.run(
         "py.test",

--- a/packages/google-cloud-automl/README.rst
+++ b/packages/google-cloud-automl/README.rst
@@ -62,14 +62,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-automl/docs/README.rst
+++ b/packages/google-cloud-automl/docs/README.rst
@@ -62,14 +62,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-automl/noxfile.py
+++ b/packages/google-cloud-automl/noxfile.py
@@ -510,24 +510,50 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1) for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -597,16 +623,24 @@ def core_deps_from_source(session, protobuf_implementation):
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
+
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(
+        f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}"
+    )
 
     session.run(
         "py.test",

--- a/packages/google-cloud-backupdr/README.rst
+++ b/packages/google-cloud-backupdr/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-backupdr/docs/README.rst
+++ b/packages/google-cloud-backupdr/docs/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-backupdr/noxfile.py
+++ b/packages/google-cloud-backupdr/noxfile.py
@@ -509,24 +509,50 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1) for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -596,16 +622,24 @@ def core_deps_from_source(session, protobuf_implementation):
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
+
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(
+        f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}"
+    )
 
     session.run(
         "py.test",

--- a/packages/google-cloud-bare-metal-solution/README.rst
+++ b/packages/google-cloud-bare-metal-solution/README.rst
@@ -62,14 +62,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-bare-metal-solution/docs/README.rst
+++ b/packages/google-cloud-bare-metal-solution/docs/README.rst
@@ -62,14 +62,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-bare-metal-solution/noxfile.py
+++ b/packages/google-cloud-bare-metal-solution/noxfile.py
@@ -509,24 +509,50 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1) for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -596,16 +622,24 @@ def core_deps_from_source(session, protobuf_implementation):
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
+
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(
+        f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}"
+    )
 
     session.run(
         "py.test",

--- a/packages/google-cloud-batch/README.rst
+++ b/packages/google-cloud-batch/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-batch/docs/README.rst
+++ b/packages/google-cloud-batch/docs/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-batch/noxfile.py
+++ b/packages/google-cloud-batch/noxfile.py
@@ -509,24 +509,50 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1) for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -596,16 +622,24 @@ def core_deps_from_source(session, protobuf_implementation):
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
+
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(
+        f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}"
+    )
 
     session.run(
         "py.test",

--- a/packages/google-cloud-beyondcorp-appconnections/README.rst
+++ b/packages/google-cloud-beyondcorp-appconnections/README.rst
@@ -64,14 +64,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-beyondcorp-appconnections/docs/README.rst
+++ b/packages/google-cloud-beyondcorp-appconnections/docs/README.rst
@@ -64,14 +64,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-beyondcorp-appconnections/noxfile.py
+++ b/packages/google-cloud-beyondcorp-appconnections/noxfile.py
@@ -509,24 +509,50 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1) for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -596,16 +622,24 @@ def core_deps_from_source(session, protobuf_implementation):
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
+
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(
+        f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}"
+    )
 
     session.run(
         "py.test",

--- a/packages/google-cloud-beyondcorp-appconnectors/README.rst
+++ b/packages/google-cloud-beyondcorp-appconnectors/README.rst
@@ -64,14 +64,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-beyondcorp-appconnectors/docs/README.rst
+++ b/packages/google-cloud-beyondcorp-appconnectors/docs/README.rst
@@ -64,14 +64,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-beyondcorp-appconnectors/noxfile.py
+++ b/packages/google-cloud-beyondcorp-appconnectors/noxfile.py
@@ -509,24 +509,50 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1) for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -596,16 +622,24 @@ def core_deps_from_source(session, protobuf_implementation):
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
+
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(
+        f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}"
+    )
 
     session.run(
         "py.test",

--- a/packages/google-cloud-beyondcorp-appgateways/README.rst
+++ b/packages/google-cloud-beyondcorp-appgateways/README.rst
@@ -64,14 +64,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-beyondcorp-appgateways/docs/README.rst
+++ b/packages/google-cloud-beyondcorp-appgateways/docs/README.rst
@@ -64,14 +64,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-beyondcorp-appgateways/noxfile.py
+++ b/packages/google-cloud-beyondcorp-appgateways/noxfile.py
@@ -509,24 +509,50 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1) for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -596,16 +622,24 @@ def core_deps_from_source(session, protobuf_implementation):
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
+
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(
+        f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}"
+    )
 
     session.run(
         "py.test",

--- a/packages/google-cloud-beyondcorp-clientconnectorservices/README.rst
+++ b/packages/google-cloud-beyondcorp-clientconnectorservices/README.rst
@@ -64,14 +64,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-beyondcorp-clientconnectorservices/docs/README.rst
+++ b/packages/google-cloud-beyondcorp-clientconnectorservices/docs/README.rst
@@ -64,14 +64,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-beyondcorp-clientconnectorservices/noxfile.py
+++ b/packages/google-cloud-beyondcorp-clientconnectorservices/noxfile.py
@@ -509,24 +509,50 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1) for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -596,16 +622,24 @@ def core_deps_from_source(session, protobuf_implementation):
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
+
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(
+        f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}"
+    )
 
     session.run(
         "py.test",

--- a/packages/google-cloud-beyondcorp-clientgateways/README.rst
+++ b/packages/google-cloud-beyondcorp-clientgateways/README.rst
@@ -64,14 +64,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-beyondcorp-clientgateways/docs/README.rst
+++ b/packages/google-cloud-beyondcorp-clientgateways/docs/README.rst
@@ -64,14 +64,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-beyondcorp-clientgateways/noxfile.py
+++ b/packages/google-cloud-beyondcorp-clientgateways/noxfile.py
@@ -509,24 +509,50 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1) for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -596,16 +622,24 @@ def core_deps_from_source(session, protobuf_implementation):
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
+
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(
+        f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}"
+    )
 
     session.run(
         "py.test",

--- a/packages/google-cloud-biglake-hive/README.rst
+++ b/packages/google-cloud-biglake-hive/README.rst
@@ -63,14 +63,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-biglake-hive/docs/README.rst
+++ b/packages/google-cloud-biglake-hive/docs/README.rst
@@ -63,14 +63,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-biglake-hive/noxfile.py
+++ b/packages/google-cloud-biglake-hive/noxfile.py
@@ -509,24 +509,50 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1) for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -596,16 +622,24 @@ def core_deps_from_source(session, protobuf_implementation):
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
+
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(
+        f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}"
+    )
 
     session.run(
         "py.test",

--- a/packages/google-cloud-biglake/README.rst
+++ b/packages/google-cloud-biglake/README.rst
@@ -63,14 +63,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-biglake/docs/README.rst
+++ b/packages/google-cloud-biglake/docs/README.rst
@@ -63,14 +63,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-biglake/google/cloud/biglake/__init__.py
+++ b/packages/google-cloud-biglake/google/cloud/biglake/__init__.py
@@ -30,8 +30,11 @@ from google.cloud.biglake_v1.types.iceberg_rest_catalog import (
     FailoverIcebergCatalogResponse,
     GetIcebergCatalogRequest,
     IcebergCatalog,
+    IcebergNamespaceUpdate,
     ListIcebergCatalogsRequest,
     ListIcebergCatalogsResponse,
+    StorageCredential,
+    TableIdentifier,
     UpdateIcebergCatalogRequest,
 )
 
@@ -43,7 +46,10 @@ __all__ = (
     "FailoverIcebergCatalogResponse",
     "GetIcebergCatalogRequest",
     "IcebergCatalog",
+    "IcebergNamespaceUpdate",
     "ListIcebergCatalogsRequest",
     "ListIcebergCatalogsResponse",
+    "StorageCredential",
+    "TableIdentifier",
     "UpdateIcebergCatalogRequest",
 )

--- a/packages/google-cloud-biglake/google/cloud/biglake_v1/__init__.py
+++ b/packages/google-cloud-biglake/google/cloud/biglake_v1/__init__.py
@@ -33,8 +33,11 @@ from .types.iceberg_rest_catalog import (
     FailoverIcebergCatalogResponse,
     GetIcebergCatalogRequest,
     IcebergCatalog,
+    IcebergNamespaceUpdate,
     ListIcebergCatalogsRequest,
     ListIcebergCatalogsResponse,
+    StorageCredential,
+    TableIdentifier,
     UpdateIcebergCatalogRequest,
 )
 
@@ -129,7 +132,10 @@ __all__ = (
     "GetIcebergCatalogRequest",
     "IcebergCatalog",
     "IcebergCatalogServiceClient",
+    "IcebergNamespaceUpdate",
     "ListIcebergCatalogsRequest",
     "ListIcebergCatalogsResponse",
+    "StorageCredential",
+    "TableIdentifier",
     "UpdateIcebergCatalogRequest",
 )

--- a/packages/google-cloud-biglake/google/cloud/biglake_v1/types/__init__.py
+++ b/packages/google-cloud-biglake/google/cloud/biglake_v1/types/__init__.py
@@ -19,8 +19,11 @@ from .iceberg_rest_catalog import (
     FailoverIcebergCatalogResponse,
     GetIcebergCatalogRequest,
     IcebergCatalog,
+    IcebergNamespaceUpdate,
     ListIcebergCatalogsRequest,
     ListIcebergCatalogsResponse,
+    StorageCredential,
+    TableIdentifier,
     UpdateIcebergCatalogRequest,
 )
 
@@ -30,7 +33,10 @@ __all__ = (
     "FailoverIcebergCatalogResponse",
     "GetIcebergCatalogRequest",
     "IcebergCatalog",
+    "IcebergNamespaceUpdate",
     "ListIcebergCatalogsRequest",
     "ListIcebergCatalogsResponse",
+    "StorageCredential",
+    "TableIdentifier",
     "UpdateIcebergCatalogRequest",
 )

--- a/packages/google-cloud-biglake/google/cloud/biglake_v1/types/iceberg_rest_catalog.py
+++ b/packages/google-cloud-biglake/google/cloud/biglake_v1/types/iceberg_rest_catalog.py
@@ -32,6 +32,9 @@ __protobuf__ = proto.module(
         "ListIcebergCatalogsResponse",
         "FailoverIcebergCatalogRequest",
         "FailoverIcebergCatalogResponse",
+        "TableIdentifier",
+        "IcebergNamespaceUpdate",
+        "StorageCredential",
     },
 )
 
@@ -379,6 +382,77 @@ class FailoverIcebergCatalogResponse(proto.Message):
         proto.MESSAGE,
         number=1,
         message=timestamp_pb2.Timestamp,
+    )
+
+
+class TableIdentifier(proto.Message):
+    r"""The table identifier.
+
+    Attributes:
+        namespace (MutableSequence[str]):
+            The namespace of the table. This is always 1
+            element, since we don't support nested
+            namespaces.
+        name (str):
+            The table name.
+    """
+
+    namespace: MutableSequence[str] = proto.RepeatedField(
+        proto.STRING,
+        number=1,
+    )
+    name: str = proto.Field(
+        proto.STRING,
+        number=2,
+    )
+
+
+class IcebergNamespaceUpdate(proto.Message):
+    r"""The request message for the ``UpdateIcebergNamespace`` API.
+
+    Attributes:
+        removals (MutableSequence[str]):
+            Optional. Keys of the properties to remove.
+        updates (MutableMapping[str, str]):
+            Optional. List of properties to update or
+            add.
+    """
+
+    removals: MutableSequence[str] = proto.RepeatedField(
+        proto.STRING,
+        number=2,
+    )
+    updates: MutableMapping[str, str] = proto.MapField(
+        proto.STRING,
+        proto.STRING,
+        number=3,
+    )
+
+
+class StorageCredential(proto.Message):
+    r"""The storage credential for a path in the table.
+
+    Attributes:
+        prefix (str):
+            Indicates a storage location prefix where the
+            credential is relevant.
+        config (MutableMapping[str, str]):
+            The credentials for the storage location. The keys that are
+            populated are:
+
+            - ``gcs.oauth2.token``
+            - ``gcs.oauth2.token_expires_at``
+            - ``expiration-time`` (to support federation from Polaris).
+    """
+
+    prefix: str = proto.Field(
+        proto.STRING,
+        number=1,
+    )
+    config: MutableMapping[str, str] = proto.MapField(
+        proto.STRING,
+        proto.STRING,
+        number=2,
     )
 
 

--- a/packages/google-cloud-biglake/noxfile.py
+++ b/packages/google-cloud-biglake/noxfile.py
@@ -509,24 +509,50 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1) for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -596,16 +622,24 @@ def core_deps_from_source(session, protobuf_implementation):
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
+
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(
+        f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}"
+    )
 
     session.run(
         "py.test",

--- a/packages/google-cloud-bigquery-analyticshub/README.rst
+++ b/packages/google-cloud-bigquery-analyticshub/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-bigquery-analyticshub/docs/README.rst
+++ b/packages/google-cloud-bigquery-analyticshub/docs/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-bigquery-analyticshub/noxfile.py
+++ b/packages/google-cloud-bigquery-analyticshub/noxfile.py
@@ -509,24 +509,50 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1) for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -596,16 +622,24 @@ def core_deps_from_source(session, protobuf_implementation):
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
+
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(
+        f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}"
+    )
 
     session.run(
         "py.test",

--- a/packages/google-cloud-bigquery-biglake/README.rst
+++ b/packages/google-cloud-bigquery-biglake/README.rst
@@ -63,14 +63,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-bigquery-biglake/docs/README.rst
+++ b/packages/google-cloud-bigquery-biglake/docs/README.rst
@@ -63,14 +63,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-bigquery-biglake/noxfile.py
+++ b/packages/google-cloud-bigquery-biglake/noxfile.py
@@ -509,24 +509,50 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1) for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -596,16 +622,24 @@ def core_deps_from_source(session, protobuf_implementation):
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
+
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(
+        f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}"
+    )
 
     session.run(
         "py.test",

--- a/packages/google-cloud-bigquery-connection/README.rst
+++ b/packages/google-cloud-bigquery-connection/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-bigquery-connection/docs/README.rst
+++ b/packages/google-cloud-bigquery-connection/docs/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-bigquery-connection/noxfile.py
+++ b/packages/google-cloud-bigquery-connection/noxfile.py
@@ -509,24 +509,50 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1) for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -596,16 +622,24 @@ def core_deps_from_source(session, protobuf_implementation):
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
+
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(
+        f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}"
+    )
 
     session.run(
         "py.test",

--- a/packages/google-cloud-bigquery-data-exchange/README.rst
+++ b/packages/google-cloud-bigquery-data-exchange/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-bigquery-data-exchange/docs/README.rst
+++ b/packages/google-cloud-bigquery-data-exchange/docs/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-bigquery-data-exchange/noxfile.py
+++ b/packages/google-cloud-bigquery-data-exchange/noxfile.py
@@ -509,24 +509,50 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1) for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -596,16 +622,24 @@ def core_deps_from_source(session, protobuf_implementation):
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
+
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(
+        f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}"
+    )
 
     session.run(
         "py.test",

--- a/packages/google-cloud-bigquery-datapolicies/README.rst
+++ b/packages/google-cloud-bigquery-datapolicies/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-bigquery-datapolicies/docs/README.rst
+++ b/packages/google-cloud-bigquery-datapolicies/docs/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-bigquery-datapolicies/noxfile.py
+++ b/packages/google-cloud-bigquery-datapolicies/noxfile.py
@@ -509,24 +509,50 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1) for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -596,16 +622,24 @@ def core_deps_from_source(session, protobuf_implementation):
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
+
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(
+        f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}"
+    )
 
     session.run(
         "py.test",

--- a/packages/google-cloud-bigquery-datatransfer/README.rst
+++ b/packages/google-cloud-bigquery-datatransfer/README.rst
@@ -62,14 +62,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-bigquery-datatransfer/docs/README.rst
+++ b/packages/google-cloud-bigquery-datatransfer/docs/README.rst
@@ -62,14 +62,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-bigquery-datatransfer/noxfile.py
+++ b/packages/google-cloud-bigquery-datatransfer/noxfile.py
@@ -509,24 +509,50 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1) for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -596,16 +622,24 @@ def core_deps_from_source(session, protobuf_implementation):
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
+
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(
+        f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}"
+    )
 
     session.run(
         "py.test",

--- a/packages/google-cloud-bigquery-logging/README.rst
+++ b/packages/google-cloud-bigquery-logging/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-bigquery-logging/docs/README.rst
+++ b/packages/google-cloud-bigquery-logging/docs/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-bigquery-logging/noxfile.py
+++ b/packages/google-cloud-bigquery-logging/noxfile.py
@@ -509,24 +509,50 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1) for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -596,16 +622,24 @@ def core_deps_from_source(session, protobuf_implementation):
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
+
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(
+        f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}"
+    )
 
     session.run(
         "py.test",

--- a/packages/google-cloud-bigquery-migration/README.rst
+++ b/packages/google-cloud-bigquery-migration/README.rst
@@ -62,14 +62,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-bigquery-migration/docs/README.rst
+++ b/packages/google-cloud-bigquery-migration/docs/README.rst
@@ -62,14 +62,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-bigquery-migration/noxfile.py
+++ b/packages/google-cloud-bigquery-migration/noxfile.py
@@ -509,24 +509,50 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1) for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -596,16 +622,24 @@ def core_deps_from_source(session, protobuf_implementation):
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
+
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(
+        f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}"
+    )
 
     session.run(
         "py.test",

--- a/packages/google-cloud-bigquery-reservation/README.rst
+++ b/packages/google-cloud-bigquery-reservation/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-bigquery-reservation/docs/README.rst
+++ b/packages/google-cloud-bigquery-reservation/docs/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-bigquery-reservation/noxfile.py
+++ b/packages/google-cloud-bigquery-reservation/noxfile.py
@@ -509,24 +509,50 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1) for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -596,16 +622,24 @@ def core_deps_from_source(session, protobuf_implementation):
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
+
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(
+        f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}"
+    )
 
     session.run(
         "py.test",

--- a/packages/google-cloud-bigquery-storage/README.rst
+++ b/packages/google-cloud-bigquery-storage/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-bigquery-storage/docs/README.rst
+++ b/packages/google-cloud-bigquery-storage/docs/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-bigquery-storage/noxfile.py
+++ b/packages/google-cloud-bigquery-storage/noxfile.py
@@ -550,24 +550,50 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1) for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -637,16 +663,24 @@ def core_deps_from_source(session, protobuf_implementation):
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
+
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(
+        f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}"
+    )
 
     session.run(
         "py.test",

--- a/packages/google-cloud-billing-budgets/README.rst
+++ b/packages/google-cloud-billing-budgets/README.rst
@@ -63,14 +63,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-billing-budgets/docs/README.rst
+++ b/packages/google-cloud-billing-budgets/docs/README.rst
@@ -63,14 +63,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-billing-budgets/noxfile.py
+++ b/packages/google-cloud-billing-budgets/noxfile.py
@@ -509,24 +509,50 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1) for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -596,16 +622,24 @@ def core_deps_from_source(session, protobuf_implementation):
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
+
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(
+        f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}"
+    )
 
     session.run(
         "py.test",

--- a/packages/google-cloud-billing/README.rst
+++ b/packages/google-cloud-billing/README.rst
@@ -62,14 +62,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-billing/docs/README.rst
+++ b/packages/google-cloud-billing/docs/README.rst
@@ -62,14 +62,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-billing/noxfile.py
+++ b/packages/google-cloud-billing/noxfile.py
@@ -509,24 +509,50 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1) for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -596,16 +622,24 @@ def core_deps_from_source(session, protobuf_implementation):
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
+
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(
+        f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}"
+    )
 
     session.run(
         "py.test",

--- a/packages/google-cloud-binary-authorization/README.rst
+++ b/packages/google-cloud-binary-authorization/README.rst
@@ -63,14 +63,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-binary-authorization/docs/README.rst
+++ b/packages/google-cloud-binary-authorization/docs/README.rst
@@ -63,14 +63,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-binary-authorization/noxfile.py
+++ b/packages/google-cloud-binary-authorization/noxfile.py
@@ -509,24 +509,50 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1) for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -596,16 +622,24 @@ def core_deps_from_source(session, protobuf_implementation):
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
+
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(
+        f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}"
+    )
 
     session.run(
         "py.test",

--- a/packages/google-cloud-build/README.rst
+++ b/packages/google-cloud-build/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-build/docs/README.rst
+++ b/packages/google-cloud-build/docs/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-build/noxfile.py
+++ b/packages/google-cloud-build/noxfile.py
@@ -509,24 +509,50 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1) for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -596,16 +622,24 @@ def core_deps_from_source(session, protobuf_implementation):
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
+
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(
+        f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}"
+    )
 
     session.run(
         "py.test",

--- a/packages/google-cloud-capacityplanner/README.rst
+++ b/packages/google-cloud-capacityplanner/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-capacityplanner/docs/README.rst
+++ b/packages/google-cloud-capacityplanner/docs/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-capacityplanner/noxfile.py
+++ b/packages/google-cloud-capacityplanner/noxfile.py
@@ -509,24 +509,50 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1) for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -596,16 +622,24 @@ def core_deps_from_source(session, protobuf_implementation):
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
+
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(
+        f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}"
+    )
 
     session.run(
         "py.test",

--- a/packages/google-cloud-certificate-manager/README.rst
+++ b/packages/google-cloud-certificate-manager/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-certificate-manager/docs/README.rst
+++ b/packages/google-cloud-certificate-manager/docs/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-certificate-manager/noxfile.py
+++ b/packages/google-cloud-certificate-manager/noxfile.py
@@ -509,24 +509,50 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1) for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -596,16 +622,24 @@ def core_deps_from_source(session, protobuf_implementation):
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
+
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(
+        f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}"
+    )
 
     session.run(
         "py.test",

--- a/packages/google-cloud-ces/README.rst
+++ b/packages/google-cloud-ces/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-ces/docs/README.rst
+++ b/packages/google-cloud-ces/docs/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-ces/noxfile.py
+++ b/packages/google-cloud-ces/noxfile.py
@@ -509,24 +509,50 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1) for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -596,16 +622,24 @@ def core_deps_from_source(session, protobuf_implementation):
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
+
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(
+        f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}"
+    )
 
     session.run(
         "py.test",

--- a/packages/google-cloud-channel/README.rst
+++ b/packages/google-cloud-channel/README.rst
@@ -63,14 +63,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-channel/docs/README.rst
+++ b/packages/google-cloud-channel/docs/README.rst
@@ -63,14 +63,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-channel/noxfile.py
+++ b/packages/google-cloud-channel/noxfile.py
@@ -509,24 +509,50 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1) for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -596,16 +622,24 @@ def core_deps_from_source(session, protobuf_implementation):
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
+
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(
+        f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}"
+    )
 
     session.run(
         "py.test",

--- a/packages/google-cloud-chronicle/README.rst
+++ b/packages/google-cloud-chronicle/README.rst
@@ -63,14 +63,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-chronicle/docs/README.rst
+++ b/packages/google-cloud-chronicle/docs/README.rst
@@ -63,14 +63,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/big_query_export_service/async_client.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/big_query_export_service/async_client.py
@@ -15,7 +15,6 @@
 #
 import logging as std_logging
 import re
-import uuid
 from collections import OrderedDict
 from typing import (
     Callable,

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/big_query_export_service/client.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/big_query_export_service/client.py
@@ -17,7 +17,6 @@ import json
 import logging as std_logging
 import os
 import re
-import uuid
 import warnings
 from collections import OrderedDict
 from http import HTTPStatus

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/dashboard_chart_service/async_client.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/dashboard_chart_service/async_client.py
@@ -15,7 +15,6 @@
 #
 import logging as std_logging
 import re
-import uuid
 from collections import OrderedDict
 from typing import (
     Callable,

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/dashboard_chart_service/client.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/dashboard_chart_service/client.py
@@ -17,7 +17,6 @@ import json
 import logging as std_logging
 import os
 import re
-import uuid
 import warnings
 from collections import OrderedDict
 from http import HTTPStatus

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/dashboard_query_service/async_client.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/dashboard_query_service/async_client.py
@@ -15,7 +15,6 @@
 #
 import logging as std_logging
 import re
-import uuid
 from collections import OrderedDict
 from typing import (
     Callable,

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/dashboard_query_service/client.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/dashboard_query_service/client.py
@@ -17,7 +17,6 @@ import json
 import logging as std_logging
 import os
 import re
-import uuid
 import warnings
 from collections import OrderedDict
 from http import HTTPStatus

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/data_access_control_service/async_client.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/data_access_control_service/async_client.py
@@ -15,7 +15,6 @@
 #
 import logging as std_logging
 import re
-import uuid
 from collections import OrderedDict
 from typing import (
     Callable,

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/data_access_control_service/client.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/data_access_control_service/client.py
@@ -17,7 +17,6 @@ import json
 import logging as std_logging
 import os
 import re
-import uuid
 import warnings
 from collections import OrderedDict
 from http import HTTPStatus

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/data_table_service/async_client.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/data_table_service/async_client.py
@@ -15,7 +15,6 @@
 #
 import logging as std_logging
 import re
-import uuid
 from collections import OrderedDict
 from typing import (
     Callable,

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/data_table_service/client.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/data_table_service/client.py
@@ -17,7 +17,6 @@ import json
 import logging as std_logging
 import os
 import re
-import uuid
 import warnings
 from collections import OrderedDict
 from http import HTTPStatus

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/entity_service/async_client.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/entity_service/async_client.py
@@ -15,7 +15,6 @@
 #
 import logging as std_logging
 import re
-import uuid
 from collections import OrderedDict
 from typing import (
     Callable,

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/entity_service/client.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/entity_service/client.py
@@ -17,7 +17,6 @@ import json
 import logging as std_logging
 import os
 import re
-import uuid
 import warnings
 from collections import OrderedDict
 from http import HTTPStatus

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/featured_content_native_dashboard_service/async_client.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/featured_content_native_dashboard_service/async_client.py
@@ -15,7 +15,6 @@
 #
 import logging as std_logging
 import re
-import uuid
 from collections import OrderedDict
 from typing import (
     Callable,

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/featured_content_native_dashboard_service/client.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/featured_content_native_dashboard_service/client.py
@@ -17,7 +17,6 @@ import json
 import logging as std_logging
 import os
 import re
-import uuid
 import warnings
 from collections import OrderedDict
 from http import HTTPStatus

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/instance_service/async_client.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/instance_service/async_client.py
@@ -15,7 +15,6 @@
 #
 import logging as std_logging
 import re
-import uuid
 from collections import OrderedDict
 from typing import (
     Callable,

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/instance_service/client.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/instance_service/client.py
@@ -17,7 +17,6 @@ import json
 import logging as std_logging
 import os
 import re
-import uuid
 import warnings
 from collections import OrderedDict
 from http import HTTPStatus

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/native_dashboard_service/async_client.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/native_dashboard_service/async_client.py
@@ -15,7 +15,6 @@
 #
 import logging as std_logging
 import re
-import uuid
 from collections import OrderedDict
 from typing import (
     Callable,

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/native_dashboard_service/client.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/native_dashboard_service/client.py
@@ -17,7 +17,6 @@ import json
 import logging as std_logging
 import os
 import re
-import uuid
 import warnings
 from collections import OrderedDict
 from http import HTTPStatus

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/reference_list_service/async_client.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/reference_list_service/async_client.py
@@ -15,7 +15,6 @@
 #
 import logging as std_logging
 import re
-import uuid
 from collections import OrderedDict
 from typing import (
     Callable,

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/reference_list_service/client.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/reference_list_service/client.py
@@ -17,7 +17,6 @@ import json
 import logging as std_logging
 import os
 import re
-import uuid
 import warnings
 from collections import OrderedDict
 from http import HTTPStatus

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/rule_service/async_client.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/rule_service/async_client.py
@@ -15,7 +15,6 @@
 #
 import logging as std_logging
 import re
-import uuid
 from collections import OrderedDict
 from typing import (
     Callable,

--- a/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/rule_service/client.py
+++ b/packages/google-cloud-chronicle/google/cloud/chronicle_v1/services/rule_service/client.py
@@ -17,7 +17,6 @@ import json
 import logging as std_logging
 import os
 import re
-import uuid
 import warnings
 from collections import OrderedDict
 from http import HTTPStatus

--- a/packages/google-cloud-chronicle/noxfile.py
+++ b/packages/google-cloud-chronicle/noxfile.py
@@ -509,24 +509,50 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1) for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -596,16 +622,24 @@ def core_deps_from_source(session, protobuf_implementation):
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
+
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(
+        f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}"
+    )
 
     session.run(
         "py.test",

--- a/packages/google-cloud-chronicle/tests/unit/gapic/chronicle_v1/test_big_query_export_service.py
+++ b/packages/google-cloud-chronicle/tests/unit/gapic/chronicle_v1/test_big_query_export_service.py
@@ -16,7 +16,6 @@
 import json
 import math
 import os
-import re
 from collections.abc import AsyncIterable, Iterable, Mapping, Sequence
 from unittest import mock
 from unittest.mock import AsyncMock

--- a/packages/google-cloud-chronicle/tests/unit/gapic/chronicle_v1/test_dashboard_chart_service.py
+++ b/packages/google-cloud-chronicle/tests/unit/gapic/chronicle_v1/test_dashboard_chart_service.py
@@ -16,7 +16,6 @@
 import json
 import math
 import os
-import re
 from collections.abc import AsyncIterable, Iterable, Mapping, Sequence
 from unittest import mock
 from unittest.mock import AsyncMock

--- a/packages/google-cloud-chronicle/tests/unit/gapic/chronicle_v1/test_dashboard_query_service.py
+++ b/packages/google-cloud-chronicle/tests/unit/gapic/chronicle_v1/test_dashboard_query_service.py
@@ -16,7 +16,6 @@
 import json
 import math
 import os
-import re
 from collections.abc import AsyncIterable, Iterable, Mapping, Sequence
 from unittest import mock
 from unittest.mock import AsyncMock

--- a/packages/google-cloud-chronicle/tests/unit/gapic/chronicle_v1/test_data_access_control_service.py
+++ b/packages/google-cloud-chronicle/tests/unit/gapic/chronicle_v1/test_data_access_control_service.py
@@ -16,7 +16,6 @@
 import json
 import math
 import os
-import re
 from collections.abc import AsyncIterable, Iterable, Mapping, Sequence
 from unittest import mock
 from unittest.mock import AsyncMock

--- a/packages/google-cloud-chronicle/tests/unit/gapic/chronicle_v1/test_data_table_service.py
+++ b/packages/google-cloud-chronicle/tests/unit/gapic/chronicle_v1/test_data_table_service.py
@@ -16,7 +16,6 @@
 import json
 import math
 import os
-import re
 from collections.abc import AsyncIterable, Iterable, Mapping, Sequence
 from unittest import mock
 from unittest.mock import AsyncMock

--- a/packages/google-cloud-chronicle/tests/unit/gapic/chronicle_v1/test_entity_service.py
+++ b/packages/google-cloud-chronicle/tests/unit/gapic/chronicle_v1/test_entity_service.py
@@ -16,7 +16,6 @@
 import json
 import math
 import os
-import re
 from collections.abc import AsyncIterable, Iterable, Mapping, Sequence
 from unittest import mock
 from unittest.mock import AsyncMock

--- a/packages/google-cloud-chronicle/tests/unit/gapic/chronicle_v1/test_featured_content_native_dashboard_service.py
+++ b/packages/google-cloud-chronicle/tests/unit/gapic/chronicle_v1/test_featured_content_native_dashboard_service.py
@@ -16,7 +16,6 @@
 import json
 import math
 import os
-import re
 from collections.abc import AsyncIterable, Iterable, Mapping, Sequence
 from unittest import mock
 from unittest.mock import AsyncMock

--- a/packages/google-cloud-chronicle/tests/unit/gapic/chronicle_v1/test_instance_service.py
+++ b/packages/google-cloud-chronicle/tests/unit/gapic/chronicle_v1/test_instance_service.py
@@ -16,7 +16,6 @@
 import json
 import math
 import os
-import re
 from collections.abc import AsyncIterable, Iterable, Mapping, Sequence
 from unittest import mock
 from unittest.mock import AsyncMock

--- a/packages/google-cloud-chronicle/tests/unit/gapic/chronicle_v1/test_native_dashboard_service.py
+++ b/packages/google-cloud-chronicle/tests/unit/gapic/chronicle_v1/test_native_dashboard_service.py
@@ -16,7 +16,6 @@
 import json
 import math
 import os
-import re
 from collections.abc import AsyncIterable, Iterable, Mapping, Sequence
 from unittest import mock
 from unittest.mock import AsyncMock

--- a/packages/google-cloud-chronicle/tests/unit/gapic/chronicle_v1/test_reference_list_service.py
+++ b/packages/google-cloud-chronicle/tests/unit/gapic/chronicle_v1/test_reference_list_service.py
@@ -16,7 +16,6 @@
 import json
 import math
 import os
-import re
 from collections.abc import AsyncIterable, Iterable, Mapping, Sequence
 from unittest import mock
 from unittest.mock import AsyncMock

--- a/packages/google-cloud-chronicle/tests/unit/gapic/chronicle_v1/test_rule_service.py
+++ b/packages/google-cloud-chronicle/tests/unit/gapic/chronicle_v1/test_rule_service.py
@@ -16,7 +16,6 @@
 import json
 import math
 import os
-import re
 from collections.abc import AsyncIterable, Iterable, Mapping, Sequence
 from unittest import mock
 from unittest.mock import AsyncMock

--- a/packages/google-cloud-cloudcontrolspartner/README.rst
+++ b/packages/google-cloud-cloudcontrolspartner/README.rst
@@ -62,14 +62,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-cloudcontrolspartner/docs/README.rst
+++ b/packages/google-cloud-cloudcontrolspartner/docs/README.rst
@@ -62,14 +62,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-cloudcontrolspartner/noxfile.py
+++ b/packages/google-cloud-cloudcontrolspartner/noxfile.py
@@ -509,24 +509,50 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1) for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -596,16 +622,24 @@ def core_deps_from_source(session, protobuf_implementation):
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
+
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(
+        f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}"
+    )
 
     session.run(
         "py.test",

--- a/packages/google-cloud-cloudsecuritycompliance/README.rst
+++ b/packages/google-cloud-cloudsecuritycompliance/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-cloudsecuritycompliance/docs/README.rst
+++ b/packages/google-cloud-cloudsecuritycompliance/docs/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-cloudsecuritycompliance/noxfile.py
+++ b/packages/google-cloud-cloudsecuritycompliance/noxfile.py
@@ -509,24 +509,50 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1) for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -596,16 +622,24 @@ def core_deps_from_source(session, protobuf_implementation):
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
+
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(
+        f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}"
+    )
 
     session.run(
         "py.test",

--- a/packages/google-cloud-commerce-consumer-procurement/README.rst
+++ b/packages/google-cloud-commerce-consumer-procurement/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-commerce-consumer-procurement/docs/README.rst
+++ b/packages/google-cloud-commerce-consumer-procurement/docs/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-commerce-consumer-procurement/noxfile.py
+++ b/packages/google-cloud-commerce-consumer-procurement/noxfile.py
@@ -509,24 +509,50 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1) for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -596,16 +622,24 @@ def core_deps_from_source(session, protobuf_implementation):
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
+
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(
+        f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}"
+    )
 
     session.run(
         "py.test",

--- a/packages/google-cloud-common/README.rst
+++ b/packages/google-cloud-common/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-common/docs/README.rst
+++ b/packages/google-cloud-common/docs/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-common/noxfile.py
+++ b/packages/google-cloud-common/noxfile.py
@@ -509,24 +509,50 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1) for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -596,16 +622,24 @@ def core_deps_from_source(session, protobuf_implementation):
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
+
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(
+        f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}"
+    )
 
     session.run(
         "py.test",

--- a/packages/google-cloud-compute-v1beta/README.rst
+++ b/packages/google-cloud-compute-v1beta/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-compute-v1beta/docs/README.rst
+++ b/packages/google-cloud-compute-v1beta/docs/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-compute-v1beta/noxfile.py
+++ b/packages/google-cloud-compute-v1beta/noxfile.py
@@ -509,24 +509,50 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1) for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -596,16 +622,24 @@ def core_deps_from_source(session, protobuf_implementation):
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
+
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(
+        f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}"
+    )
 
     session.run(
         "py.test",

--- a/packages/google-cloud-compute/README.rst
+++ b/packages/google-cloud-compute/README.rst
@@ -70,14 +70,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-compute/docs/README.rst
+++ b/packages/google-cloud-compute/docs/README.rst
@@ -70,14 +70,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-compute/noxfile.py
+++ b/packages/google-cloud-compute/noxfile.py
@@ -509,24 +509,50 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1) for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -596,16 +622,24 @@ def core_deps_from_source(session, protobuf_implementation):
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
+
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(
+        f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}"
+    )
 
     session.run(
         "py.test",

--- a/packages/google-cloud-confidentialcomputing/README.rst
+++ b/packages/google-cloud-confidentialcomputing/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-confidentialcomputing/docs/README.rst
+++ b/packages/google-cloud-confidentialcomputing/docs/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-confidentialcomputing/noxfile.py
+++ b/packages/google-cloud-confidentialcomputing/noxfile.py
@@ -509,24 +509,50 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1) for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -596,16 +622,24 @@ def core_deps_from_source(session, protobuf_implementation):
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
+
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(
+        f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}"
+    )
 
     session.run(
         "py.test",

--- a/packages/google-cloud-config/README.rst
+++ b/packages/google-cloud-config/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-config/docs/README.rst
+++ b/packages/google-cloud-config/docs/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-config/google/cloud/config_v1/services/config/async_client.py
+++ b/packages/google-cloud-config/google/cloud/config_v1/services/config/async_client.py
@@ -15,7 +15,6 @@
 #
 import logging as std_logging
 import re
-import uuid
 from collections import OrderedDict
 from typing import (
     Callable,

--- a/packages/google-cloud-config/google/cloud/config_v1/services/config/client.py
+++ b/packages/google-cloud-config/google/cloud/config_v1/services/config/client.py
@@ -17,7 +17,6 @@ import json
 import logging as std_logging
 import os
 import re
-import uuid
 import warnings
 from collections import OrderedDict
 from http import HTTPStatus

--- a/packages/google-cloud-config/noxfile.py
+++ b/packages/google-cloud-config/noxfile.py
@@ -509,24 +509,50 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1) for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -596,16 +622,24 @@ def core_deps_from_source(session, protobuf_implementation):
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
+
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(
+        f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}"
+    )
 
     session.run(
         "py.test",

--- a/packages/google-cloud-config/tests/unit/gapic/config_v1/test_config.py
+++ b/packages/google-cloud-config/tests/unit/gapic/config_v1/test_config.py
@@ -16,7 +16,6 @@
 import json
 import math
 import os
-import re
 from collections.abc import AsyncIterable, Iterable, Mapping, Sequence
 from unittest import mock
 from unittest.mock import AsyncMock

--- a/packages/google-cloud-configdelivery/README.rst
+++ b/packages/google-cloud-configdelivery/README.rst
@@ -62,14 +62,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-configdelivery/docs/README.rst
+++ b/packages/google-cloud-configdelivery/docs/README.rst
@@ -62,14 +62,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-configdelivery/noxfile.py
+++ b/packages/google-cloud-configdelivery/noxfile.py
@@ -509,24 +509,50 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1) for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -596,16 +622,24 @@ def core_deps_from_source(session, protobuf_implementation):
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
+
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(
+        f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}"
+    )
 
     session.run(
         "py.test",

--- a/packages/google-cloud-contact-center-insights/README.rst
+++ b/packages/google-cloud-contact-center-insights/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-contact-center-insights/docs/README.rst
+++ b/packages/google-cloud-contact-center-insights/docs/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-contact-center-insights/noxfile.py
+++ b/packages/google-cloud-contact-center-insights/noxfile.py
@@ -509,24 +509,50 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1) for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -596,16 +622,24 @@ def core_deps_from_source(session, protobuf_implementation):
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
+
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(
+        f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}"
+    )
 
     session.run(
         "py.test",

--- a/packages/google-cloud-container/README.rst
+++ b/packages/google-cloud-container/README.rst
@@ -62,14 +62,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-container/docs/README.rst
+++ b/packages/google-cloud-container/docs/README.rst
@@ -62,14 +62,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-container/noxfile.py
+++ b/packages/google-cloud-container/noxfile.py
@@ -509,24 +509,50 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1) for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -596,16 +622,24 @@ def core_deps_from_source(session, protobuf_implementation):
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
+
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(
+        f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}"
+    )
 
     session.run(
         "py.test",

--- a/packages/google-cloud-containeranalysis/README.rst
+++ b/packages/google-cloud-containeranalysis/README.rst
@@ -68,14 +68,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-containeranalysis/docs/README.rst
+++ b/packages/google-cloud-containeranalysis/docs/README.rst
@@ -68,14 +68,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-containeranalysis/noxfile.py
+++ b/packages/google-cloud-containeranalysis/noxfile.py
@@ -509,24 +509,50 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1) for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -596,16 +622,24 @@ def core_deps_from_source(session, protobuf_implementation):
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
+
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(
+        f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}"
+    )
 
     session.run(
         "py.test",

--- a/packages/google-cloud-contentwarehouse/README.rst
+++ b/packages/google-cloud-contentwarehouse/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-contentwarehouse/docs/README.rst
+++ b/packages/google-cloud-contentwarehouse/docs/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-contentwarehouse/noxfile.py
+++ b/packages/google-cloud-contentwarehouse/noxfile.py
@@ -509,24 +509,50 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1) for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -596,16 +622,24 @@ def core_deps_from_source(session, protobuf_implementation):
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
+
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(
+        f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}"
+    )
 
     session.run(
         "py.test",

--- a/packages/google-cloud-data-fusion/README.rst
+++ b/packages/google-cloud-data-fusion/README.rst
@@ -67,14 +67,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-data-fusion/docs/README.rst
+++ b/packages/google-cloud-data-fusion/docs/README.rst
@@ -67,14 +67,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-data-fusion/noxfile.py
+++ b/packages/google-cloud-data-fusion/noxfile.py
@@ -509,24 +509,50 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1) for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -596,16 +622,24 @@ def core_deps_from_source(session, protobuf_implementation):
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
+
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(
+        f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}"
+    )
 
     session.run(
         "py.test",

--- a/packages/google-cloud-data-qna/README.rst
+++ b/packages/google-cloud-data-qna/README.rst
@@ -62,14 +62,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-data-qna/docs/README.rst
+++ b/packages/google-cloud-data-qna/docs/README.rst
@@ -62,14 +62,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-data-qna/noxfile.py
+++ b/packages/google-cloud-data-qna/noxfile.py
@@ -509,24 +509,50 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1) for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -596,16 +622,24 @@ def core_deps_from_source(session, protobuf_implementation):
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
+
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(
+        f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}"
+    )
 
     session.run(
         "py.test",

--- a/packages/google-cloud-databasecenter/README.rst
+++ b/packages/google-cloud-databasecenter/README.rst
@@ -67,14 +67,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-databasecenter/docs/README.rst
+++ b/packages/google-cloud-databasecenter/docs/README.rst
@@ -67,14 +67,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-databasecenter/noxfile.py
+++ b/packages/google-cloud-databasecenter/noxfile.py
@@ -509,24 +509,50 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1) for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -596,16 +622,24 @@ def core_deps_from_source(session, protobuf_implementation):
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
+
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(
+        f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}"
+    )
 
     session.run(
         "py.test",

--- a/packages/google-cloud-datacatalog-lineage-configmanagement/README.rst
+++ b/packages/google-cloud-datacatalog-lineage-configmanagement/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-datacatalog-lineage-configmanagement/docs/README.rst
+++ b/packages/google-cloud-datacatalog-lineage-configmanagement/docs/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-datacatalog-lineage-configmanagement/noxfile.py
+++ b/packages/google-cloud-datacatalog-lineage-configmanagement/noxfile.py
@@ -509,24 +509,50 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1) for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -596,16 +622,24 @@ def core_deps_from_source(session, protobuf_implementation):
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
+
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(
+        f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}"
+    )
 
     session.run(
         "py.test",

--- a/packages/google-cloud-datacatalog-lineage/README.rst
+++ b/packages/google-cloud-datacatalog-lineage/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-datacatalog-lineage/docs/README.rst
+++ b/packages/google-cloud-datacatalog-lineage/docs/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-datacatalog-lineage/noxfile.py
+++ b/packages/google-cloud-datacatalog-lineage/noxfile.py
@@ -509,24 +509,50 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1) for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -596,16 +622,24 @@ def core_deps_from_source(session, protobuf_implementation):
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
+
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(
+        f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}"
+    )
 
     session.run(
         "py.test",

--- a/packages/google-cloud-datacatalog-lineage/tests/unit/gapic/datacatalog_lineage_v1/test_lineage.py
+++ b/packages/google-cloud-datacatalog-lineage/tests/unit/gapic/datacatalog_lineage_v1/test_lineage.py
@@ -1321,7 +1321,7 @@ def test_process_open_lineage_run_event_non_empty_request_with_auto_populated_fi
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         # Ensure that the uuid4 field is set according to AIP 4235
-        assert re.match(
+        assert re.fullmatch(
             r"[a-f0-9]{8}-?[a-f0-9]{4}-?4[a-f0-9]{3}-?[89ab][a-f0-9]{3}-?[a-f0-9]{12}",
             args[0].request_id,
         )
@@ -1729,7 +1729,7 @@ def test_create_process_non_empty_request_with_auto_populated_field():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         # Ensure that the uuid4 field is set according to AIP 4235
-        assert re.match(
+        assert re.fullmatch(
             r"[a-f0-9]{8}-?[a-f0-9]{4}-?4[a-f0-9]{3}-?[89ab][a-f0-9]{3}-?[a-f0-9]{12}",
             args[0].request_id,
         )
@@ -2077,7 +2077,7 @@ def test_update_process_non_empty_request_with_auto_populated_field():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         # Ensure that the uuid4 field is set according to AIP 4235
-        assert re.match(
+        assert re.fullmatch(
             r"[a-f0-9]{8}-?[a-f0-9]{4}-?4[a-f0-9]{3}-?[89ab][a-f0-9]{3}-?[a-f0-9]{12}",
             args[0].request_id,
         )
@@ -3592,7 +3592,7 @@ def test_create_run_non_empty_request_with_auto_populated_field():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         # Ensure that the uuid4 field is set according to AIP 4235
-        assert re.match(
+        assert re.fullmatch(
             r"[a-f0-9]{8}-?[a-f0-9]{4}-?4[a-f0-9]{3}-?[89ab][a-f0-9]{3}-?[a-f0-9]{12}",
             args[0].request_id,
         )
@@ -5438,7 +5438,7 @@ def test_create_lineage_event_non_empty_request_with_auto_populated_field():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         # Ensure that the uuid4 field is set according to AIP 4235
-        assert re.match(
+        assert re.fullmatch(
             r"[a-f0-9]{8}-?[a-f0-9]{4}-?4[a-f0-9]{3}-?[89ab][a-f0-9]{3}-?[a-f0-9]{12}",
             args[0].request_id,
         )
@@ -8210,7 +8210,7 @@ def test_process_open_lineage_run_event_rest_required_fields(
             # Ensure that the uuid4 field is set according to AIP 4235
             for i, (key, value) in enumerate(req.call_args.kwargs["params"]):
                 if key == "requestId":
-                    assert re.match(
+                    assert re.fullmatch(
                         r"[a-f0-9]{8}-?[a-f0-9]{4}-?4[a-f0-9]{3}-?[89ab][a-f0-9]{3}-?[a-f0-9]{12}",
                         value,
                     )
@@ -8425,7 +8425,7 @@ def test_create_process_rest_required_fields(request_type=lineage.CreateProcessR
             # Ensure that the uuid4 field is set according to AIP 4235
             for i, (key, value) in enumerate(req.call_args.kwargs["params"]):
                 if key == "requestId":
-                    assert re.match(
+                    assert re.fullmatch(
                         r"[a-f0-9]{8}-?[a-f0-9]{4}-?4[a-f0-9]{3}-?[89ab][a-f0-9]{3}-?[a-f0-9]{12}",
                         value,
                     )
@@ -8626,7 +8626,7 @@ def test_update_process_rest_required_fields(request_type=lineage.UpdateProcessR
             # Ensure that the uuid4 field is set according to AIP 4235
             for i, (key, value) in enumerate(req.call_args.kwargs["params"]):
                 if key == "requestId":
-                    assert re.match(
+                    assert re.fullmatch(
                         r"[a-f0-9]{8}-?[a-f0-9]{4}-?4[a-f0-9]{3}-?[89ab][a-f0-9]{3}-?[a-f0-9]{12}",
                         value,
                     )
@@ -9436,7 +9436,7 @@ def test_create_run_rest_required_fields(request_type=lineage.CreateRunRequest):
             # Ensure that the uuid4 field is set according to AIP 4235
             for i, (key, value) in enumerate(req.call_args.kwargs["params"]):
                 if key == "requestId":
-                    assert re.match(
+                    assert re.fullmatch(
                         r"[a-f0-9]{8}-?[a-f0-9]{4}-?4[a-f0-9]{3}-?[89ab][a-f0-9]{3}-?[a-f0-9]{12}",
                         value,
                     )
@@ -10451,7 +10451,7 @@ def test_create_lineage_event_rest_required_fields(
             # Ensure that the uuid4 field is set according to AIP 4235
             for i, (key, value) in enumerate(req.call_args.kwargs["params"]):
                 if key == "requestId":
-                    assert re.match(
+                    assert re.fullmatch(
                         r"[a-f0-9]{8}-?[a-f0-9]{4}-?4[a-f0-9]{3}-?[89ab][a-f0-9]{3}-?[a-f0-9]{12}",
                         value,
                     )
@@ -11817,7 +11817,7 @@ def test_process_open_lineage_run_event_empty_call_grpc():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         # Ensure that the uuid4 field is set according to AIP 4235
-        assert re.match(
+        assert re.fullmatch(
             r"[a-f0-9]{8}-?[a-f0-9]{4}-?4[a-f0-9]{3}-?[89ab][a-f0-9]{3}-?[a-f0-9]{12}",
             args[0].request_id,
         )
@@ -11845,7 +11845,7 @@ def test_create_process_empty_call_grpc():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         # Ensure that the uuid4 field is set according to AIP 4235
-        assert re.match(
+        assert re.fullmatch(
             r"[a-f0-9]{8}-?[a-f0-9]{4}-?4[a-f0-9]{3}-?[89ab][a-f0-9]{3}-?[a-f0-9]{12}",
             args[0].request_id,
         )
@@ -11873,7 +11873,7 @@ def test_update_process_empty_call_grpc():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         # Ensure that the uuid4 field is set according to AIP 4235
-        assert re.match(
+        assert re.fullmatch(
             r"[a-f0-9]{8}-?[a-f0-9]{4}-?4[a-f0-9]{3}-?[89ab][a-f0-9]{3}-?[a-f0-9]{12}",
             args[0].request_id,
         )
@@ -11964,7 +11964,7 @@ def test_create_run_empty_call_grpc():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         # Ensure that the uuid4 field is set according to AIP 4235
-        assert re.match(
+        assert re.fullmatch(
             r"[a-f0-9]{8}-?[a-f0-9]{4}-?4[a-f0-9]{3}-?[89ab][a-f0-9]{3}-?[a-f0-9]{12}",
             args[0].request_id,
         )
@@ -12078,7 +12078,7 @@ def test_create_lineage_event_empty_call_grpc():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         # Ensure that the uuid4 field is set according to AIP 4235
-        assert re.match(
+        assert re.fullmatch(
             r"[a-f0-9]{8}-?[a-f0-9]{4}-?4[a-f0-9]{3}-?[89ab][a-f0-9]{3}-?[a-f0-9]{12}",
             args[0].request_id,
         )
@@ -12266,7 +12266,7 @@ async def test_process_open_lineage_run_event_empty_call_grpc_asyncio():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         # Ensure that the uuid4 field is set according to AIP 4235
-        assert re.match(
+        assert re.fullmatch(
             r"[a-f0-9]{8}-?[a-f0-9]{4}-?4[a-f0-9]{3}-?[89ab][a-f0-9]{3}-?[a-f0-9]{12}",
             args[0].request_id,
         )
@@ -12301,7 +12301,7 @@ async def test_create_process_empty_call_grpc_asyncio():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         # Ensure that the uuid4 field is set according to AIP 4235
-        assert re.match(
+        assert re.fullmatch(
             r"[a-f0-9]{8}-?[a-f0-9]{4}-?4[a-f0-9]{3}-?[89ab][a-f0-9]{3}-?[a-f0-9]{12}",
             args[0].request_id,
         )
@@ -12336,7 +12336,7 @@ async def test_update_process_empty_call_grpc_asyncio():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         # Ensure that the uuid4 field is set according to AIP 4235
-        assert re.match(
+        assert re.fullmatch(
             r"[a-f0-9]{8}-?[a-f0-9]{4}-?4[a-f0-9]{3}-?[89ab][a-f0-9]{3}-?[a-f0-9]{12}",
             args[0].request_id,
         )
@@ -12452,7 +12452,7 @@ async def test_create_run_empty_call_grpc_asyncio():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         # Ensure that the uuid4 field is set according to AIP 4235
-        assert re.match(
+        assert re.fullmatch(
             r"[a-f0-9]{8}-?[a-f0-9]{4}-?4[a-f0-9]{3}-?[89ab][a-f0-9]{3}-?[a-f0-9]{12}",
             args[0].request_id,
         )
@@ -12598,7 +12598,7 @@ async def test_create_lineage_event_empty_call_grpc_asyncio():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         # Ensure that the uuid4 field is set according to AIP 4235
-        assert re.match(
+        assert re.fullmatch(
             r"[a-f0-9]{8}-?[a-f0-9]{4}-?4[a-f0-9]{3}-?[89ab][a-f0-9]{3}-?[a-f0-9]{12}",
             args[0].request_id,
         )
@@ -15796,7 +15796,7 @@ def test_process_open_lineage_run_event_empty_call_rest():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         # Ensure that the uuid4 field is set according to AIP 4235
-        assert re.match(
+        assert re.fullmatch(
             r"[a-f0-9]{8}-?[a-f0-9]{4}-?4[a-f0-9]{3}-?[89ab][a-f0-9]{3}-?[a-f0-9]{12}",
             args[0].request_id,
         )
@@ -15823,7 +15823,7 @@ def test_create_process_empty_call_rest():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         # Ensure that the uuid4 field is set according to AIP 4235
-        assert re.match(
+        assert re.fullmatch(
             r"[a-f0-9]{8}-?[a-f0-9]{4}-?4[a-f0-9]{3}-?[89ab][a-f0-9]{3}-?[a-f0-9]{12}",
             args[0].request_id,
         )
@@ -15850,7 +15850,7 @@ def test_update_process_empty_call_rest():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         # Ensure that the uuid4 field is set according to AIP 4235
-        assert re.match(
+        assert re.fullmatch(
             r"[a-f0-9]{8}-?[a-f0-9]{4}-?4[a-f0-9]{3}-?[89ab][a-f0-9]{3}-?[a-f0-9]{12}",
             args[0].request_id,
         )
@@ -15937,7 +15937,7 @@ def test_create_run_empty_call_rest():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         # Ensure that the uuid4 field is set according to AIP 4235
-        assert re.match(
+        assert re.fullmatch(
             r"[a-f0-9]{8}-?[a-f0-9]{4}-?4[a-f0-9]{3}-?[89ab][a-f0-9]{3}-?[a-f0-9]{12}",
             args[0].request_id,
         )
@@ -16046,7 +16046,7 @@ def test_create_lineage_event_empty_call_rest():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         # Ensure that the uuid4 field is set according to AIP 4235
-        assert re.match(
+        assert re.fullmatch(
             r"[a-f0-9]{8}-?[a-f0-9]{4}-?4[a-f0-9]{3}-?[89ab][a-f0-9]{3}-?[a-f0-9]{12}",
             args[0].request_id,
         )

--- a/packages/google-cloud-datacatalog/README.rst
+++ b/packages/google-cloud-datacatalog/README.rst
@@ -62,14 +62,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-datacatalog/docs/README.rst
+++ b/packages/google-cloud-datacatalog/docs/README.rst
@@ -62,14 +62,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-datacatalog/noxfile.py
+++ b/packages/google-cloud-datacatalog/noxfile.py
@@ -509,24 +509,50 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1) for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -596,16 +622,24 @@ def core_deps_from_source(session, protobuf_implementation):
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
+
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(
+        f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}"
+    )
 
     session.run(
         "py.test",

--- a/packages/google-cloud-dataflow-client/README.rst
+++ b/packages/google-cloud-dataflow-client/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-dataflow-client/docs/README.rst
+++ b/packages/google-cloud-dataflow-client/docs/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-dataflow-client/noxfile.py
+++ b/packages/google-cloud-dataflow-client/noxfile.py
@@ -509,24 +509,50 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1) for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -596,16 +622,24 @@ def core_deps_from_source(session, protobuf_implementation):
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
+
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(
+        f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}"
+    )
 
     session.run(
         "py.test",

--- a/packages/google-cloud-dataform/README.rst
+++ b/packages/google-cloud-dataform/README.rst
@@ -62,14 +62,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-dataform/docs/README.rst
+++ b/packages/google-cloud-dataform/docs/README.rst
@@ -62,14 +62,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-dataform/noxfile.py
+++ b/packages/google-cloud-dataform/noxfile.py
@@ -509,24 +509,50 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1) for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -596,16 +622,24 @@ def core_deps_from_source(session, protobuf_implementation):
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
+
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(
+        f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}"
+    )
 
     session.run(
         "py.test",

--- a/packages/google-cloud-datalabeling/README.rst
+++ b/packages/google-cloud-datalabeling/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-datalabeling/docs/README.rst
+++ b/packages/google-cloud-datalabeling/docs/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-datalabeling/noxfile.py
+++ b/packages/google-cloud-datalabeling/noxfile.py
@@ -509,24 +509,50 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1) for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -596,16 +622,24 @@ def core_deps_from_source(session, protobuf_implementation):
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
+
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(
+        f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}"
+    )
 
     session.run(
         "py.test",

--- a/packages/google-cloud-dataplex/README.rst
+++ b/packages/google-cloud-dataplex/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-dataplex/docs/README.rst
+++ b/packages/google-cloud-dataplex/docs/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-dataplex/noxfile.py
+++ b/packages/google-cloud-dataplex/noxfile.py
@@ -509,24 +509,50 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1) for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -596,16 +622,24 @@ def core_deps_from_source(session, protobuf_implementation):
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
+
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(
+        f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}"
+    )
 
     session.run(
         "py.test",

--- a/packages/google-cloud-dataproc-metastore/README.rst
+++ b/packages/google-cloud-dataproc-metastore/README.rst
@@ -62,14 +62,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-dataproc-metastore/docs/README.rst
+++ b/packages/google-cloud-dataproc-metastore/docs/README.rst
@@ -62,14 +62,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1/services/dataproc_metastore/async_client.py
+++ b/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1/services/dataproc_metastore/async_client.py
@@ -15,7 +15,6 @@
 #
 import logging as std_logging
 import re
-import uuid
 from collections import OrderedDict
 from typing import (
     Callable,

--- a/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1/services/dataproc_metastore/client.py
+++ b/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1/services/dataproc_metastore/client.py
@@ -17,7 +17,6 @@ import json
 import logging as std_logging
 import os
 import re
-import uuid
 import warnings
 from collections import OrderedDict
 from http import HTTPStatus

--- a/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1/services/dataproc_metastore_federation/async_client.py
+++ b/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1/services/dataproc_metastore_federation/async_client.py
@@ -15,7 +15,6 @@
 #
 import logging as std_logging
 import re
-import uuid
 from collections import OrderedDict
 from typing import (
     Callable,

--- a/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1/services/dataproc_metastore_federation/client.py
+++ b/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1/services/dataproc_metastore_federation/client.py
@@ -17,7 +17,6 @@ import json
 import logging as std_logging
 import os
 import re
-import uuid
 import warnings
 from collections import OrderedDict
 from http import HTTPStatus

--- a/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1alpha/services/dataproc_metastore/async_client.py
+++ b/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1alpha/services/dataproc_metastore/async_client.py
@@ -15,7 +15,6 @@
 #
 import logging as std_logging
 import re
-import uuid
 from collections import OrderedDict
 from typing import (
     Callable,

--- a/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1alpha/services/dataproc_metastore/client.py
+++ b/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1alpha/services/dataproc_metastore/client.py
@@ -17,7 +17,6 @@ import json
 import logging as std_logging
 import os
 import re
-import uuid
 import warnings
 from collections import OrderedDict
 from http import HTTPStatus

--- a/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1alpha/services/dataproc_metastore_federation/async_client.py
+++ b/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1alpha/services/dataproc_metastore_federation/async_client.py
@@ -15,7 +15,6 @@
 #
 import logging as std_logging
 import re
-import uuid
 from collections import OrderedDict
 from typing import (
     Callable,

--- a/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1alpha/services/dataproc_metastore_federation/client.py
+++ b/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1alpha/services/dataproc_metastore_federation/client.py
@@ -17,7 +17,6 @@ import json
 import logging as std_logging
 import os
 import re
-import uuid
 import warnings
 from collections import OrderedDict
 from http import HTTPStatus

--- a/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1beta/services/dataproc_metastore/async_client.py
+++ b/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1beta/services/dataproc_metastore/async_client.py
@@ -15,7 +15,6 @@
 #
 import logging as std_logging
 import re
-import uuid
 from collections import OrderedDict
 from typing import (
     Callable,

--- a/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1beta/services/dataproc_metastore/client.py
+++ b/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1beta/services/dataproc_metastore/client.py
@@ -17,7 +17,6 @@ import json
 import logging as std_logging
 import os
 import re
-import uuid
 import warnings
 from collections import OrderedDict
 from http import HTTPStatus

--- a/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1beta/services/dataproc_metastore_federation/async_client.py
+++ b/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1beta/services/dataproc_metastore_federation/async_client.py
@@ -15,7 +15,6 @@
 #
 import logging as std_logging
 import re
-import uuid
 from collections import OrderedDict
 from typing import (
     Callable,

--- a/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1beta/services/dataproc_metastore_federation/client.py
+++ b/packages/google-cloud-dataproc-metastore/google/cloud/metastore_v1beta/services/dataproc_metastore_federation/client.py
@@ -17,7 +17,6 @@ import json
 import logging as std_logging
 import os
 import re
-import uuid
 import warnings
 from collections import OrderedDict
 from http import HTTPStatus

--- a/packages/google-cloud-dataproc-metastore/noxfile.py
+++ b/packages/google-cloud-dataproc-metastore/noxfile.py
@@ -509,24 +509,50 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1) for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -596,16 +622,24 @@ def core_deps_from_source(session, protobuf_implementation):
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
+
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(
+        f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}"
+    )
 
     session.run(
         "py.test",

--- a/packages/google-cloud-dataproc-metastore/tests/unit/gapic/metastore_v1/test_dataproc_metastore.py
+++ b/packages/google-cloud-dataproc-metastore/tests/unit/gapic/metastore_v1/test_dataproc_metastore.py
@@ -16,7 +16,6 @@
 import json
 import math
 import os
-import re
 from collections.abc import AsyncIterable, Iterable, Mapping, Sequence
 from unittest import mock
 from unittest.mock import AsyncMock

--- a/packages/google-cloud-dataproc-metastore/tests/unit/gapic/metastore_v1/test_dataproc_metastore_federation.py
+++ b/packages/google-cloud-dataproc-metastore/tests/unit/gapic/metastore_v1/test_dataproc_metastore_federation.py
@@ -16,7 +16,6 @@
 import json
 import math
 import os
-import re
 from collections.abc import AsyncIterable, Iterable, Mapping, Sequence
 from unittest import mock
 from unittest.mock import AsyncMock

--- a/packages/google-cloud-dataproc-metastore/tests/unit/gapic/metastore_v1alpha/test_dataproc_metastore.py
+++ b/packages/google-cloud-dataproc-metastore/tests/unit/gapic/metastore_v1alpha/test_dataproc_metastore.py
@@ -16,7 +16,6 @@
 import json
 import math
 import os
-import re
 from collections.abc import AsyncIterable, Iterable, Mapping, Sequence
 from unittest import mock
 from unittest.mock import AsyncMock

--- a/packages/google-cloud-dataproc-metastore/tests/unit/gapic/metastore_v1alpha/test_dataproc_metastore_federation.py
+++ b/packages/google-cloud-dataproc-metastore/tests/unit/gapic/metastore_v1alpha/test_dataproc_metastore_federation.py
@@ -16,7 +16,6 @@
 import json
 import math
 import os
-import re
 from collections.abc import AsyncIterable, Iterable, Mapping, Sequence
 from unittest import mock
 from unittest.mock import AsyncMock

--- a/packages/google-cloud-dataproc-metastore/tests/unit/gapic/metastore_v1beta/test_dataproc_metastore.py
+++ b/packages/google-cloud-dataproc-metastore/tests/unit/gapic/metastore_v1beta/test_dataproc_metastore.py
@@ -16,7 +16,6 @@
 import json
 import math
 import os
-import re
 from collections.abc import AsyncIterable, Iterable, Mapping, Sequence
 from unittest import mock
 from unittest.mock import AsyncMock

--- a/packages/google-cloud-dataproc-metastore/tests/unit/gapic/metastore_v1beta/test_dataproc_metastore_federation.py
+++ b/packages/google-cloud-dataproc-metastore/tests/unit/gapic/metastore_v1beta/test_dataproc_metastore_federation.py
@@ -16,7 +16,6 @@
 import json
 import math
 import os
-import re
 from collections.abc import AsyncIterable, Iterable, Mapping, Sequence
 from unittest import mock
 from unittest.mock import AsyncMock

--- a/packages/google-cloud-dataproc/README.rst
+++ b/packages/google-cloud-dataproc/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-dataproc/docs/README.rst
+++ b/packages/google-cloud-dataproc/docs/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-dataproc/noxfile.py
+++ b/packages/google-cloud-dataproc/noxfile.py
@@ -509,24 +509,50 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1) for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -596,16 +622,24 @@ def core_deps_from_source(session, protobuf_implementation):
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
+
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(
+        f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}"
+    )
 
     session.run(
         "py.test",

--- a/packages/google-cloud-datastore/noxfile.py
+++ b/packages/google-cloud-datastore/noxfile.py
@@ -517,24 +517,50 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1) for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -604,16 +630,24 @@ def core_deps_from_source(session, protobuf_implementation):
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
+
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(
+        f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}"
+    )
 
     session.run(
         "py.test",

--- a/packages/google-cloud-datastream/README.rst
+++ b/packages/google-cloud-datastream/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-datastream/docs/README.rst
+++ b/packages/google-cloud-datastream/docs/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-datastream/noxfile.py
+++ b/packages/google-cloud-datastream/noxfile.py
@@ -509,24 +509,50 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1) for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -596,16 +622,24 @@ def core_deps_from_source(session, protobuf_implementation):
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
+
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(
+        f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}"
+    )
 
     session.run(
         "py.test",

--- a/packages/google-cloud-deploy/README.rst
+++ b/packages/google-cloud-deploy/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-deploy/docs/README.rst
+++ b/packages/google-cloud-deploy/docs/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-deploy/noxfile.py
+++ b/packages/google-cloud-deploy/noxfile.py
@@ -509,24 +509,50 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1) for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -596,16 +622,24 @@ def core_deps_from_source(session, protobuf_implementation):
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
+
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(
+        f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}"
+    )
 
     session.run(
         "py.test",

--- a/packages/google-cloud-developerconnect/README.rst
+++ b/packages/google-cloud-developerconnect/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-developerconnect/docs/README.rst
+++ b/packages/google-cloud-developerconnect/docs/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-developerconnect/noxfile.py
+++ b/packages/google-cloud-developerconnect/noxfile.py
@@ -509,24 +509,50 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1) for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -596,16 +622,24 @@ def core_deps_from_source(session, protobuf_implementation):
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
+
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(
+        f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}"
+    )
 
     session.run(
         "py.test",

--- a/packages/google-cloud-devicestreaming/README.rst
+++ b/packages/google-cloud-devicestreaming/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-devicestreaming/docs/README.rst
+++ b/packages/google-cloud-devicestreaming/docs/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-devicestreaming/noxfile.py
+++ b/packages/google-cloud-devicestreaming/noxfile.py
@@ -509,24 +509,50 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1) for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -596,16 +622,24 @@ def core_deps_from_source(session, protobuf_implementation):
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
+
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(
+        f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}"
+    )
 
     session.run(
         "py.test",

--- a/packages/google-cloud-dialogflow-cx/README.rst
+++ b/packages/google-cloud-dialogflow-cx/README.rst
@@ -62,14 +62,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-dialogflow-cx/docs/README.rst
+++ b/packages/google-cloud-dialogflow-cx/docs/README.rst
@@ -62,14 +62,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-dialogflow-cx/noxfile.py
+++ b/packages/google-cloud-dialogflow-cx/noxfile.py
@@ -509,24 +509,50 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1) for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -596,16 +622,24 @@ def core_deps_from_source(session, protobuf_implementation):
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
+
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(
+        f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}"
+    )
 
     session.run(
         "py.test",

--- a/packages/google-cloud-dialogflow/README.rst
+++ b/packages/google-cloud-dialogflow/README.rst
@@ -62,14 +62,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-dialogflow/docs/README.rst
+++ b/packages/google-cloud-dialogflow/docs/README.rst
@@ -62,14 +62,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-dialogflow/noxfile.py
+++ b/packages/google-cloud-dialogflow/noxfile.py
@@ -509,24 +509,50 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1) for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -596,16 +622,24 @@ def core_deps_from_source(session, protobuf_implementation):
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
+
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(
+        f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}"
+    )
 
     session.run(
         "py.test",

--- a/packages/google-cloud-discoveryengine/README.rst
+++ b/packages/google-cloud-discoveryengine/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-discoveryengine/docs/README.rst
+++ b/packages/google-cloud-discoveryengine/docs/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-discoveryengine/noxfile.py
+++ b/packages/google-cloud-discoveryengine/noxfile.py
@@ -509,24 +509,50 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1) for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -596,16 +622,24 @@ def core_deps_from_source(session, protobuf_implementation):
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
+
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(
+        f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}"
+    )
 
     session.run(
         "py.test",

--- a/packages/google-cloud-dlp/README.rst
+++ b/packages/google-cloud-dlp/README.rst
@@ -63,14 +63,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-dlp/docs/README.rst
+++ b/packages/google-cloud-dlp/docs/README.rst
@@ -63,14 +63,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-dlp/noxfile.py
+++ b/packages/google-cloud-dlp/noxfile.py
@@ -509,24 +509,50 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1) for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -596,16 +622,24 @@ def core_deps_from_source(session, protobuf_implementation):
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
+
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(
+        f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}"
+    )
 
     session.run(
         "py.test",

--- a/packages/google-cloud-dms/README.rst
+++ b/packages/google-cloud-dms/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-dms/docs/README.rst
+++ b/packages/google-cloud-dms/docs/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-dms/noxfile.py
+++ b/packages/google-cloud-dms/noxfile.py
@@ -509,24 +509,50 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1) for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -596,16 +622,24 @@ def core_deps_from_source(session, protobuf_implementation):
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
+
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(
+        f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}"
+    )
 
     session.run(
         "py.test",

--- a/packages/google-cloud-documentai/README.rst
+++ b/packages/google-cloud-documentai/README.rst
@@ -63,14 +63,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-documentai/docs/README.rst
+++ b/packages/google-cloud-documentai/docs/README.rst
@@ -63,14 +63,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-documentai/noxfile.py
+++ b/packages/google-cloud-documentai/noxfile.py
@@ -509,24 +509,50 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1) for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -596,16 +622,24 @@ def core_deps_from_source(session, protobuf_implementation):
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
+
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(
+        f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}"
+    )
 
     session.run(
         "py.test",

--- a/packages/google-cloud-domains/README.rst
+++ b/packages/google-cloud-domains/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-domains/docs/README.rst
+++ b/packages/google-cloud-domains/docs/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-domains/noxfile.py
+++ b/packages/google-cloud-domains/noxfile.py
@@ -509,24 +509,50 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1) for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -596,16 +622,24 @@ def core_deps_from_source(session, protobuf_implementation):
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
+
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(
+        f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}"
+    )
 
     session.run(
         "py.test",

--- a/packages/google-cloud-edgecontainer/README.rst
+++ b/packages/google-cloud-edgecontainer/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-edgecontainer/docs/README.rst
+++ b/packages/google-cloud-edgecontainer/docs/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-edgecontainer/google/cloud/edgecontainer_v1/services/edge_container/async_client.py
+++ b/packages/google-cloud-edgecontainer/google/cloud/edgecontainer_v1/services/edge_container/async_client.py
@@ -15,7 +15,6 @@
 #
 import logging as std_logging
 import re
-import uuid
 from collections import OrderedDict
 from typing import (
     Callable,

--- a/packages/google-cloud-edgecontainer/google/cloud/edgecontainer_v1/services/edge_container/client.py
+++ b/packages/google-cloud-edgecontainer/google/cloud/edgecontainer_v1/services/edge_container/client.py
@@ -17,7 +17,6 @@ import json
 import logging as std_logging
 import os
 import re
-import uuid
 import warnings
 from collections import OrderedDict
 from http import HTTPStatus

--- a/packages/google-cloud-edgecontainer/noxfile.py
+++ b/packages/google-cloud-edgecontainer/noxfile.py
@@ -509,24 +509,50 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1) for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -596,16 +622,24 @@ def core_deps_from_source(session, protobuf_implementation):
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
+
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(
+        f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}"
+    )
 
     session.run(
         "py.test",

--- a/packages/google-cloud-edgecontainer/tests/unit/gapic/edgecontainer_v1/test_edge_container.py
+++ b/packages/google-cloud-edgecontainer/tests/unit/gapic/edgecontainer_v1/test_edge_container.py
@@ -16,7 +16,6 @@
 import json
 import math
 import os
-import re
 from collections.abc import AsyncIterable, Iterable, Mapping, Sequence
 from unittest import mock
 from unittest.mock import AsyncMock

--- a/packages/google-cloud-edgenetwork/README.rst
+++ b/packages/google-cloud-edgenetwork/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-edgenetwork/docs/README.rst
+++ b/packages/google-cloud-edgenetwork/docs/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-edgenetwork/noxfile.py
+++ b/packages/google-cloud-edgenetwork/noxfile.py
@@ -509,24 +509,50 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1) for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -596,16 +622,24 @@ def core_deps_from_source(session, protobuf_implementation):
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
+
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(
+        f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}"
+    )
 
     session.run(
         "py.test",

--- a/packages/google-cloud-enterpriseknowledgegraph/README.rst
+++ b/packages/google-cloud-enterpriseknowledgegraph/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-enterpriseknowledgegraph/docs/README.rst
+++ b/packages/google-cloud-enterpriseknowledgegraph/docs/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-enterpriseknowledgegraph/noxfile.py
+++ b/packages/google-cloud-enterpriseknowledgegraph/noxfile.py
@@ -509,24 +509,50 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1) for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -596,16 +622,24 @@ def core_deps_from_source(session, protobuf_implementation):
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
+
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(
+        f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}"
+    )
 
     session.run(
         "py.test",

--- a/packages/google-cloud-error-reporting/noxfile.py
+++ b/packages/google-cloud-error-reporting/noxfile.py
@@ -510,24 +510,50 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1) for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -597,16 +623,24 @@ def core_deps_from_source(session, protobuf_implementation):
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
+
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(
+        f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}"
+    )
 
     session.run(
         "py.test",

--- a/packages/google-cloud-essential-contacts/README.rst
+++ b/packages/google-cloud-essential-contacts/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-essential-contacts/docs/README.rst
+++ b/packages/google-cloud-essential-contacts/docs/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-essential-contacts/noxfile.py
+++ b/packages/google-cloud-essential-contacts/noxfile.py
@@ -509,24 +509,50 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1) for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -596,16 +622,24 @@ def core_deps_from_source(session, protobuf_implementation):
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
+
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(
+        f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}"
+    )
 
     session.run(
         "py.test",

--- a/packages/google-cloud-eventarc-publishing/README.rst
+++ b/packages/google-cloud-eventarc-publishing/README.rst
@@ -62,14 +62,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-eventarc-publishing/docs/README.rst
+++ b/packages/google-cloud-eventarc-publishing/docs/README.rst
@@ -62,14 +62,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-eventarc-publishing/noxfile.py
+++ b/packages/google-cloud-eventarc-publishing/noxfile.py
@@ -509,24 +509,50 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1) for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -596,16 +622,24 @@ def core_deps_from_source(session, protobuf_implementation):
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
+
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(
+        f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}"
+    )
 
     session.run(
         "py.test",

--- a/packages/google-cloud-eventarc/README.rst
+++ b/packages/google-cloud-eventarc/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-eventarc/docs/README.rst
+++ b/packages/google-cloud-eventarc/docs/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-eventarc/noxfile.py
+++ b/packages/google-cloud-eventarc/noxfile.py
@@ -509,24 +509,50 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1) for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -596,16 +622,24 @@ def core_deps_from_source(session, protobuf_implementation):
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
+
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(
+        f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}"
+    )
 
     session.run(
         "py.test",

--- a/packages/google-cloud-filestore/README.rst
+++ b/packages/google-cloud-filestore/README.rst
@@ -62,14 +62,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-filestore/docs/README.rst
+++ b/packages/google-cloud-filestore/docs/README.rst
@@ -62,14 +62,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-filestore/noxfile.py
+++ b/packages/google-cloud-filestore/noxfile.py
@@ -509,24 +509,50 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1) for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -596,16 +622,24 @@ def core_deps_from_source(session, protobuf_implementation):
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
+
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(
+        f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}"
+    )
 
     session.run(
         "py.test",

--- a/packages/google-cloud-financialservices/README.rst
+++ b/packages/google-cloud-financialservices/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-financialservices/docs/README.rst
+++ b/packages/google-cloud-financialservices/docs/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-financialservices/google/cloud/financialservices_v1/services/aml/async_client.py
+++ b/packages/google-cloud-financialservices/google/cloud/financialservices_v1/services/aml/async_client.py
@@ -15,7 +15,6 @@
 #
 import logging as std_logging
 import re
-import uuid
 from collections import OrderedDict
 from typing import (
     Callable,

--- a/packages/google-cloud-financialservices/google/cloud/financialservices_v1/services/aml/client.py
+++ b/packages/google-cloud-financialservices/google/cloud/financialservices_v1/services/aml/client.py
@@ -17,7 +17,6 @@ import json
 import logging as std_logging
 import os
 import re
-import uuid
 import warnings
 from collections import OrderedDict
 from http import HTTPStatus

--- a/packages/google-cloud-financialservices/noxfile.py
+++ b/packages/google-cloud-financialservices/noxfile.py
@@ -509,24 +509,50 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1) for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -596,16 +622,24 @@ def core_deps_from_source(session, protobuf_implementation):
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
+
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(
+        f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}"
+    )
 
     session.run(
         "py.test",

--- a/packages/google-cloud-financialservices/tests/unit/gapic/financialservices_v1/test_aml.py
+++ b/packages/google-cloud-financialservices/tests/unit/gapic/financialservices_v1/test_aml.py
@@ -16,7 +16,6 @@
 import json
 import math
 import os
-import re
 from collections.abc import AsyncIterable, Iterable, Mapping, Sequence
 from unittest import mock
 from unittest.mock import AsyncMock

--- a/packages/google-cloud-firestore/README.rst
+++ b/packages/google-cloud-firestore/README.rst
@@ -62,14 +62,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-firestore/docs/README.rst
+++ b/packages/google-cloud-firestore/docs/README.rst
@@ -62,14 +62,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-firestore/noxfile.py
+++ b/packages/google-cloud-firestore/noxfile.py
@@ -568,24 +568,50 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1) for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -655,16 +681,24 @@ def core_deps_from_source(session, protobuf_implementation):
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
+
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(
+        f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}"
+    )
 
     session.run(
         "py.test",

--- a/packages/google-cloud-functions/README.rst
+++ b/packages/google-cloud-functions/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-functions/docs/README.rst
+++ b/packages/google-cloud-functions/docs/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-functions/noxfile.py
+++ b/packages/google-cloud-functions/noxfile.py
@@ -509,24 +509,50 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1) for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -596,16 +622,24 @@ def core_deps_from_source(session, protobuf_implementation):
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
+
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(
+        f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}"
+    )
 
     session.run(
         "py.test",

--- a/packages/google-cloud-gdchardwaremanagement/README.rst
+++ b/packages/google-cloud-gdchardwaremanagement/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-gdchardwaremanagement/docs/README.rst
+++ b/packages/google-cloud-gdchardwaremanagement/docs/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-gdchardwaremanagement/noxfile.py
+++ b/packages/google-cloud-gdchardwaremanagement/noxfile.py
@@ -509,24 +509,50 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1) for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -596,16 +622,24 @@ def core_deps_from_source(session, protobuf_implementation):
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
+
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(
+        f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}"
+    )
 
     session.run(
         "py.test",

--- a/packages/google-cloud-geminidataanalytics/README.rst
+++ b/packages/google-cloud-geminidataanalytics/README.rst
@@ -63,14 +63,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-geminidataanalytics/docs/README.rst
+++ b/packages/google-cloud-geminidataanalytics/docs/README.rst
@@ -63,14 +63,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-geminidataanalytics/noxfile.py
+++ b/packages/google-cloud-geminidataanalytics/noxfile.py
@@ -509,24 +509,50 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1) for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -596,16 +622,24 @@ def core_deps_from_source(session, protobuf_implementation):
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
+
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(
+        f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}"
+    )
 
     session.run(
         "py.test",

--- a/packages/google-cloud-gke-backup/README.rst
+++ b/packages/google-cloud-gke-backup/README.rst
@@ -62,14 +62,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-gke-backup/docs/README.rst
+++ b/packages/google-cloud-gke-backup/docs/README.rst
@@ -62,14 +62,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-gke-backup/noxfile.py
+++ b/packages/google-cloud-gke-backup/noxfile.py
@@ -509,24 +509,50 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1) for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -596,16 +622,24 @@ def core_deps_from_source(session, protobuf_implementation):
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
+
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(
+        f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}"
+    )
 
     session.run(
         "py.test",

--- a/packages/google-cloud-gke-connect-gateway/README.rst
+++ b/packages/google-cloud-gke-connect-gateway/README.rst
@@ -62,14 +62,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-gke-connect-gateway/docs/README.rst
+++ b/packages/google-cloud-gke-connect-gateway/docs/README.rst
@@ -62,14 +62,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-gke-connect-gateway/noxfile.py
+++ b/packages/google-cloud-gke-connect-gateway/noxfile.py
@@ -509,24 +509,50 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1) for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -596,16 +622,24 @@ def core_deps_from_source(session, protobuf_implementation):
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
+
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(
+        f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}"
+    )
 
     session.run(
         "py.test",

--- a/packages/google-cloud-gke-hub/README.rst
+++ b/packages/google-cloud-gke-hub/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-gke-hub/docs/README.rst
+++ b/packages/google-cloud-gke-hub/docs/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-gke-hub/noxfile.py
+++ b/packages/google-cloud-gke-hub/noxfile.py
@@ -509,24 +509,50 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1) for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -596,16 +622,24 @@ def core_deps_from_source(session, protobuf_implementation):
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
+
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(
+        f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}"
+    )
 
     session.run(
         "py.test",

--- a/packages/google-cloud-gke-multicloud/README.rst
+++ b/packages/google-cloud-gke-multicloud/README.rst
@@ -69,14 +69,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-gke-multicloud/docs/README.rst
+++ b/packages/google-cloud-gke-multicloud/docs/README.rst
@@ -69,14 +69,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-gke-multicloud/noxfile.py
+++ b/packages/google-cloud-gke-multicloud/noxfile.py
@@ -509,24 +509,50 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1) for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -596,16 +622,24 @@ def core_deps_from_source(session, protobuf_implementation):
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
+
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(
+        f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}"
+    )
 
     session.run(
         "py.test",

--- a/packages/google-cloud-gkerecommender/README.rst
+++ b/packages/google-cloud-gkerecommender/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-gkerecommender/docs/README.rst
+++ b/packages/google-cloud-gkerecommender/docs/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-gkerecommender/noxfile.py
+++ b/packages/google-cloud-gkerecommender/noxfile.py
@@ -509,24 +509,50 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1) for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -596,16 +622,24 @@ def core_deps_from_source(session, protobuf_implementation):
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
+
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(
+        f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}"
+    )
 
     session.run(
         "py.test",

--- a/packages/google-cloud-gsuiteaddons/README.rst
+++ b/packages/google-cloud-gsuiteaddons/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-gsuiteaddons/docs/README.rst
+++ b/packages/google-cloud-gsuiteaddons/docs/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-gsuiteaddons/noxfile.py
+++ b/packages/google-cloud-gsuiteaddons/noxfile.py
@@ -509,24 +509,50 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1) for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -596,16 +622,24 @@ def core_deps_from_source(session, protobuf_implementation):
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
+
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(
+        f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}"
+    )
 
     session.run(
         "py.test",

--- a/packages/google-cloud-hypercomputecluster/README.rst
+++ b/packages/google-cloud-hypercomputecluster/README.rst
@@ -62,14 +62,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-hypercomputecluster/docs/README.rst
+++ b/packages/google-cloud-hypercomputecluster/docs/README.rst
@@ -62,14 +62,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-hypercomputecluster/noxfile.py
+++ b/packages/google-cloud-hypercomputecluster/noxfile.py
@@ -509,24 +509,50 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1) for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -596,16 +622,24 @@ def core_deps_from_source(session, protobuf_implementation):
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
+
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(
+        f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}"
+    )
 
     session.run(
         "py.test",

--- a/packages/google-cloud-iam-logging/README.rst
+++ b/packages/google-cloud-iam-logging/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-iam-logging/docs/README.rst
+++ b/packages/google-cloud-iam-logging/docs/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-iam-logging/noxfile.py
+++ b/packages/google-cloud-iam-logging/noxfile.py
@@ -509,24 +509,50 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1) for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -596,16 +622,24 @@ def core_deps_from_source(session, protobuf_implementation):
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
+
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(
+        f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}"
+    )
 
     session.run(
         "py.test",

--- a/packages/google-cloud-iam/README.rst
+++ b/packages/google-cloud-iam/README.rst
@@ -66,14 +66,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-iam/docs/README.rst
+++ b/packages/google-cloud-iam/docs/README.rst
@@ -66,14 +66,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-iam/noxfile.py
+++ b/packages/google-cloud-iam/noxfile.py
@@ -509,24 +509,50 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1) for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -596,16 +622,24 @@ def core_deps_from_source(session, protobuf_implementation):
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
+
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(
+        f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}"
+    )
 
     session.run(
         "py.test",

--- a/packages/google-cloud-iamconnectorcredentials/README.rst
+++ b/packages/google-cloud-iamconnectorcredentials/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-iamconnectorcredentials/docs/README.rst
+++ b/packages/google-cloud-iamconnectorcredentials/docs/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-iamconnectorcredentials/noxfile.py
+++ b/packages/google-cloud-iamconnectorcredentials/noxfile.py
@@ -509,24 +509,50 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1) for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -596,16 +622,24 @@ def core_deps_from_source(session, protobuf_implementation):
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
+
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(
+        f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}"
+    )
 
     session.run(
         "py.test",

--- a/packages/google-cloud-iap/README.rst
+++ b/packages/google-cloud-iap/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-iap/docs/README.rst
+++ b/packages/google-cloud-iap/docs/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-iap/noxfile.py
+++ b/packages/google-cloud-iap/noxfile.py
@@ -509,24 +509,50 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1) for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -596,16 +622,24 @@ def core_deps_from_source(session, protobuf_implementation):
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
+
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(
+        f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}"
+    )
 
     session.run(
         "py.test",

--- a/packages/google-cloud-ids/README.rst
+++ b/packages/google-cloud-ids/README.rst
@@ -65,14 +65,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-ids/docs/README.rst
+++ b/packages/google-cloud-ids/docs/README.rst
@@ -65,14 +65,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-ids/google/cloud/ids_v1/services/ids/async_client.py
+++ b/packages/google-cloud-ids/google/cloud/ids_v1/services/ids/async_client.py
@@ -15,7 +15,6 @@
 #
 import logging as std_logging
 import re
-import uuid
 from collections import OrderedDict
 from typing import (
     Callable,

--- a/packages/google-cloud-ids/google/cloud/ids_v1/services/ids/client.py
+++ b/packages/google-cloud-ids/google/cloud/ids_v1/services/ids/client.py
@@ -17,7 +17,6 @@ import json
 import logging as std_logging
 import os
 import re
-import uuid
 import warnings
 from collections import OrderedDict
 from http import HTTPStatus

--- a/packages/google-cloud-ids/noxfile.py
+++ b/packages/google-cloud-ids/noxfile.py
@@ -509,24 +509,50 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1) for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -596,16 +622,24 @@ def core_deps_from_source(session, protobuf_implementation):
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
+
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(
+        f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}"
+    )
 
     session.run(
         "py.test",

--- a/packages/google-cloud-ids/tests/unit/gapic/ids_v1/test_ids.py
+++ b/packages/google-cloud-ids/tests/unit/gapic/ids_v1/test_ids.py
@@ -16,7 +16,6 @@
 import json
 import math
 import os
-import re
 from collections.abc import AsyncIterable, Iterable, Mapping, Sequence
 from unittest import mock
 from unittest.mock import AsyncMock

--- a/packages/google-cloud-kms-inventory/README.rst
+++ b/packages/google-cloud-kms-inventory/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-kms-inventory/docs/README.rst
+++ b/packages/google-cloud-kms-inventory/docs/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-kms-inventory/noxfile.py
+++ b/packages/google-cloud-kms-inventory/noxfile.py
@@ -509,24 +509,50 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1) for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -596,16 +622,24 @@ def core_deps_from_source(session, protobuf_implementation):
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
+
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(
+        f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}"
+    )
 
     session.run(
         "py.test",

--- a/packages/google-cloud-kms/README.rst
+++ b/packages/google-cloud-kms/README.rst
@@ -62,14 +62,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-kms/docs/README.rst
+++ b/packages/google-cloud-kms/docs/README.rst
@@ -62,14 +62,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-kms/noxfile.py
+++ b/packages/google-cloud-kms/noxfile.py
@@ -509,24 +509,50 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1) for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -596,16 +622,24 @@ def core_deps_from_source(session, protobuf_implementation):
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
+
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(
+        f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}"
+    )
 
     session.run(
         "py.test",

--- a/packages/google-cloud-language/README.rst
+++ b/packages/google-cloud-language/README.rst
@@ -63,14 +63,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-language/docs/README.rst
+++ b/packages/google-cloud-language/docs/README.rst
@@ -63,14 +63,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-language/noxfile.py
+++ b/packages/google-cloud-language/noxfile.py
@@ -509,24 +509,50 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1) for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -596,16 +622,24 @@ def core_deps_from_source(session, protobuf_implementation):
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
+
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(
+        f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}"
+    )
 
     session.run(
         "py.test",

--- a/packages/google-cloud-licensemanager/README.rst
+++ b/packages/google-cloud-licensemanager/README.rst
@@ -62,14 +62,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-licensemanager/docs/README.rst
+++ b/packages/google-cloud-licensemanager/docs/README.rst
@@ -62,14 +62,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-licensemanager/noxfile.py
+++ b/packages/google-cloud-licensemanager/noxfile.py
@@ -509,24 +509,50 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1) for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -596,16 +622,24 @@ def core_deps_from_source(session, protobuf_implementation):
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
+
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(
+        f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}"
+    )
 
     session.run(
         "py.test",

--- a/packages/google-cloud-life-sciences/README.rst
+++ b/packages/google-cloud-life-sciences/README.rst
@@ -62,14 +62,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-life-sciences/docs/README.rst
+++ b/packages/google-cloud-life-sciences/docs/README.rst
@@ -62,14 +62,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-life-sciences/noxfile.py
+++ b/packages/google-cloud-life-sciences/noxfile.py
@@ -509,24 +509,50 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1) for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -596,16 +622,24 @@ def core_deps_from_source(session, protobuf_implementation):
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
+
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(
+        f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}"
+    )
 
     session.run(
         "py.test",

--- a/packages/google-cloud-locationfinder/README.rst
+++ b/packages/google-cloud-locationfinder/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-locationfinder/docs/README.rst
+++ b/packages/google-cloud-locationfinder/docs/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-locationfinder/noxfile.py
+++ b/packages/google-cloud-locationfinder/noxfile.py
@@ -509,24 +509,50 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1) for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -596,16 +622,24 @@ def core_deps_from_source(session, protobuf_implementation):
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
+
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(
+        f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}"
+    )
 
     session.run(
         "py.test",

--- a/packages/google-cloud-logging/README.rst
+++ b/packages/google-cloud-logging/README.rst
@@ -68,14 +68,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-logging/docs/README.rst
+++ b/packages/google-cloud-logging/docs/README.rst
@@ -68,14 +68,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-logging/google/cloud/logging_v2/services/config_service_v2/async_client.py
+++ b/packages/google-cloud-logging/google/cloud/logging_v2/services/config_service_v2/async_client.py
@@ -15,7 +15,6 @@
 #
 import logging as std_logging
 import re
-import uuid
 from collections import OrderedDict
 from typing import (
     Callable,

--- a/packages/google-cloud-logging/google/cloud/logging_v2/services/config_service_v2/client.py
+++ b/packages/google-cloud-logging/google/cloud/logging_v2/services/config_service_v2/client.py
@@ -17,7 +17,6 @@ import json
 import logging as std_logging
 import os
 import re
-import uuid
 import warnings
 from collections import OrderedDict
 from http import HTTPStatus

--- a/packages/google-cloud-logging/google/cloud/logging_v2/services/logging_service_v2/async_client.py
+++ b/packages/google-cloud-logging/google/cloud/logging_v2/services/logging_service_v2/async_client.py
@@ -15,7 +15,6 @@
 #
 import logging as std_logging
 import re
-import uuid
 from collections import OrderedDict
 from typing import (
     AsyncIterable,

--- a/packages/google-cloud-logging/google/cloud/logging_v2/services/logging_service_v2/client.py
+++ b/packages/google-cloud-logging/google/cloud/logging_v2/services/logging_service_v2/client.py
@@ -17,7 +17,6 @@ import json
 import logging as std_logging
 import os
 import re
-import uuid
 import warnings
 from collections import OrderedDict
 from http import HTTPStatus

--- a/packages/google-cloud-logging/google/cloud/logging_v2/services/metrics_service_v2/async_client.py
+++ b/packages/google-cloud-logging/google/cloud/logging_v2/services/metrics_service_v2/async_client.py
@@ -15,7 +15,6 @@
 #
 import logging as std_logging
 import re
-import uuid
 from collections import OrderedDict
 from typing import (
     Callable,

--- a/packages/google-cloud-logging/google/cloud/logging_v2/services/metrics_service_v2/client.py
+++ b/packages/google-cloud-logging/google/cloud/logging_v2/services/metrics_service_v2/client.py
@@ -17,7 +17,6 @@ import json
 import logging as std_logging
 import os
 import re
-import uuid
 import warnings
 from collections import OrderedDict
 from http import HTTPStatus

--- a/packages/google-cloud-logging/noxfile.py
+++ b/packages/google-cloud-logging/noxfile.py
@@ -508,24 +508,50 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1) for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -595,16 +621,24 @@ def core_deps_from_source(session, protobuf_implementation):
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
+
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(
+        f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}"
+    )
 
     session.run(
         "py.test",

--- a/packages/google-cloud-logging/tests/unit/gapic/logging_v2/test_config_service_v2.py
+++ b/packages/google-cloud-logging/tests/unit/gapic/logging_v2/test_config_service_v2.py
@@ -16,7 +16,6 @@
 import json
 import math
 import os
-import re
 from collections.abc import Mapping, Sequence
 from unittest import mock
 from unittest.mock import AsyncMock

--- a/packages/google-cloud-logging/tests/unit/gapic/logging_v2/test_logging_service_v2.py
+++ b/packages/google-cloud-logging/tests/unit/gapic/logging_v2/test_logging_service_v2.py
@@ -16,7 +16,6 @@
 import json
 import math
 import os
-import re
 from collections.abc import Mapping, Sequence
 from unittest import mock
 from unittest.mock import AsyncMock

--- a/packages/google-cloud-logging/tests/unit/gapic/logging_v2/test_metrics_service_v2.py
+++ b/packages/google-cloud-logging/tests/unit/gapic/logging_v2/test_metrics_service_v2.py
@@ -16,7 +16,6 @@
 import json
 import math
 import os
-import re
 from collections.abc import Mapping, Sequence
 from unittest import mock
 from unittest.mock import AsyncMock

--- a/packages/google-cloud-lustre/README.rst
+++ b/packages/google-cloud-lustre/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-lustre/docs/README.rst
+++ b/packages/google-cloud-lustre/docs/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-lustre/noxfile.py
+++ b/packages/google-cloud-lustre/noxfile.py
@@ -509,24 +509,50 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1) for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -596,16 +622,24 @@ def core_deps_from_source(session, protobuf_implementation):
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
+
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(
+        f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}"
+    )
 
     session.run(
         "py.test",

--- a/packages/google-cloud-maintenance-api/README.rst
+++ b/packages/google-cloud-maintenance-api/README.rst
@@ -65,14 +65,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-maintenance-api/docs/README.rst
+++ b/packages/google-cloud-maintenance-api/docs/README.rst
@@ -65,14 +65,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-maintenance-api/noxfile.py
+++ b/packages/google-cloud-maintenance-api/noxfile.py
@@ -509,24 +509,50 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1) for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -596,16 +622,24 @@ def core_deps_from_source(session, protobuf_implementation):
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
+
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(
+        f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}"
+    )
 
     session.run(
         "py.test",

--- a/packages/google-cloud-managed-identities/README.rst
+++ b/packages/google-cloud-managed-identities/README.rst
@@ -63,14 +63,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-managed-identities/docs/README.rst
+++ b/packages/google-cloud-managed-identities/docs/README.rst
@@ -63,14 +63,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-managed-identities/noxfile.py
+++ b/packages/google-cloud-managed-identities/noxfile.py
@@ -509,24 +509,50 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1) for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -596,16 +622,24 @@ def core_deps_from_source(session, protobuf_implementation):
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
+
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(
+        f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}"
+    )
 
     session.run(
         "py.test",

--- a/packages/google-cloud-managedkafka-schemaregistry/README.rst
+++ b/packages/google-cloud-managedkafka-schemaregistry/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-managedkafka-schemaregistry/docs/README.rst
+++ b/packages/google-cloud-managedkafka-schemaregistry/docs/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-managedkafka-schemaregistry/noxfile.py
+++ b/packages/google-cloud-managedkafka-schemaregistry/noxfile.py
@@ -509,24 +509,50 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1) for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -596,16 +622,24 @@ def core_deps_from_source(session, protobuf_implementation):
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
+
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(
+        f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}"
+    )
 
     session.run(
         "py.test",

--- a/packages/google-cloud-managedkafka/README.rst
+++ b/packages/google-cloud-managedkafka/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-managedkafka/docs/README.rst
+++ b/packages/google-cloud-managedkafka/docs/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-managedkafka/noxfile.py
+++ b/packages/google-cloud-managedkafka/noxfile.py
@@ -509,24 +509,50 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1) for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -596,16 +622,24 @@ def core_deps_from_source(session, protobuf_implementation):
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
+
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(
+        f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}"
+    )
 
     session.run(
         "py.test",

--- a/packages/google-cloud-media-translation/README.rst
+++ b/packages/google-cloud-media-translation/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-media-translation/docs/README.rst
+++ b/packages/google-cloud-media-translation/docs/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-media-translation/noxfile.py
+++ b/packages/google-cloud-media-translation/noxfile.py
@@ -509,24 +509,50 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1) for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -596,16 +622,24 @@ def core_deps_from_source(session, protobuf_implementation):
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
+
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(
+        f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}"
+    )
 
     session.run(
         "py.test",

--- a/packages/google-cloud-memcache/README.rst
+++ b/packages/google-cloud-memcache/README.rst
@@ -62,14 +62,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-memcache/docs/README.rst
+++ b/packages/google-cloud-memcache/docs/README.rst
@@ -62,14 +62,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-memcache/noxfile.py
+++ b/packages/google-cloud-memcache/noxfile.py
@@ -509,24 +509,50 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1) for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -596,16 +622,24 @@ def core_deps_from_source(session, protobuf_implementation):
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
+
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(
+        f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}"
+    )
 
     session.run(
         "py.test",

--- a/packages/google-cloud-memorystore/README.rst
+++ b/packages/google-cloud-memorystore/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-memorystore/docs/README.rst
+++ b/packages/google-cloud-memorystore/docs/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-memorystore/noxfile.py
+++ b/packages/google-cloud-memorystore/noxfile.py
@@ -509,24 +509,50 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1) for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -596,16 +622,24 @@ def core_deps_from_source(session, protobuf_implementation):
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
+
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(
+        f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}"
+    )
 
     session.run(
         "py.test",

--- a/packages/google-cloud-migrationcenter/README.rst
+++ b/packages/google-cloud-migrationcenter/README.rst
@@ -62,14 +62,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-migrationcenter/docs/README.rst
+++ b/packages/google-cloud-migrationcenter/docs/README.rst
@@ -62,14 +62,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-migrationcenter/noxfile.py
+++ b/packages/google-cloud-migrationcenter/noxfile.py
@@ -509,24 +509,50 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1) for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -596,16 +622,24 @@ def core_deps_from_source(session, protobuf_implementation):
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
+
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(
+        f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}"
+    )
 
     session.run(
         "py.test",

--- a/packages/google-cloud-modelarmor/README.rst
+++ b/packages/google-cloud-modelarmor/README.rst
@@ -63,14 +63,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-modelarmor/docs/README.rst
+++ b/packages/google-cloud-modelarmor/docs/README.rst
@@ -63,14 +63,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-modelarmor/noxfile.py
+++ b/packages/google-cloud-modelarmor/noxfile.py
@@ -509,24 +509,50 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1) for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -596,16 +622,24 @@ def core_deps_from_source(session, protobuf_implementation):
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
+
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(
+        f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}"
+    )
 
     session.run(
         "py.test",

--- a/packages/google-cloud-monitoring-dashboards/README.rst
+++ b/packages/google-cloud-monitoring-dashboards/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-monitoring-dashboards/docs/README.rst
+++ b/packages/google-cloud-monitoring-dashboards/docs/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-monitoring-dashboards/noxfile.py
+++ b/packages/google-cloud-monitoring-dashboards/noxfile.py
@@ -510,24 +510,50 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1) for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -597,16 +623,24 @@ def core_deps_from_source(session, protobuf_implementation):
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
+
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(
+        f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}"
+    )
 
     session.run(
         "py.test",

--- a/packages/google-cloud-monitoring-metrics-scopes/README.rst
+++ b/packages/google-cloud-monitoring-metrics-scopes/README.rst
@@ -66,14 +66,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-monitoring-metrics-scopes/docs/README.rst
+++ b/packages/google-cloud-monitoring-metrics-scopes/docs/README.rst
@@ -66,14 +66,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-monitoring-metrics-scopes/google/cloud/monitoring_metrics_scope_v1/services/metrics_scopes/async_client.py
+++ b/packages/google-cloud-monitoring-metrics-scopes/google/cloud/monitoring_metrics_scope_v1/services/metrics_scopes/async_client.py
@@ -15,7 +15,6 @@
 #
 import logging as std_logging
 import re
-import uuid
 from collections import OrderedDict
 from typing import (
     Callable,

--- a/packages/google-cloud-monitoring-metrics-scopes/google/cloud/monitoring_metrics_scope_v1/services/metrics_scopes/client.py
+++ b/packages/google-cloud-monitoring-metrics-scopes/google/cloud/monitoring_metrics_scope_v1/services/metrics_scopes/client.py
@@ -17,7 +17,6 @@ import json
 import logging as std_logging
 import os
 import re
-import uuid
 import warnings
 from collections import OrderedDict
 from http import HTTPStatus

--- a/packages/google-cloud-monitoring-metrics-scopes/noxfile.py
+++ b/packages/google-cloud-monitoring-metrics-scopes/noxfile.py
@@ -509,24 +509,50 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1) for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -596,16 +622,24 @@ def core_deps_from_source(session, protobuf_implementation):
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
+
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(
+        f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}"
+    )
 
     session.run(
         "py.test",

--- a/packages/google-cloud-monitoring-metrics-scopes/tests/unit/gapic/monitoring_metrics_scope_v1/test_metrics_scopes.py
+++ b/packages/google-cloud-monitoring-metrics-scopes/tests/unit/gapic/monitoring_metrics_scope_v1/test_metrics_scopes.py
@@ -16,7 +16,6 @@
 import json
 import math
 import os
-import re
 from collections.abc import Mapping, Sequence
 from unittest import mock
 from unittest.mock import AsyncMock

--- a/packages/google-cloud-monitoring/README.rst
+++ b/packages/google-cloud-monitoring/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-monitoring/docs/README.rst
+++ b/packages/google-cloud-monitoring/docs/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-monitoring/noxfile.py
+++ b/packages/google-cloud-monitoring/noxfile.py
@@ -511,24 +511,50 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1) for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -598,16 +624,24 @@ def core_deps_from_source(session, protobuf_implementation):
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
+
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(
+        f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}"
+    )
 
     session.run(
         "py.test",

--- a/packages/google-cloud-netapp/README.rst
+++ b/packages/google-cloud-netapp/README.rst
@@ -63,14 +63,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-netapp/docs/README.rst
+++ b/packages/google-cloud-netapp/docs/README.rst
@@ -63,14 +63,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-netapp/noxfile.py
+++ b/packages/google-cloud-netapp/noxfile.py
@@ -509,24 +509,50 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1) for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -596,16 +622,24 @@ def core_deps_from_source(session, protobuf_implementation):
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
+
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(
+        f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}"
+    )
 
     session.run(
         "py.test",

--- a/packages/google-cloud-network-connectivity/README.rst
+++ b/packages/google-cloud-network-connectivity/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-network-connectivity/docs/README.rst
+++ b/packages/google-cloud-network-connectivity/docs/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-network-connectivity/noxfile.py
+++ b/packages/google-cloud-network-connectivity/noxfile.py
@@ -509,24 +509,50 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1) for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -596,16 +622,24 @@ def core_deps_from_source(session, protobuf_implementation):
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
+
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(
+        f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}"
+    )
 
     session.run(
         "py.test",

--- a/packages/google-cloud-network-management/README.rst
+++ b/packages/google-cloud-network-management/README.rst
@@ -62,14 +62,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-network-management/docs/README.rst
+++ b/packages/google-cloud-network-management/docs/README.rst
@@ -62,14 +62,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-network-management/noxfile.py
+++ b/packages/google-cloud-network-management/noxfile.py
@@ -509,24 +509,50 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1) for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -596,16 +622,24 @@ def core_deps_from_source(session, protobuf_implementation):
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
+
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(
+        f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}"
+    )
 
     session.run(
         "py.test",

--- a/packages/google-cloud-network-security/README.rst
+++ b/packages/google-cloud-network-security/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-network-security/docs/README.rst
+++ b/packages/google-cloud-network-security/docs/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-network-security/noxfile.py
+++ b/packages/google-cloud-network-security/noxfile.py
@@ -509,24 +509,50 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1) for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -596,16 +622,24 @@ def core_deps_from_source(session, protobuf_implementation):
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
+
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(
+        f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}"
+    )
 
     session.run(
         "py.test",

--- a/packages/google-cloud-network-services/README.rst
+++ b/packages/google-cloud-network-services/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-network-services/docs/README.rst
+++ b/packages/google-cloud-network-services/docs/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-network-services/noxfile.py
+++ b/packages/google-cloud-network-services/noxfile.py
@@ -509,24 +509,50 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1) for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -596,16 +622,24 @@ def core_deps_from_source(session, protobuf_implementation):
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
+
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(
+        f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}"
+    )
 
     session.run(
         "py.test",

--- a/packages/google-cloud-notebooks/README.rst
+++ b/packages/google-cloud-notebooks/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-notebooks/docs/README.rst
+++ b/packages/google-cloud-notebooks/docs/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-notebooks/noxfile.py
+++ b/packages/google-cloud-notebooks/noxfile.py
@@ -509,24 +509,50 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1) for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -596,16 +622,24 @@ def core_deps_from_source(session, protobuf_implementation):
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
+
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(
+        f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}"
+    )
 
     session.run(
         "py.test",

--- a/packages/google-cloud-optimization/README.rst
+++ b/packages/google-cloud-optimization/README.rst
@@ -63,14 +63,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-optimization/docs/README.rst
+++ b/packages/google-cloud-optimization/docs/README.rst
@@ -63,14 +63,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-optimization/google/cloud/optimization_v1/services/fleet_routing/async_client.py
+++ b/packages/google-cloud-optimization/google/cloud/optimization_v1/services/fleet_routing/async_client.py
@@ -15,7 +15,6 @@
 #
 import logging as std_logging
 import re
-import uuid
 from collections import OrderedDict
 from typing import (
     Callable,

--- a/packages/google-cloud-optimization/google/cloud/optimization_v1/services/fleet_routing/client.py
+++ b/packages/google-cloud-optimization/google/cloud/optimization_v1/services/fleet_routing/client.py
@@ -17,7 +17,6 @@ import json
 import logging as std_logging
 import os
 import re
-import uuid
 import warnings
 from collections import OrderedDict
 from http import HTTPStatus

--- a/packages/google-cloud-optimization/noxfile.py
+++ b/packages/google-cloud-optimization/noxfile.py
@@ -509,24 +509,50 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1) for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -596,16 +622,24 @@ def core_deps_from_source(session, protobuf_implementation):
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
+
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(
+        f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}"
+    )
 
     session.run(
         "py.test",

--- a/packages/google-cloud-optimization/tests/unit/gapic/optimization_v1/test_fleet_routing.py
+++ b/packages/google-cloud-optimization/tests/unit/gapic/optimization_v1/test_fleet_routing.py
@@ -16,7 +16,6 @@
 import json
 import math
 import os
-import re
 from collections.abc import AsyncIterable, Iterable, Mapping, Sequence
 from unittest import mock
 from unittest.mock import AsyncMock

--- a/packages/google-cloud-oracledatabase/README.rst
+++ b/packages/google-cloud-oracledatabase/README.rst
@@ -62,14 +62,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-oracledatabase/docs/README.rst
+++ b/packages/google-cloud-oracledatabase/docs/README.rst
@@ -62,14 +62,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-oracledatabase/noxfile.py
+++ b/packages/google-cloud-oracledatabase/noxfile.py
@@ -509,24 +509,50 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1) for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -596,16 +622,24 @@ def core_deps_from_source(session, protobuf_implementation):
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
+
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(
+        f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}"
+    )
 
     session.run(
         "py.test",

--- a/packages/google-cloud-orchestration-airflow/README.rst
+++ b/packages/google-cloud-orchestration-airflow/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-orchestration-airflow/docs/README.rst
+++ b/packages/google-cloud-orchestration-airflow/docs/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-orchestration-airflow/noxfile.py
+++ b/packages/google-cloud-orchestration-airflow/noxfile.py
@@ -509,24 +509,50 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1) for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -596,16 +622,24 @@ def core_deps_from_source(session, protobuf_implementation):
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
+
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(
+        f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}"
+    )
 
     session.run(
         "py.test",

--- a/packages/google-cloud-org-policy/README.rst
+++ b/packages/google-cloud-org-policy/README.rst
@@ -62,14 +62,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-org-policy/docs/README.rst
+++ b/packages/google-cloud-org-policy/docs/README.rst
@@ -62,14 +62,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-org-policy/noxfile.py
+++ b/packages/google-cloud-org-policy/noxfile.py
@@ -509,24 +509,50 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1) for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -596,16 +622,24 @@ def core_deps_from_source(session, protobuf_implementation):
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
+
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(
+        f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}"
+    )
 
     session.run(
         "py.test",

--- a/packages/google-cloud-os-config/README.rst
+++ b/packages/google-cloud-os-config/README.rst
@@ -62,14 +62,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-os-config/docs/README.rst
+++ b/packages/google-cloud-os-config/docs/README.rst
@@ -62,14 +62,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-os-config/noxfile.py
+++ b/packages/google-cloud-os-config/noxfile.py
@@ -509,24 +509,50 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1) for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -596,16 +622,24 @@ def core_deps_from_source(session, protobuf_implementation):
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
+
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(
+        f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}"
+    )
 
     session.run(
         "py.test",

--- a/packages/google-cloud-os-login/README.rst
+++ b/packages/google-cloud-os-login/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-os-login/docs/README.rst
+++ b/packages/google-cloud-os-login/docs/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-os-login/noxfile.py
+++ b/packages/google-cloud-os-login/noxfile.py
@@ -509,24 +509,50 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1) for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -596,16 +622,24 @@ def core_deps_from_source(session, protobuf_implementation):
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
+
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(
+        f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}"
+    )
 
     session.run(
         "py.test",

--- a/packages/google-cloud-parallelstore/README.rst
+++ b/packages/google-cloud-parallelstore/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-parallelstore/docs/README.rst
+++ b/packages/google-cloud-parallelstore/docs/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-parallelstore/noxfile.py
+++ b/packages/google-cloud-parallelstore/noxfile.py
@@ -509,24 +509,50 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1) for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -596,16 +622,24 @@ def core_deps_from_source(session, protobuf_implementation):
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
+
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(
+        f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}"
+    )
 
     session.run(
         "py.test",

--- a/packages/google-cloud-parametermanager/README.rst
+++ b/packages/google-cloud-parametermanager/README.rst
@@ -64,14 +64,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-parametermanager/docs/README.rst
+++ b/packages/google-cloud-parametermanager/docs/README.rst
@@ -64,14 +64,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-parametermanager/noxfile.py
+++ b/packages/google-cloud-parametermanager/noxfile.py
@@ -509,24 +509,50 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1) for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -596,16 +622,24 @@ def core_deps_from_source(session, protobuf_implementation):
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
+
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(
+        f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}"
+    )
 
     session.run(
         "py.test",

--- a/packages/google-cloud-phishing-protection/README.rst
+++ b/packages/google-cloud-phishing-protection/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-phishing-protection/docs/README.rst
+++ b/packages/google-cloud-phishing-protection/docs/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-phishing-protection/noxfile.py
+++ b/packages/google-cloud-phishing-protection/noxfile.py
@@ -509,24 +509,50 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1) for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -596,16 +622,24 @@ def core_deps_from_source(session, protobuf_implementation):
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
+
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(
+        f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}"
+    )
 
     session.run(
         "py.test",

--- a/packages/google-cloud-policy-troubleshooter/README.rst
+++ b/packages/google-cloud-policy-troubleshooter/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-policy-troubleshooter/docs/README.rst
+++ b/packages/google-cloud-policy-troubleshooter/docs/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-policy-troubleshooter/noxfile.py
+++ b/packages/google-cloud-policy-troubleshooter/noxfile.py
@@ -509,24 +509,50 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1) for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -596,16 +622,24 @@ def core_deps_from_source(session, protobuf_implementation):
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
+
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(
+        f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}"
+    )
 
     session.run(
         "py.test",

--- a/packages/google-cloud-policysimulator/README.rst
+++ b/packages/google-cloud-policysimulator/README.rst
@@ -70,14 +70,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-policysimulator/docs/README.rst
+++ b/packages/google-cloud-policysimulator/docs/README.rst
@@ -70,14 +70,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-policysimulator/google/cloud/policysimulator_v1/services/org_policy_violations_preview_service/async_client.py
+++ b/packages/google-cloud-policysimulator/google/cloud/policysimulator_v1/services/org_policy_violations_preview_service/async_client.py
@@ -15,7 +15,6 @@
 #
 import logging as std_logging
 import re
-import uuid
 from collections import OrderedDict
 from typing import (
     Callable,

--- a/packages/google-cloud-policysimulator/google/cloud/policysimulator_v1/services/org_policy_violations_preview_service/client.py
+++ b/packages/google-cloud-policysimulator/google/cloud/policysimulator_v1/services/org_policy_violations_preview_service/client.py
@@ -17,7 +17,6 @@ import json
 import logging as std_logging
 import os
 import re
-import uuid
 import warnings
 from collections import OrderedDict
 from http import HTTPStatus

--- a/packages/google-cloud-policysimulator/google/cloud/policysimulator_v1/services/simulator/async_client.py
+++ b/packages/google-cloud-policysimulator/google/cloud/policysimulator_v1/services/simulator/async_client.py
@@ -15,7 +15,6 @@
 #
 import logging as std_logging
 import re
-import uuid
 from collections import OrderedDict
 from typing import (
     Callable,

--- a/packages/google-cloud-policysimulator/google/cloud/policysimulator_v1/services/simulator/client.py
+++ b/packages/google-cloud-policysimulator/google/cloud/policysimulator_v1/services/simulator/client.py
@@ -17,7 +17,6 @@ import json
 import logging as std_logging
 import os
 import re
-import uuid
 import warnings
 from collections import OrderedDict
 from http import HTTPStatus

--- a/packages/google-cloud-policysimulator/noxfile.py
+++ b/packages/google-cloud-policysimulator/noxfile.py
@@ -509,24 +509,50 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1) for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -596,16 +622,24 @@ def core_deps_from_source(session, protobuf_implementation):
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
+
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(
+        f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}"
+    )
 
     session.run(
         "py.test",

--- a/packages/google-cloud-policysimulator/tests/unit/gapic/policysimulator_v1/test_org_policy_violations_preview_service.py
+++ b/packages/google-cloud-policysimulator/tests/unit/gapic/policysimulator_v1/test_org_policy_violations_preview_service.py
@@ -16,7 +16,6 @@
 import json
 import math
 import os
-import re
 from collections.abc import AsyncIterable, Iterable, Mapping, Sequence
 from unittest import mock
 from unittest.mock import AsyncMock

--- a/packages/google-cloud-policysimulator/tests/unit/gapic/policysimulator_v1/test_simulator.py
+++ b/packages/google-cloud-policysimulator/tests/unit/gapic/policysimulator_v1/test_simulator.py
@@ -16,7 +16,6 @@
 import json
 import math
 import os
-import re
 from collections.abc import AsyncIterable, Iterable, Mapping, Sequence
 from unittest import mock
 from unittest.mock import AsyncMock

--- a/packages/google-cloud-policytroubleshooter-iam/README.rst
+++ b/packages/google-cloud-policytroubleshooter-iam/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-policytroubleshooter-iam/docs/README.rst
+++ b/packages/google-cloud-policytroubleshooter-iam/docs/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-policytroubleshooter-iam/noxfile.py
+++ b/packages/google-cloud-policytroubleshooter-iam/noxfile.py
@@ -509,24 +509,50 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1) for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -596,16 +622,24 @@ def core_deps_from_source(session, protobuf_implementation):
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
+
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(
+        f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}"
+    )
 
     session.run(
         "py.test",

--- a/packages/google-cloud-private-ca/README.rst
+++ b/packages/google-cloud-private-ca/README.rst
@@ -64,14 +64,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-private-ca/docs/README.rst
+++ b/packages/google-cloud-private-ca/docs/README.rst
@@ -64,14 +64,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-private-ca/noxfile.py
+++ b/packages/google-cloud-private-ca/noxfile.py
@@ -509,24 +509,50 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1) for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -596,16 +622,24 @@ def core_deps_from_source(session, protobuf_implementation):
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
+
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(
+        f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}"
+    )
 
     session.run(
         "py.test",

--- a/packages/google-cloud-private-catalog/README.rst
+++ b/packages/google-cloud-private-catalog/README.rst
@@ -62,14 +62,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-private-catalog/docs/README.rst
+++ b/packages/google-cloud-private-catalog/docs/README.rst
@@ -62,14 +62,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-private-catalog/noxfile.py
+++ b/packages/google-cloud-private-catalog/noxfile.py
@@ -509,24 +509,50 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1) for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -596,16 +622,24 @@ def core_deps_from_source(session, protobuf_implementation):
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
+
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(
+        f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}"
+    )
 
     session.run(
         "py.test",

--- a/packages/google-cloud-privilegedaccessmanager/README.rst
+++ b/packages/google-cloud-privilegedaccessmanager/README.rst
@@ -73,14 +73,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-privilegedaccessmanager/docs/README.rst
+++ b/packages/google-cloud-privilegedaccessmanager/docs/README.rst
@@ -73,14 +73,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-privilegedaccessmanager/google/cloud/privilegedaccessmanager_v1/services/privileged_access_manager/async_client.py
+++ b/packages/google-cloud-privilegedaccessmanager/google/cloud/privilegedaccessmanager_v1/services/privileged_access_manager/async_client.py
@@ -15,7 +15,6 @@
 #
 import logging as std_logging
 import re
-import uuid
 from collections import OrderedDict
 from typing import (
     Callable,

--- a/packages/google-cloud-privilegedaccessmanager/google/cloud/privilegedaccessmanager_v1/services/privileged_access_manager/client.py
+++ b/packages/google-cloud-privilegedaccessmanager/google/cloud/privilegedaccessmanager_v1/services/privileged_access_manager/client.py
@@ -17,7 +17,6 @@ import json
 import logging as std_logging
 import os
 import re
-import uuid
 import warnings
 from collections import OrderedDict
 from http import HTTPStatus

--- a/packages/google-cloud-privilegedaccessmanager/noxfile.py
+++ b/packages/google-cloud-privilegedaccessmanager/noxfile.py
@@ -509,24 +509,50 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1) for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -596,16 +622,24 @@ def core_deps_from_source(session, protobuf_implementation):
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
+
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(
+        f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}"
+    )
 
     session.run(
         "py.test",

--- a/packages/google-cloud-privilegedaccessmanager/tests/unit/gapic/privilegedaccessmanager_v1/test_privileged_access_manager.py
+++ b/packages/google-cloud-privilegedaccessmanager/tests/unit/gapic/privilegedaccessmanager_v1/test_privileged_access_manager.py
@@ -16,7 +16,6 @@
 import json
 import math
 import os
-import re
 from collections.abc import AsyncIterable, Iterable, Mapping, Sequence
 from unittest import mock
 from unittest.mock import AsyncMock

--- a/packages/google-cloud-pubsub/noxfile.py
+++ b/packages/google-cloud-pubsub/noxfile.py
@@ -558,24 +558,50 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1) for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",

--- a/packages/google-cloud-quotas/README.rst
+++ b/packages/google-cloud-quotas/README.rst
@@ -63,14 +63,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-quotas/docs/README.rst
+++ b/packages/google-cloud-quotas/docs/README.rst
@@ -63,14 +63,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-quotas/noxfile.py
+++ b/packages/google-cloud-quotas/noxfile.py
@@ -509,24 +509,50 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1) for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -596,16 +622,24 @@ def core_deps_from_source(session, protobuf_implementation):
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
+
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(
+        f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}"
+    )
 
     session.run(
         "py.test",

--- a/packages/google-cloud-rapidmigrationassessment/README.rst
+++ b/packages/google-cloud-rapidmigrationassessment/README.rst
@@ -62,14 +62,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-rapidmigrationassessment/docs/README.rst
+++ b/packages/google-cloud-rapidmigrationassessment/docs/README.rst
@@ -62,14 +62,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-rapidmigrationassessment/noxfile.py
+++ b/packages/google-cloud-rapidmigrationassessment/noxfile.py
@@ -509,24 +509,50 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1) for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -596,16 +622,24 @@ def core_deps_from_source(session, protobuf_implementation):
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
+
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(
+        f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}"
+    )
 
     session.run(
         "py.test",

--- a/packages/google-cloud-recaptcha-enterprise/README.rst
+++ b/packages/google-cloud-recaptcha-enterprise/README.rst
@@ -62,14 +62,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-recaptcha-enterprise/docs/README.rst
+++ b/packages/google-cloud-recaptcha-enterprise/docs/README.rst
@@ -62,14 +62,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-recaptcha-enterprise/noxfile.py
+++ b/packages/google-cloud-recaptcha-enterprise/noxfile.py
@@ -509,24 +509,50 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1) for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -596,16 +622,24 @@ def core_deps_from_source(session, protobuf_implementation):
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
+
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(
+        f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}"
+    )
 
     session.run(
         "py.test",

--- a/packages/google-cloud-recommendations-ai/README.rst
+++ b/packages/google-cloud-recommendations-ai/README.rst
@@ -63,14 +63,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-recommendations-ai/docs/README.rst
+++ b/packages/google-cloud-recommendations-ai/docs/README.rst
@@ -63,14 +63,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-recommendations-ai/noxfile.py
+++ b/packages/google-cloud-recommendations-ai/noxfile.py
@@ -509,24 +509,50 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1) for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -596,16 +622,24 @@ def core_deps_from_source(session, protobuf_implementation):
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
+
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(
+        f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}"
+    )
 
     session.run(
         "py.test",

--- a/packages/google-cloud-recommender/README.rst
+++ b/packages/google-cloud-recommender/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-recommender/docs/README.rst
+++ b/packages/google-cloud-recommender/docs/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-recommender/noxfile.py
+++ b/packages/google-cloud-recommender/noxfile.py
@@ -509,24 +509,50 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1) for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -596,16 +622,24 @@ def core_deps_from_source(session, protobuf_implementation):
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
+
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(
+        f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}"
+    )
 
     session.run(
         "py.test",

--- a/packages/google-cloud-redis-cluster/README.rst
+++ b/packages/google-cloud-redis-cluster/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-redis-cluster/docs/README.rst
+++ b/packages/google-cloud-redis-cluster/docs/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-redis-cluster/google/cloud/redis_cluster_v1/services/cloud_redis_cluster/async_client.py
+++ b/packages/google-cloud-redis-cluster/google/cloud/redis_cluster_v1/services/cloud_redis_cluster/async_client.py
@@ -15,7 +15,6 @@
 #
 import logging as std_logging
 import re
-import uuid
 from collections import OrderedDict
 from typing import (
     Callable,

--- a/packages/google-cloud-redis-cluster/google/cloud/redis_cluster_v1/services/cloud_redis_cluster/client.py
+++ b/packages/google-cloud-redis-cluster/google/cloud/redis_cluster_v1/services/cloud_redis_cluster/client.py
@@ -17,7 +17,6 @@ import json
 import logging as std_logging
 import os
 import re
-import uuid
 import warnings
 from collections import OrderedDict
 from http import HTTPStatus

--- a/packages/google-cloud-redis-cluster/google/cloud/redis_cluster_v1beta1/services/cloud_redis_cluster/async_client.py
+++ b/packages/google-cloud-redis-cluster/google/cloud/redis_cluster_v1beta1/services/cloud_redis_cluster/async_client.py
@@ -15,7 +15,6 @@
 #
 import logging as std_logging
 import re
-import uuid
 from collections import OrderedDict
 from typing import (
     Callable,

--- a/packages/google-cloud-redis-cluster/google/cloud/redis_cluster_v1beta1/services/cloud_redis_cluster/client.py
+++ b/packages/google-cloud-redis-cluster/google/cloud/redis_cluster_v1beta1/services/cloud_redis_cluster/client.py
@@ -17,7 +17,6 @@ import json
 import logging as std_logging
 import os
 import re
-import uuid
 import warnings
 from collections import OrderedDict
 from http import HTTPStatus

--- a/packages/google-cloud-redis-cluster/noxfile.py
+++ b/packages/google-cloud-redis-cluster/noxfile.py
@@ -509,24 +509,50 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1) for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -596,16 +622,24 @@ def core_deps_from_source(session, protobuf_implementation):
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
+
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(
+        f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}"
+    )
 
     session.run(
         "py.test",

--- a/packages/google-cloud-redis-cluster/tests/unit/gapic/redis_cluster_v1/test_cloud_redis_cluster.py
+++ b/packages/google-cloud-redis-cluster/tests/unit/gapic/redis_cluster_v1/test_cloud_redis_cluster.py
@@ -16,7 +16,6 @@
 import json
 import math
 import os
-import re
 from collections.abc import AsyncIterable, Iterable, Mapping, Sequence
 from unittest import mock
 from unittest.mock import AsyncMock

--- a/packages/google-cloud-redis-cluster/tests/unit/gapic/redis_cluster_v1beta1/test_cloud_redis_cluster.py
+++ b/packages/google-cloud-redis-cluster/tests/unit/gapic/redis_cluster_v1beta1/test_cloud_redis_cluster.py
@@ -16,7 +16,6 @@
 import json
 import math
 import os
-import re
 from collections.abc import AsyncIterable, Iterable, Mapping, Sequence
 from unittest import mock
 from unittest.mock import AsyncMock

--- a/packages/google-cloud-redis/README.rst
+++ b/packages/google-cloud-redis/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-redis/docs/README.rst
+++ b/packages/google-cloud-redis/docs/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-redis/google/cloud/redis_v1/services/cloud_redis/async_client.py
+++ b/packages/google-cloud-redis/google/cloud/redis_v1/services/cloud_redis/async_client.py
@@ -15,7 +15,6 @@
 #
 import logging as std_logging
 import re
-import uuid
 from collections import OrderedDict
 from typing import (
     Callable,

--- a/packages/google-cloud-redis/google/cloud/redis_v1/services/cloud_redis/client.py
+++ b/packages/google-cloud-redis/google/cloud/redis_v1/services/cloud_redis/client.py
@@ -17,7 +17,6 @@ import json
 import logging as std_logging
 import os
 import re
-import uuid
 import warnings
 from collections import OrderedDict
 from http import HTTPStatus

--- a/packages/google-cloud-redis/google/cloud/redis_v1beta1/services/cloud_redis/async_client.py
+++ b/packages/google-cloud-redis/google/cloud/redis_v1beta1/services/cloud_redis/async_client.py
@@ -15,7 +15,6 @@
 #
 import logging as std_logging
 import re
-import uuid
 from collections import OrderedDict
 from typing import (
     Callable,

--- a/packages/google-cloud-redis/google/cloud/redis_v1beta1/services/cloud_redis/client.py
+++ b/packages/google-cloud-redis/google/cloud/redis_v1beta1/services/cloud_redis/client.py
@@ -17,7 +17,6 @@ import json
 import logging as std_logging
 import os
 import re
-import uuid
 import warnings
 from collections import OrderedDict
 from http import HTTPStatus

--- a/packages/google-cloud-redis/noxfile.py
+++ b/packages/google-cloud-redis/noxfile.py
@@ -509,24 +509,50 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1) for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -596,16 +622,24 @@ def core_deps_from_source(session, protobuf_implementation):
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
+
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(
+        f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}"
+    )
 
     session.run(
         "py.test",

--- a/packages/google-cloud-redis/tests/unit/gapic/redis_v1/test_cloud_redis.py
+++ b/packages/google-cloud-redis/tests/unit/gapic/redis_v1/test_cloud_redis.py
@@ -16,7 +16,6 @@
 import json
 import math
 import os
-import re
 from collections.abc import AsyncIterable, Iterable, Mapping, Sequence
 from unittest import mock
 from unittest.mock import AsyncMock

--- a/packages/google-cloud-redis/tests/unit/gapic/redis_v1beta1/test_cloud_redis.py
+++ b/packages/google-cloud-redis/tests/unit/gapic/redis_v1beta1/test_cloud_redis.py
@@ -16,7 +16,6 @@
 import json
 import math
 import os
-import re
 from collections.abc import AsyncIterable, Iterable, Mapping, Sequence
 from unittest import mock
 from unittest.mock import AsyncMock

--- a/packages/google-cloud-resource-manager/README.rst
+++ b/packages/google-cloud-resource-manager/README.rst
@@ -62,14 +62,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-resource-manager/docs/README.rst
+++ b/packages/google-cloud-resource-manager/docs/README.rst
@@ -62,14 +62,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-resource-manager/noxfile.py
+++ b/packages/google-cloud-resource-manager/noxfile.py
@@ -509,24 +509,50 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1) for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -596,16 +622,24 @@ def core_deps_from_source(session, protobuf_implementation):
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
+
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(
+        f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}"
+    )
 
     session.run(
         "py.test",

--- a/packages/google-cloud-retail/README.rst
+++ b/packages/google-cloud-retail/README.rst
@@ -64,14 +64,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-retail/docs/README.rst
+++ b/packages/google-cloud-retail/docs/README.rst
@@ -64,14 +64,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-retail/noxfile.py
+++ b/packages/google-cloud-retail/noxfile.py
@@ -509,24 +509,50 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1) for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -596,16 +622,24 @@ def core_deps_from_source(session, protobuf_implementation):
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
+
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(
+        f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}"
+    )
 
     session.run(
         "py.test",

--- a/packages/google-cloud-run/README.rst
+++ b/packages/google-cloud-run/README.rst
@@ -64,14 +64,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-run/docs/README.rst
+++ b/packages/google-cloud-run/docs/README.rst
@@ -64,14 +64,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-run/noxfile.py
+++ b/packages/google-cloud-run/noxfile.py
@@ -509,24 +509,50 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1) for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -596,16 +622,24 @@ def core_deps_from_source(session, protobuf_implementation):
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
+
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(
+        f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}"
+    )
 
     session.run(
         "py.test",

--- a/packages/google-cloud-saasplatform-saasservicemgmt/README.rst
+++ b/packages/google-cloud-saasplatform-saasservicemgmt/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-saasplatform-saasservicemgmt/docs/README.rst
+++ b/packages/google-cloud-saasplatform-saasservicemgmt/docs/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-saasplatform-saasservicemgmt/noxfile.py
+++ b/packages/google-cloud-saasplatform-saasservicemgmt/noxfile.py
@@ -509,24 +509,50 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1) for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -596,16 +622,24 @@ def core_deps_from_source(session, protobuf_implementation):
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
+
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(
+        f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}"
+    )
 
     session.run(
         "py.test",

--- a/packages/google-cloud-scheduler/README.rst
+++ b/packages/google-cloud-scheduler/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-scheduler/docs/README.rst
+++ b/packages/google-cloud-scheduler/docs/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-scheduler/noxfile.py
+++ b/packages/google-cloud-scheduler/noxfile.py
@@ -509,24 +509,50 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1) for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -596,16 +622,24 @@ def core_deps_from_source(session, protobuf_implementation):
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
+
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(
+        f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}"
+    )
 
     session.run(
         "py.test",

--- a/packages/google-cloud-secret-manager/README.rst
+++ b/packages/google-cloud-secret-manager/README.rst
@@ -62,14 +62,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-secret-manager/docs/README.rst
+++ b/packages/google-cloud-secret-manager/docs/README.rst
@@ -62,14 +62,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-secret-manager/noxfile.py
+++ b/packages/google-cloud-secret-manager/noxfile.py
@@ -509,24 +509,50 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1) for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -596,16 +622,24 @@ def core_deps_from_source(session, protobuf_implementation):
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
+
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(
+        f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}"
+    )
 
     session.run(
         "py.test",

--- a/packages/google-cloud-securesourcemanager/README.rst
+++ b/packages/google-cloud-securesourcemanager/README.rst
@@ -62,14 +62,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-securesourcemanager/docs/README.rst
+++ b/packages/google-cloud-securesourcemanager/docs/README.rst
@@ -62,14 +62,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-securesourcemanager/noxfile.py
+++ b/packages/google-cloud-securesourcemanager/noxfile.py
@@ -509,24 +509,50 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1) for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -596,16 +622,24 @@ def core_deps_from_source(session, protobuf_implementation):
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
+
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(
+        f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}"
+    )
 
     session.run(
         "py.test",

--- a/packages/google-cloud-security-publicca/README.rst
+++ b/packages/google-cloud-security-publicca/README.rst
@@ -63,14 +63,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-security-publicca/docs/README.rst
+++ b/packages/google-cloud-security-publicca/docs/README.rst
@@ -63,14 +63,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-security-publicca/noxfile.py
+++ b/packages/google-cloud-security-publicca/noxfile.py
@@ -509,24 +509,50 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1) for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -596,16 +622,24 @@ def core_deps_from_source(session, protobuf_implementation):
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
+
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(
+        f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}"
+    )
 
     session.run(
         "py.test",

--- a/packages/google-cloud-securitycenter/README.rst
+++ b/packages/google-cloud-securitycenter/README.rst
@@ -62,14 +62,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-securitycenter/docs/README.rst
+++ b/packages/google-cloud-securitycenter/docs/README.rst
@@ -62,14 +62,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-securitycenter/noxfile.py
+++ b/packages/google-cloud-securitycenter/noxfile.py
@@ -509,24 +509,50 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1) for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -596,16 +622,24 @@ def core_deps_from_source(session, protobuf_implementation):
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
+
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(
+        f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}"
+    )
 
     session.run(
         "py.test",

--- a/packages/google-cloud-securitycentermanagement/README.rst
+++ b/packages/google-cloud-securitycentermanagement/README.rst
@@ -63,14 +63,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-securitycentermanagement/docs/README.rst
+++ b/packages/google-cloud-securitycentermanagement/docs/README.rst
@@ -63,14 +63,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-securitycentermanagement/noxfile.py
+++ b/packages/google-cloud-securitycentermanagement/noxfile.py
@@ -509,24 +509,50 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1) for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -596,16 +622,24 @@ def core_deps_from_source(session, protobuf_implementation):
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
+
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(
+        f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}"
+    )
 
     session.run(
         "py.test",

--- a/packages/google-cloud-service-control/README.rst
+++ b/packages/google-cloud-service-control/README.rst
@@ -62,14 +62,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-service-control/docs/README.rst
+++ b/packages/google-cloud-service-control/docs/README.rst
@@ -62,14 +62,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-service-control/noxfile.py
+++ b/packages/google-cloud-service-control/noxfile.py
@@ -509,24 +509,50 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1) for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -596,16 +622,24 @@ def core_deps_from_source(session, protobuf_implementation):
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
+
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(
+        f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}"
+    )
 
     session.run(
         "py.test",

--- a/packages/google-cloud-service-directory/README.rst
+++ b/packages/google-cloud-service-directory/README.rst
@@ -62,14 +62,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-service-directory/docs/README.rst
+++ b/packages/google-cloud-service-directory/docs/README.rst
@@ -62,14 +62,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-service-directory/noxfile.py
+++ b/packages/google-cloud-service-directory/noxfile.py
@@ -509,24 +509,50 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1) for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -596,16 +622,24 @@ def core_deps_from_source(session, protobuf_implementation):
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
+
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(
+        f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}"
+    )
 
     session.run(
         "py.test",

--- a/packages/google-cloud-service-management/README.rst
+++ b/packages/google-cloud-service-management/README.rst
@@ -63,14 +63,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-service-management/docs/README.rst
+++ b/packages/google-cloud-service-management/docs/README.rst
@@ -63,14 +63,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-service-management/noxfile.py
+++ b/packages/google-cloud-service-management/noxfile.py
@@ -509,24 +509,50 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1) for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -596,16 +622,24 @@ def core_deps_from_source(session, protobuf_implementation):
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
+
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(
+        f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}"
+    )
 
     session.run(
         "py.test",

--- a/packages/google-cloud-service-usage/README.rst
+++ b/packages/google-cloud-service-usage/README.rst
@@ -63,14 +63,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-service-usage/docs/README.rst
+++ b/packages/google-cloud-service-usage/docs/README.rst
@@ -63,14 +63,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-service-usage/noxfile.py
+++ b/packages/google-cloud-service-usage/noxfile.py
@@ -509,24 +509,50 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1) for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -596,16 +622,24 @@ def core_deps_from_source(session, protobuf_implementation):
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
+
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(
+        f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}"
+    )
 
     session.run(
         "py.test",

--- a/packages/google-cloud-servicehealth/README.rst
+++ b/packages/google-cloud-servicehealth/README.rst
@@ -62,14 +62,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-servicehealth/docs/README.rst
+++ b/packages/google-cloud-servicehealth/docs/README.rst
@@ -62,14 +62,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-servicehealth/noxfile.py
+++ b/packages/google-cloud-servicehealth/noxfile.py
@@ -509,24 +509,50 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1) for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -596,16 +622,24 @@ def core_deps_from_source(session, protobuf_implementation):
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
+
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(
+        f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}"
+    )
 
     session.run(
         "py.test",

--- a/packages/google-cloud-shell/README.rst
+++ b/packages/google-cloud-shell/README.rst
@@ -62,14 +62,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-shell/docs/README.rst
+++ b/packages/google-cloud-shell/docs/README.rst
@@ -62,14 +62,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-shell/noxfile.py
+++ b/packages/google-cloud-shell/noxfile.py
@@ -509,24 +509,50 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1) for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -596,16 +622,24 @@ def core_deps_from_source(session, protobuf_implementation):
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
+
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(
+        f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}"
+    )
 
     session.run(
         "py.test",

--- a/packages/google-cloud-source-context/README.rst
+++ b/packages/google-cloud-source-context/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-source-context/docs/README.rst
+++ b/packages/google-cloud-source-context/docs/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-source-context/noxfile.py
+++ b/packages/google-cloud-source-context/noxfile.py
@@ -509,24 +509,50 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1) for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -596,16 +622,24 @@ def core_deps_from_source(session, protobuf_implementation):
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
+
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(
+        f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}"
+    )
 
     session.run(
         "py.test",

--- a/packages/google-cloud-spanner/README.rst
+++ b/packages/google-cloud-spanner/README.rst
@@ -71,6 +71,7 @@ Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Python <= 3.9
 
+
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.
 

--- a/packages/google-cloud-spanner/docs/README.rst
+++ b/packages/google-cloud-spanner/docs/README.rst
@@ -71,6 +71,7 @@ Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Python <= 3.9
 
+
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.
 

--- a/packages/google-cloud-spanner/google/cloud/spanner_admin_database_v1/services/database_admin/async_client.py
+++ b/packages/google-cloud-spanner/google/cloud/spanner_admin_database_v1/services/database_admin/async_client.py
@@ -15,7 +15,6 @@
 #
 import logging as std_logging
 import re
-import uuid
 from collections import OrderedDict
 from typing import (
     Callable,

--- a/packages/google-cloud-spanner/google/cloud/spanner_admin_database_v1/services/database_admin/client.py
+++ b/packages/google-cloud-spanner/google/cloud/spanner_admin_database_v1/services/database_admin/client.py
@@ -17,7 +17,6 @@ import json
 import logging as std_logging
 import os
 import re
-import uuid
 import warnings
 from collections import OrderedDict
 from http import HTTPStatus

--- a/packages/google-cloud-spanner/google/cloud/spanner_admin_instance_v1/services/instance_admin/async_client.py
+++ b/packages/google-cloud-spanner/google/cloud/spanner_admin_instance_v1/services/instance_admin/async_client.py
@@ -15,7 +15,6 @@
 #
 import logging as std_logging
 import re
-import uuid
 from collections import OrderedDict
 from typing import (
     Callable,

--- a/packages/google-cloud-spanner/google/cloud/spanner_admin_instance_v1/services/instance_admin/client.py
+++ b/packages/google-cloud-spanner/google/cloud/spanner_admin_instance_v1/services/instance_admin/client.py
@@ -17,7 +17,6 @@ import json
 import logging as std_logging
 import os
 import re
-import uuid
 import warnings
 from collections import OrderedDict
 from http import HTTPStatus

--- a/packages/google-cloud-spanner/noxfile.py
+++ b/packages/google-cloud-spanner/noxfile.py
@@ -825,16 +825,24 @@ def core_deps_from_source(session, protobuf_implementation):
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
+
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(
+        f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}"
+    )
 
     session.run(
         "py.test",

--- a/packages/google-cloud-spanner/tests/unit/gapic/spanner_admin_database_v1/test_database_admin.py
+++ b/packages/google-cloud-spanner/tests/unit/gapic/spanner_admin_database_v1/test_database_admin.py
@@ -16,7 +16,6 @@
 import json
 import math
 import os
-import re
 from collections.abc import AsyncIterable, Iterable, Mapping, Sequence
 from unittest import mock
 from unittest.mock import AsyncMock

--- a/packages/google-cloud-spanner/tests/unit/gapic/spanner_admin_instance_v1/test_instance_admin.py
+++ b/packages/google-cloud-spanner/tests/unit/gapic/spanner_admin_instance_v1/test_instance_admin.py
@@ -16,7 +16,6 @@
 import json
 import math
 import os
-import re
 from collections.abc import AsyncIterable, Iterable, Mapping, Sequence
 from unittest import mock
 from unittest.mock import AsyncMock

--- a/packages/google-cloud-speech/README.rst
+++ b/packages/google-cloud-speech/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-speech/docs/README.rst
+++ b/packages/google-cloud-speech/docs/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-speech/noxfile.py
+++ b/packages/google-cloud-speech/noxfile.py
@@ -510,24 +510,50 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1) for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -597,16 +623,24 @@ def core_deps_from_source(session, protobuf_implementation):
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
+
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(
+        f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}"
+    )
 
     session.run(
         "py.test",

--- a/packages/google-cloud-storage-control/README.rst
+++ b/packages/google-cloud-storage-control/README.rst
@@ -67,14 +67,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-storage-control/docs/README.rst
+++ b/packages/google-cloud-storage-control/docs/README.rst
@@ -67,14 +67,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-storage-control/noxfile.py
+++ b/packages/google-cloud-storage-control/noxfile.py
@@ -509,24 +509,50 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1) for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -596,16 +622,24 @@ def core_deps_from_source(session, protobuf_implementation):
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
+
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(
+        f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}"
+    )
 
     session.run(
         "py.test",

--- a/packages/google-cloud-storage-control/tests/unit/gapic/storage_control_v2/test_storage_control.py
+++ b/packages/google-cloud-storage-control/tests/unit/gapic/storage_control_v2/test_storage_control.py
@@ -1395,7 +1395,7 @@ def test_create_folder_non_empty_request_with_auto_populated_field():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         # Ensure that the uuid4 field is set according to AIP 4235
-        assert re.match(
+        assert re.fullmatch(
             r"[a-f0-9]{8}-?[a-f0-9]{4}-?4[a-f0-9]{3}-?[89ab][a-f0-9]{3}-?[a-f0-9]{12}",
             args[0].request_id,
         )
@@ -1694,7 +1694,7 @@ def test_delete_folder_non_empty_request_with_auto_populated_field():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         # Ensure that the uuid4 field is set according to AIP 4235
-        assert re.match(
+        assert re.fullmatch(
             r"[a-f0-9]{8}-?[a-f0-9]{4}-?4[a-f0-9]{3}-?[89ab][a-f0-9]{3}-?[a-f0-9]{12}",
             args[0].request_id,
         )
@@ -1968,7 +1968,7 @@ def test_get_folder_non_empty_request_with_auto_populated_field():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         # Ensure that the uuid4 field is set according to AIP 4235
-        assert re.match(
+        assert re.fullmatch(
             r"[a-f0-9]{8}-?[a-f0-9]{4}-?4[a-f0-9]{3}-?[89ab][a-f0-9]{3}-?[a-f0-9]{12}",
             args[0].request_id,
         )
@@ -2704,7 +2704,7 @@ def test_rename_folder_non_empty_request_with_auto_populated_field():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         # Ensure that the uuid4 field is set according to AIP 4235
-        assert re.match(
+        assert re.fullmatch(
             r"[a-f0-9]{8}-?[a-f0-9]{4}-?4[a-f0-9]{3}-?[89ab][a-f0-9]{3}-?[a-f0-9]{12}",
             args[0].request_id,
         )
@@ -3002,7 +3002,7 @@ def test_delete_folder_recursive_non_empty_request_with_auto_populated_field():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         # Ensure that the uuid4 field is set according to AIP 4235
-        assert re.match(
+        assert re.fullmatch(
             r"[a-f0-9]{8}-?[a-f0-9]{4}-?4[a-f0-9]{3}-?[89ab][a-f0-9]{3}-?[a-f0-9]{12}",
             args[0].request_id,
         )
@@ -3309,7 +3309,7 @@ def test_get_storage_layout_non_empty_request_with_auto_populated_field():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         # Ensure that the uuid4 field is set according to AIP 4235
-        assert re.match(
+        assert re.fullmatch(
             r"[a-f0-9]{8}-?[a-f0-9]{4}-?4[a-f0-9]{3}-?[89ab][a-f0-9]{3}-?[a-f0-9]{12}",
             args[0].request_id,
         )
@@ -3611,7 +3611,7 @@ def test_create_managed_folder_non_empty_request_with_auto_populated_field():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         # Ensure that the uuid4 field is set according to AIP 4235
-        assert re.match(
+        assert re.fullmatch(
             r"[a-f0-9]{8}-?[a-f0-9]{4}-?4[a-f0-9]{3}-?[89ab][a-f0-9]{3}-?[a-f0-9]{12}",
             args[0].request_id,
         )
@@ -3926,7 +3926,7 @@ def test_delete_managed_folder_non_empty_request_with_auto_populated_field():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         # Ensure that the uuid4 field is set according to AIP 4235
-        assert re.match(
+        assert re.fullmatch(
             r"[a-f0-9]{8}-?[a-f0-9]{4}-?4[a-f0-9]{3}-?[89ab][a-f0-9]{3}-?[a-f0-9]{12}",
             args[0].request_id,
         )
@@ -4216,7 +4216,7 @@ def test_get_managed_folder_non_empty_request_with_auto_populated_field():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         # Ensure that the uuid4 field is set according to AIP 4235
-        assert re.match(
+        assert re.fullmatch(
             r"[a-f0-9]{8}-?[a-f0-9]{4}-?4[a-f0-9]{3}-?[89ab][a-f0-9]{3}-?[a-f0-9]{12}",
             args[0].request_id,
         )
@@ -4514,7 +4514,7 @@ def test_list_managed_folders_non_empty_request_with_auto_populated_field():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         # Ensure that the uuid4 field is set according to AIP 4235
-        assert re.match(
+        assert re.fullmatch(
             r"[a-f0-9]{8}-?[a-f0-9]{4}-?4[a-f0-9]{3}-?[89ab][a-f0-9]{3}-?[a-f0-9]{12}",
             args[0].request_id,
         )
@@ -5002,7 +5002,7 @@ def test_create_anywhere_cache_non_empty_request_with_auto_populated_field():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         # Ensure that the uuid4 field is set according to AIP 4235
-        assert re.match(
+        assert re.fullmatch(
             r"[a-f0-9]{8}-?[a-f0-9]{4}-?4[a-f0-9]{3}-?[89ab][a-f0-9]{3}-?[a-f0-9]{12}",
             args[0].request_id,
         )
@@ -5309,7 +5309,7 @@ def test_update_anywhere_cache_non_empty_request_with_auto_populated_field():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         # Ensure that the uuid4 field is set according to AIP 4235
-        assert re.match(
+        assert re.fullmatch(
             r"[a-f0-9]{8}-?[a-f0-9]{4}-?4[a-f0-9]{3}-?[89ab][a-f0-9]{3}-?[a-f0-9]{12}",
             args[0].request_id,
         )
@@ -5627,7 +5627,7 @@ def test_disable_anywhere_cache_non_empty_request_with_auto_populated_field():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         # Ensure that the uuid4 field is set according to AIP 4235
-        assert re.match(
+        assert re.fullmatch(
             r"[a-f0-9]{8}-?[a-f0-9]{4}-?4[a-f0-9]{3}-?[89ab][a-f0-9]{3}-?[a-f0-9]{12}",
             args[0].request_id,
         )
@@ -5938,7 +5938,7 @@ def test_pause_anywhere_cache_non_empty_request_with_auto_populated_field():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         # Ensure that the uuid4 field is set according to AIP 4235
-        assert re.match(
+        assert re.fullmatch(
             r"[a-f0-9]{8}-?[a-f0-9]{4}-?4[a-f0-9]{3}-?[89ab][a-f0-9]{3}-?[a-f0-9]{12}",
             args[0].request_id,
         )
@@ -6248,7 +6248,7 @@ def test_resume_anywhere_cache_non_empty_request_with_auto_populated_field():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         # Ensure that the uuid4 field is set according to AIP 4235
-        assert re.match(
+        assert re.fullmatch(
             r"[a-f0-9]{8}-?[a-f0-9]{4}-?4[a-f0-9]{3}-?[89ab][a-f0-9]{3}-?[a-f0-9]{12}",
             args[0].request_id,
         )
@@ -6559,7 +6559,7 @@ def test_get_anywhere_cache_non_empty_request_with_auto_populated_field():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         # Ensure that the uuid4 field is set according to AIP 4235
-        assert re.match(
+        assert re.fullmatch(
             r"[a-f0-9]{8}-?[a-f0-9]{4}-?4[a-f0-9]{3}-?[89ab][a-f0-9]{3}-?[a-f0-9]{12}",
             args[0].request_id,
         )
@@ -6862,7 +6862,7 @@ def test_list_anywhere_caches_non_empty_request_with_auto_populated_field():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         # Ensure that the uuid4 field is set according to AIP 4235
-        assert re.match(
+        assert re.fullmatch(
             r"[a-f0-9]{8}-?[a-f0-9]{4}-?4[a-f0-9]{3}-?[89ab][a-f0-9]{3}-?[a-f0-9]{12}",
             args[0].request_id,
         )
@@ -12088,7 +12088,7 @@ def test_create_folder_empty_call_grpc():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         # Ensure that the uuid4 field is set according to AIP 4235
-        assert re.match(
+        assert re.fullmatch(
             r"[a-f0-9]{8}-?[a-f0-9]{4}-?4[a-f0-9]{3}-?[89ab][a-f0-9]{3}-?[a-f0-9]{12}",
             args[0].request_id,
         )
@@ -12116,7 +12116,7 @@ def test_delete_folder_empty_call_grpc():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         # Ensure that the uuid4 field is set according to AIP 4235
-        assert re.match(
+        assert re.fullmatch(
             r"[a-f0-9]{8}-?[a-f0-9]{4}-?4[a-f0-9]{3}-?[89ab][a-f0-9]{3}-?[a-f0-9]{12}",
             args[0].request_id,
         )
@@ -12144,7 +12144,7 @@ def test_get_folder_empty_call_grpc():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         # Ensure that the uuid4 field is set according to AIP 4235
-        assert re.match(
+        assert re.fullmatch(
             r"[a-f0-9]{8}-?[a-f0-9]{4}-?4[a-f0-9]{3}-?[89ab][a-f0-9]{3}-?[a-f0-9]{12}",
             args[0].request_id,
         )
@@ -12193,7 +12193,7 @@ def test_rename_folder_empty_call_grpc():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         # Ensure that the uuid4 field is set according to AIP 4235
-        assert re.match(
+        assert re.fullmatch(
             r"[a-f0-9]{8}-?[a-f0-9]{4}-?4[a-f0-9]{3}-?[89ab][a-f0-9]{3}-?[a-f0-9]{12}",
             args[0].request_id,
         )
@@ -12223,7 +12223,7 @@ def test_delete_folder_recursive_empty_call_grpc():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         # Ensure that the uuid4 field is set according to AIP 4235
-        assert re.match(
+        assert re.fullmatch(
             r"[a-f0-9]{8}-?[a-f0-9]{4}-?4[a-f0-9]{3}-?[89ab][a-f0-9]{3}-?[a-f0-9]{12}",
             args[0].request_id,
         )
@@ -12253,7 +12253,7 @@ def test_get_storage_layout_empty_call_grpc():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         # Ensure that the uuid4 field is set according to AIP 4235
-        assert re.match(
+        assert re.fullmatch(
             r"[a-f0-9]{8}-?[a-f0-9]{4}-?4[a-f0-9]{3}-?[89ab][a-f0-9]{3}-?[a-f0-9]{12}",
             args[0].request_id,
         )
@@ -12283,7 +12283,7 @@ def test_create_managed_folder_empty_call_grpc():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         # Ensure that the uuid4 field is set according to AIP 4235
-        assert re.match(
+        assert re.fullmatch(
             r"[a-f0-9]{8}-?[a-f0-9]{4}-?4[a-f0-9]{3}-?[89ab][a-f0-9]{3}-?[a-f0-9]{12}",
             args[0].request_id,
         )
@@ -12313,7 +12313,7 @@ def test_delete_managed_folder_empty_call_grpc():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         # Ensure that the uuid4 field is set according to AIP 4235
-        assert re.match(
+        assert re.fullmatch(
             r"[a-f0-9]{8}-?[a-f0-9]{4}-?4[a-f0-9]{3}-?[89ab][a-f0-9]{3}-?[a-f0-9]{12}",
             args[0].request_id,
         )
@@ -12343,7 +12343,7 @@ def test_get_managed_folder_empty_call_grpc():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         # Ensure that the uuid4 field is set according to AIP 4235
-        assert re.match(
+        assert re.fullmatch(
             r"[a-f0-9]{8}-?[a-f0-9]{4}-?4[a-f0-9]{3}-?[89ab][a-f0-9]{3}-?[a-f0-9]{12}",
             args[0].request_id,
         )
@@ -12373,7 +12373,7 @@ def test_list_managed_folders_empty_call_grpc():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         # Ensure that the uuid4 field is set according to AIP 4235
-        assert re.match(
+        assert re.fullmatch(
             r"[a-f0-9]{8}-?[a-f0-9]{4}-?4[a-f0-9]{3}-?[89ab][a-f0-9]{3}-?[a-f0-9]{12}",
             args[0].request_id,
         )
@@ -12403,7 +12403,7 @@ def test_create_anywhere_cache_empty_call_grpc():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         # Ensure that the uuid4 field is set according to AIP 4235
-        assert re.match(
+        assert re.fullmatch(
             r"[a-f0-9]{8}-?[a-f0-9]{4}-?4[a-f0-9]{3}-?[89ab][a-f0-9]{3}-?[a-f0-9]{12}",
             args[0].request_id,
         )
@@ -12433,7 +12433,7 @@ def test_update_anywhere_cache_empty_call_grpc():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         # Ensure that the uuid4 field is set according to AIP 4235
-        assert re.match(
+        assert re.fullmatch(
             r"[a-f0-9]{8}-?[a-f0-9]{4}-?4[a-f0-9]{3}-?[89ab][a-f0-9]{3}-?[a-f0-9]{12}",
             args[0].request_id,
         )
@@ -12463,7 +12463,7 @@ def test_disable_anywhere_cache_empty_call_grpc():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         # Ensure that the uuid4 field is set according to AIP 4235
-        assert re.match(
+        assert re.fullmatch(
             r"[a-f0-9]{8}-?[a-f0-9]{4}-?4[a-f0-9]{3}-?[89ab][a-f0-9]{3}-?[a-f0-9]{12}",
             args[0].request_id,
         )
@@ -12493,7 +12493,7 @@ def test_pause_anywhere_cache_empty_call_grpc():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         # Ensure that the uuid4 field is set according to AIP 4235
-        assert re.match(
+        assert re.fullmatch(
             r"[a-f0-9]{8}-?[a-f0-9]{4}-?4[a-f0-9]{3}-?[89ab][a-f0-9]{3}-?[a-f0-9]{12}",
             args[0].request_id,
         )
@@ -12523,7 +12523,7 @@ def test_resume_anywhere_cache_empty_call_grpc():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         # Ensure that the uuid4 field is set according to AIP 4235
-        assert re.match(
+        assert re.fullmatch(
             r"[a-f0-9]{8}-?[a-f0-9]{4}-?4[a-f0-9]{3}-?[89ab][a-f0-9]{3}-?[a-f0-9]{12}",
             args[0].request_id,
         )
@@ -12553,7 +12553,7 @@ def test_get_anywhere_cache_empty_call_grpc():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         # Ensure that the uuid4 field is set according to AIP 4235
-        assert re.match(
+        assert re.fullmatch(
             r"[a-f0-9]{8}-?[a-f0-9]{4}-?4[a-f0-9]{3}-?[89ab][a-f0-9]{3}-?[a-f0-9]{12}",
             args[0].request_id,
         )
@@ -12583,7 +12583,7 @@ def test_list_anywhere_caches_empty_call_grpc():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         # Ensure that the uuid4 field is set according to AIP 4235
-        assert re.match(
+        assert re.fullmatch(
             r"[a-f0-9]{8}-?[a-f0-9]{4}-?4[a-f0-9]{3}-?[89ab][a-f0-9]{3}-?[a-f0-9]{12}",
             args[0].request_id,
         )
@@ -12812,7 +12812,7 @@ def test_create_folder_routing_parameters_request_1_grpc():
         call.assert_called()
         _, args, kw = call.mock_calls[0]
         # Ensure that the uuid4 field is set according to AIP 4235
-        assert re.match(
+        assert re.fullmatch(
             r"[a-f0-9]{8}-?[a-f0-9]{4}-?4[a-f0-9]{3}-?[89ab][a-f0-9]{3}-?[a-f0-9]{12}",
             args[0].request_id,
         )
@@ -12845,7 +12845,7 @@ def test_delete_folder_routing_parameters_request_1_grpc():
         call.assert_called()
         _, args, kw = call.mock_calls[0]
         # Ensure that the uuid4 field is set according to AIP 4235
-        assert re.match(
+        assert re.fullmatch(
             r"[a-f0-9]{8}-?[a-f0-9]{4}-?4[a-f0-9]{3}-?[89ab][a-f0-9]{3}-?[a-f0-9]{12}",
             args[0].request_id,
         )
@@ -12878,7 +12878,7 @@ def test_get_folder_routing_parameters_request_1_grpc():
         call.assert_called()
         _, args, kw = call.mock_calls[0]
         # Ensure that the uuid4 field is set according to AIP 4235
-        assert re.match(
+        assert re.fullmatch(
             r"[a-f0-9]{8}-?[a-f0-9]{4}-?4[a-f0-9]{3}-?[89ab][a-f0-9]{3}-?[a-f0-9]{12}",
             args[0].request_id,
         )
@@ -12937,7 +12937,7 @@ def test_rename_folder_routing_parameters_request_1_grpc():
         call.assert_called()
         _, args, kw = call.mock_calls[0]
         # Ensure that the uuid4 field is set according to AIP 4235
-        assert re.match(
+        assert re.fullmatch(
             r"[a-f0-9]{8}-?[a-f0-9]{4}-?4[a-f0-9]{3}-?[89ab][a-f0-9]{3}-?[a-f0-9]{12}",
             args[0].request_id,
         )
@@ -12974,7 +12974,7 @@ def test_delete_folder_recursive_routing_parameters_request_1_grpc():
         call.assert_called()
         _, args, kw = call.mock_calls[0]
         # Ensure that the uuid4 field is set according to AIP 4235
-        assert re.match(
+        assert re.fullmatch(
             r"[a-f0-9]{8}-?[a-f0-9]{4}-?4[a-f0-9]{3}-?[89ab][a-f0-9]{3}-?[a-f0-9]{12}",
             args[0].request_id,
         )
@@ -13011,7 +13011,7 @@ def test_get_storage_layout_routing_parameters_request_1_grpc():
         call.assert_called()
         _, args, kw = call.mock_calls[0]
         # Ensure that the uuid4 field is set according to AIP 4235
-        assert re.match(
+        assert re.fullmatch(
             r"[a-f0-9]{8}-?[a-f0-9]{4}-?4[a-f0-9]{3}-?[89ab][a-f0-9]{3}-?[a-f0-9]{12}",
             args[0].request_id,
         )
@@ -13046,7 +13046,7 @@ def test_create_managed_folder_routing_parameters_request_1_grpc():
         call.assert_called()
         _, args, kw = call.mock_calls[0]
         # Ensure that the uuid4 field is set according to AIP 4235
-        assert re.match(
+        assert re.fullmatch(
             r"[a-f0-9]{8}-?[a-f0-9]{4}-?4[a-f0-9]{3}-?[89ab][a-f0-9]{3}-?[a-f0-9]{12}",
             args[0].request_id,
         )
@@ -13083,7 +13083,7 @@ def test_delete_managed_folder_routing_parameters_request_1_grpc():
         call.assert_called()
         _, args, kw = call.mock_calls[0]
         # Ensure that the uuid4 field is set according to AIP 4235
-        assert re.match(
+        assert re.fullmatch(
             r"[a-f0-9]{8}-?[a-f0-9]{4}-?4[a-f0-9]{3}-?[89ab][a-f0-9]{3}-?[a-f0-9]{12}",
             args[0].request_id,
         )
@@ -13120,7 +13120,7 @@ def test_get_managed_folder_routing_parameters_request_1_grpc():
         call.assert_called()
         _, args, kw = call.mock_calls[0]
         # Ensure that the uuid4 field is set according to AIP 4235
-        assert re.match(
+        assert re.fullmatch(
             r"[a-f0-9]{8}-?[a-f0-9]{4}-?4[a-f0-9]{3}-?[89ab][a-f0-9]{3}-?[a-f0-9]{12}",
             args[0].request_id,
         )
@@ -13155,7 +13155,7 @@ def test_list_managed_folders_routing_parameters_request_1_grpc():
         call.assert_called()
         _, args, kw = call.mock_calls[0]
         # Ensure that the uuid4 field is set according to AIP 4235
-        assert re.match(
+        assert re.fullmatch(
             r"[a-f0-9]{8}-?[a-f0-9]{4}-?4[a-f0-9]{3}-?[89ab][a-f0-9]{3}-?[a-f0-9]{12}",
             args[0].request_id,
         )
@@ -13188,7 +13188,7 @@ def test_create_anywhere_cache_routing_parameters_request_1_grpc():
         call.assert_called()
         _, args, kw = call.mock_calls[0]
         # Ensure that the uuid4 field is set according to AIP 4235
-        assert re.match(
+        assert re.fullmatch(
             r"[a-f0-9]{8}-?[a-f0-9]{4}-?4[a-f0-9]{3}-?[89ab][a-f0-9]{3}-?[a-f0-9]{12}",
             args[0].request_id,
         )
@@ -13227,7 +13227,7 @@ def test_update_anywhere_cache_routing_parameters_request_1_grpc():
         call.assert_called()
         _, args, kw = call.mock_calls[0]
         # Ensure that the uuid4 field is set according to AIP 4235
-        assert re.match(
+        assert re.fullmatch(
             r"[a-f0-9]{8}-?[a-f0-9]{4}-?4[a-f0-9]{3}-?[89ab][a-f0-9]{3}-?[a-f0-9]{12}",
             args[0].request_id,
         )
@@ -13264,7 +13264,7 @@ def test_disable_anywhere_cache_routing_parameters_request_1_grpc():
         call.assert_called()
         _, args, kw = call.mock_calls[0]
         # Ensure that the uuid4 field is set according to AIP 4235
-        assert re.match(
+        assert re.fullmatch(
             r"[a-f0-9]{8}-?[a-f0-9]{4}-?4[a-f0-9]{3}-?[89ab][a-f0-9]{3}-?[a-f0-9]{12}",
             args[0].request_id,
         )
@@ -13301,7 +13301,7 @@ def test_pause_anywhere_cache_routing_parameters_request_1_grpc():
         call.assert_called()
         _, args, kw = call.mock_calls[0]
         # Ensure that the uuid4 field is set according to AIP 4235
-        assert re.match(
+        assert re.fullmatch(
             r"[a-f0-9]{8}-?[a-f0-9]{4}-?4[a-f0-9]{3}-?[89ab][a-f0-9]{3}-?[a-f0-9]{12}",
             args[0].request_id,
         )
@@ -13338,7 +13338,7 @@ def test_resume_anywhere_cache_routing_parameters_request_1_grpc():
         call.assert_called()
         _, args, kw = call.mock_calls[0]
         # Ensure that the uuid4 field is set according to AIP 4235
-        assert re.match(
+        assert re.fullmatch(
             r"[a-f0-9]{8}-?[a-f0-9]{4}-?4[a-f0-9]{3}-?[89ab][a-f0-9]{3}-?[a-f0-9]{12}",
             args[0].request_id,
         )
@@ -13375,7 +13375,7 @@ def test_get_anywhere_cache_routing_parameters_request_1_grpc():
         call.assert_called()
         _, args, kw = call.mock_calls[0]
         # Ensure that the uuid4 field is set according to AIP 4235
-        assert re.match(
+        assert re.fullmatch(
             r"[a-f0-9]{8}-?[a-f0-9]{4}-?4[a-f0-9]{3}-?[89ab][a-f0-9]{3}-?[a-f0-9]{12}",
             args[0].request_id,
         )
@@ -13410,7 +13410,7 @@ def test_list_anywhere_caches_routing_parameters_request_1_grpc():
         call.assert_called()
         _, args, kw = call.mock_calls[0]
         # Ensure that the uuid4 field is set according to AIP 4235
-        assert re.match(
+        assert re.fullmatch(
             r"[a-f0-9]{8}-?[a-f0-9]{4}-?4[a-f0-9]{3}-?[89ab][a-f0-9]{3}-?[a-f0-9]{12}",
             args[0].request_id,
         )
@@ -13658,7 +13658,7 @@ async def test_create_folder_empty_call_grpc_asyncio():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         # Ensure that the uuid4 field is set according to AIP 4235
-        assert re.match(
+        assert re.fullmatch(
             r"[a-f0-9]{8}-?[a-f0-9]{4}-?4[a-f0-9]{3}-?[89ab][a-f0-9]{3}-?[a-f0-9]{12}",
             args[0].request_id,
         )
@@ -13688,7 +13688,7 @@ async def test_delete_folder_empty_call_grpc_asyncio():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         # Ensure that the uuid4 field is set according to AIP 4235
-        assert re.match(
+        assert re.fullmatch(
             r"[a-f0-9]{8}-?[a-f0-9]{4}-?4[a-f0-9]{3}-?[89ab][a-f0-9]{3}-?[a-f0-9]{12}",
             args[0].request_id,
         )
@@ -13723,7 +13723,7 @@ async def test_get_folder_empty_call_grpc_asyncio():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         # Ensure that the uuid4 field is set according to AIP 4235
-        assert re.match(
+        assert re.fullmatch(
             r"[a-f0-9]{8}-?[a-f0-9]{4}-?4[a-f0-9]{3}-?[89ab][a-f0-9]{3}-?[a-f0-9]{12}",
             args[0].request_id,
         )
@@ -13782,7 +13782,7 @@ async def test_rename_folder_empty_call_grpc_asyncio():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         # Ensure that the uuid4 field is set according to AIP 4235
-        assert re.match(
+        assert re.fullmatch(
             r"[a-f0-9]{8}-?[a-f0-9]{4}-?4[a-f0-9]{3}-?[89ab][a-f0-9]{3}-?[a-f0-9]{12}",
             args[0].request_id,
         )
@@ -13816,7 +13816,7 @@ async def test_delete_folder_recursive_empty_call_grpc_asyncio():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         # Ensure that the uuid4 field is set according to AIP 4235
-        assert re.match(
+        assert re.fullmatch(
             r"[a-f0-9]{8}-?[a-f0-9]{4}-?4[a-f0-9]{3}-?[89ab][a-f0-9]{3}-?[a-f0-9]{12}",
             args[0].request_id,
         )
@@ -13854,7 +13854,7 @@ async def test_get_storage_layout_empty_call_grpc_asyncio():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         # Ensure that the uuid4 field is set according to AIP 4235
-        assert re.match(
+        assert re.fullmatch(
             r"[a-f0-9]{8}-?[a-f0-9]{4}-?4[a-f0-9]{3}-?[89ab][a-f0-9]{3}-?[a-f0-9]{12}",
             args[0].request_id,
         )
@@ -13891,7 +13891,7 @@ async def test_create_managed_folder_empty_call_grpc_asyncio():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         # Ensure that the uuid4 field is set according to AIP 4235
-        assert re.match(
+        assert re.fullmatch(
             r"[a-f0-9]{8}-?[a-f0-9]{4}-?4[a-f0-9]{3}-?[89ab][a-f0-9]{3}-?[a-f0-9]{12}",
             args[0].request_id,
         )
@@ -13923,7 +13923,7 @@ async def test_delete_managed_folder_empty_call_grpc_asyncio():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         # Ensure that the uuid4 field is set according to AIP 4235
-        assert re.match(
+        assert re.fullmatch(
             r"[a-f0-9]{8}-?[a-f0-9]{4}-?4[a-f0-9]{3}-?[89ab][a-f0-9]{3}-?[a-f0-9]{12}",
             args[0].request_id,
         )
@@ -13960,7 +13960,7 @@ async def test_get_managed_folder_empty_call_grpc_asyncio():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         # Ensure that the uuid4 field is set according to AIP 4235
-        assert re.match(
+        assert re.fullmatch(
             r"[a-f0-9]{8}-?[a-f0-9]{4}-?4[a-f0-9]{3}-?[89ab][a-f0-9]{3}-?[a-f0-9]{12}",
             args[0].request_id,
         )
@@ -13996,7 +13996,7 @@ async def test_list_managed_folders_empty_call_grpc_asyncio():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         # Ensure that the uuid4 field is set according to AIP 4235
-        assert re.match(
+        assert re.fullmatch(
             r"[a-f0-9]{8}-?[a-f0-9]{4}-?4[a-f0-9]{3}-?[89ab][a-f0-9]{3}-?[a-f0-9]{12}",
             args[0].request_id,
         )
@@ -14030,7 +14030,7 @@ async def test_create_anywhere_cache_empty_call_grpc_asyncio():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         # Ensure that the uuid4 field is set according to AIP 4235
-        assert re.match(
+        assert re.fullmatch(
             r"[a-f0-9]{8}-?[a-f0-9]{4}-?4[a-f0-9]{3}-?[89ab][a-f0-9]{3}-?[a-f0-9]{12}",
             args[0].request_id,
         )
@@ -14064,7 +14064,7 @@ async def test_update_anywhere_cache_empty_call_grpc_asyncio():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         # Ensure that the uuid4 field is set according to AIP 4235
-        assert re.match(
+        assert re.fullmatch(
             r"[a-f0-9]{8}-?[a-f0-9]{4}-?4[a-f0-9]{3}-?[89ab][a-f0-9]{3}-?[a-f0-9]{12}",
             args[0].request_id,
         )
@@ -14104,7 +14104,7 @@ async def test_disable_anywhere_cache_empty_call_grpc_asyncio():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         # Ensure that the uuid4 field is set according to AIP 4235
-        assert re.match(
+        assert re.fullmatch(
             r"[a-f0-9]{8}-?[a-f0-9]{4}-?4[a-f0-9]{3}-?[89ab][a-f0-9]{3}-?[a-f0-9]{12}",
             args[0].request_id,
         )
@@ -14144,7 +14144,7 @@ async def test_pause_anywhere_cache_empty_call_grpc_asyncio():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         # Ensure that the uuid4 field is set according to AIP 4235
-        assert re.match(
+        assert re.fullmatch(
             r"[a-f0-9]{8}-?[a-f0-9]{4}-?4[a-f0-9]{3}-?[89ab][a-f0-9]{3}-?[a-f0-9]{12}",
             args[0].request_id,
         )
@@ -14184,7 +14184,7 @@ async def test_resume_anywhere_cache_empty_call_grpc_asyncio():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         # Ensure that the uuid4 field is set according to AIP 4235
-        assert re.match(
+        assert re.fullmatch(
             r"[a-f0-9]{8}-?[a-f0-9]{4}-?4[a-f0-9]{3}-?[89ab][a-f0-9]{3}-?[a-f0-9]{12}",
             args[0].request_id,
         )
@@ -14224,7 +14224,7 @@ async def test_get_anywhere_cache_empty_call_grpc_asyncio():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         # Ensure that the uuid4 field is set according to AIP 4235
-        assert re.match(
+        assert re.fullmatch(
             r"[a-f0-9]{8}-?[a-f0-9]{4}-?4[a-f0-9]{3}-?[89ab][a-f0-9]{3}-?[a-f0-9]{12}",
             args[0].request_id,
         )
@@ -14260,7 +14260,7 @@ async def test_list_anywhere_caches_empty_call_grpc_asyncio():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         # Ensure that the uuid4 field is set according to AIP 4235
-        assert re.match(
+        assert re.fullmatch(
             r"[a-f0-9]{8}-?[a-f0-9]{4}-?4[a-f0-9]{3}-?[89ab][a-f0-9]{3}-?[a-f0-9]{12}",
             args[0].request_id,
         )
@@ -14558,7 +14558,7 @@ async def test_create_folder_routing_parameters_request_1_grpc_asyncio():
         call.assert_called()
         _, args, kw = call.mock_calls[0]
         # Ensure that the uuid4 field is set according to AIP 4235
-        assert re.match(
+        assert re.fullmatch(
             r"[a-f0-9]{8}-?[a-f0-9]{4}-?4[a-f0-9]{3}-?[89ab][a-f0-9]{3}-?[a-f0-9]{12}",
             args[0].request_id,
         )
@@ -14593,7 +14593,7 @@ async def test_delete_folder_routing_parameters_request_1_grpc_asyncio():
         call.assert_called()
         _, args, kw = call.mock_calls[0]
         # Ensure that the uuid4 field is set according to AIP 4235
-        assert re.match(
+        assert re.fullmatch(
             r"[a-f0-9]{8}-?[a-f0-9]{4}-?4[a-f0-9]{3}-?[89ab][a-f0-9]{3}-?[a-f0-9]{12}",
             args[0].request_id,
         )
@@ -14635,7 +14635,7 @@ async def test_get_folder_routing_parameters_request_1_grpc_asyncio():
         call.assert_called()
         _, args, kw = call.mock_calls[0]
         # Ensure that the uuid4 field is set according to AIP 4235
-        assert re.match(
+        assert re.fullmatch(
             r"[a-f0-9]{8}-?[a-f0-9]{4}-?4[a-f0-9]{3}-?[89ab][a-f0-9]{3}-?[a-f0-9]{12}",
             args[0].request_id,
         )
@@ -14704,7 +14704,7 @@ async def test_rename_folder_routing_parameters_request_1_grpc_asyncio():
         call.assert_called()
         _, args, kw = call.mock_calls[0]
         # Ensure that the uuid4 field is set according to AIP 4235
-        assert re.match(
+        assert re.fullmatch(
             r"[a-f0-9]{8}-?[a-f0-9]{4}-?4[a-f0-9]{3}-?[89ab][a-f0-9]{3}-?[a-f0-9]{12}",
             args[0].request_id,
         )
@@ -14745,7 +14745,7 @@ async def test_delete_folder_recursive_routing_parameters_request_1_grpc_asyncio
         call.assert_called()
         _, args, kw = call.mock_calls[0]
         # Ensure that the uuid4 field is set according to AIP 4235
-        assert re.match(
+        assert re.fullmatch(
             r"[a-f0-9]{8}-?[a-f0-9]{4}-?4[a-f0-9]{3}-?[89ab][a-f0-9]{3}-?[a-f0-9]{12}",
             args[0].request_id,
         )
@@ -14790,7 +14790,7 @@ async def test_get_storage_layout_routing_parameters_request_1_grpc_asyncio():
         call.assert_called()
         _, args, kw = call.mock_calls[0]
         # Ensure that the uuid4 field is set according to AIP 4235
-        assert re.match(
+        assert re.fullmatch(
             r"[a-f0-9]{8}-?[a-f0-9]{4}-?4[a-f0-9]{3}-?[89ab][a-f0-9]{3}-?[a-f0-9]{12}",
             args[0].request_id,
         )
@@ -14832,7 +14832,7 @@ async def test_create_managed_folder_routing_parameters_request_1_grpc_asyncio()
         call.assert_called()
         _, args, kw = call.mock_calls[0]
         # Ensure that the uuid4 field is set according to AIP 4235
-        assert re.match(
+        assert re.fullmatch(
             r"[a-f0-9]{8}-?[a-f0-9]{4}-?4[a-f0-9]{3}-?[89ab][a-f0-9]{3}-?[a-f0-9]{12}",
             args[0].request_id,
         )
@@ -14871,7 +14871,7 @@ async def test_delete_managed_folder_routing_parameters_request_1_grpc_asyncio()
         call.assert_called()
         _, args, kw = call.mock_calls[0]
         # Ensure that the uuid4 field is set according to AIP 4235
-        assert re.match(
+        assert re.fullmatch(
             r"[a-f0-9]{8}-?[a-f0-9]{4}-?4[a-f0-9]{3}-?[89ab][a-f0-9]{3}-?[a-f0-9]{12}",
             args[0].request_id,
         )
@@ -14915,7 +14915,7 @@ async def test_get_managed_folder_routing_parameters_request_1_grpc_asyncio():
         call.assert_called()
         _, args, kw = call.mock_calls[0]
         # Ensure that the uuid4 field is set according to AIP 4235
-        assert re.match(
+        assert re.fullmatch(
             r"[a-f0-9]{8}-?[a-f0-9]{4}-?4[a-f0-9]{3}-?[89ab][a-f0-9]{3}-?[a-f0-9]{12}",
             args[0].request_id,
         )
@@ -14956,7 +14956,7 @@ async def test_list_managed_folders_routing_parameters_request_1_grpc_asyncio():
         call.assert_called()
         _, args, kw = call.mock_calls[0]
         # Ensure that the uuid4 field is set according to AIP 4235
-        assert re.match(
+        assert re.fullmatch(
             r"[a-f0-9]{8}-?[a-f0-9]{4}-?4[a-f0-9]{3}-?[89ab][a-f0-9]{3}-?[a-f0-9]{12}",
             args[0].request_id,
         )
@@ -14993,7 +14993,7 @@ async def test_create_anywhere_cache_routing_parameters_request_1_grpc_asyncio()
         call.assert_called()
         _, args, kw = call.mock_calls[0]
         # Ensure that the uuid4 field is set according to AIP 4235
-        assert re.match(
+        assert re.fullmatch(
             r"[a-f0-9]{8}-?[a-f0-9]{4}-?4[a-f0-9]{3}-?[89ab][a-f0-9]{3}-?[a-f0-9]{12}",
             args[0].request_id,
         )
@@ -15036,7 +15036,7 @@ async def test_update_anywhere_cache_routing_parameters_request_1_grpc_asyncio()
         call.assert_called()
         _, args, kw = call.mock_calls[0]
         # Ensure that the uuid4 field is set according to AIP 4235
-        assert re.match(
+        assert re.fullmatch(
             r"[a-f0-9]{8}-?[a-f0-9]{4}-?4[a-f0-9]{3}-?[89ab][a-f0-9]{3}-?[a-f0-9]{12}",
             args[0].request_id,
         )
@@ -15083,7 +15083,7 @@ async def test_disable_anywhere_cache_routing_parameters_request_1_grpc_asyncio(
         call.assert_called()
         _, args, kw = call.mock_calls[0]
         # Ensure that the uuid4 field is set according to AIP 4235
-        assert re.match(
+        assert re.fullmatch(
             r"[a-f0-9]{8}-?[a-f0-9]{4}-?4[a-f0-9]{3}-?[89ab][a-f0-9]{3}-?[a-f0-9]{12}",
             args[0].request_id,
         )
@@ -15130,7 +15130,7 @@ async def test_pause_anywhere_cache_routing_parameters_request_1_grpc_asyncio():
         call.assert_called()
         _, args, kw = call.mock_calls[0]
         # Ensure that the uuid4 field is set according to AIP 4235
-        assert re.match(
+        assert re.fullmatch(
             r"[a-f0-9]{8}-?[a-f0-9]{4}-?4[a-f0-9]{3}-?[89ab][a-f0-9]{3}-?[a-f0-9]{12}",
             args[0].request_id,
         )
@@ -15177,7 +15177,7 @@ async def test_resume_anywhere_cache_routing_parameters_request_1_grpc_asyncio()
         call.assert_called()
         _, args, kw = call.mock_calls[0]
         # Ensure that the uuid4 field is set according to AIP 4235
-        assert re.match(
+        assert re.fullmatch(
             r"[a-f0-9]{8}-?[a-f0-9]{4}-?4[a-f0-9]{3}-?[89ab][a-f0-9]{3}-?[a-f0-9]{12}",
             args[0].request_id,
         )
@@ -15224,7 +15224,7 @@ async def test_get_anywhere_cache_routing_parameters_request_1_grpc_asyncio():
         call.assert_called()
         _, args, kw = call.mock_calls[0]
         # Ensure that the uuid4 field is set according to AIP 4235
-        assert re.match(
+        assert re.fullmatch(
             r"[a-f0-9]{8}-?[a-f0-9]{4}-?4[a-f0-9]{3}-?[89ab][a-f0-9]{3}-?[a-f0-9]{12}",
             args[0].request_id,
         )
@@ -15265,7 +15265,7 @@ async def test_list_anywhere_caches_routing_parameters_request_1_grpc_asyncio():
         call.assert_called()
         _, args, kw = call.mock_calls[0]
         # Ensure that the uuid4 field is set according to AIP 4235
-        assert re.match(
+        assert re.fullmatch(
             r"[a-f0-9]{8}-?[a-f0-9]{4}-?4[a-f0-9]{3}-?[89ab][a-f0-9]{3}-?[a-f0-9]{12}",
             args[0].request_id,
         )
@@ -16949,7 +16949,7 @@ def test_create_folder_empty_call_rest():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         # Ensure that the uuid4 field is set according to AIP 4235
-        assert re.match(
+        assert re.fullmatch(
             r"[a-f0-9]{8}-?[a-f0-9]{4}-?4[a-f0-9]{3}-?[89ab][a-f0-9]{3}-?[a-f0-9]{12}",
             args[0].request_id,
         )
@@ -16976,7 +16976,7 @@ def test_delete_folder_empty_call_rest():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         # Ensure that the uuid4 field is set according to AIP 4235
-        assert re.match(
+        assert re.fullmatch(
             r"[a-f0-9]{8}-?[a-f0-9]{4}-?4[a-f0-9]{3}-?[89ab][a-f0-9]{3}-?[a-f0-9]{12}",
             args[0].request_id,
         )
@@ -17003,7 +17003,7 @@ def test_get_folder_empty_call_rest():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         # Ensure that the uuid4 field is set according to AIP 4235
-        assert re.match(
+        assert re.fullmatch(
             r"[a-f0-9]{8}-?[a-f0-9]{4}-?4[a-f0-9]{3}-?[89ab][a-f0-9]{3}-?[a-f0-9]{12}",
             args[0].request_id,
         )
@@ -17050,7 +17050,7 @@ def test_rename_folder_empty_call_rest():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         # Ensure that the uuid4 field is set according to AIP 4235
-        assert re.match(
+        assert re.fullmatch(
             r"[a-f0-9]{8}-?[a-f0-9]{4}-?4[a-f0-9]{3}-?[89ab][a-f0-9]{3}-?[a-f0-9]{12}",
             args[0].request_id,
         )
@@ -17079,7 +17079,7 @@ def test_delete_folder_recursive_empty_call_rest():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         # Ensure that the uuid4 field is set according to AIP 4235
-        assert re.match(
+        assert re.fullmatch(
             r"[a-f0-9]{8}-?[a-f0-9]{4}-?4[a-f0-9]{3}-?[89ab][a-f0-9]{3}-?[a-f0-9]{12}",
             args[0].request_id,
         )
@@ -17108,7 +17108,7 @@ def test_get_storage_layout_empty_call_rest():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         # Ensure that the uuid4 field is set according to AIP 4235
-        assert re.match(
+        assert re.fullmatch(
             r"[a-f0-9]{8}-?[a-f0-9]{4}-?4[a-f0-9]{3}-?[89ab][a-f0-9]{3}-?[a-f0-9]{12}",
             args[0].request_id,
         )
@@ -17137,7 +17137,7 @@ def test_create_managed_folder_empty_call_rest():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         # Ensure that the uuid4 field is set according to AIP 4235
-        assert re.match(
+        assert re.fullmatch(
             r"[a-f0-9]{8}-?[a-f0-9]{4}-?4[a-f0-9]{3}-?[89ab][a-f0-9]{3}-?[a-f0-9]{12}",
             args[0].request_id,
         )
@@ -17166,7 +17166,7 @@ def test_delete_managed_folder_empty_call_rest():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         # Ensure that the uuid4 field is set according to AIP 4235
-        assert re.match(
+        assert re.fullmatch(
             r"[a-f0-9]{8}-?[a-f0-9]{4}-?4[a-f0-9]{3}-?[89ab][a-f0-9]{3}-?[a-f0-9]{12}",
             args[0].request_id,
         )
@@ -17195,7 +17195,7 @@ def test_get_managed_folder_empty_call_rest():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         # Ensure that the uuid4 field is set according to AIP 4235
-        assert re.match(
+        assert re.fullmatch(
             r"[a-f0-9]{8}-?[a-f0-9]{4}-?4[a-f0-9]{3}-?[89ab][a-f0-9]{3}-?[a-f0-9]{12}",
             args[0].request_id,
         )
@@ -17224,7 +17224,7 @@ def test_list_managed_folders_empty_call_rest():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         # Ensure that the uuid4 field is set according to AIP 4235
-        assert re.match(
+        assert re.fullmatch(
             r"[a-f0-9]{8}-?[a-f0-9]{4}-?4[a-f0-9]{3}-?[89ab][a-f0-9]{3}-?[a-f0-9]{12}",
             args[0].request_id,
         )
@@ -17253,7 +17253,7 @@ def test_create_anywhere_cache_empty_call_rest():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         # Ensure that the uuid4 field is set according to AIP 4235
-        assert re.match(
+        assert re.fullmatch(
             r"[a-f0-9]{8}-?[a-f0-9]{4}-?4[a-f0-9]{3}-?[89ab][a-f0-9]{3}-?[a-f0-9]{12}",
             args[0].request_id,
         )
@@ -17282,7 +17282,7 @@ def test_update_anywhere_cache_empty_call_rest():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         # Ensure that the uuid4 field is set according to AIP 4235
-        assert re.match(
+        assert re.fullmatch(
             r"[a-f0-9]{8}-?[a-f0-9]{4}-?4[a-f0-9]{3}-?[89ab][a-f0-9]{3}-?[a-f0-9]{12}",
             args[0].request_id,
         )
@@ -17311,7 +17311,7 @@ def test_disable_anywhere_cache_empty_call_rest():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         # Ensure that the uuid4 field is set according to AIP 4235
-        assert re.match(
+        assert re.fullmatch(
             r"[a-f0-9]{8}-?[a-f0-9]{4}-?4[a-f0-9]{3}-?[89ab][a-f0-9]{3}-?[a-f0-9]{12}",
             args[0].request_id,
         )
@@ -17340,7 +17340,7 @@ def test_pause_anywhere_cache_empty_call_rest():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         # Ensure that the uuid4 field is set according to AIP 4235
-        assert re.match(
+        assert re.fullmatch(
             r"[a-f0-9]{8}-?[a-f0-9]{4}-?4[a-f0-9]{3}-?[89ab][a-f0-9]{3}-?[a-f0-9]{12}",
             args[0].request_id,
         )
@@ -17369,7 +17369,7 @@ def test_resume_anywhere_cache_empty_call_rest():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         # Ensure that the uuid4 field is set according to AIP 4235
-        assert re.match(
+        assert re.fullmatch(
             r"[a-f0-9]{8}-?[a-f0-9]{4}-?4[a-f0-9]{3}-?[89ab][a-f0-9]{3}-?[a-f0-9]{12}",
             args[0].request_id,
         )
@@ -17398,7 +17398,7 @@ def test_get_anywhere_cache_empty_call_rest():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         # Ensure that the uuid4 field is set according to AIP 4235
-        assert re.match(
+        assert re.fullmatch(
             r"[a-f0-9]{8}-?[a-f0-9]{4}-?4[a-f0-9]{3}-?[89ab][a-f0-9]{3}-?[a-f0-9]{12}",
             args[0].request_id,
         )
@@ -17427,7 +17427,7 @@ def test_list_anywhere_caches_empty_call_rest():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         # Ensure that the uuid4 field is set according to AIP 4235
-        assert re.match(
+        assert re.fullmatch(
             r"[a-f0-9]{8}-?[a-f0-9]{4}-?4[a-f0-9]{3}-?[89ab][a-f0-9]{3}-?[a-f0-9]{12}",
             args[0].request_id,
         )
@@ -17646,7 +17646,7 @@ def test_create_folder_routing_parameters_request_1_rest():
         call.assert_called()
         _, args, kw = call.mock_calls[0]
         # Ensure that the uuid4 field is set according to AIP 4235
-        assert re.match(
+        assert re.fullmatch(
             r"[a-f0-9]{8}-?[a-f0-9]{4}-?4[a-f0-9]{3}-?[89ab][a-f0-9]{3}-?[a-f0-9]{12}",
             args[0].request_id,
         )
@@ -17678,7 +17678,7 @@ def test_delete_folder_routing_parameters_request_1_rest():
         call.assert_called()
         _, args, kw = call.mock_calls[0]
         # Ensure that the uuid4 field is set according to AIP 4235
-        assert re.match(
+        assert re.fullmatch(
             r"[a-f0-9]{8}-?[a-f0-9]{4}-?4[a-f0-9]{3}-?[89ab][a-f0-9]{3}-?[a-f0-9]{12}",
             args[0].request_id,
         )
@@ -17710,7 +17710,7 @@ def test_get_folder_routing_parameters_request_1_rest():
         call.assert_called()
         _, args, kw = call.mock_calls[0]
         # Ensure that the uuid4 field is set according to AIP 4235
-        assert re.match(
+        assert re.fullmatch(
             r"[a-f0-9]{8}-?[a-f0-9]{4}-?4[a-f0-9]{3}-?[89ab][a-f0-9]{3}-?[a-f0-9]{12}",
             args[0].request_id,
         )
@@ -17767,7 +17767,7 @@ def test_rename_folder_routing_parameters_request_1_rest():
         call.assert_called()
         _, args, kw = call.mock_calls[0]
         # Ensure that the uuid4 field is set according to AIP 4235
-        assert re.match(
+        assert re.fullmatch(
             r"[a-f0-9]{8}-?[a-f0-9]{4}-?4[a-f0-9]{3}-?[89ab][a-f0-9]{3}-?[a-f0-9]{12}",
             args[0].request_id,
         )
@@ -17803,7 +17803,7 @@ def test_delete_folder_recursive_routing_parameters_request_1_rest():
         call.assert_called()
         _, args, kw = call.mock_calls[0]
         # Ensure that the uuid4 field is set according to AIP 4235
-        assert re.match(
+        assert re.fullmatch(
             r"[a-f0-9]{8}-?[a-f0-9]{4}-?4[a-f0-9]{3}-?[89ab][a-f0-9]{3}-?[a-f0-9]{12}",
             args[0].request_id,
         )
@@ -17839,7 +17839,7 @@ def test_get_storage_layout_routing_parameters_request_1_rest():
         call.assert_called()
         _, args, kw = call.mock_calls[0]
         # Ensure that the uuid4 field is set according to AIP 4235
-        assert re.match(
+        assert re.fullmatch(
             r"[a-f0-9]{8}-?[a-f0-9]{4}-?4[a-f0-9]{3}-?[89ab][a-f0-9]{3}-?[a-f0-9]{12}",
             args[0].request_id,
         )
@@ -17873,7 +17873,7 @@ def test_create_managed_folder_routing_parameters_request_1_rest():
         call.assert_called()
         _, args, kw = call.mock_calls[0]
         # Ensure that the uuid4 field is set according to AIP 4235
-        assert re.match(
+        assert re.fullmatch(
             r"[a-f0-9]{8}-?[a-f0-9]{4}-?4[a-f0-9]{3}-?[89ab][a-f0-9]{3}-?[a-f0-9]{12}",
             args[0].request_id,
         )
@@ -17909,7 +17909,7 @@ def test_delete_managed_folder_routing_parameters_request_1_rest():
         call.assert_called()
         _, args, kw = call.mock_calls[0]
         # Ensure that the uuid4 field is set according to AIP 4235
-        assert re.match(
+        assert re.fullmatch(
             r"[a-f0-9]{8}-?[a-f0-9]{4}-?4[a-f0-9]{3}-?[89ab][a-f0-9]{3}-?[a-f0-9]{12}",
             args[0].request_id,
         )
@@ -17945,7 +17945,7 @@ def test_get_managed_folder_routing_parameters_request_1_rest():
         call.assert_called()
         _, args, kw = call.mock_calls[0]
         # Ensure that the uuid4 field is set according to AIP 4235
-        assert re.match(
+        assert re.fullmatch(
             r"[a-f0-9]{8}-?[a-f0-9]{4}-?4[a-f0-9]{3}-?[89ab][a-f0-9]{3}-?[a-f0-9]{12}",
             args[0].request_id,
         )
@@ -17979,7 +17979,7 @@ def test_list_managed_folders_routing_parameters_request_1_rest():
         call.assert_called()
         _, args, kw = call.mock_calls[0]
         # Ensure that the uuid4 field is set according to AIP 4235
-        assert re.match(
+        assert re.fullmatch(
             r"[a-f0-9]{8}-?[a-f0-9]{4}-?4[a-f0-9]{3}-?[89ab][a-f0-9]{3}-?[a-f0-9]{12}",
             args[0].request_id,
         )
@@ -18011,7 +18011,7 @@ def test_create_anywhere_cache_routing_parameters_request_1_rest():
         call.assert_called()
         _, args, kw = call.mock_calls[0]
         # Ensure that the uuid4 field is set according to AIP 4235
-        assert re.match(
+        assert re.fullmatch(
             r"[a-f0-9]{8}-?[a-f0-9]{4}-?4[a-f0-9]{3}-?[89ab][a-f0-9]{3}-?[a-f0-9]{12}",
             args[0].request_id,
         )
@@ -18049,7 +18049,7 @@ def test_update_anywhere_cache_routing_parameters_request_1_rest():
         call.assert_called()
         _, args, kw = call.mock_calls[0]
         # Ensure that the uuid4 field is set according to AIP 4235
-        assert re.match(
+        assert re.fullmatch(
             r"[a-f0-9]{8}-?[a-f0-9]{4}-?4[a-f0-9]{3}-?[89ab][a-f0-9]{3}-?[a-f0-9]{12}",
             args[0].request_id,
         )
@@ -18085,7 +18085,7 @@ def test_disable_anywhere_cache_routing_parameters_request_1_rest():
         call.assert_called()
         _, args, kw = call.mock_calls[0]
         # Ensure that the uuid4 field is set according to AIP 4235
-        assert re.match(
+        assert re.fullmatch(
             r"[a-f0-9]{8}-?[a-f0-9]{4}-?4[a-f0-9]{3}-?[89ab][a-f0-9]{3}-?[a-f0-9]{12}",
             args[0].request_id,
         )
@@ -18121,7 +18121,7 @@ def test_pause_anywhere_cache_routing_parameters_request_1_rest():
         call.assert_called()
         _, args, kw = call.mock_calls[0]
         # Ensure that the uuid4 field is set according to AIP 4235
-        assert re.match(
+        assert re.fullmatch(
             r"[a-f0-9]{8}-?[a-f0-9]{4}-?4[a-f0-9]{3}-?[89ab][a-f0-9]{3}-?[a-f0-9]{12}",
             args[0].request_id,
         )
@@ -18157,7 +18157,7 @@ def test_resume_anywhere_cache_routing_parameters_request_1_rest():
         call.assert_called()
         _, args, kw = call.mock_calls[0]
         # Ensure that the uuid4 field is set according to AIP 4235
-        assert re.match(
+        assert re.fullmatch(
             r"[a-f0-9]{8}-?[a-f0-9]{4}-?4[a-f0-9]{3}-?[89ab][a-f0-9]{3}-?[a-f0-9]{12}",
             args[0].request_id,
         )
@@ -18193,7 +18193,7 @@ def test_get_anywhere_cache_routing_parameters_request_1_rest():
         call.assert_called()
         _, args, kw = call.mock_calls[0]
         # Ensure that the uuid4 field is set according to AIP 4235
-        assert re.match(
+        assert re.fullmatch(
             r"[a-f0-9]{8}-?[a-f0-9]{4}-?4[a-f0-9]{3}-?[89ab][a-f0-9]{3}-?[a-f0-9]{12}",
             args[0].request_id,
         )
@@ -18227,7 +18227,7 @@ def test_list_anywhere_caches_routing_parameters_request_1_rest():
         call.assert_called()
         _, args, kw = call.mock_calls[0]
         # Ensure that the uuid4 field is set according to AIP 4235
-        assert re.match(
+        assert re.fullmatch(
             r"[a-f0-9]{8}-?[a-f0-9]{4}-?4[a-f0-9]{3}-?[89ab][a-f0-9]{3}-?[a-f0-9]{12}",
             args[0].request_id,
         )

--- a/packages/google-cloud-storage-transfer/README.rst
+++ b/packages/google-cloud-storage-transfer/README.rst
@@ -62,14 +62,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-storage-transfer/docs/README.rst
+++ b/packages/google-cloud-storage-transfer/docs/README.rst
@@ -62,14 +62,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-storage-transfer/noxfile.py
+++ b/packages/google-cloud-storage-transfer/noxfile.py
@@ -509,24 +509,50 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1) for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -596,16 +622,24 @@ def core_deps_from_source(session, protobuf_implementation):
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
+
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(
+        f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}"
+    )
 
     session.run(
         "py.test",

--- a/packages/google-cloud-storage/google/cloud/storage/_bucket_metadata_cache.py
+++ b/packages/google-cloud-storage/google/cloud/storage/_bucket_metadata_cache.py
@@ -19,6 +19,7 @@ import threading
 
 from google.api_core import exceptions as api_exceptions
 from google.cloud.exceptions import NotFound
+
 from google.cloud.storage._lru_cache import LRUCache
 
 logger = logging.getLogger(__name__)

--- a/packages/google-cloud-storage/google/cloud/storage/_helpers.py
+++ b/packages/google-cloud-storage/google/cloud/storage/_helpers.py
@@ -29,17 +29,16 @@ from urllib.parse import urlsplit, urlunsplit
 from uuid import uuid4
 
 from google.api_core import exceptions as api_exceptions
+from google.auth import environment_vars
 from google.cloud.exceptions import NotFound
 
-from google.auth import environment_vars
-
+from google.cloud.storage._opentelemetry_tracing import (
+    create_trace_span as _base_create_trace_span,
+)
 from google.cloud.storage.constants import _DEFAULT_TIMEOUT
 from google.cloud.storage.retry import (
     DEFAULT_RETRY,
     DEFAULT_RETRY_IF_METAGENERATION_SPECIFIED,
-)
-from google.cloud.storage._opentelemetry_tracing import (
-    create_trace_span as _base_create_trace_span,
 )
 
 _logger = logging.getLogger(__name__)

--- a/packages/google-cloud-storage/google/cloud/storage/_http.py
+++ b/packages/google-cloud-storage/google/cloud/storage/_http.py
@@ -19,13 +19,14 @@ import logging
 import re
 
 from google.api_core import exceptions as api_exceptions
-from google.cloud import _http
 from google.cloud.exceptions import NotFound
+
+from google.cloud import _http
 from google.cloud.storage import __version__, _helpers
 from google.cloud.storage._opentelemetry_tracing import (
+    HAS_OPENTELEMETRY,
     create_trace_span,
     enable_otel_traces,
-    HAS_OPENTELEMETRY,
 )
 
 logger = logging.getLogger(__name__)

--- a/packages/google-cloud-storage/google/cloud/storage/bucket.py
+++ b/packages/google-cloud-storage/google/cloud/storage/bucket.py
@@ -21,7 +21,8 @@ import json
 import warnings
 from urllib.parse import urlsplit
 
-from google.api_core import datetime_helpers, exceptions as api_exceptions
+from google.api_core import datetime_helpers
+from google.api_core import exceptions as api_exceptions
 from google.api_core.iam import Policy
 from google.cloud._helpers import _datetime_to_rfc3339, _rfc3339_nanos_to_datetime
 from google.cloud.exceptions import NotFound

--- a/packages/google-cloud-storage/google/cloud/storage/client.py
+++ b/packages/google-cloud-storage/google/cloud/storage/client.py
@@ -24,13 +24,15 @@ import os
 import warnings
 
 import google.api_core.client_options
-from google.api_core import exceptions as api_exceptions, page_iterator
+from google.api_core import exceptions as api_exceptions
+from google.api_core import page_iterator
 from google.auth.credentials import AnonymousCredentials
 from google.auth.transport import mtls
 from google.cloud._helpers import _LocalStack
 from google.cloud.client import ClientWithProject
 from google.cloud.exceptions import NotFound
 
+from google.cloud.storage._bucket_metadata_cache import BucketMetadataCache
 from google.cloud.storage._helpers import (
     _DEFAULT_SCHEME,
     _DEFAULT_UNIVERSE_DOMAIN,
@@ -45,7 +47,6 @@ from google.cloud.storage._helpers import (
     _virtual_hosted_style_base_url,
     create_trace_span_helper,
 )
-from google.cloud.storage._bucket_metadata_cache import BucketMetadataCache
 from google.cloud.storage._http import Connection
 from google.cloud.storage._opentelemetry_tracing import create_trace_span
 from google.cloud.storage._signing import (

--- a/packages/google-cloud-storage/noxfile.py
+++ b/packages/google-cloud-storage/noxfile.py
@@ -689,16 +689,24 @@ def core_deps_from_source(session, protobuf_implementation):
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
+
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(
+        f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}"
+    )
 
     session.run(
         "py.test",

--- a/packages/google-cloud-storage/tests/unit/test__bucket_metadata_cache.py
+++ b/packages/google-cloud-storage/tests/unit/test__bucket_metadata_cache.py
@@ -17,6 +17,7 @@ from unittest import mock
 
 from google.api_core import exceptions as api_exceptions
 from google.cloud.exceptions import NotFound
+
 from google.cloud.storage._bucket_metadata_cache import BucketMetadataCache
 
 

--- a/packages/google-cloud-storage/tests/unit/test_bucket.py
+++ b/packages/google-cloud-storage/tests/unit/test_bucket.py
@@ -2079,6 +2079,7 @@ class Test_Bucket(unittest.TestCase):
 
     def test_reload_forbidden_sync_cache_fallback(self):
         from google.api_core.exceptions import Forbidden
+
         from google.cloud.storage._bucket_metadata_cache import BucketMetadataCache
 
         name = "forbidden-bucket"

--- a/packages/google-cloud-storagebatchoperations/README.rst
+++ b/packages/google-cloud-storagebatchoperations/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-storagebatchoperations/docs/README.rst
+++ b/packages/google-cloud-storagebatchoperations/docs/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-storagebatchoperations/noxfile.py
+++ b/packages/google-cloud-storagebatchoperations/noxfile.py
@@ -509,24 +509,50 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1) for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -596,16 +622,24 @@ def core_deps_from_source(session, protobuf_implementation):
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
+
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(
+        f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}"
+    )
 
     session.run(
         "py.test",

--- a/packages/google-cloud-storageinsights/README.rst
+++ b/packages/google-cloud-storageinsights/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-storageinsights/docs/README.rst
+++ b/packages/google-cloud-storageinsights/docs/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-storageinsights/noxfile.py
+++ b/packages/google-cloud-storageinsights/noxfile.py
@@ -509,24 +509,50 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1) for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -596,16 +622,24 @@ def core_deps_from_source(session, protobuf_implementation):
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
+
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(
+        f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}"
+    )
 
     session.run(
         "py.test",

--- a/packages/google-cloud-support/README.rst
+++ b/packages/google-cloud-support/README.rst
@@ -62,14 +62,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-support/docs/README.rst
+++ b/packages/google-cloud-support/docs/README.rst
@@ -62,14 +62,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-support/noxfile.py
+++ b/packages/google-cloud-support/noxfile.py
@@ -509,24 +509,50 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1) for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -596,16 +622,24 @@ def core_deps_from_source(session, protobuf_implementation):
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
+
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(
+        f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}"
+    )
 
     session.run(
         "py.test",

--- a/packages/google-cloud-talent/README.rst
+++ b/packages/google-cloud-talent/README.rst
@@ -62,14 +62,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-talent/docs/README.rst
+++ b/packages/google-cloud-talent/docs/README.rst
@@ -62,14 +62,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-talent/noxfile.py
+++ b/packages/google-cloud-talent/noxfile.py
@@ -509,24 +509,50 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1) for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -596,16 +622,24 @@ def core_deps_from_source(session, protobuf_implementation):
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
+
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(
+        f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}"
+    )
 
     session.run(
         "py.test",

--- a/packages/google-cloud-tasks/README.rst
+++ b/packages/google-cloud-tasks/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-tasks/docs/README.rst
+++ b/packages/google-cloud-tasks/docs/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-tasks/noxfile.py
+++ b/packages/google-cloud-tasks/noxfile.py
@@ -509,24 +509,50 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1) for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -596,16 +622,24 @@ def core_deps_from_source(session, protobuf_implementation):
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
+
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(
+        f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}"
+    )
 
     session.run(
         "py.test",

--- a/packages/google-cloud-telcoautomation/README.rst
+++ b/packages/google-cloud-telcoautomation/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-telcoautomation/docs/README.rst
+++ b/packages/google-cloud-telcoautomation/docs/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-telcoautomation/noxfile.py
+++ b/packages/google-cloud-telcoautomation/noxfile.py
@@ -509,24 +509,50 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1) for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -596,16 +622,24 @@ def core_deps_from_source(session, protobuf_implementation):
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
+
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(
+        f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}"
+    )
 
     session.run(
         "py.test",

--- a/packages/google-cloud-texttospeech/README.rst
+++ b/packages/google-cloud-texttospeech/README.rst
@@ -62,14 +62,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-texttospeech/docs/README.rst
+++ b/packages/google-cloud-texttospeech/docs/README.rst
@@ -62,14 +62,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-texttospeech/noxfile.py
+++ b/packages/google-cloud-texttospeech/noxfile.py
@@ -509,24 +509,50 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1) for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -596,16 +622,24 @@ def core_deps_from_source(session, protobuf_implementation):
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
+
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(
+        f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}"
+    )
 
     session.run(
         "py.test",

--- a/packages/google-cloud-tpu/README.rst
+++ b/packages/google-cloud-tpu/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-tpu/docs/README.rst
+++ b/packages/google-cloud-tpu/docs/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-tpu/noxfile.py
+++ b/packages/google-cloud-tpu/noxfile.py
@@ -509,24 +509,50 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1) for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -596,16 +622,24 @@ def core_deps_from_source(session, protobuf_implementation):
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
+
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(
+        f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}"
+    )
 
     session.run(
         "py.test",

--- a/packages/google-cloud-trace/README.rst
+++ b/packages/google-cloud-trace/README.rst
@@ -65,14 +65,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-trace/docs/README.rst
+++ b/packages/google-cloud-trace/docs/README.rst
@@ -65,14 +65,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-trace/noxfile.py
+++ b/packages/google-cloud-trace/noxfile.py
@@ -509,24 +509,50 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1) for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -596,16 +622,24 @@ def core_deps_from_source(session, protobuf_implementation):
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
+
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(
+        f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}"
+    )
 
     session.run(
         "py.test",

--- a/packages/google-cloud-translate/README.rst
+++ b/packages/google-cloud-translate/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-translate/docs/README.rst
+++ b/packages/google-cloud-translate/docs/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-translate/noxfile.py
+++ b/packages/google-cloud-translate/noxfile.py
@@ -509,24 +509,50 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1) for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -596,16 +622,24 @@ def core_deps_from_source(session, protobuf_implementation):
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
+
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(
+        f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}"
+    )
 
     session.run(
         "py.test",

--- a/packages/google-cloud-vectorsearch/README.rst
+++ b/packages/google-cloud-vectorsearch/README.rst
@@ -69,14 +69,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-vectorsearch/docs/README.rst
+++ b/packages/google-cloud-vectorsearch/docs/README.rst
@@ -69,14 +69,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-vectorsearch/noxfile.py
+++ b/packages/google-cloud-vectorsearch/noxfile.py
@@ -509,24 +509,50 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1) for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -596,16 +622,24 @@ def core_deps_from_source(session, protobuf_implementation):
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
+
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(
+        f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}"
+    )
 
     session.run(
         "py.test",

--- a/packages/google-cloud-video-live-stream/README.rst
+++ b/packages/google-cloud-video-live-stream/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-video-live-stream/docs/README.rst
+++ b/packages/google-cloud-video-live-stream/docs/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-video-live-stream/noxfile.py
+++ b/packages/google-cloud-video-live-stream/noxfile.py
@@ -509,24 +509,50 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1) for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -596,16 +622,24 @@ def core_deps_from_source(session, protobuf_implementation):
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
+
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(
+        f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}"
+    )
 
     session.run(
         "py.test",

--- a/packages/google-cloud-video-stitcher/README.rst
+++ b/packages/google-cloud-video-stitcher/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-video-stitcher/docs/README.rst
+++ b/packages/google-cloud-video-stitcher/docs/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-video-stitcher/noxfile.py
+++ b/packages/google-cloud-video-stitcher/noxfile.py
@@ -509,24 +509,50 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1) for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -596,16 +622,24 @@ def core_deps_from_source(session, protobuf_implementation):
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
+
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(
+        f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}"
+    )
 
     session.run(
         "py.test",

--- a/packages/google-cloud-video-transcoder/README.rst
+++ b/packages/google-cloud-video-transcoder/README.rst
@@ -64,14 +64,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-video-transcoder/docs/README.rst
+++ b/packages/google-cloud-video-transcoder/docs/README.rst
@@ -64,14 +64,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-video-transcoder/noxfile.py
+++ b/packages/google-cloud-video-transcoder/noxfile.py
@@ -509,24 +509,50 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1) for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -596,16 +622,24 @@ def core_deps_from_source(session, protobuf_implementation):
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
+
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(
+        f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}"
+    )
 
     session.run(
         "py.test",

--- a/packages/google-cloud-videointelligence/README.rst
+++ b/packages/google-cloud-videointelligence/README.rst
@@ -63,14 +63,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-videointelligence/docs/README.rst
+++ b/packages/google-cloud-videointelligence/docs/README.rst
@@ -63,14 +63,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1/services/video_intelligence_service/async_client.py
+++ b/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1/services/video_intelligence_service/async_client.py
@@ -15,7 +15,6 @@
 #
 import logging as std_logging
 import re
-import uuid
 from collections import OrderedDict
 from typing import (
     Callable,

--- a/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1/services/video_intelligence_service/client.py
+++ b/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1/services/video_intelligence_service/client.py
@@ -17,7 +17,6 @@ import json
 import logging as std_logging
 import os
 import re
-import uuid
 import warnings
 from collections import OrderedDict
 from http import HTTPStatus

--- a/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1beta2/services/video_intelligence_service/async_client.py
+++ b/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1beta2/services/video_intelligence_service/async_client.py
@@ -15,7 +15,6 @@
 #
 import logging as std_logging
 import re
-import uuid
 from collections import OrderedDict
 from typing import (
     Callable,

--- a/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1beta2/services/video_intelligence_service/client.py
+++ b/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1beta2/services/video_intelligence_service/client.py
@@ -17,7 +17,6 @@ import json
 import logging as std_logging
 import os
 import re
-import uuid
 import warnings
 from collections import OrderedDict
 from http import HTTPStatus

--- a/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1p1beta1/services/video_intelligence_service/async_client.py
+++ b/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1p1beta1/services/video_intelligence_service/async_client.py
@@ -15,7 +15,6 @@
 #
 import logging as std_logging
 import re
-import uuid
 from collections import OrderedDict
 from typing import (
     Callable,

--- a/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1p1beta1/services/video_intelligence_service/client.py
+++ b/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1p1beta1/services/video_intelligence_service/client.py
@@ -17,7 +17,6 @@ import json
 import logging as std_logging
 import os
 import re
-import uuid
 import warnings
 from collections import OrderedDict
 from http import HTTPStatus

--- a/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1p2beta1/services/video_intelligence_service/async_client.py
+++ b/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1p2beta1/services/video_intelligence_service/async_client.py
@@ -15,7 +15,6 @@
 #
 import logging as std_logging
 import re
-import uuid
 from collections import OrderedDict
 from typing import (
     Callable,

--- a/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1p2beta1/services/video_intelligence_service/client.py
+++ b/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1p2beta1/services/video_intelligence_service/client.py
@@ -17,7 +17,6 @@ import json
 import logging as std_logging
 import os
 import re
-import uuid
 import warnings
 from collections import OrderedDict
 from http import HTTPStatus

--- a/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1p3beta1/services/streaming_video_intelligence_service/async_client.py
+++ b/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1p3beta1/services/streaming_video_intelligence_service/async_client.py
@@ -15,7 +15,6 @@
 #
 import logging as std_logging
 import re
-import uuid
 from collections import OrderedDict
 from typing import (
     AsyncIterable,

--- a/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1p3beta1/services/streaming_video_intelligence_service/client.py
+++ b/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1p3beta1/services/streaming_video_intelligence_service/client.py
@@ -17,7 +17,6 @@ import json
 import logging as std_logging
 import os
 import re
-import uuid
 import warnings
 from collections import OrderedDict
 from http import HTTPStatus

--- a/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1p3beta1/services/video_intelligence_service/async_client.py
+++ b/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1p3beta1/services/video_intelligence_service/async_client.py
@@ -15,7 +15,6 @@
 #
 import logging as std_logging
 import re
-import uuid
 from collections import OrderedDict
 from typing import (
     Callable,

--- a/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1p3beta1/services/video_intelligence_service/client.py
+++ b/packages/google-cloud-videointelligence/google/cloud/videointelligence_v1p3beta1/services/video_intelligence_service/client.py
@@ -17,7 +17,6 @@ import json
 import logging as std_logging
 import os
 import re
-import uuid
 import warnings
 from collections import OrderedDict
 from http import HTTPStatus

--- a/packages/google-cloud-videointelligence/noxfile.py
+++ b/packages/google-cloud-videointelligence/noxfile.py
@@ -509,24 +509,50 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1) for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -596,16 +622,24 @@ def core_deps_from_source(session, protobuf_implementation):
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
+
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(
+        f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}"
+    )
 
     session.run(
         "py.test",

--- a/packages/google-cloud-videointelligence/tests/unit/gapic/videointelligence_v1/test_video_intelligence_service.py
+++ b/packages/google-cloud-videointelligence/tests/unit/gapic/videointelligence_v1/test_video_intelligence_service.py
@@ -16,7 +16,6 @@
 import json
 import math
 import os
-import re
 from collections.abc import AsyncIterable, Iterable, Mapping, Sequence
 from unittest import mock
 from unittest.mock import AsyncMock

--- a/packages/google-cloud-videointelligence/tests/unit/gapic/videointelligence_v1beta2/test_video_intelligence_service.py
+++ b/packages/google-cloud-videointelligence/tests/unit/gapic/videointelligence_v1beta2/test_video_intelligence_service.py
@@ -16,7 +16,6 @@
 import json
 import math
 import os
-import re
 from collections.abc import AsyncIterable, Iterable, Mapping, Sequence
 from unittest import mock
 from unittest.mock import AsyncMock

--- a/packages/google-cloud-videointelligence/tests/unit/gapic/videointelligence_v1p1beta1/test_video_intelligence_service.py
+++ b/packages/google-cloud-videointelligence/tests/unit/gapic/videointelligence_v1p1beta1/test_video_intelligence_service.py
@@ -16,7 +16,6 @@
 import json
 import math
 import os
-import re
 from collections.abc import AsyncIterable, Iterable, Mapping, Sequence
 from unittest import mock
 from unittest.mock import AsyncMock

--- a/packages/google-cloud-videointelligence/tests/unit/gapic/videointelligence_v1p2beta1/test_video_intelligence_service.py
+++ b/packages/google-cloud-videointelligence/tests/unit/gapic/videointelligence_v1p2beta1/test_video_intelligence_service.py
@@ -16,7 +16,6 @@
 import json
 import math
 import os
-import re
 from collections.abc import AsyncIterable, Iterable, Mapping, Sequence
 from unittest import mock
 from unittest.mock import AsyncMock

--- a/packages/google-cloud-videointelligence/tests/unit/gapic/videointelligence_v1p3beta1/test_streaming_video_intelligence_service.py
+++ b/packages/google-cloud-videointelligence/tests/unit/gapic/videointelligence_v1p3beta1/test_streaming_video_intelligence_service.py
@@ -16,7 +16,6 @@
 import json
 import math
 import os
-import re
 from collections.abc import Mapping, Sequence
 from unittest import mock
 from unittest.mock import AsyncMock

--- a/packages/google-cloud-videointelligence/tests/unit/gapic/videointelligence_v1p3beta1/test_video_intelligence_service.py
+++ b/packages/google-cloud-videointelligence/tests/unit/gapic/videointelligence_v1p3beta1/test_video_intelligence_service.py
@@ -16,7 +16,6 @@
 import json
 import math
 import os
-import re
 from collections.abc import Mapping, Sequence
 from unittest import mock
 from unittest.mock import AsyncMock

--- a/packages/google-cloud-vision/README.rst
+++ b/packages/google-cloud-vision/README.rst
@@ -63,14 +63,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-vision/docs/README.rst
+++ b/packages/google-cloud-vision/docs/README.rst
@@ -63,14 +63,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-vision/google/cloud/vision_v1p2beta1/services/image_annotator/async_client.py
+++ b/packages/google-cloud-vision/google/cloud/vision_v1p2beta1/services/image_annotator/async_client.py
@@ -15,7 +15,6 @@
 #
 import logging as std_logging
 import re
-import uuid
 from collections import OrderedDict
 from typing import (
     Callable,

--- a/packages/google-cloud-vision/google/cloud/vision_v1p2beta1/services/image_annotator/client.py
+++ b/packages/google-cloud-vision/google/cloud/vision_v1p2beta1/services/image_annotator/client.py
@@ -17,7 +17,6 @@ import json
 import logging as std_logging
 import os
 import re
-import uuid
 import warnings
 from collections import OrderedDict
 from http import HTTPStatus

--- a/packages/google-cloud-vision/noxfile.py
+++ b/packages/google-cloud-vision/noxfile.py
@@ -510,24 +510,50 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1) for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -597,16 +623,24 @@ def core_deps_from_source(session, protobuf_implementation):
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
+
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(
+        f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}"
+    )
 
     session.run(
         "py.test",

--- a/packages/google-cloud-vision/tests/unit/gapic/vision_v1p2beta1/test_image_annotator.py
+++ b/packages/google-cloud-vision/tests/unit/gapic/vision_v1p2beta1/test_image_annotator.py
@@ -16,7 +16,6 @@
 import json
 import math
 import os
-import re
 from collections.abc import AsyncIterable, Iterable, Mapping, Sequence
 from unittest import mock
 from unittest.mock import AsyncMock

--- a/packages/google-cloud-visionai/README.rst
+++ b/packages/google-cloud-visionai/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-visionai/docs/README.rst
+++ b/packages/google-cloud-visionai/docs/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-visionai/noxfile.py
+++ b/packages/google-cloud-visionai/noxfile.py
@@ -509,24 +509,50 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1) for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -596,16 +622,24 @@ def core_deps_from_source(session, protobuf_implementation):
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
+
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(
+        f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}"
+    )
 
     session.run(
         "py.test",

--- a/packages/google-cloud-vm-migration/README.rst
+++ b/packages/google-cloud-vm-migration/README.rst
@@ -62,14 +62,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-vm-migration/docs/README.rst
+++ b/packages/google-cloud-vm-migration/docs/README.rst
@@ -62,14 +62,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-vm-migration/noxfile.py
+++ b/packages/google-cloud-vm-migration/noxfile.py
@@ -509,24 +509,50 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1) for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -596,16 +622,24 @@ def core_deps_from_source(session, protobuf_implementation):
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
+
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(
+        f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}"
+    )
 
     session.run(
         "py.test",

--- a/packages/google-cloud-vmwareengine/README.rst
+++ b/packages/google-cloud-vmwareengine/README.rst
@@ -62,14 +62,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-vmwareengine/docs/README.rst
+++ b/packages/google-cloud-vmwareengine/docs/README.rst
@@ -62,14 +62,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-vmwareengine/noxfile.py
+++ b/packages/google-cloud-vmwareengine/noxfile.py
@@ -509,24 +509,50 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1) for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -596,16 +622,24 @@ def core_deps_from_source(session, protobuf_implementation):
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
+
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(
+        f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}"
+    )
 
     session.run(
         "py.test",

--- a/packages/google-cloud-vpc-access/README.rst
+++ b/packages/google-cloud-vpc-access/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-vpc-access/docs/README.rst
+++ b/packages/google-cloud-vpc-access/docs/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-vpc-access/noxfile.py
+++ b/packages/google-cloud-vpc-access/noxfile.py
@@ -509,24 +509,50 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1) for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -596,16 +622,24 @@ def core_deps_from_source(session, protobuf_implementation):
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
+
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(
+        f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}"
+    )
 
     session.run(
         "py.test",

--- a/packages/google-cloud-webrisk/README.rst
+++ b/packages/google-cloud-webrisk/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-webrisk/docs/README.rst
+++ b/packages/google-cloud-webrisk/docs/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-webrisk/noxfile.py
+++ b/packages/google-cloud-webrisk/noxfile.py
@@ -509,24 +509,50 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1) for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -596,16 +622,24 @@ def core_deps_from_source(session, protobuf_implementation):
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
+
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(
+        f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}"
+    )
 
     session.run(
         "py.test",

--- a/packages/google-cloud-websecurityscanner/README.rst
+++ b/packages/google-cloud-websecurityscanner/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-websecurityscanner/docs/README.rst
+++ b/packages/google-cloud-websecurityscanner/docs/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-websecurityscanner/noxfile.py
+++ b/packages/google-cloud-websecurityscanner/noxfile.py
@@ -509,24 +509,50 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1) for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -596,16 +622,24 @@ def core_deps_from_source(session, protobuf_implementation):
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
+
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(
+        f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}"
+    )
 
     session.run(
         "py.test",

--- a/packages/google-cloud-workflows/README.rst
+++ b/packages/google-cloud-workflows/README.rst
@@ -62,14 +62,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-workflows/docs/README.rst
+++ b/packages/google-cloud-workflows/docs/README.rst
@@ -62,14 +62,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-workflows/noxfile.py
+++ b/packages/google-cloud-workflows/noxfile.py
@@ -509,24 +509,50 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1) for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -596,16 +622,24 @@ def core_deps_from_source(session, protobuf_implementation):
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
+
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(
+        f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}"
+    )
 
     session.run(
         "py.test",

--- a/packages/google-cloud-workloadmanager/README.rst
+++ b/packages/google-cloud-workloadmanager/README.rst
@@ -63,14 +63,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-workloadmanager/docs/README.rst
+++ b/packages/google-cloud-workloadmanager/docs/README.rst
@@ -63,14 +63,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-workloadmanager/noxfile.py
+++ b/packages/google-cloud-workloadmanager/noxfile.py
@@ -509,24 +509,50 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1) for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -596,16 +622,24 @@ def core_deps_from_source(session, protobuf_implementation):
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
+
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(
+        f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}"
+    )
 
     session.run(
         "py.test",

--- a/packages/google-cloud-workstations/README.rst
+++ b/packages/google-cloud-workstations/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-workstations/docs/README.rst
+++ b/packages/google-cloud-workstations/docs/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-workstations/noxfile.py
+++ b/packages/google-cloud-workstations/noxfile.py
@@ -509,24 +509,50 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1) for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -596,16 +622,24 @@ def core_deps_from_source(session, protobuf_implementation):
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
+
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(
+        f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}"
+    )
 
     session.run(
         "py.test",

--- a/packages/google-geo-type/README.rst
+++ b/packages/google-geo-type/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-geo-type/docs/README.rst
+++ b/packages/google-geo-type/docs/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-geo-type/noxfile.py
+++ b/packages/google-geo-type/noxfile.py
@@ -509,24 +509,50 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1) for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -596,16 +622,24 @@ def core_deps_from_source(session, protobuf_implementation):
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
+
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(
+        f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}"
+    )
 
     session.run(
         "py.test",

--- a/packages/google-maps-addressvalidation/README.rst
+++ b/packages/google-maps-addressvalidation/README.rst
@@ -64,14 +64,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-maps-addressvalidation/docs/README.rst
+++ b/packages/google-maps-addressvalidation/docs/README.rst
@@ -64,14 +64,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-maps-addressvalidation/noxfile.py
+++ b/packages/google-maps-addressvalidation/noxfile.py
@@ -509,24 +509,50 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1) for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -596,16 +622,24 @@ def core_deps_from_source(session, protobuf_implementation):
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
+
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(
+        f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}"
+    )
 
     session.run(
         "py.test",

--- a/packages/google-maps-areainsights/README.rst
+++ b/packages/google-maps-areainsights/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-maps-areainsights/docs/README.rst
+++ b/packages/google-maps-areainsights/docs/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-maps-areainsights/noxfile.py
+++ b/packages/google-maps-areainsights/noxfile.py
@@ -509,24 +509,50 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1) for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -596,16 +622,24 @@ def core_deps_from_source(session, protobuf_implementation):
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
+
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(
+        f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}"
+    )
 
     session.run(
         "py.test",

--- a/packages/google-maps-fleetengine-delivery/README.rst
+++ b/packages/google-maps-fleetengine-delivery/README.rst
@@ -64,14 +64,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-maps-fleetengine-delivery/docs/README.rst
+++ b/packages/google-maps-fleetengine-delivery/docs/README.rst
@@ -64,14 +64,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-maps-fleetengine-delivery/noxfile.py
+++ b/packages/google-maps-fleetengine-delivery/noxfile.py
@@ -509,24 +509,50 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1) for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -596,16 +622,24 @@ def core_deps_from_source(session, protobuf_implementation):
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
+
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(
+        f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}"
+    )
 
     session.run(
         "py.test",

--- a/packages/google-maps-fleetengine/README.rst
+++ b/packages/google-maps-fleetengine/README.rst
@@ -64,14 +64,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-maps-fleetengine/docs/README.rst
+++ b/packages/google-maps-fleetengine/docs/README.rst
@@ -64,14 +64,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-maps-fleetengine/noxfile.py
+++ b/packages/google-maps-fleetengine/noxfile.py
@@ -509,24 +509,50 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1) for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -596,16 +622,24 @@ def core_deps_from_source(session, protobuf_implementation):
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
+
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(
+        f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}"
+    )
 
     session.run(
         "py.test",

--- a/packages/google-maps-geocode/README.rst
+++ b/packages/google-maps-geocode/README.rst
@@ -63,14 +63,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-maps-geocode/docs/README.rst
+++ b/packages/google-maps-geocode/docs/README.rst
@@ -63,14 +63,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-maps-geocode/noxfile.py
+++ b/packages/google-maps-geocode/noxfile.py
@@ -509,24 +509,50 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1) for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -596,16 +622,24 @@ def core_deps_from_source(session, protobuf_implementation):
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
+
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(
+        f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}"
+    )
 
     session.run(
         "py.test",

--- a/packages/google-maps-mapmanagement/README.rst
+++ b/packages/google-maps-mapmanagement/README.rst
@@ -64,14 +64,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-maps-mapmanagement/docs/README.rst
+++ b/packages/google-maps-mapmanagement/docs/README.rst
@@ -64,14 +64,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-maps-mapmanagement/noxfile.py
+++ b/packages/google-maps-mapmanagement/noxfile.py
@@ -509,24 +509,50 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1) for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -596,16 +622,24 @@ def core_deps_from_source(session, protobuf_implementation):
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
+
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(
+        f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}"
+    )
 
     session.run(
         "py.test",

--- a/packages/google-maps-mapsplatformdatasets/README.rst
+++ b/packages/google-maps-mapsplatformdatasets/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-maps-mapsplatformdatasets/docs/README.rst
+++ b/packages/google-maps-mapsplatformdatasets/docs/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-maps-mapsplatformdatasets/noxfile.py
+++ b/packages/google-maps-mapsplatformdatasets/noxfile.py
@@ -509,24 +509,50 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1) for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -596,16 +622,24 @@ def core_deps_from_source(session, protobuf_implementation):
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
+
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(
+        f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}"
+    )
 
     session.run(
         "py.test",

--- a/packages/google-maps-navconnect/README.rst
+++ b/packages/google-maps-navconnect/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-maps-navconnect/docs/README.rst
+++ b/packages/google-maps-navconnect/docs/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-maps-navconnect/noxfile.py
+++ b/packages/google-maps-navconnect/noxfile.py
@@ -509,24 +509,50 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1) for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -596,16 +622,24 @@ def core_deps_from_source(session, protobuf_implementation):
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
+
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(
+        f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}"
+    )
 
     session.run(
         "py.test",

--- a/packages/google-maps-places/README.rst
+++ b/packages/google-maps-places/README.rst
@@ -62,14 +62,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-maps-places/docs/README.rst
+++ b/packages/google-maps-places/docs/README.rst
@@ -62,14 +62,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-maps-places/noxfile.py
+++ b/packages/google-maps-places/noxfile.py
@@ -509,24 +509,50 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1) for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -596,16 +622,24 @@ def core_deps_from_source(session, protobuf_implementation):
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
+
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(
+        f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}"
+    )
 
     session.run(
         "py.test",

--- a/packages/google-maps-routeoptimization/README.rst
+++ b/packages/google-maps-routeoptimization/README.rst
@@ -63,14 +63,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-maps-routeoptimization/docs/README.rst
+++ b/packages/google-maps-routeoptimization/docs/README.rst
@@ -63,14 +63,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-maps-routeoptimization/noxfile.py
+++ b/packages/google-maps-routeoptimization/noxfile.py
@@ -509,24 +509,50 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1) for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -596,16 +622,24 @@ def core_deps_from_source(session, protobuf_implementation):
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
+
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(
+        f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}"
+    )
 
     session.run(
         "py.test",

--- a/packages/google-maps-routing/README.rst
+++ b/packages/google-maps-routing/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-maps-routing/docs/README.rst
+++ b/packages/google-maps-routing/docs/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-maps-routing/noxfile.py
+++ b/packages/google-maps-routing/noxfile.py
@@ -509,24 +509,50 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1) for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -596,16 +622,24 @@ def core_deps_from_source(session, protobuf_implementation):
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
+
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(
+        f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}"
+    )
 
     session.run(
         "py.test",

--- a/packages/google-maps-solar/README.rst
+++ b/packages/google-maps-solar/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-maps-solar/docs/README.rst
+++ b/packages/google-maps-solar/docs/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-maps-solar/noxfile.py
+++ b/packages/google-maps-solar/noxfile.py
@@ -509,24 +509,50 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1) for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -596,16 +622,24 @@ def core_deps_from_source(session, protobuf_implementation):
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
+
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(
+        f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}"
+    )
 
     session.run(
         "py.test",

--- a/packages/google-shopping-css/README.rst
+++ b/packages/google-shopping-css/README.rst
@@ -62,14 +62,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-shopping-css/docs/README.rst
+++ b/packages/google-shopping-css/docs/README.rst
@@ -62,14 +62,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-shopping-css/noxfile.py
+++ b/packages/google-shopping-css/noxfile.py
@@ -509,24 +509,50 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1) for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -596,16 +622,24 @@ def core_deps_from_source(session, protobuf_implementation):
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
+
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(
+        f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}"
+    )
 
     session.run(
         "py.test",

--- a/packages/google-shopping-merchant-accounts/README.rst
+++ b/packages/google-shopping-merchant-accounts/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-shopping-merchant-accounts/docs/README.rst
+++ b/packages/google-shopping-merchant-accounts/docs/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-shopping-merchant-accounts/noxfile.py
+++ b/packages/google-shopping-merchant-accounts/noxfile.py
@@ -509,24 +509,50 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1) for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -596,16 +622,24 @@ def core_deps_from_source(session, protobuf_implementation):
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
+
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(
+        f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}"
+    )
 
     session.run(
         "py.test",

--- a/packages/google-shopping-merchant-conversions/README.rst
+++ b/packages/google-shopping-merchant-conversions/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-shopping-merchant-conversions/docs/README.rst
+++ b/packages/google-shopping-merchant-conversions/docs/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-shopping-merchant-conversions/noxfile.py
+++ b/packages/google-shopping-merchant-conversions/noxfile.py
@@ -509,24 +509,50 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1) for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -596,16 +622,24 @@ def core_deps_from_source(session, protobuf_implementation):
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
+
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(
+        f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}"
+    )
 
     session.run(
         "py.test",

--- a/packages/google-shopping-merchant-datasources/README.rst
+++ b/packages/google-shopping-merchant-datasources/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-shopping-merchant-datasources/docs/README.rst
+++ b/packages/google-shopping-merchant-datasources/docs/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-shopping-merchant-datasources/noxfile.py
+++ b/packages/google-shopping-merchant-datasources/noxfile.py
@@ -509,24 +509,50 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1) for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -596,16 +622,24 @@ def core_deps_from_source(session, protobuf_implementation):
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
+
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(
+        f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}"
+    )
 
     session.run(
         "py.test",

--- a/packages/google-shopping-merchant-inventories/README.rst
+++ b/packages/google-shopping-merchant-inventories/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-shopping-merchant-inventories/docs/README.rst
+++ b/packages/google-shopping-merchant-inventories/docs/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-shopping-merchant-inventories/noxfile.py
+++ b/packages/google-shopping-merchant-inventories/noxfile.py
@@ -509,24 +509,50 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1) for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -596,16 +622,24 @@ def core_deps_from_source(session, protobuf_implementation):
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
+
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(
+        f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}"
+    )
 
     session.run(
         "py.test",

--- a/packages/google-shopping-merchant-issueresolution/README.rst
+++ b/packages/google-shopping-merchant-issueresolution/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-shopping-merchant-issueresolution/docs/README.rst
+++ b/packages/google-shopping-merchant-issueresolution/docs/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-shopping-merchant-issueresolution/noxfile.py
+++ b/packages/google-shopping-merchant-issueresolution/noxfile.py
@@ -509,24 +509,50 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1) for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -596,16 +622,24 @@ def core_deps_from_source(session, protobuf_implementation):
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
+
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(
+        f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}"
+    )
 
     session.run(
         "py.test",

--- a/packages/google-shopping-merchant-lfp/README.rst
+++ b/packages/google-shopping-merchant-lfp/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-shopping-merchant-lfp/docs/README.rst
+++ b/packages/google-shopping-merchant-lfp/docs/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-shopping-merchant-lfp/noxfile.py
+++ b/packages/google-shopping-merchant-lfp/noxfile.py
@@ -509,24 +509,50 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1) for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -596,16 +622,24 @@ def core_deps_from_source(session, protobuf_implementation):
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
+
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(
+        f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}"
+    )
 
     session.run(
         "py.test",

--- a/packages/google-shopping-merchant-notifications/README.rst
+++ b/packages/google-shopping-merchant-notifications/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-shopping-merchant-notifications/docs/README.rst
+++ b/packages/google-shopping-merchant-notifications/docs/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-shopping-merchant-notifications/noxfile.py
+++ b/packages/google-shopping-merchant-notifications/noxfile.py
@@ -509,24 +509,50 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1) for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -596,16 +622,24 @@ def core_deps_from_source(session, protobuf_implementation):
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
+
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(
+        f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}"
+    )
 
     session.run(
         "py.test",

--- a/packages/google-shopping-merchant-ordertracking/README.rst
+++ b/packages/google-shopping-merchant-ordertracking/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-shopping-merchant-ordertracking/docs/README.rst
+++ b/packages/google-shopping-merchant-ordertracking/docs/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-shopping-merchant-ordertracking/noxfile.py
+++ b/packages/google-shopping-merchant-ordertracking/noxfile.py
@@ -509,24 +509,50 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1) for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -596,16 +622,24 @@ def core_deps_from_source(session, protobuf_implementation):
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
+
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(
+        f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}"
+    )
 
     session.run(
         "py.test",

--- a/packages/google-shopping-merchant-products/README.rst
+++ b/packages/google-shopping-merchant-products/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-shopping-merchant-products/docs/README.rst
+++ b/packages/google-shopping-merchant-products/docs/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-shopping-merchant-products/noxfile.py
+++ b/packages/google-shopping-merchant-products/noxfile.py
@@ -509,24 +509,50 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1) for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -596,16 +622,24 @@ def core_deps_from_source(session, protobuf_implementation):
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
+
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(
+        f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}"
+    )
 
     session.run(
         "py.test",

--- a/packages/google-shopping-merchant-productstudio/README.rst
+++ b/packages/google-shopping-merchant-productstudio/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-shopping-merchant-productstudio/docs/README.rst
+++ b/packages/google-shopping-merchant-productstudio/docs/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-shopping-merchant-productstudio/noxfile.py
+++ b/packages/google-shopping-merchant-productstudio/noxfile.py
@@ -509,24 +509,50 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1) for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -596,16 +622,24 @@ def core_deps_from_source(session, protobuf_implementation):
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
+
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(
+        f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}"
+    )
 
     session.run(
         "py.test",

--- a/packages/google-shopping-merchant-promotions/README.rst
+++ b/packages/google-shopping-merchant-promotions/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-shopping-merchant-promotions/docs/README.rst
+++ b/packages/google-shopping-merchant-promotions/docs/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-shopping-merchant-promotions/noxfile.py
+++ b/packages/google-shopping-merchant-promotions/noxfile.py
@@ -509,24 +509,50 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1) for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -596,16 +622,24 @@ def core_deps_from_source(session, protobuf_implementation):
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
+
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(
+        f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}"
+    )
 
     session.run(
         "py.test",

--- a/packages/google-shopping-merchant-quota/README.rst
+++ b/packages/google-shopping-merchant-quota/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-shopping-merchant-quota/docs/README.rst
+++ b/packages/google-shopping-merchant-quota/docs/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-shopping-merchant-quota/noxfile.py
+++ b/packages/google-shopping-merchant-quota/noxfile.py
@@ -509,24 +509,50 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1) for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -596,16 +622,24 @@ def core_deps_from_source(session, protobuf_implementation):
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
+
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(
+        f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}"
+    )
 
     session.run(
         "py.test",

--- a/packages/google-shopping-merchant-reports/README.rst
+++ b/packages/google-shopping-merchant-reports/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-shopping-merchant-reports/docs/README.rst
+++ b/packages/google-shopping-merchant-reports/docs/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-shopping-merchant-reports/noxfile.py
+++ b/packages/google-shopping-merchant-reports/noxfile.py
@@ -509,24 +509,50 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1) for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -596,16 +622,24 @@ def core_deps_from_source(session, protobuf_implementation):
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
+
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(
+        f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}"
+    )
 
     session.run(
         "py.test",

--- a/packages/google-shopping-merchant-reviews/README.rst
+++ b/packages/google-shopping-merchant-reviews/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-shopping-merchant-reviews/docs/README.rst
+++ b/packages/google-shopping-merchant-reviews/docs/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-shopping-merchant-reviews/noxfile.py
+++ b/packages/google-shopping-merchant-reviews/noxfile.py
@@ -509,24 +509,50 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1) for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -596,16 +622,24 @@ def core_deps_from_source(session, protobuf_implementation):
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
+
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(
+        f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}"
+    )
 
     session.run(
         "py.test",

--- a/packages/google-shopping-type/README.rst
+++ b/packages/google-shopping-type/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-shopping-type/docs/README.rst
+++ b/packages/google-shopping-type/docs/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-shopping-type/noxfile.py
+++ b/packages/google-shopping-type/noxfile.py
@@ -509,24 +509,50 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1) for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -596,16 +622,24 @@ def core_deps_from_source(session, protobuf_implementation):
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
+
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(
+        f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}"
+    )
 
     session.run(
         "py.test",

--- a/packages/googleapis-common-protos/README.rst
+++ b/packages/googleapis-common-protos/README.rst
@@ -54,14 +54,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/googleapis-common-protos/docs/README.rst
+++ b/packages/googleapis-common-protos/docs/README.rst
@@ -54,14 +54,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/grafeas/README.rst
+++ b/packages/grafeas/README.rst
@@ -62,14 +62,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/grafeas/docs/README.rst
+++ b/packages/grafeas/docs/README.rst
@@ -62,14 +62,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/grafeas/noxfile.py
+++ b/packages/grafeas/noxfile.py
@@ -509,24 +509,50 @@ def prerelease_deps(session, protobuf_implementation):
         "proto-plus",
     ]
 
-    for dep in prerel_deps:
-        session.install("--pre", "--no-deps", "--ignore-installed", dep)
-        # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
-        # to the dictionary below once this bug is fixed.
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
-        # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
-        # once this bug is fixed.
-        package_namespaces = {
-            "google-api-core": "google.api_core",
-            "google-auth": "google.auth",
-            "grpcio": "grpc",
-            "protobuf": "google.protobuf",
-            "proto-plus": "proto",
-        }
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
 
-        version_namespace = package_namespaces.get(dep)
+    # Extract the base package name, safely ignoring version bounds and spaces
+    # (e.g., "grpcio>=1.75.1" becomes "grpcio")
+    parsed_deps = {
+        dep: re.match(r"^([a-zA-Z0-9_-]+)", dep).group(1) for dep in prerel_deps
+    }
 
+    # Dynamically sort local packages vs PyPI dependencies
+    local_paths = []
+    pypi_deps = []
+
+    for dep, pkg_name in parsed_deps.items():
+        if (deps_dir / pkg_name).exists():
+            local_paths.append(str(deps_dir / pkg_name))
+        else:
+            pypi_deps.append(dep)
+
+    # Batch pip installations to avoid sequential overhead
+    if local_paths:
+        session.install(*local_paths, "--no-deps", "--ignore-installed")
+    if pypi_deps:
+        session.install(*pypi_deps, "--pre", "--no-deps", "--ignore-installed")
+
+    # TODO(https://github.com/grpc/grpc/issues/38965): Add `grpcio-status``
+    # to the dictionary below once this bug is fixed.
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/13643): Add
+    # `googleapis-common-protos` and `grpc-google-iam-v1` to the dictionary below
+    # once this bug is fixed.
+    package_namespaces = {
+        "google-api-core": "google.api_core",
+        "google-auth": "google.auth",
+        "grpcio": "grpc",
+        "protobuf": "google.protobuf",
+        "proto-plus": "proto",
+    }
+
+    # Reuse the parsed names for logging and version verification
+    for dep, pkg_name in parsed_deps.items():
         print(f"Installed {dep}")
+        version_namespace = package_namespaces.get(pkg_name)
+
         if version_namespace:
             session.run(
                 "python",
@@ -596,16 +622,24 @@ def core_deps_from_source(session, protobuf_implementation):
     # Note: If a dependency is added to the `core_dependencies_from_source` list,
     # the `prerel_deps` list in the `prerelease_deps` nox session should also be updated.
     core_dependencies_from_source = [
-        "googleapis-common-protos @ git+https://github.com/googleapis/google-cloud-python#egg=googleapis-common-protos&subdirectory=packages/googleapis-common-protos",
-        "google-api-core @ git+https://github.com/googleapis/google-cloud-python#egg=google-api-core&subdirectory=packages/google-api-core",
-        "google-auth @ git+https://github.com/googleapis/google-cloud-python#egg=google-auth&subdirectory=packages/google-auth",
-        "grpc-google-iam-v1 @ git+https://github.com/googleapis/google-cloud-python#egg=grpc-google-iam-v1&subdirectory=packages/grpc-google-iam-v1",
-        "proto-plus @ git+https://github.com/googleapis/google-cloud-python#egg=proto-plus&subdirectory=packages/proto-plus",
+        "googleapis-common-protos",
+        "google-api-core",
+        "google-auth",
+        "grpc-google-iam-v1",
+        "proto-plus",
     ]
 
-    for dep in core_dependencies_from_source:
-        session.install(dep, "--no-deps", "--ignore-installed")
-        print(f"Installed {dep}")
+    deps_dir = CURRENT_DIRECTORY.parent
+    while deps_dir.name != "packages" and deps_dir.parent != deps_dir:
+        deps_dir = deps_dir.parent
+
+    # Batch the pip installation to avoid sequential overhead
+    dep_paths = [str(deps_dir / dep) for dep in core_dependencies_from_source]
+
+    session.install(*dep_paths, "--no-deps", "--ignore-installed")
+    print(
+        f"Installed {', '.join(core_dependencies_from_source)} locally from {deps_dir}"
+    )
 
     session.run(
         "py.test",

--- a/packages/grpc-google-iam-v1/README.rst
+++ b/packages/grpc-google-iam-v1/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/grpc-google-iam-v1/docs/README.rst
+++ b/packages/grpc-google-iam-v1/docs/README.rst
@@ -61,14 +61,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.


### PR DESCRIPTION
Using Librarian revision [433d9e6211ade41965f4be8b8fe8ca33c1d820ee](https://github.com/googleapis/librarian/commit/433d9e6211ade41965f4be8b8fe8ca33c1d820ee).

```
google-cloud-python$ go run github.com/googleapis/librarian/tool/cmd/builddockerimages@latest --language python --version=433d9e6211ade41965f4be8b8fe8ca33c1d820ee
...
google-cloud-python$ docker run -u $(id -u):$(id -g) -v .:/repo -v ~/.cache:/.cache -w /repo docker.io/library/librarian-python:433d9e6211ade41965f4be8b8fe8ca33c1d820ee  generate -v --all
...
```