### PR TITLE
chore(ci): add librarian tidy check

### DIFF
--- a/.github/workflows/librarian_tidy.yml
+++ b/.github/workflows/librarian_tidy.yml
@@ -1,4 +1,4 @@
-name: Check that librarian.yaml is tidy
+name: librarian tidy
 
 on:
   pull_request:

--- a/.github/workflows/librarian_tidy.yml
+++ b/.github/workflows/librarian_tidy.yml
@@ -22,18 +22,7 @@ jobs:
 
       - name: Run librarian tidy
         run: |
-          # go run can flake if the downloads fail, so run it several times until it succeeds.
-          go run github.com/googleapis/librarian/cmd/librarian@latest version || \
-          go run github.com/googleapis/librarian/cmd/librarian@latest version || \
-          go run github.com/googleapis/librarian/cmd/librarian@latest version
-
           V=$(go run github.com/googleapis/librarian/cmd/librarian@latest config get version)
-
-          # This is a different download, so it can flake even after the first one succeeds.
-          go run github.com/googleapis/librarian/cmd/librarian@${V} version || \
-          go run github.com/googleapis/librarian/cmd/librarian@${V} version || \
-          go run github.com/googleapis/librarian/cmd/librarian@${V} version
-
           go run github.com/googleapis/librarian/cmd/librarian@${V} tidy
           git diff
 

--- a/.github/workflows/librarian_tidy.yml
+++ b/.github/workflows/librarian_tidy.yml
@@ -1,0 +1,51 @@
+name: Check that librarian.yaml is tidy
+
+on:
+  pull_request:
+    paths:
+      - 'librarian.yaml'
+
+permissions:
+  contents: read
+
+jobs:
+  tidy-check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Install Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: '1.26.x'
+
+      - name: Run librarian tidy
+        run: |
+          # go run can flake if the downloads fail, so run it several times until it succeeds.
+          go run github.com/googleapis/librarian/cmd/librarian@latest version || \
+          go run github.com/googleapis/librarian/cmd/librarian@latest version || \
+          go run github.com/googleapis/librarian/cmd/librarian@latest version
+
+          V=$(go run github.com/googleapis/librarian/cmd/librarian@latest config get version)
+
+          # This is a different download, so it can flake even after the first one succeeds.
+          go run github.com/googleapis/librarian/cmd/librarian@${V} version || \
+          go run github.com/googleapis/librarian/cmd/librarian@${V} version || \
+          go run github.com/googleapis/librarian/cmd/librarian@${V} version
+
+          go run github.com/googleapis/librarian/cmd/librarian@${V} tidy
+          git diff
+
+      - name: Check for diff
+        run: |
+          if ! git diff --exit-code; then
+            V=$(go run github.com/googleapis/librarian/cmd/librarian@latest config get version)
+            echo "librarian.yaml is not tidy. Please run:"
+            echo ""
+            echo "  go run github.com/googleapis/librarian/cmd/librarian@${V} tidy"
+            echo ""
+            echo "to tidy librarian.yaml and commit the changes."
+            exit 1
+          fi
+


### PR DESCRIPTION
Adds a `librarian tidy` check for pull requests touching `librarian.yaml`.

It uses the version of librarian specified in the `librarian.yaml`, runs `librarian tidy`, reports any diff, and fails if there is any diff.

Fixes https://github.com/googleapis/librarian/issues/5908