### PR TITLE
tests: filter DeprecationWarning in opentelemetry-api

### DIFF
--- a/packages/google-cloud-logging/pytest.ini
+++ b/packages/google-cloud-logging/pytest.ini
@@ -38,4 +38,5 @@ filterwarnings =
     ignore:The load_credentials_from_file method is deprecated:DeprecationWarning
     ignore:.*Please upgrade to the latest Python version.*:FutureWarning
     ignore:(?s).*using a Python version.*past its end of life.*:FutureWarning
-
+    # Remove once https://github.com/open-telemetry/opentelemetry-python/issues/5231 is fixed
+    ignore:(?s).*SelectableGroups dict interface is deprecated. Use select.*:DeprecationWarning


### PR DESCRIPTION
This PR is needed to resolve the failing `unit-3.11` presubmit in https://github.com/googleapis/google-cloud-python/pull/17235 which is due to a new DeprecationWarning from `opentelemetry-api`. See [build log](https://github.com/googleapis/google-cloud-python/actions/runs/26299236667/job/77419821319?pr=17235).

This PR filters the deprecation warning in `opentelemetry-api` until a fix is available. See the linked issue for more information.