### PR TITLE
chore(storage): support DISABLE_GCS_PYTHON_CLIENT_OTEL_BUCKET_METADATA environment variable flag

### DIFF
--- a/packages/google-cloud-storage/google/cloud/storage/_helpers.py
+++ b/packages/google-cloud-storage/google/cloud/storage/_helpers.py
@@ -150,8 +150,17 @@ def _validate_name(name):
 def create_trace_span_helper(client, bucket_name, name, attributes=None, **kwargs):
     span_attrs = dict(attributes) if attributes else {}
 
+    # Check if GCS destination annotations are explicitly disabled via environment
+    disable_bucket_md = os.environ.get("DISABLE_BUCKET_MD_IN_OTEL", "").lower() in (
+        "1",
+        "true",
+        "yes",
+        "on",
+    )
+
     if (
-        bucket_name
+        not disable_bucket_md
+        and bucket_name
         and isinstance(bucket_name, str)
         and client
         and hasattr(client, "_bucket_metadata_cache")

--- a/packages/google-cloud-storage/google/cloud/storage/_helpers.py
+++ b/packages/google-cloud-storage/google/cloud/storage/_helpers.py
@@ -150,21 +150,16 @@ def _validate_name(name):
 def create_trace_span_helper(client, bucket_name, name, attributes=None, **kwargs):
     span_attrs = dict(attributes) if attributes else {}
 
-    # Check if GCS destination annotations are explicitly disabled via environment
-    disable_bucket_md = os.environ.get("DISABLE_BUCKET_MD_IN_OTEL", "").lower() in (
-        "1",
-        "true",
-        "yes",
-        "on",
-    )
-
     if (
-        not disable_bucket_md
-        and bucket_name
+        bucket_name
         and isinstance(bucket_name, str)
         and client
         and hasattr(client, "_bucket_metadata_cache")
         and client._bucket_metadata_cache
+        and not (
+            os.environ.get("DISABLE_BUCKET_MD_IN_OTEL", "").lower()
+            in ("1", "true", "yes", "on")
+        )
     ):
         try:
             if name in (

--- a/packages/google-cloud-storage/google/cloud/storage/_helpers.py
+++ b/packages/google-cloud-storage/google/cloud/storage/_helpers.py
@@ -34,6 +34,7 @@ from google.cloud.exceptions import NotFound
 
 from google.cloud.storage._opentelemetry_tracing import (
     create_trace_span as _base_create_trace_span,
+    _is_bucket_metadata_disabled,
 )
 from google.cloud.storage.constants import _DEFAULT_TIMEOUT
 from google.cloud.storage.retry import (
@@ -156,10 +157,7 @@ def create_trace_span_helper(client, bucket_name, name, attributes=None, **kwarg
         and client
         and hasattr(client, "_bucket_metadata_cache")
         and client._bucket_metadata_cache
-        and not (
-            os.environ.get("DISABLE_BUCKET_MD_IN_OTEL", "").lower()
-            in ("1", "true", "yes", "on")
-        )
+        and not _is_bucket_metadata_disabled()
     ):
         try:
             if name in (

--- a/packages/google-cloud-storage/google/cloud/storage/_http.py
+++ b/packages/google-cloud-storage/google/cloud/storage/_http.py
@@ -83,21 +83,16 @@ class Connection(_http.JSONConnection):
         span_attributes = {
             "gccl-invocation-id": invocation_id,
         }
-        # Check if GCS destination annotations are explicitly disabled via environment
-        disable_bucket_md = os.environ.get("DISABLE_BUCKET_MD_IN_OTEL", "").lower() in (
-            "1",
-            "true",
-            "yes",
-            "on",
-        )
         client = self._client
-
         if (
-            not disable_bucket_md
-            and HAS_OPENTELEMETRY
+            HAS_OPENTELEMETRY
             and enable_otel_traces
             and hasattr(client, "_bucket_metadata_cache")
             and client._bucket_metadata_cache
+            and not (
+                os.environ.get("DISABLE_BUCKET_MD_IN_OTEL", "").lower()
+                in ("1", "true", "yes", "on")
+            )
         ):
             path = kwargs.get("path") or ""
             match = re.search(r"/b/([^/?#]+)", path)

--- a/packages/google-cloud-storage/google/cloud/storage/_http.py
+++ b/packages/google-cloud-storage/google/cloud/storage/_http.py
@@ -16,6 +16,7 @@
 
 import functools
 import logging
+import os
 import re
 
 from google.api_core import exceptions as api_exceptions
@@ -82,9 +83,18 @@ class Connection(_http.JSONConnection):
         span_attributes = {
             "gccl-invocation-id": invocation_id,
         }
+        # Check if GCS destination annotations are explicitly disabled via environment
+        disable_bucket_md = os.environ.get("DISABLE_BUCKET_MD_IN_OTEL", "").lower() in (
+            "1",
+            "true",
+            "yes",
+            "on",
+        )
         client = self._client
+
         if (
-            HAS_OPENTELEMETRY
+            not disable_bucket_md
+            and HAS_OPENTELEMETRY
             and enable_otel_traces
             and hasattr(client, "_bucket_metadata_cache")
             and client._bucket_metadata_cache

--- a/packages/google-cloud-storage/google/cloud/storage/_http.py
+++ b/packages/google-cloud-storage/google/cloud/storage/_http.py
@@ -16,7 +16,6 @@
 
 import functools
 import logging
-import os
 import re
 
 from google.api_core import exceptions as api_exceptions
@@ -28,6 +27,7 @@ from google.cloud.storage._opentelemetry_tracing import (
     HAS_OPENTELEMETRY,
     create_trace_span,
     enable_otel_traces,
+    _is_bucket_metadata_disabled,
 )
 
 logger = logging.getLogger(__name__)
@@ -89,10 +89,7 @@ class Connection(_http.JSONConnection):
             and enable_otel_traces
             and hasattr(client, "_bucket_metadata_cache")
             and client._bucket_metadata_cache
-            and not (
-                os.environ.get("DISABLE_BUCKET_MD_IN_OTEL", "").lower()
-                in ("1", "true", "yes", "on")
-            )
+            and not _is_bucket_metadata_disabled()
         ):
             path = kwargs.get("path") or ""
             match = re.search(r"/b/([^/?#]+)", path)

--- a/packages/google-cloud-storage/google/cloud/storage/_opentelemetry_tracing.py
+++ b/packages/google-cloud-storage/google/cloud/storage/_opentelemetry_tracing.py
@@ -27,7 +27,7 @@ from google.cloud.storage.retry import ConditionalRetryPolicy
 
 ENABLE_OTEL_TRACES_ENV_VAR = "ENABLE_GCS_PYTHON_CLIENT_OTEL_TRACES"
 _DEFAULT_ENABLE_OTEL_TRACES_VALUE = False
-DISABLE_BUCKET_MD_ENV_VAR = "DISABLE_BUCKET_MD_IN_OTEL"
+DISABLE_BUCKET_MD_ENV_VAR = "DISABLE_GCS_PYTHON_CLIENT_OTEL_BUCKET_METADATA"
 
 
 def _parse_bool_env(name: str, default: bool = False) -> bool:

--- a/packages/google-cloud-storage/google/cloud/storage/_opentelemetry_tracing.py
+++ b/packages/google-cloud-storage/google/cloud/storage/_opentelemetry_tracing.py
@@ -27,6 +27,7 @@ from google.cloud.storage.retry import ConditionalRetryPolicy
 
 ENABLE_OTEL_TRACES_ENV_VAR = "ENABLE_GCS_PYTHON_CLIENT_OTEL_TRACES"
 _DEFAULT_ENABLE_OTEL_TRACES_VALUE = False
+DISABLE_BUCKET_MD_ENV_VAR = "DISABLE_BUCKET_MD_IN_OTEL"
 
 
 def _parse_bool_env(name: str, default: bool = False) -> bool:
@@ -36,10 +37,15 @@ def _parse_bool_env(name: str, default: bool = False) -> bool:
     return str(val).strip().lower() in {"1", "true", "yes", "on"}
 
 
+def _is_bucket_metadata_disabled() -> bool:
+    return _parse_bool_env(DISABLE_BUCKET_MD_ENV_VAR, False)
+
+
 enable_otel_traces = _parse_bool_env(
     ENABLE_OTEL_TRACES_ENV_VAR, _DEFAULT_ENABLE_OTEL_TRACES_VALUE
 )
 logger = logging.getLogger(__name__)
+
 
 try:
     from opentelemetry import trace

--- a/packages/google-cloud-storage/tests/system/test_aco_observability.py
+++ b/packages/google-cloud-storage/tests/system/test_aco_observability.py
@@ -554,7 +554,7 @@ def test_sequential_cache_priming_multi_region(
 def test_disable_bucket_md_env_flag(
     storage_client, exporter, buckets_to_delete, monkeypatch
 ):
-    """Verifies that setting DISABLE_BUCKET_MD_IN_OTEL=true disables GCS
+    """Verifies that setting DISABLE_GCS_PYTHON_CLIENT_OTEL_BUCKET_METADATA=true disables GCS
     destination annotations, even on cache hits."""
     # Clear cache and OTel exporter logs
     storage_client._bucket_metadata_cache.clear()
@@ -572,8 +572,8 @@ def test_disable_bucket_md_env_flag(
     # Warm cache directly via GCS creation warming (client.create_bucket already primes the cache)
     assert storage_client._bucket_metadata_cache.get(bucket_name) is not None
 
-    # Enable the DISABLE_BUCKET_MD_IN_OTEL environment variable using monkeypatch
-    monkeypatch.setenv("DISABLE_BUCKET_MD_IN_OTEL", "true")
+    # Enable the DISABLE_GCS_PYTHON_CLIENT_OTEL_BUCKET_METADATA environment variable using monkeypatch
+    monkeypatch.setenv("DISABLE_GCS_PYTHON_CLIENT_OTEL_BUCKET_METADATA", "true")
 
     # Download (normally would be a cache hit with GCS annotations)
     blob.download_as_bytes()

--- a/packages/google-cloud-storage/tests/system/test_aco_observability.py
+++ b/packages/google-cloud-storage/tests/system/test_aco_observability.py
@@ -16,7 +16,6 @@ import concurrent.futures
 import threading
 import time
 
-import os
 import pytest
 from google.api_core import exceptions
 
@@ -552,7 +551,9 @@ def test_sequential_cache_priming_multi_region(
         storage_client._bucket_metadata_cache.update_cache = original_update
 
 
-def test_disable_bucket_md_env_flag(storage_client, exporter, buckets_to_delete):
+def test_disable_bucket_md_env_flag(
+    storage_client, exporter, buckets_to_delete, monkeypatch
+):
     """Verifies that setting DISABLE_BUCKET_MD_IN_OTEL=true disables GCS
     destination annotations, even on cache hits."""
     # Clear cache and OTel exporter logs
@@ -571,20 +572,16 @@ def test_disable_bucket_md_env_flag(storage_client, exporter, buckets_to_delete)
     # Warm cache directly via GCS creation warming (client.create_bucket already primes the cache)
     assert storage_client._bucket_metadata_cache.get(bucket_name) is not None
 
-    # Enable the DISABLE_BUCKET_MD_IN_OTEL environment variable
-    os.environ["DISABLE_BUCKET_MD_IN_OTEL"] = "true"
+    # Enable the DISABLE_BUCKET_MD_IN_OTEL environment variable using monkeypatch
+    monkeypatch.setenv("DISABLE_BUCKET_MD_IN_OTEL", "true")
 
-    try:
-        # Download (normally would be a cache hit with GCS annotations)
-        blob.download_as_bytes()
+    # Download (normally would be a cache hit with GCS annotations)
+    blob.download_as_bytes()
 
-        # Verify that ACO attributes are NOT present in the OTel span!
-        spans = exporter.get_finished_spans()
-        dl_spans = [s for s in spans if s.name == "Storage.Blob.downloadAsBytes"]
-        assert len(dl_spans) == 1
-        attrs = dl_spans[0].attributes
-        assert "gcp.resource.destination.id" not in attrs
-        assert "gcp.resource.destination.location" not in attrs
-    finally:
-        # Restore env var
-        os.environ.pop("DISABLE_BUCKET_MD_IN_OTEL", None)
+    # Verify that ACO attributes are NOT present in the OTel span!
+    spans = exporter.get_finished_spans()
+    dl_spans = [s for s in spans if s.name == "Storage.Blob.downloadAsBytes"]
+    assert len(dl_spans) == 1
+    attrs = dl_spans[0].attributes
+    assert "gcp.resource.destination.id" not in attrs
+    assert "gcp.resource.destination.location" not in attrs

--- a/packages/google-cloud-storage/tests/system/test_aco_observability.py
+++ b/packages/google-cloud-storage/tests/system/test_aco_observability.py
@@ -551,10 +551,11 @@ def test_sequential_cache_priming_multi_region(
         storage_client._bucket_metadata_cache.update_cache = original_update
 
 
+@pytest.mark.parametrize("env_value", ["true", "1", "yes", "on"])
 def test_disable_bucket_md_env_flag(
-    storage_client, exporter, buckets_to_delete, monkeypatch
+    storage_client, exporter, buckets_to_delete, monkeypatch, env_value
 ):
-    """Verifies that setting DISABLE_GCS_PYTHON_CLIENT_OTEL_BUCKET_METADATA=true disables GCS
+    """Verifies that setting DISABLE_GCS_PYTHON_CLIENT_OTEL_BUCKET_METADATA to a truthy value disables GCS
     destination annotations, even on cache hits."""
     # Clear cache and OTel exporter logs
     storage_client._bucket_metadata_cache.clear()
@@ -573,7 +574,7 @@ def test_disable_bucket_md_env_flag(
     assert storage_client._bucket_metadata_cache.get(bucket_name) is not None
 
     # Enable the DISABLE_GCS_PYTHON_CLIENT_OTEL_BUCKET_METADATA environment variable using monkeypatch
-    monkeypatch.setenv("DISABLE_GCS_PYTHON_CLIENT_OTEL_BUCKET_METADATA", "true")
+    monkeypatch.setenv("DISABLE_GCS_PYTHON_CLIENT_OTEL_BUCKET_METADATA", env_value)
 
     # Download (normally would be a cache hit with GCS annotations)
     blob.download_as_bytes()

--- a/packages/google-cloud-storage/tests/system/test_aco_observability.py
+++ b/packages/google-cloud-storage/tests/system/test_aco_observability.py
@@ -16,6 +16,7 @@ import concurrent.futures
 import threading
 import time
 
+import os
 import pytest
 from google.api_core import exceptions
 
@@ -549,3 +550,41 @@ def test_sequential_cache_priming_multi_region(
         assert attrs["gcp.resource.destination.location"] == "global"
     finally:
         storage_client._bucket_metadata_cache.update_cache = original_update
+
+
+def test_disable_bucket_md_env_flag(storage_client, exporter, buckets_to_delete):
+    """Verifies that setting DISABLE_BUCKET_MD_IN_OTEL=true disables GCS
+    destination annotations, even on cache hits."""
+    # Clear cache and OTel exporter logs
+    storage_client._bucket_metadata_cache.clear()
+    exporter.clear()
+
+    bucket_name = _helpers.unique_name("aco-disable")
+    bucket = storage_client.bucket(bucket_name)
+    storage_client.create_bucket(bucket)
+    buckets_to_delete.append(bucket)
+
+    blob_name = "test_blob.txt"
+    blob = bucket.blob(blob_name)
+    blob.upload_from_string("hello")
+
+    # Warm cache directly via GCS creation warming (client.create_bucket already primes the cache)
+    assert storage_client._bucket_metadata_cache.get(bucket_name) is not None
+
+    # Enable the DISABLE_BUCKET_MD_IN_OTEL environment variable
+    os.environ["DISABLE_BUCKET_MD_IN_OTEL"] = "true"
+
+    try:
+        # Download (normally would be a cache hit with GCS annotations)
+        blob.download_as_bytes()
+
+        # Verify that ACO attributes are NOT present in the OTel span!
+        spans = exporter.get_finished_spans()
+        dl_spans = [s for s in spans if s.name == "Storage.Blob.downloadAsBytes"]
+        assert len(dl_spans) == 1
+        attrs = dl_spans[0].attributes
+        assert "gcp.resource.destination.id" not in attrs
+        assert "gcp.resource.destination.location" not in attrs
+    finally:
+        # Restore env var
+        os.environ.pop("DISABLE_BUCKET_MD_IN_OTEL", None)

--- a/packages/google-cloud-storage/tests/unit/test__opentelemetry_tracing.py
+++ b/packages/google-cloud-storage/tests/unit/test__opentelemetry_tracing.py
@@ -335,6 +335,12 @@ def test__is_bucket_metadata_disabled(monkeypatch):
     monkeypatch.setenv("DISABLE_GCS_PYTHON_CLIENT_OTEL_BUCKET_METADATA", "1")
     assert _opentelemetry_tracing._is_bucket_metadata_disabled()
 
+    monkeypatch.setenv("DISABLE_GCS_PYTHON_CLIENT_OTEL_BUCKET_METADATA", "yes")
+    assert _opentelemetry_tracing._is_bucket_metadata_disabled()
+
+    monkeypatch.setenv("DISABLE_GCS_PYTHON_CLIENT_OTEL_BUCKET_METADATA", "on")
+    assert _opentelemetry_tracing._is_bucket_metadata_disabled()
+
     # Test falsy
     monkeypatch.setenv("DISABLE_GCS_PYTHON_CLIENT_OTEL_BUCKET_METADATA", "false")
     assert not _opentelemetry_tracing._is_bucket_metadata_disabled()

--- a/packages/google-cloud-storage/tests/unit/test__opentelemetry_tracing.py
+++ b/packages/google-cloud-storage/tests/unit/test__opentelemetry_tracing.py
@@ -323,28 +323,33 @@ def test__parse_bool_env(monkeypatch, env_value, default, expected):
     assert result is expected
 
 
-def test__is_bucket_metadata_disabled(monkeypatch):
-    # Test default (not set)
-    monkeypatch.delenv("DISABLE_GCS_PYTHON_CLIENT_OTEL_BUCKET_METADATA", raising=False)
-    assert not _opentelemetry_tracing._is_bucket_metadata_disabled()
+@pytest.mark.parametrize(
+    "env_value, expected",
+    [
+        # Test default (not set)
+        (None, False),
+        # Test truthy values
+        ("true", True),
+        ("1", True),
+        ("yes", True),
+        ("on", True),
+        ("TRUE", True),
+        (" Yes ", True),
+        # Test falsy values
+        ("false", False),
+        ("0", False),
+        ("no", False),
+        ("off", False),
+        ("any_other_string", False),
+        ("", False),
+    ],
+)
+def test__is_bucket_metadata_disabled(monkeypatch, env_value, expected):
+    env_var_name = "DISABLE_GCS_PYTHON_CLIENT_OTEL_BUCKET_METADATA"
+    if env_value is not None:
+        monkeypatch.setenv(env_var_name, str(env_value))
+    else:
+        monkeypatch.delenv(env_var_name, raising=False)
 
-    # Test truthy
-    monkeypatch.setenv("DISABLE_GCS_PYTHON_CLIENT_OTEL_BUCKET_METADATA", "true")
-    assert _opentelemetry_tracing._is_bucket_metadata_disabled()
-
-    monkeypatch.setenv("DISABLE_GCS_PYTHON_CLIENT_OTEL_BUCKET_METADATA", "1")
-    assert _opentelemetry_tracing._is_bucket_metadata_disabled()
-
-    monkeypatch.setenv("DISABLE_GCS_PYTHON_CLIENT_OTEL_BUCKET_METADATA", "yes")
-    assert _opentelemetry_tracing._is_bucket_metadata_disabled()
-
-    monkeypatch.setenv("DISABLE_GCS_PYTHON_CLIENT_OTEL_BUCKET_METADATA", "on")
-    assert _opentelemetry_tracing._is_bucket_metadata_disabled()
-
-    # Test falsy
-    monkeypatch.setenv("DISABLE_GCS_PYTHON_CLIENT_OTEL_BUCKET_METADATA", "false")
-    assert not _opentelemetry_tracing._is_bucket_metadata_disabled()
-
-    monkeypatch.setenv("DISABLE_GCS_PYTHON_CLIENT_OTEL_BUCKET_METADATA", "0")
-    assert not _opentelemetry_tracing._is_bucket_metadata_disabled()
+    assert _opentelemetry_tracing._is_bucket_metadata_disabled() is expected
 

--- a/packages/google-cloud-storage/tests/unit/test__opentelemetry_tracing.py
+++ b/packages/google-cloud-storage/tests/unit/test__opentelemetry_tracing.py
@@ -352,4 +352,3 @@ def test__is_bucket_metadata_disabled(monkeypatch, env_value, expected):
         monkeypatch.delenv(env_var_name, raising=False)
 
     assert _opentelemetry_tracing._is_bucket_metadata_disabled() is expected
-

--- a/packages/google-cloud-storage/tests/unit/test__opentelemetry_tracing.py
+++ b/packages/google-cloud-storage/tests/unit/test__opentelemetry_tracing.py
@@ -325,20 +325,20 @@ def test__parse_bool_env(monkeypatch, env_value, default, expected):
 
 def test__is_bucket_metadata_disabled(monkeypatch):
     # Test default (not set)
-    monkeypatch.delenv("DISABLE_BUCKET_MD_IN_OTEL", raising=False)
+    monkeypatch.delenv("DISABLE_GCS_PYTHON_CLIENT_OTEL_BUCKET_METADATA", raising=False)
     assert not _opentelemetry_tracing._is_bucket_metadata_disabled()
 
     # Test truthy
-    monkeypatch.setenv("DISABLE_BUCKET_MD_IN_OTEL", "true")
+    monkeypatch.setenv("DISABLE_GCS_PYTHON_CLIENT_OTEL_BUCKET_METADATA", "true")
     assert _opentelemetry_tracing._is_bucket_metadata_disabled()
 
-    monkeypatch.setenv("DISABLE_BUCKET_MD_IN_OTEL", "1")
+    monkeypatch.setenv("DISABLE_GCS_PYTHON_CLIENT_OTEL_BUCKET_METADATA", "1")
     assert _opentelemetry_tracing._is_bucket_metadata_disabled()
 
     # Test falsy
-    monkeypatch.setenv("DISABLE_BUCKET_MD_IN_OTEL", "false")
+    monkeypatch.setenv("DISABLE_GCS_PYTHON_CLIENT_OTEL_BUCKET_METADATA", "false")
     assert not _opentelemetry_tracing._is_bucket_metadata_disabled()
 
-    monkeypatch.setenv("DISABLE_BUCKET_MD_IN_OTEL", "0")
+    monkeypatch.setenv("DISABLE_GCS_PYTHON_CLIENT_OTEL_BUCKET_METADATA", "0")
     assert not _opentelemetry_tracing._is_bucket_metadata_disabled()
 

--- a/packages/google-cloud-storage/tests/unit/test__opentelemetry_tracing.py
+++ b/packages/google-cloud-storage/tests/unit/test__opentelemetry_tracing.py
@@ -321,3 +321,24 @@ def test__parse_bool_env(monkeypatch, env_value, default, expected):
 
     result = _opentelemetry_tracing._parse_bool_env(env_var_name, default)
     assert result is expected
+
+
+def test__is_bucket_metadata_disabled(monkeypatch):
+    # Test default (not set)
+    monkeypatch.delenv("DISABLE_BUCKET_MD_IN_OTEL", raising=False)
+    assert not _opentelemetry_tracing._is_bucket_metadata_disabled()
+
+    # Test truthy
+    monkeypatch.setenv("DISABLE_BUCKET_MD_IN_OTEL", "true")
+    assert _opentelemetry_tracing._is_bucket_metadata_disabled()
+
+    monkeypatch.setenv("DISABLE_BUCKET_MD_IN_OTEL", "1")
+    assert _opentelemetry_tracing._is_bucket_metadata_disabled()
+
+    # Test falsy
+    monkeypatch.setenv("DISABLE_BUCKET_MD_IN_OTEL", "false")
+    assert not _opentelemetry_tracing._is_bucket_metadata_disabled()
+
+    monkeypatch.setenv("DISABLE_BUCKET_MD_IN_OTEL", "0")
+    assert not _opentelemetry_tracing._is_bucket_metadata_disabled()
+


### PR DESCRIPTION
This PR introduces the `DISABLE_GCS_PYTHON_CLIENT_OTEL_BUCKET_METADATA` environment flag to dynamically disable injecting Cloud Storage bucket metadata destination attributes (`gcp.resource.destination.id` and `gcp.resource.destination.location`) inside OTel spans.