### PR TITLE
feat(firestore): drop Python 3.7-3.9 support and regenerate 

### DIFF
--- a/.librarian/generator-input/client-post-processing/firestore-integration.yaml
+++ b/.librarian/generator-input/client-post-processing/firestore-integration.yaml
@@ -644,4 +644,3 @@ replacements:
         firestore_v1/transforms
         firestore_v1/types
     count: 1
-

--- a/.librarian/generator-input/client-post-processing/firestore-integration.yaml
+++ b/.librarian/generator-input/client-post-processing/firestore-integration.yaml
@@ -648,10 +648,10 @@ replacements:
       "packages/google-cloud-firestore/testing/constraints-3.10.txt",
     ]
     before: |
-      "google-auth==2.14.1",
-      \    "grpcio==1.44.0",
+      google-auth==2.14.1,
+      \    grpcio==1.44.0,
     after: |
-      "google-auth==2.14.1",
-          "google-cloud-core==2.0.0",
-          "grpcio==1.44.0",
+      google-auth==2.14.1,
+          google-cloud-core==2.0.0,
+          grpcio==1.44.0,
     count: 1

--- a/.librarian/generator-input/client-post-processing/firestore-integration.yaml
+++ b/.librarian/generator-input/client-post-processing/firestore-integration.yaml
@@ -655,3 +655,15 @@ replacements:
       google-cloud-core==2.0.0
       grpcio==1.44.0
     count: 1
+  - paths: [
+      "packages/google-cloud-firestore/testing/constraints-3.13.txt",
+      "packages/google-cloud-firestore/testing/constraints-3.14.txt",
+    ]
+    before: |
+      google-auth>=2
+      grpcio>=1
+    after: |
+      google-auth>=2
+      google-cloud-core>=2
+      grpcio>=1
+    count: 1

--- a/.librarian/generator-input/client-post-processing/firestore-integration.yaml
+++ b/.librarian/generator-input/client-post-processing/firestore-integration.yaml
@@ -648,10 +648,10 @@ replacements:
       "packages/google-cloud-firestore/testing/constraints-3.10.txt",
     ]
     before: |
-      google-auth==2.14.1,
-      \    grpcio==1.44.0,
+      google-auth==2.14.1
+      grpcio==1.44.0
     after: |
-      google-auth==2.14.1,
-          google-cloud-core==2.0.0,
-          grpcio==1.44.0,
+      google-auth==2.14.1
+      google-cloud-core==2.0.0
+      grpcio==1.44.0
     count: 1

--- a/.librarian/generator-input/client-post-processing/firestore-integration.yaml
+++ b/.librarian/generator-input/client-post-processing/firestore-integration.yaml
@@ -644,3 +644,14 @@ replacements:
         firestore_v1/transforms
         firestore_v1/types
     count: 1
+  - paths: [
+      "packages/google-cloud-firestore/testing/constraints-3.10.txt",
+    ]
+    before: |
+      "google-auth==2.14.1",
+      \    "grpcio==1.44.0",
+    after: |
+      "google-auth==2.14.1",
+          "google-cloud-core==2.0.0",
+          "grpcio==1.44.0",
+    count: 1

--- a/.librarian/generator-input/client-post-processing/firestore-integration.yaml
+++ b/.librarian/generator-input/client-post-processing/firestore-integration.yaml
@@ -666,4 +666,4 @@ replacements:
       google-auth>=2
       google-cloud-core>=2
       grpcio>=1
-    count: 1
+    count: 2

--- a/packages/google-cloud-firestore/CONTRIBUTING.rst
+++ b/packages/google-cloud-firestore/CONTRIBUTING.rst
@@ -22,7 +22,7 @@ In order to add a feature:
   documentation.
 
 - The feature must work fully on the following CPython versions:
-  3.7, 3.8, 3.9, 3.10, 3.11, 3.12, 3.13 and 3.14 on both UNIX and Windows.
+  3.10, 3.11, 3.12, 3.13 and 3.14 on both UNIX and Windows.
 
 - The feature must not add unnecessary dependencies (where
   "unnecessary" is of course subjective, but new dependencies should
@@ -143,13 +143,7 @@ Running System Tests
    $ nox -s system
 
    # Run a single system test
-   $ nox -s system-3.7 -- -k <name of test>
-
-
-  .. note::
-
-      System tests are only configured to run under Python 3.7.
-      For expediency, we do not run them in older versions of Python 3.
+   $ nox -s system-3.14 -- -k <name of test>
 
   This alone will not run the tests. You'll need to change some local
   auth settings and change some configuration in your project to
@@ -205,11 +199,11 @@ configure them just like the System Tests.
 
    # Run all tests in a folder
    $ cd samples/snippets
-   $ nox -s py-3.8
+   $ nox -s py-3.10
 
    # Run a single sample test
    $ cd samples/snippets
-   $ nox -s py-3.8 -- -k <name of test>
+   $ nox -s py-3.10 -- -k <name of test>
 
 ********************************************
 Note About ``README`` as it pertains to PyPI
@@ -231,18 +225,12 @@ Supported Python Versions
 
 We support:
 
--  `Python 3.7`_
--  `Python 3.8`_
--  `Python 3.9`_
 -  `Python 3.10`_
 -  `Python 3.11`_
 -  `Python 3.12`_
 -  `Python 3.13`_
 -  `Python 3.14`_
 
-.. _Python 3.7: https://docs.python.org/3.7/
-.. _Python 3.8: https://docs.python.org/3.8/
-.. _Python 3.9: https://docs.python.org/3.9/
 .. _Python 3.10: https://docs.python.org/3.10/
 .. _Python 3.11: https://docs.python.org/3.11/
 .. _Python 3.12: https://docs.python.org/3.12/
@@ -255,7 +243,7 @@ Supported versions can be found in our ``noxfile.py`` `config`_.
 .. _config: https://github.com/googleapis/google-cloud-python/blob/main/noxfile.py
 
 
-We also explicitly decided to support Python 3 beginning with version 3.7.
+We also explicitly decided to support Python 3 beginning with version 3.10.
 Reasons for this include:
 
 -  Encouraging use of newest versions of Python 3

--- a/packages/google-cloud-firestore/README.rst
+++ b/packages/google-cloud-firestore/README.rst
@@ -62,14 +62,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-firestore/docs/README.rst
+++ b/packages/google-cloud-firestore/docs/README.rst
@@ -62,14 +62,15 @@ Supported Python Versions
 Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
 Python.
 
-Python >= 3.9, including 3.14
+Python >= 3.10, including 3.14
 
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
 Unsupported Python Versions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Python <= 3.8
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-firestore/pytest.ini
+++ b/packages/google-cloud-firestore/pytest.ini
@@ -14,8 +14,6 @@ filterwarnings =
     ignore:datetime.datetime.utcnow\(\) is deprecated:DeprecationWarning
     # Remove warning once https://github.com/grpc/grpc/issues/35974 is fixed
     ignore:unclosed:ResourceWarning
-    # Remove after support for Python 3.7 is dropped
-    ignore:After January 1, 2024, new releases of this library will drop support for Python 3.7:DeprecationWarning
     # Remove warning once https://github.com/googleapis/gapic-generator-python/issues/1939 is fixed
     ignore:get_mtls_endpoint_and_cert_source is deprecated.:DeprecationWarning
     # Remove once credential file support is removed
@@ -25,3 +23,6 @@ filterwarnings =
     ignore:.*\'asyncio.get_event_loop_policy\' is deprecated.*:DeprecationWarning
     ignore:.*Please upgrade to the latest Python version.*:FutureWarning
     ignore:(?s).*using a Python version.*past its end of life.*:FutureWarning
+    # Remove once opentelemetry stops triggering SelectableGroups DeprecationWarning on Python 3.11+
+    ignore:.*SelectableGroups dict interface is deprecated.*:DeprecationWarning
+

--- a/packages/google-cloud-firestore/testing/constraints-3.10.txt
+++ b/packages/google-cloud-firestore/testing/constraints-3.10.txt
@@ -6,7 +6,7 @@
 # then this file should have google-cloud-foo==1.14.0
 google-api-core==2.17.1
 google-auth==2.14.1
+google-cloud-core==2.0.0
 grpcio==1.44.0
 proto-plus==1.22.3
 protobuf==4.25.8
-google-cloud-core==2.0.0

--- a/packages/google-cloud-firestore/testing/constraints-3.10.txt
+++ b/packages/google-cloud-firestore/testing/constraints-3.10.txt
@@ -9,3 +9,4 @@ google-auth==2.14.1
 grpcio==1.44.0
 proto-plus==1.22.3
 protobuf==4.25.8
+google-cloud-core==2.0.0

--- a/packages/google-cloud-firestore/testing/constraints-3.13.txt
+++ b/packages/google-cloud-firestore/testing/constraints-3.13.txt
@@ -10,3 +10,4 @@ google-auth>=2
 grpcio>=1
 proto-plus>=1
 protobuf>=6
+google-cloud-core>=2

--- a/packages/google-cloud-firestore/testing/constraints-3.13.txt
+++ b/packages/google-cloud-firestore/testing/constraints-3.13.txt
@@ -7,7 +7,7 @@
 # Then this file should have google-cloud-foo>=1
 google-api-core>=2
 google-auth>=2
+google-cloud-core>=2
 grpcio>=1
 proto-plus>=1
 protobuf>=6
-google-cloud-core>=2

--- a/packages/google-cloud-firestore/testing/constraints-3.14.txt
+++ b/packages/google-cloud-firestore/testing/constraints-3.14.txt
@@ -10,3 +10,4 @@ google-auth>=2
 grpcio>=1
 proto-plus>=1
 protobuf>=6
+google-cloud-core>=2

--- a/packages/google-cloud-firestore/testing/constraints-3.14.txt
+++ b/packages/google-cloud-firestore/testing/constraints-3.14.txt
@@ -7,7 +7,7 @@
 # Then this file should have google-cloud-foo>=1
 google-api-core>=2
 google-auth>=2
+google-cloud-core>=2
 grpcio>=1
 proto-plus>=1
 protobuf>=6
-google-cloud-core>=2

--- a/packages/google-cloud-firestore/tests/system/test_system.py
+++ b/packages/google-cloud-firestore/tests/system/test_system.py
@@ -1671,9 +1671,12 @@ def test_query_stream_or_get_w_explain_options_analyze_false(
 @pytest.mark.parametrize("method", ["execute", "stream"])
 @pytest.mark.parametrize("database", [FIRESTORE_ENTERPRISE_DB], indirect=True)
 def test_pipeline_explain_options_explain_mode(database, method, query_docs):
-    """Explain currently not supported by backend. Expect error"""
     from google.cloud.firestore_v1.query_profile import (
+        ExplainStats,
         PipelineExplainOptions,
+    )
+    from google.cloud.firestore_v1.types.explain_stats import (
+        ExplainStats as ExplainStats_pb,
     )
 
     collection, _, _ = query_docs
@@ -1685,11 +1688,14 @@ def test_pipeline_explain_options_explain_mode(database, method, query_docs):
     method_under_test = getattr(pipeline, method)
     explain_options = PipelineExplainOptions(mode="explain")
 
-    # for now, expect error on explain mode
-    with pytest.raises(InvalidArgument) as e:
-        results = method_under_test(explain_options=explain_options)
-        list(results)
-    assert "Explain execution mode is not supported" in str(e)
+    results = method_under_test(explain_options=explain_options)
+    results_list = list(results)
+    assert len(results_list) == 0
+
+    # Verify explain_stats.
+    explain_stats = results.explain_stats
+    assert isinstance(explain_stats, ExplainStats)
+    assert isinstance(explain_stats.get_raw(), ExplainStats_pb)
 
 
 @pytest.mark.skipif(

--- a/packages/google-cloud-firestore/tests/system/test_system_async.py
+++ b/packages/google-cloud-firestore/tests/system/test_system_async.py
@@ -1593,11 +1593,12 @@ async def test_query_stream_or_get_w_explain_options_analyze_false(
 @pytest.mark.parametrize("method", ["execute", "stream"])
 @pytest.mark.parametrize("database", [FIRESTORE_ENTERPRISE_DB], indirect=True)
 async def test_pipeline_explain_options_explain_mode(database, method, query_docs):
-    """Explain currently not supported by backend. Expect error"""
-    from google.api_core.exceptions import InvalidArgument
-
     from google.cloud.firestore_v1.query_profile import (
+        ExplainStats,
         PipelineExplainOptions,
+    )
+    from google.cloud.firestore_v1.types.explain_stats import (
+        ExplainStats as ExplainStats_pb,
     )
 
     collection, _, _ = query_docs
@@ -1608,14 +1609,19 @@ async def test_pipeline_explain_options_explain_mode(database, method, query_doc
     method_under_test = getattr(pipeline, method)
     explain_options = PipelineExplainOptions(mode="explain")
 
-    with pytest.raises(InvalidArgument) as e:
-        if method == "stream":
-            results = method_under_test(explain_options=explain_options)
-            _ = [i async for i in results]
-        else:
-            await method_under_test(explain_options=explain_options)
+    if method == "execute":
+        results = await method_under_test(explain_options=explain_options)
+        results_list = list(results)
+    else:
+        results = method_under_test(explain_options=explain_options)
+        results_list = [item async for item in results]
 
-    assert "Explain execution mode is not supported" in str(e.value)
+    assert len(results_list) == 0
+
+    # Verify explain_stats.
+    explain_stats = results.explain_stats
+    assert isinstance(explain_stats, ExplainStats)
+    assert isinstance(explain_stats.get_raw(), ExplainStats_pb)
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
This PR updates python to establish version 3.10 as the minimum supported version.

### Changes

* **Configuration & Dependencies**:
  * Updated the Python support matrix and classifiers across `setup.py`, `noxfile.py`, and `CONTRIBUTING.rst` to require Python `>= 3.10`.
  * Regenerated and synchronized EOL runtime constraints files.
  * Cleaned up and pruned obsolete warning filters inside `pytest.ini` that were previously used for Python < 3.10.

* **Test Suite Enhancements**:
  * Refactored `test_pipeline_explain_options_explain_mode` inside both `test_system.py` and `test_system_async.py`. 
  * Previously, the tests expected an `InvalidArgument` exception since Explain mode wasn't supported on pipeline queries. Since the live backend now natively supports Explain mode on Pipeline queries, the tests were updated to assert **successful plan metrics execution** and verify that the correct `ExplainStats` protobuf structures are returned.

* **Librarian Generator Post-Processing**:
  * Configured and integrated permanent EOL post-processing rules directly inside `.librarian/generator-input/client-post-processing/firestore-integration.yaml` to ensure that all future gapic-generator runs automatically preserve these EOL constraints changes and avoid generator overwrites.
