### PR TITLE
feat(generator): Universalize constraints path and grpcio requirement in gapic-generator templates

### DIFF
--- a/packages/gapic-generator/gapic/templates/noxfile.py.j2
+++ b/packages/gapic-generator/gapic/templates/noxfile.py.j2
@@ -41,7 +41,12 @@ PREVIEW_PYTHON_VERSION = "3.14"
 
 CURRENT_DIRECTORY = pathlib.Path(__file__).parent.absolute()
 
-LOWER_BOUND_CONSTRAINTS_FILE = CURRENT_DIRECTORY / "constraints.txt"
+if (CURRENT_DIRECTORY / "testing").exists():
+    LOWER_BOUND_CONSTRAINTS_FILE = (
+        CURRENT_DIRECTORY / "testing" / f"constraints-{ALL_PYTHON[0]}.txt"
+    )
+else:
+    LOWER_BOUND_CONSTRAINTS_FILE = CURRENT_DIRECTORY / "constraints.txt"
 PACKAGE_NAME = "{{ api.naming.warehouse_package_name }}"
 
 UNIT_TEST_STANDARD_DEPENDENCIES = [

--- a/packages/gapic-generator/gapic/templates/setup.py.j2
+++ b/packages/gapic-generator/gapic/templates/setup.py.j2
@@ -37,7 +37,7 @@ dependencies = [
     # Exclude incompatible versions of `google-auth`
     # See https://github.com/googleapis/google-cloud-python/issues/12364
     "google-auth >= 2.14.1, <3.0.0,!=2.24.0,!=2.25.0",
-    "grpcio >= 1.44.0, < 2.0.0",
+    "grpcio >= 1.59.0, < 2.0.0",
     "grpcio >= 1.75.1, < 2.0.0; python_version >= '3.14'",
     "proto-plus >= 1.22.3, <2.0.0",
     "proto-plus >= 1.25.0, <2.0.0; python_version >= '3.13'",

--- a/packages/gapic-generator/gapic/templates/testing/constraints-3.10-async-rest.txt.j2
+++ b/packages/gapic-generator/gapic/templates/testing/constraints-3.10-async-rest.txt.j2
@@ -10,7 +10,7 @@
 # then this file should have google-cloud-foo==1.14.0
 google-api-core==2.21.0
 google-auth==2.35.0
-grpcio==1.44.0
+grpcio==1.59.0
 proto-plus==1.22.3
 protobuf==4.25.8
 {% for package_tuple, package_info in pypi_packages.items() %}

--- a/packages/gapic-generator/gapic/templates/testing/constraints-3.10.txt.j2
+++ b/packages/gapic-generator/gapic/templates/testing/constraints-3.10.txt.j2
@@ -7,7 +7,7 @@
 # then this file should have google-cloud-foo==1.14.0
 google-api-core==2.17.1
 google-auth==2.14.1
-grpcio==1.44.0
+grpcio==1.59.0
 proto-plus==1.22.3
 protobuf==4.25.8
 {% for package_tuple, package_info in pypi_packages.items() %}

--- a/packages/gapic-generator/gapic/templates/tests/unit/gapic/%name_%version/%sub/test_%service.py.j2
+++ b/packages/gapic-generator/gapic/templates/tests/unit/gapic/%name_%version/%sub/test_%service.py.j2
@@ -7,6 +7,7 @@
 {% import "%namespace/%name_%version/%sub/services/%service/_shared_macros.j2" as shared_macros %}
 
 import os
+import asyncio
 {% if api.all_method_settings.values()|map(attribute="auto_populated_fields", default=[])|select|list %}
 import re
 {% endif %}
@@ -138,6 +139,15 @@ def modify_default_endpoint(client):
 # mtls endpoint for endpoint testing purposes.
 def modify_default_endpoint_template(client):
     return "test.{UNIVERSE_DOMAIN}" if ("localhost" in client._DEFAULT_ENDPOINT_TEMPLATE) else client._DEFAULT_ENDPOINT_TEMPLATE
+
+
+@pytest.fixture(autouse=True)
+def set_event_loop():
+    try:
+        asyncio.get_event_loop()
+    except RuntimeError:
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
 
 
 def test__get_default_mtls_endpoint():

--- a/packages/gapic-generator/tests/integration/goldens/asset/noxfile.py
+++ b/packages/gapic-generator/tests/integration/goldens/asset/noxfile.py
@@ -48,7 +48,12 @@ PREVIEW_PYTHON_VERSION = "3.14"
 
 CURRENT_DIRECTORY = pathlib.Path(__file__).parent.absolute()
 
-LOWER_BOUND_CONSTRAINTS_FILE = CURRENT_DIRECTORY / "constraints.txt"
+if (CURRENT_DIRECTORY / "testing").exists():
+    LOWER_BOUND_CONSTRAINTS_FILE = (
+        CURRENT_DIRECTORY / "testing" / f"constraints-{ALL_PYTHON[0]}.txt"
+    )
+else:
+    LOWER_BOUND_CONSTRAINTS_FILE = CURRENT_DIRECTORY / "constraints.txt"
 PACKAGE_NAME = "google-cloud-asset"
 
 UNIT_TEST_STANDARD_DEPENDENCIES = [

--- a/packages/gapic-generator/tests/integration/goldens/asset/setup.py
+++ b/packages/gapic-generator/tests/integration/goldens/asset/setup.py
@@ -43,7 +43,7 @@ dependencies = [
     # Exclude incompatible versions of `google-auth`
     # See https://github.com/googleapis/google-cloud-python/issues/12364
     "google-auth >= 2.14.1, <3.0.0,!=2.24.0,!=2.25.0",
-    "grpcio >= 1.44.0, < 2.0.0",
+    "grpcio >= 1.59.0, < 2.0.0",
     "grpcio >= 1.75.1, < 2.0.0; python_version >= '3.14'",
     "proto-plus >= 1.22.3, <2.0.0",
     "proto-plus >= 1.25.0, <2.0.0; python_version >= '3.13'",

--- a/packages/gapic-generator/tests/integration/goldens/asset/testing/constraints-3.10.txt
+++ b/packages/gapic-generator/tests/integration/goldens/asset/testing/constraints-3.10.txt
@@ -6,7 +6,7 @@
 # then this file should have google-cloud-foo==1.14.0
 google-api-core==2.17.1
 google-auth==2.14.1
-grpcio==1.44.0
+grpcio==1.59.0
 proto-plus==1.22.3
 protobuf==4.25.8
 google-cloud-access-context-manager==0.2.0

--- a/packages/gapic-generator/tests/integration/goldens/asset/tests/unit/gapic/asset_v1/test_asset_service.py
+++ b/packages/gapic-generator/tests/integration/goldens/asset/tests/unit/gapic/asset_v1/test_asset_service.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 #
 import os
+import asyncio
 from unittest import mock
 from unittest.mock import AsyncMock
 
@@ -103,6 +104,15 @@ def modify_default_endpoint(client):
 # mtls endpoint for endpoint testing purposes.
 def modify_default_endpoint_template(client):
     return "test.{UNIVERSE_DOMAIN}" if ("localhost" in client._DEFAULT_ENDPOINT_TEMPLATE) else client._DEFAULT_ENDPOINT_TEMPLATE
+
+
+@pytest.fixture(autouse=True)
+def set_event_loop():
+    try:
+        asyncio.get_event_loop()
+    except RuntimeError:
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
 
 
 def test__get_default_mtls_endpoint():

--- a/packages/gapic-generator/tests/integration/goldens/credentials/noxfile.py
+++ b/packages/gapic-generator/tests/integration/goldens/credentials/noxfile.py
@@ -48,7 +48,12 @@ PREVIEW_PYTHON_VERSION = "3.14"
 
 CURRENT_DIRECTORY = pathlib.Path(__file__).parent.absolute()
 
-LOWER_BOUND_CONSTRAINTS_FILE = CURRENT_DIRECTORY / "constraints.txt"
+if (CURRENT_DIRECTORY / "testing").exists():
+    LOWER_BOUND_CONSTRAINTS_FILE = (
+        CURRENT_DIRECTORY / "testing" / f"constraints-{ALL_PYTHON[0]}.txt"
+    )
+else:
+    LOWER_BOUND_CONSTRAINTS_FILE = CURRENT_DIRECTORY / "constraints.txt"
 PACKAGE_NAME = "google-iam-credentials"
 
 UNIT_TEST_STANDARD_DEPENDENCIES = [

--- a/packages/gapic-generator/tests/integration/goldens/credentials/setup.py
+++ b/packages/gapic-generator/tests/integration/goldens/credentials/setup.py
@@ -43,7 +43,7 @@ dependencies = [
     # Exclude incompatible versions of `google-auth`
     # See https://github.com/googleapis/google-cloud-python/issues/12364
     "google-auth >= 2.14.1, <3.0.0,!=2.24.0,!=2.25.0",
-    "grpcio >= 1.44.0, < 2.0.0",
+    "grpcio >= 1.59.0, < 2.0.0",
     "grpcio >= 1.75.1, < 2.0.0; python_version >= '3.14'",
     "proto-plus >= 1.22.3, <2.0.0",
     "proto-plus >= 1.25.0, <2.0.0; python_version >= '3.13'",

--- a/packages/gapic-generator/tests/integration/goldens/credentials/testing/constraints-3.10.txt
+++ b/packages/gapic-generator/tests/integration/goldens/credentials/testing/constraints-3.10.txt
@@ -6,6 +6,6 @@
 # then this file should have google-cloud-foo==1.14.0
 google-api-core==2.17.1
 google-auth==2.14.1
-grpcio==1.44.0
+grpcio==1.59.0
 proto-plus==1.22.3
 protobuf==4.25.8

--- a/packages/gapic-generator/tests/integration/goldens/credentials/tests/unit/gapic/credentials_v1/test_iam_credentials.py
+++ b/packages/gapic-generator/tests/integration/goldens/credentials/tests/unit/gapic/credentials_v1/test_iam_credentials.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 #
 import os
+import asyncio
 from unittest import mock
 from unittest.mock import AsyncMock
 
@@ -93,6 +94,15 @@ def modify_default_endpoint(client):
 # mtls endpoint for endpoint testing purposes.
 def modify_default_endpoint_template(client):
     return "test.{UNIVERSE_DOMAIN}" if ("localhost" in client._DEFAULT_ENDPOINT_TEMPLATE) else client._DEFAULT_ENDPOINT_TEMPLATE
+
+
+@pytest.fixture(autouse=True)
+def set_event_loop():
+    try:
+        asyncio.get_event_loop()
+    except RuntimeError:
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
 
 
 def test__get_default_mtls_endpoint():

--- a/packages/gapic-generator/tests/integration/goldens/eventarc/noxfile.py
+++ b/packages/gapic-generator/tests/integration/goldens/eventarc/noxfile.py
@@ -48,7 +48,12 @@ PREVIEW_PYTHON_VERSION = "3.14"
 
 CURRENT_DIRECTORY = pathlib.Path(__file__).parent.absolute()
 
-LOWER_BOUND_CONSTRAINTS_FILE = CURRENT_DIRECTORY / "constraints.txt"
+if (CURRENT_DIRECTORY / "testing").exists():
+    LOWER_BOUND_CONSTRAINTS_FILE = (
+        CURRENT_DIRECTORY / "testing" / f"constraints-{ALL_PYTHON[0]}.txt"
+    )
+else:
+    LOWER_BOUND_CONSTRAINTS_FILE = CURRENT_DIRECTORY / "constraints.txt"
 PACKAGE_NAME = "google-cloud-eventarc"
 
 UNIT_TEST_STANDARD_DEPENDENCIES = [

--- a/packages/gapic-generator/tests/integration/goldens/eventarc/setup.py
+++ b/packages/gapic-generator/tests/integration/goldens/eventarc/setup.py
@@ -43,7 +43,7 @@ dependencies = [
     # Exclude incompatible versions of `google-auth`
     # See https://github.com/googleapis/google-cloud-python/issues/12364
     "google-auth >= 2.14.1, <3.0.0,!=2.24.0,!=2.25.0",
-    "grpcio >= 1.44.0, < 2.0.0",
+    "grpcio >= 1.59.0, < 2.0.0",
     "grpcio >= 1.75.1, < 2.0.0; python_version >= '3.14'",
     "proto-plus >= 1.22.3, <2.0.0",
     "proto-plus >= 1.25.0, <2.0.0; python_version >= '3.13'",

--- a/packages/gapic-generator/tests/integration/goldens/eventarc/testing/constraints-3.10.txt
+++ b/packages/gapic-generator/tests/integration/goldens/eventarc/testing/constraints-3.10.txt
@@ -6,7 +6,7 @@
 # then this file should have google-cloud-foo==1.14.0
 google-api-core==2.17.1
 google-auth==2.14.1
-grpcio==1.44.0
+grpcio==1.59.0
 proto-plus==1.22.3
 protobuf==4.25.8
 grpc-google-iam-v1==0.14.0

--- a/packages/gapic-generator/tests/integration/goldens/eventarc/tests/unit/gapic/eventarc_v1/test_eventarc.py
+++ b/packages/gapic-generator/tests/integration/goldens/eventarc/tests/unit/gapic/eventarc_v1/test_eventarc.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 #
 import os
+import asyncio
 from unittest import mock
 from unittest.mock import AsyncMock
 
@@ -124,6 +125,15 @@ def modify_default_endpoint(client):
 # mtls endpoint for endpoint testing purposes.
 def modify_default_endpoint_template(client):
     return "test.{UNIVERSE_DOMAIN}" if ("localhost" in client._DEFAULT_ENDPOINT_TEMPLATE) else client._DEFAULT_ENDPOINT_TEMPLATE
+
+
+@pytest.fixture(autouse=True)
+def set_event_loop():
+    try:
+        asyncio.get_event_loop()
+    except RuntimeError:
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
 
 
 def test__get_default_mtls_endpoint():

--- a/packages/gapic-generator/tests/integration/goldens/logging/noxfile.py
+++ b/packages/gapic-generator/tests/integration/goldens/logging/noxfile.py
@@ -48,7 +48,12 @@ PREVIEW_PYTHON_VERSION = "3.14"
 
 CURRENT_DIRECTORY = pathlib.Path(__file__).parent.absolute()
 
-LOWER_BOUND_CONSTRAINTS_FILE = CURRENT_DIRECTORY / "constraints.txt"
+if (CURRENT_DIRECTORY / "testing").exists():
+    LOWER_BOUND_CONSTRAINTS_FILE = (
+        CURRENT_DIRECTORY / "testing" / f"constraints-{ALL_PYTHON[0]}.txt"
+    )
+else:
+    LOWER_BOUND_CONSTRAINTS_FILE = CURRENT_DIRECTORY / "constraints.txt"
 PACKAGE_NAME = "google-cloud-logging"
 
 UNIT_TEST_STANDARD_DEPENDENCIES = [

--- a/packages/gapic-generator/tests/integration/goldens/logging/setup.py
+++ b/packages/gapic-generator/tests/integration/goldens/logging/setup.py
@@ -43,7 +43,7 @@ dependencies = [
     # Exclude incompatible versions of `google-auth`
     # See https://github.com/googleapis/google-cloud-python/issues/12364
     "google-auth >= 2.14.1, <3.0.0,!=2.24.0,!=2.25.0",
-    "grpcio >= 1.44.0, < 2.0.0",
+    "grpcio >= 1.59.0, < 2.0.0",
     "grpcio >= 1.75.1, < 2.0.0; python_version >= '3.14'",
     "proto-plus >= 1.22.3, <2.0.0",
     "proto-plus >= 1.25.0, <2.0.0; python_version >= '3.13'",

--- a/packages/gapic-generator/tests/integration/goldens/logging/testing/constraints-3.10.txt
+++ b/packages/gapic-generator/tests/integration/goldens/logging/testing/constraints-3.10.txt
@@ -6,6 +6,6 @@
 # then this file should have google-cloud-foo==1.14.0
 google-api-core==2.17.1
 google-auth==2.14.1
-grpcio==1.44.0
+grpcio==1.59.0
 proto-plus==1.22.3
 protobuf==4.25.8

--- a/packages/gapic-generator/tests/integration/goldens/logging/tests/unit/gapic/logging_v2/test_config_service_v2.py
+++ b/packages/gapic-generator/tests/integration/goldens/logging/tests/unit/gapic/logging_v2/test_config_service_v2.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 #
 import os
+import asyncio
 from unittest import mock
 from unittest.mock import AsyncMock
 
@@ -94,6 +95,15 @@ def modify_default_endpoint(client):
 # mtls endpoint for endpoint testing purposes.
 def modify_default_endpoint_template(client):
     return "test.{UNIVERSE_DOMAIN}" if ("localhost" in client._DEFAULT_ENDPOINT_TEMPLATE) else client._DEFAULT_ENDPOINT_TEMPLATE
+
+
+@pytest.fixture(autouse=True)
+def set_event_loop():
+    try:
+        asyncio.get_event_loop()
+    except RuntimeError:
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
 
 
 def test__get_default_mtls_endpoint():

--- a/packages/gapic-generator/tests/integration/goldens/logging/tests/unit/gapic/logging_v2/test_logging_service_v2.py
+++ b/packages/gapic-generator/tests/integration/goldens/logging/tests/unit/gapic/logging_v2/test_logging_service_v2.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 #
 import os
+import asyncio
 from unittest import mock
 from unittest.mock import AsyncMock
 
@@ -95,6 +96,15 @@ def modify_default_endpoint(client):
 # mtls endpoint for endpoint testing purposes.
 def modify_default_endpoint_template(client):
     return "test.{UNIVERSE_DOMAIN}" if ("localhost" in client._DEFAULT_ENDPOINT_TEMPLATE) else client._DEFAULT_ENDPOINT_TEMPLATE
+
+
+@pytest.fixture(autouse=True)
+def set_event_loop():
+    try:
+        asyncio.get_event_loop()
+    except RuntimeError:
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
 
 
 def test__get_default_mtls_endpoint():

--- a/packages/gapic-generator/tests/integration/goldens/logging/tests/unit/gapic/logging_v2/test_metrics_service_v2.py
+++ b/packages/gapic-generator/tests/integration/goldens/logging/tests/unit/gapic/logging_v2/test_metrics_service_v2.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 #
 import os
+import asyncio
 from unittest import mock
 from unittest.mock import AsyncMock
 
@@ -93,6 +94,15 @@ def modify_default_endpoint(client):
 # mtls endpoint for endpoint testing purposes.
 def modify_default_endpoint_template(client):
     return "test.{UNIVERSE_DOMAIN}" if ("localhost" in client._DEFAULT_ENDPOINT_TEMPLATE) else client._DEFAULT_ENDPOINT_TEMPLATE
+
+
+@pytest.fixture(autouse=True)
+def set_event_loop():
+    try:
+        asyncio.get_event_loop()
+    except RuntimeError:
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
 
 
 def test__get_default_mtls_endpoint():

--- a/packages/gapic-generator/tests/integration/goldens/logging_internal/noxfile.py
+++ b/packages/gapic-generator/tests/integration/goldens/logging_internal/noxfile.py
@@ -48,7 +48,12 @@ PREVIEW_PYTHON_VERSION = "3.14"
 
 CURRENT_DIRECTORY = pathlib.Path(__file__).parent.absolute()
 
-LOWER_BOUND_CONSTRAINTS_FILE = CURRENT_DIRECTORY / "constraints.txt"
+if (CURRENT_DIRECTORY / "testing").exists():
+    LOWER_BOUND_CONSTRAINTS_FILE = (
+        CURRENT_DIRECTORY / "testing" / f"constraints-{ALL_PYTHON[0]}.txt"
+    )
+else:
+    LOWER_BOUND_CONSTRAINTS_FILE = CURRENT_DIRECTORY / "constraints.txt"
 PACKAGE_NAME = "google-cloud-logging"
 
 UNIT_TEST_STANDARD_DEPENDENCIES = [

--- a/packages/gapic-generator/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_config_service_v2_copy_log_entries_async.py
+++ b/packages/gapic-generator/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_config_service_v2_copy_log_entries_async.py
@@ -1,0 +1,57 @@
+# -*- coding: utf-8 -*-
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Generated code. DO NOT EDIT!
+#
+# Snippet for CopyLogEntries
+# NOTE: This snippet has been automatically generated for illustrative purposes only.
+# It may require modifications to work in your environment.
+
+# To install the latest published package dependency, execute the following:
+#   python3 -m pip install google-cloud-logging
+
+
+# [START logging_v2_generated_ConfigServiceV2_CopyLogEntries_async]
+# This snippet has been automatically generated and should be regarded as a
+# code template only.
+# It will require modifications to work:
+# - It may require correct/in-range values for request initialization.
+# - It may require specifying regional endpoints when creating the service
+#   client as shown in:
+#   https://googleapis.dev/python/google-api-core/latest/client_options.html
+from google.cloud import logging_v2
+
+
+async def sample_copy_log_entries():
+    # Create a client
+    client = logging_v2.ConfigServiceV2AsyncClient()
+
+    # Initialize request argument(s)
+    request = logging_v2.CopyLogEntriesRequest(
+        name="name_value",
+        destination="destination_value",
+    )
+
+    # Make the request
+    operation = await client.copy_log_entries(request=request)
+
+    print("Waiting for operation to complete...")
+
+    response = await operation.result()
+
+    # Handle the response
+    print(response)
+
+# [END logging_v2_generated_ConfigServiceV2_CopyLogEntries_async]

--- a/packages/gapic-generator/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_config_service_v2_copy_log_entries_sync.py
+++ b/packages/gapic-generator/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_config_service_v2_copy_log_entries_sync.py
@@ -1,0 +1,57 @@
+# -*- coding: utf-8 -*-
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Generated code. DO NOT EDIT!
+#
+# Snippet for CopyLogEntries
+# NOTE: This snippet has been automatically generated for illustrative purposes only.
+# It may require modifications to work in your environment.
+
+# To install the latest published package dependency, execute the following:
+#   python3 -m pip install google-cloud-logging
+
+
+# [START logging_v2_generated_ConfigServiceV2_CopyLogEntries_sync]
+# This snippet has been automatically generated and should be regarded as a
+# code template only.
+# It will require modifications to work:
+# - It may require correct/in-range values for request initialization.
+# - It may require specifying regional endpoints when creating the service
+#   client as shown in:
+#   https://googleapis.dev/python/google-api-core/latest/client_options.html
+from google.cloud import logging_v2
+
+
+def sample_copy_log_entries():
+    # Create a client
+    client = logging_v2.ConfigServiceV2Client()
+
+    # Initialize request argument(s)
+    request = logging_v2.CopyLogEntriesRequest(
+        name="name_value",
+        destination="destination_value",
+    )
+
+    # Make the request
+    operation = client.copy_log_entries(request=request)
+
+    print("Waiting for operation to complete...")
+
+    response = operation.result()
+
+    # Handle the response
+    print(response)
+
+# [END logging_v2_generated_ConfigServiceV2_CopyLogEntries_sync]

--- a/packages/gapic-generator/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_config_service_v2_create_exclusion_async.py
+++ b/packages/gapic-generator/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_config_service_v2_create_exclusion_async.py
@@ -1,0 +1,57 @@
+# -*- coding: utf-8 -*-
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Generated code. DO NOT EDIT!
+#
+# Snippet for CreateExclusion
+# NOTE: This snippet has been automatically generated for illustrative purposes only.
+# It may require modifications to work in your environment.
+
+# To install the latest published package dependency, execute the following:
+#   python3 -m pip install google-cloud-logging
+
+
+# [START logging_v2_generated_ConfigServiceV2_CreateExclusion_async]
+# This snippet has been automatically generated and should be regarded as a
+# code template only.
+# It will require modifications to work:
+# - It may require correct/in-range values for request initialization.
+# - It may require specifying regional endpoints when creating the service
+#   client as shown in:
+#   https://googleapis.dev/python/google-api-core/latest/client_options.html
+from google.cloud import logging_v2
+
+
+async def sample_create_exclusion():
+    # Create a client
+    client = logging_v2.ConfigServiceV2AsyncClient()
+
+    # Initialize request argument(s)
+    exclusion = logging_v2.LogExclusion()
+    exclusion.name = "name_value"
+    exclusion.filter = "filter_value"
+
+    request = logging_v2.CreateExclusionRequest(
+        parent="parent_value",
+        exclusion=exclusion,
+    )
+
+    # Make the request
+    response = await client.create_exclusion(request=request)
+
+    # Handle the response
+    print(response)
+
+# [END logging_v2_generated_ConfigServiceV2_CreateExclusion_async]

--- a/packages/gapic-generator/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_config_service_v2_create_exclusion_sync.py
+++ b/packages/gapic-generator/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_config_service_v2_create_exclusion_sync.py
@@ -1,0 +1,57 @@
+# -*- coding: utf-8 -*-
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Generated code. DO NOT EDIT!
+#
+# Snippet for CreateExclusion
+# NOTE: This snippet has been automatically generated for illustrative purposes only.
+# It may require modifications to work in your environment.
+
+# To install the latest published package dependency, execute the following:
+#   python3 -m pip install google-cloud-logging
+
+
+# [START logging_v2_generated_ConfigServiceV2_CreateExclusion_sync]
+# This snippet has been automatically generated and should be regarded as a
+# code template only.
+# It will require modifications to work:
+# - It may require correct/in-range values for request initialization.
+# - It may require specifying regional endpoints when creating the service
+#   client as shown in:
+#   https://googleapis.dev/python/google-api-core/latest/client_options.html
+from google.cloud import logging_v2
+
+
+def sample_create_exclusion():
+    # Create a client
+    client = logging_v2.ConfigServiceV2Client()
+
+    # Initialize request argument(s)
+    exclusion = logging_v2.LogExclusion()
+    exclusion.name = "name_value"
+    exclusion.filter = "filter_value"
+
+    request = logging_v2.CreateExclusionRequest(
+        parent="parent_value",
+        exclusion=exclusion,
+    )
+
+    # Make the request
+    response = client.create_exclusion(request=request)
+
+    # Handle the response
+    print(response)
+
+# [END logging_v2_generated_ConfigServiceV2_CreateExclusion_sync]

--- a/packages/gapic-generator/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_config_service_v2_create_link_async.py
+++ b/packages/gapic-generator/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_config_service_v2_create_link_async.py
@@ -1,0 +1,57 @@
+# -*- coding: utf-8 -*-
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Generated code. DO NOT EDIT!
+#
+# Snippet for CreateLink
+# NOTE: This snippet has been automatically generated for illustrative purposes only.
+# It may require modifications to work in your environment.
+
+# To install the latest published package dependency, execute the following:
+#   python3 -m pip install google-cloud-logging
+
+
+# [START logging_v2_generated_ConfigServiceV2_CreateLink_async]
+# This snippet has been automatically generated and should be regarded as a
+# code template only.
+# It will require modifications to work:
+# - It may require correct/in-range values for request initialization.
+# - It may require specifying regional endpoints when creating the service
+#   client as shown in:
+#   https://googleapis.dev/python/google-api-core/latest/client_options.html
+from google.cloud import logging_v2
+
+
+async def sample_create_link():
+    # Create a client
+    client = logging_v2.ConfigServiceV2AsyncClient()
+
+    # Initialize request argument(s)
+    request = logging_v2.CreateLinkRequest(
+        parent="parent_value",
+        link_id="link_id_value",
+    )
+
+    # Make the request
+    operation = await client.create_link(request=request)
+
+    print("Waiting for operation to complete...")
+
+    response = await operation.result()
+
+    # Handle the response
+    print(response)
+
+# [END logging_v2_generated_ConfigServiceV2_CreateLink_async]

--- a/packages/gapic-generator/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_config_service_v2_create_link_sync.py
+++ b/packages/gapic-generator/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_config_service_v2_create_link_sync.py
@@ -1,0 +1,57 @@
+# -*- coding: utf-8 -*-
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Generated code. DO NOT EDIT!
+#
+# Snippet for CreateLink
+# NOTE: This snippet has been automatically generated for illustrative purposes only.
+# It may require modifications to work in your environment.
+
+# To install the latest published package dependency, execute the following:
+#   python3 -m pip install google-cloud-logging
+
+
+# [START logging_v2_generated_ConfigServiceV2_CreateLink_sync]
+# This snippet has been automatically generated and should be regarded as a
+# code template only.
+# It will require modifications to work:
+# - It may require correct/in-range values for request initialization.
+# - It may require specifying regional endpoints when creating the service
+#   client as shown in:
+#   https://googleapis.dev/python/google-api-core/latest/client_options.html
+from google.cloud import logging_v2
+
+
+def sample_create_link():
+    # Create a client
+    client = logging_v2.ConfigServiceV2Client()
+
+    # Initialize request argument(s)
+    request = logging_v2.CreateLinkRequest(
+        parent="parent_value",
+        link_id="link_id_value",
+    )
+
+    # Make the request
+    operation = client.create_link(request=request)
+
+    print("Waiting for operation to complete...")
+
+    response = operation.result()
+
+    # Handle the response
+    print(response)
+
+# [END logging_v2_generated_ConfigServiceV2_CreateLink_sync]

--- a/packages/gapic-generator/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_config_service_v2_create_sink_async.py
+++ b/packages/gapic-generator/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_config_service_v2_create_sink_async.py
@@ -1,0 +1,57 @@
+# -*- coding: utf-8 -*-
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Generated code. DO NOT EDIT!
+#
+# Snippet for CreateSink
+# NOTE: This snippet has been automatically generated for illustrative purposes only.
+# It may require modifications to work in your environment.
+
+# To install the latest published package dependency, execute the following:
+#   python3 -m pip install google-cloud-logging
+
+
+# [START logging_v2_generated_ConfigServiceV2_CreateSink_async]
+# This snippet has been automatically generated and should be regarded as a
+# code template only.
+# It will require modifications to work:
+# - It may require correct/in-range values for request initialization.
+# - It may require specifying regional endpoints when creating the service
+#   client as shown in:
+#   https://googleapis.dev/python/google-api-core/latest/client_options.html
+from google.cloud import logging_v2
+
+
+async def sample_create_sink():
+    # Create a client
+    client = logging_v2.ConfigServiceV2AsyncClient()
+
+    # Initialize request argument(s)
+    sink = logging_v2.LogSink()
+    sink.name = "name_value"
+    sink.destination = "destination_value"
+
+    request = logging_v2.CreateSinkRequest(
+        parent="parent_value",
+        sink=sink,
+    )
+
+    # Make the request
+    response = await client.create_sink(request=request)
+
+    # Handle the response
+    print(response)
+
+# [END logging_v2_generated_ConfigServiceV2_CreateSink_async]

--- a/packages/gapic-generator/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_config_service_v2_create_sink_sync.py
+++ b/packages/gapic-generator/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_config_service_v2_create_sink_sync.py
@@ -1,0 +1,57 @@
+# -*- coding: utf-8 -*-
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Generated code. DO NOT EDIT!
+#
+# Snippet for CreateSink
+# NOTE: This snippet has been automatically generated for illustrative purposes only.
+# It may require modifications to work in your environment.
+
+# To install the latest published package dependency, execute the following:
+#   python3 -m pip install google-cloud-logging
+
+
+# [START logging_v2_generated_ConfigServiceV2_CreateSink_sync]
+# This snippet has been automatically generated and should be regarded as a
+# code template only.
+# It will require modifications to work:
+# - It may require correct/in-range values for request initialization.
+# - It may require specifying regional endpoints when creating the service
+#   client as shown in:
+#   https://googleapis.dev/python/google-api-core/latest/client_options.html
+from google.cloud import logging_v2
+
+
+def sample_create_sink():
+    # Create a client
+    client = logging_v2.ConfigServiceV2Client()
+
+    # Initialize request argument(s)
+    sink = logging_v2.LogSink()
+    sink.name = "name_value"
+    sink.destination = "destination_value"
+
+    request = logging_v2.CreateSinkRequest(
+        parent="parent_value",
+        sink=sink,
+    )
+
+    # Make the request
+    response = client.create_sink(request=request)
+
+    # Handle the response
+    print(response)
+
+# [END logging_v2_generated_ConfigServiceV2_CreateSink_sync]

--- a/packages/gapic-generator/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_config_service_v2_create_view_async.py
+++ b/packages/gapic-generator/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_config_service_v2_create_view_async.py
@@ -1,0 +1,53 @@
+# -*- coding: utf-8 -*-
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Generated code. DO NOT EDIT!
+#
+# Snippet for CreateView
+# NOTE: This snippet has been automatically generated for illustrative purposes only.
+# It may require modifications to work in your environment.
+
+# To install the latest published package dependency, execute the following:
+#   python3 -m pip install google-cloud-logging
+
+
+# [START logging_v2_generated_ConfigServiceV2_CreateView_async]
+# This snippet has been automatically generated and should be regarded as a
+# code template only.
+# It will require modifications to work:
+# - It may require correct/in-range values for request initialization.
+# - It may require specifying regional endpoints when creating the service
+#   client as shown in:
+#   https://googleapis.dev/python/google-api-core/latest/client_options.html
+from google.cloud import logging_v2
+
+
+async def sample_create_view():
+    # Create a client
+    client = logging_v2.ConfigServiceV2AsyncClient()
+
+    # Initialize request argument(s)
+    request = logging_v2.CreateViewRequest(
+        parent="parent_value",
+        view_id="view_id_value",
+    )
+
+    # Make the request
+    response = await client.create_view(request=request)
+
+    # Handle the response
+    print(response)
+
+# [END logging_v2_generated_ConfigServiceV2_CreateView_async]

--- a/packages/gapic-generator/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_config_service_v2_create_view_sync.py
+++ b/packages/gapic-generator/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_config_service_v2_create_view_sync.py
@@ -1,0 +1,53 @@
+# -*- coding: utf-8 -*-
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Generated code. DO NOT EDIT!
+#
+# Snippet for CreateView
+# NOTE: This snippet has been automatically generated for illustrative purposes only.
+# It may require modifications to work in your environment.
+
+# To install the latest published package dependency, execute the following:
+#   python3 -m pip install google-cloud-logging
+
+
+# [START logging_v2_generated_ConfigServiceV2_CreateView_sync]
+# This snippet has been automatically generated and should be regarded as a
+# code template only.
+# It will require modifications to work:
+# - It may require correct/in-range values for request initialization.
+# - It may require specifying regional endpoints when creating the service
+#   client as shown in:
+#   https://googleapis.dev/python/google-api-core/latest/client_options.html
+from google.cloud import logging_v2
+
+
+def sample_create_view():
+    # Create a client
+    client = logging_v2.ConfigServiceV2Client()
+
+    # Initialize request argument(s)
+    request = logging_v2.CreateViewRequest(
+        parent="parent_value",
+        view_id="view_id_value",
+    )
+
+    # Make the request
+    response = client.create_view(request=request)
+
+    # Handle the response
+    print(response)
+
+# [END logging_v2_generated_ConfigServiceV2_CreateView_sync]

--- a/packages/gapic-generator/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_config_service_v2_delete_exclusion_async.py
+++ b/packages/gapic-generator/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_config_service_v2_delete_exclusion_async.py
@@ -1,0 +1,50 @@
+# -*- coding: utf-8 -*-
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Generated code. DO NOT EDIT!
+#
+# Snippet for DeleteExclusion
+# NOTE: This snippet has been automatically generated for illustrative purposes only.
+# It may require modifications to work in your environment.
+
+# To install the latest published package dependency, execute the following:
+#   python3 -m pip install google-cloud-logging
+
+
+# [START logging_v2_generated_ConfigServiceV2_DeleteExclusion_async]
+# This snippet has been automatically generated and should be regarded as a
+# code template only.
+# It will require modifications to work:
+# - It may require correct/in-range values for request initialization.
+# - It may require specifying regional endpoints when creating the service
+#   client as shown in:
+#   https://googleapis.dev/python/google-api-core/latest/client_options.html
+from google.cloud import logging_v2
+
+
+async def sample_delete_exclusion():
+    # Create a client
+    client = logging_v2.ConfigServiceV2AsyncClient()
+
+    # Initialize request argument(s)
+    request = logging_v2.DeleteExclusionRequest(
+        name="name_value",
+    )
+
+    # Make the request
+    await client.delete_exclusion(request=request)
+
+
+# [END logging_v2_generated_ConfigServiceV2_DeleteExclusion_async]

--- a/packages/gapic-generator/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_config_service_v2_delete_exclusion_sync.py
+++ b/packages/gapic-generator/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_config_service_v2_delete_exclusion_sync.py
@@ -1,0 +1,50 @@
+# -*- coding: utf-8 -*-
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Generated code. DO NOT EDIT!
+#
+# Snippet for DeleteExclusion
+# NOTE: This snippet has been automatically generated for illustrative purposes only.
+# It may require modifications to work in your environment.
+
+# To install the latest published package dependency, execute the following:
+#   python3 -m pip install google-cloud-logging
+
+
+# [START logging_v2_generated_ConfigServiceV2_DeleteExclusion_sync]
+# This snippet has been automatically generated and should be regarded as a
+# code template only.
+# It will require modifications to work:
+# - It may require correct/in-range values for request initialization.
+# - It may require specifying regional endpoints when creating the service
+#   client as shown in:
+#   https://googleapis.dev/python/google-api-core/latest/client_options.html
+from google.cloud import logging_v2
+
+
+def sample_delete_exclusion():
+    # Create a client
+    client = logging_v2.ConfigServiceV2Client()
+
+    # Initialize request argument(s)
+    request = logging_v2.DeleteExclusionRequest(
+        name="name_value",
+    )
+
+    # Make the request
+    client.delete_exclusion(request=request)
+
+
+# [END logging_v2_generated_ConfigServiceV2_DeleteExclusion_sync]

--- a/packages/gapic-generator/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_config_service_v2_delete_link_async.py
+++ b/packages/gapic-generator/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_config_service_v2_delete_link_async.py
@@ -1,0 +1,56 @@
+# -*- coding: utf-8 -*-
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Generated code. DO NOT EDIT!
+#
+# Snippet for DeleteLink
+# NOTE: This snippet has been automatically generated for illustrative purposes only.
+# It may require modifications to work in your environment.
+
+# To install the latest published package dependency, execute the following:
+#   python3 -m pip install google-cloud-logging
+
+
+# [START logging_v2_generated_ConfigServiceV2_DeleteLink_async]
+# This snippet has been automatically generated and should be regarded as a
+# code template only.
+# It will require modifications to work:
+# - It may require correct/in-range values for request initialization.
+# - It may require specifying regional endpoints when creating the service
+#   client as shown in:
+#   https://googleapis.dev/python/google-api-core/latest/client_options.html
+from google.cloud import logging_v2
+
+
+async def sample_delete_link():
+    # Create a client
+    client = logging_v2.ConfigServiceV2AsyncClient()
+
+    # Initialize request argument(s)
+    request = logging_v2.DeleteLinkRequest(
+        name="name_value",
+    )
+
+    # Make the request
+    operation = await client.delete_link(request=request)
+
+    print("Waiting for operation to complete...")
+
+    response = await operation.result()
+
+    # Handle the response
+    print(response)
+
+# [END logging_v2_generated_ConfigServiceV2_DeleteLink_async]

--- a/packages/gapic-generator/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_config_service_v2_delete_link_sync.py
+++ b/packages/gapic-generator/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_config_service_v2_delete_link_sync.py
@@ -1,0 +1,56 @@
+# -*- coding: utf-8 -*-
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Generated code. DO NOT EDIT!
+#
+# Snippet for DeleteLink
+# NOTE: This snippet has been automatically generated for illustrative purposes only.
+# It may require modifications to work in your environment.
+
+# To install the latest published package dependency, execute the following:
+#   python3 -m pip install google-cloud-logging
+
+
+# [START logging_v2_generated_ConfigServiceV2_DeleteLink_sync]
+# This snippet has been automatically generated and should be regarded as a
+# code template only.
+# It will require modifications to work:
+# - It may require correct/in-range values for request initialization.
+# - It may require specifying regional endpoints when creating the service
+#   client as shown in:
+#   https://googleapis.dev/python/google-api-core/latest/client_options.html
+from google.cloud import logging_v2
+
+
+def sample_delete_link():
+    # Create a client
+    client = logging_v2.ConfigServiceV2Client()
+
+    # Initialize request argument(s)
+    request = logging_v2.DeleteLinkRequest(
+        name="name_value",
+    )
+
+    # Make the request
+    operation = client.delete_link(request=request)
+
+    print("Waiting for operation to complete...")
+
+    response = operation.result()
+
+    # Handle the response
+    print(response)
+
+# [END logging_v2_generated_ConfigServiceV2_DeleteLink_sync]

--- a/packages/gapic-generator/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_config_service_v2_delete_sink_async.py
+++ b/packages/gapic-generator/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_config_service_v2_delete_sink_async.py
@@ -1,0 +1,50 @@
+# -*- coding: utf-8 -*-
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Generated code. DO NOT EDIT!
+#
+# Snippet for DeleteSink
+# NOTE: This snippet has been automatically generated for illustrative purposes only.
+# It may require modifications to work in your environment.
+
+# To install the latest published package dependency, execute the following:
+#   python3 -m pip install google-cloud-logging
+
+
+# [START logging_v2_generated_ConfigServiceV2_DeleteSink_async]
+# This snippet has been automatically generated and should be regarded as a
+# code template only.
+# It will require modifications to work:
+# - It may require correct/in-range values for request initialization.
+# - It may require specifying regional endpoints when creating the service
+#   client as shown in:
+#   https://googleapis.dev/python/google-api-core/latest/client_options.html
+from google.cloud import logging_v2
+
+
+async def sample_delete_sink():
+    # Create a client
+    client = logging_v2.ConfigServiceV2AsyncClient()
+
+    # Initialize request argument(s)
+    request = logging_v2.DeleteSinkRequest(
+        sink_name="sink_name_value",
+    )
+
+    # Make the request
+    await client.delete_sink(request=request)
+
+
+# [END logging_v2_generated_ConfigServiceV2_DeleteSink_async]

--- a/packages/gapic-generator/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_config_service_v2_delete_sink_sync.py
+++ b/packages/gapic-generator/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_config_service_v2_delete_sink_sync.py
@@ -1,0 +1,50 @@
+# -*- coding: utf-8 -*-
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Generated code. DO NOT EDIT!
+#
+# Snippet for DeleteSink
+# NOTE: This snippet has been automatically generated for illustrative purposes only.
+# It may require modifications to work in your environment.
+
+# To install the latest published package dependency, execute the following:
+#   python3 -m pip install google-cloud-logging
+
+
+# [START logging_v2_generated_ConfigServiceV2_DeleteSink_sync]
+# This snippet has been automatically generated and should be regarded as a
+# code template only.
+# It will require modifications to work:
+# - It may require correct/in-range values for request initialization.
+# - It may require specifying regional endpoints when creating the service
+#   client as shown in:
+#   https://googleapis.dev/python/google-api-core/latest/client_options.html
+from google.cloud import logging_v2
+
+
+def sample_delete_sink():
+    # Create a client
+    client = logging_v2.ConfigServiceV2Client()
+
+    # Initialize request argument(s)
+    request = logging_v2.DeleteSinkRequest(
+        sink_name="sink_name_value",
+    )
+
+    # Make the request
+    client.delete_sink(request=request)
+
+
+# [END logging_v2_generated_ConfigServiceV2_DeleteSink_sync]

--- a/packages/gapic-generator/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_config_service_v2_delete_view_async.py
+++ b/packages/gapic-generator/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_config_service_v2_delete_view_async.py
@@ -1,0 +1,50 @@
+# -*- coding: utf-8 -*-
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Generated code. DO NOT EDIT!
+#
+# Snippet for DeleteView
+# NOTE: This snippet has been automatically generated for illustrative purposes only.
+# It may require modifications to work in your environment.
+
+# To install the latest published package dependency, execute the following:
+#   python3 -m pip install google-cloud-logging
+
+
+# [START logging_v2_generated_ConfigServiceV2_DeleteView_async]
+# This snippet has been automatically generated and should be regarded as a
+# code template only.
+# It will require modifications to work:
+# - It may require correct/in-range values for request initialization.
+# - It may require specifying regional endpoints when creating the service
+#   client as shown in:
+#   https://googleapis.dev/python/google-api-core/latest/client_options.html
+from google.cloud import logging_v2
+
+
+async def sample_delete_view():
+    # Create a client
+    client = logging_v2.ConfigServiceV2AsyncClient()
+
+    # Initialize request argument(s)
+    request = logging_v2.DeleteViewRequest(
+        name="name_value",
+    )
+
+    # Make the request
+    await client.delete_view(request=request)
+
+
+# [END logging_v2_generated_ConfigServiceV2_DeleteView_async]

--- a/packages/gapic-generator/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_config_service_v2_delete_view_sync.py
+++ b/packages/gapic-generator/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_config_service_v2_delete_view_sync.py
@@ -1,0 +1,50 @@
+# -*- coding: utf-8 -*-
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Generated code. DO NOT EDIT!
+#
+# Snippet for DeleteView
+# NOTE: This snippet has been automatically generated for illustrative purposes only.
+# It may require modifications to work in your environment.
+
+# To install the latest published package dependency, execute the following:
+#   python3 -m pip install google-cloud-logging
+
+
+# [START logging_v2_generated_ConfigServiceV2_DeleteView_sync]
+# This snippet has been automatically generated and should be regarded as a
+# code template only.
+# It will require modifications to work:
+# - It may require correct/in-range values for request initialization.
+# - It may require specifying regional endpoints when creating the service
+#   client as shown in:
+#   https://googleapis.dev/python/google-api-core/latest/client_options.html
+from google.cloud import logging_v2
+
+
+def sample_delete_view():
+    # Create a client
+    client = logging_v2.ConfigServiceV2Client()
+
+    # Initialize request argument(s)
+    request = logging_v2.DeleteViewRequest(
+        name="name_value",
+    )
+
+    # Make the request
+    client.delete_view(request=request)
+
+
+# [END logging_v2_generated_ConfigServiceV2_DeleteView_sync]

--- a/packages/gapic-generator/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_config_service_v2_get_cmek_settings_async.py
+++ b/packages/gapic-generator/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_config_service_v2_get_cmek_settings_async.py
@@ -1,0 +1,52 @@
+# -*- coding: utf-8 -*-
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Generated code. DO NOT EDIT!
+#
+# Snippet for GetCmekSettings
+# NOTE: This snippet has been automatically generated for illustrative purposes only.
+# It may require modifications to work in your environment.
+
+# To install the latest published package dependency, execute the following:
+#   python3 -m pip install google-cloud-logging
+
+
+# [START logging_v2_generated_ConfigServiceV2_GetCmekSettings_async]
+# This snippet has been automatically generated and should be regarded as a
+# code template only.
+# It will require modifications to work:
+# - It may require correct/in-range values for request initialization.
+# - It may require specifying regional endpoints when creating the service
+#   client as shown in:
+#   https://googleapis.dev/python/google-api-core/latest/client_options.html
+from google.cloud import logging_v2
+
+
+async def sample_get_cmek_settings():
+    # Create a client
+    client = logging_v2.ConfigServiceV2AsyncClient()
+
+    # Initialize request argument(s)
+    request = logging_v2.GetCmekSettingsRequest(
+        name="name_value",
+    )
+
+    # Make the request
+    response = await client.get_cmek_settings(request=request)
+
+    # Handle the response
+    print(response)
+
+# [END logging_v2_generated_ConfigServiceV2_GetCmekSettings_async]

--- a/packages/gapic-generator/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_config_service_v2_get_cmek_settings_sync.py
+++ b/packages/gapic-generator/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_config_service_v2_get_cmek_settings_sync.py
@@ -1,0 +1,52 @@
+# -*- coding: utf-8 -*-
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Generated code. DO NOT EDIT!
+#
+# Snippet for GetCmekSettings
+# NOTE: This snippet has been automatically generated for illustrative purposes only.
+# It may require modifications to work in your environment.
+
+# To install the latest published package dependency, execute the following:
+#   python3 -m pip install google-cloud-logging
+
+
+# [START logging_v2_generated_ConfigServiceV2_GetCmekSettings_sync]
+# This snippet has been automatically generated and should be regarded as a
+# code template only.
+# It will require modifications to work:
+# - It may require correct/in-range values for request initialization.
+# - It may require specifying regional endpoints when creating the service
+#   client as shown in:
+#   https://googleapis.dev/python/google-api-core/latest/client_options.html
+from google.cloud import logging_v2
+
+
+def sample_get_cmek_settings():
+    # Create a client
+    client = logging_v2.ConfigServiceV2Client()
+
+    # Initialize request argument(s)
+    request = logging_v2.GetCmekSettingsRequest(
+        name="name_value",
+    )
+
+    # Make the request
+    response = client.get_cmek_settings(request=request)
+
+    # Handle the response
+    print(response)
+
+# [END logging_v2_generated_ConfigServiceV2_GetCmekSettings_sync]

--- a/packages/gapic-generator/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_config_service_v2_get_exclusion_async.py
+++ b/packages/gapic-generator/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_config_service_v2_get_exclusion_async.py
@@ -1,0 +1,52 @@
+# -*- coding: utf-8 -*-
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Generated code. DO NOT EDIT!
+#
+# Snippet for GetExclusion
+# NOTE: This snippet has been automatically generated for illustrative purposes only.
+# It may require modifications to work in your environment.
+
+# To install the latest published package dependency, execute the following:
+#   python3 -m pip install google-cloud-logging
+
+
+# [START logging_v2_generated_ConfigServiceV2_GetExclusion_async]
+# This snippet has been automatically generated and should be regarded as a
+# code template only.
+# It will require modifications to work:
+# - It may require correct/in-range values for request initialization.
+# - It may require specifying regional endpoints when creating the service
+#   client as shown in:
+#   https://googleapis.dev/python/google-api-core/latest/client_options.html
+from google.cloud import logging_v2
+
+
+async def sample_get_exclusion():
+    # Create a client
+    client = logging_v2.ConfigServiceV2AsyncClient()
+
+    # Initialize request argument(s)
+    request = logging_v2.GetExclusionRequest(
+        name="name_value",
+    )
+
+    # Make the request
+    response = await client.get_exclusion(request=request)
+
+    # Handle the response
+    print(response)
+
+# [END logging_v2_generated_ConfigServiceV2_GetExclusion_async]

--- a/packages/gapic-generator/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_config_service_v2_get_exclusion_sync.py
+++ b/packages/gapic-generator/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_config_service_v2_get_exclusion_sync.py
@@ -1,0 +1,52 @@
+# -*- coding: utf-8 -*-
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Generated code. DO NOT EDIT!
+#
+# Snippet for GetExclusion
+# NOTE: This snippet has been automatically generated for illustrative purposes only.
+# It may require modifications to work in your environment.
+
+# To install the latest published package dependency, execute the following:
+#   python3 -m pip install google-cloud-logging
+
+
+# [START logging_v2_generated_ConfigServiceV2_GetExclusion_sync]
+# This snippet has been automatically generated and should be regarded as a
+# code template only.
+# It will require modifications to work:
+# - It may require correct/in-range values for request initialization.
+# - It may require specifying regional endpoints when creating the service
+#   client as shown in:
+#   https://googleapis.dev/python/google-api-core/latest/client_options.html
+from google.cloud import logging_v2
+
+
+def sample_get_exclusion():
+    # Create a client
+    client = logging_v2.ConfigServiceV2Client()
+
+    # Initialize request argument(s)
+    request = logging_v2.GetExclusionRequest(
+        name="name_value",
+    )
+
+    # Make the request
+    response = client.get_exclusion(request=request)
+
+    # Handle the response
+    print(response)
+
+# [END logging_v2_generated_ConfigServiceV2_GetExclusion_sync]

--- a/packages/gapic-generator/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_config_service_v2_get_link_async.py
+++ b/packages/gapic-generator/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_config_service_v2_get_link_async.py
@@ -1,0 +1,52 @@
+# -*- coding: utf-8 -*-
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Generated code. DO NOT EDIT!
+#
+# Snippet for GetLink
+# NOTE: This snippet has been automatically generated for illustrative purposes only.
+# It may require modifications to work in your environment.
+
+# To install the latest published package dependency, execute the following:
+#   python3 -m pip install google-cloud-logging
+
+
+# [START logging_v2_generated_ConfigServiceV2_GetLink_async]
+# This snippet has been automatically generated and should be regarded as a
+# code template only.
+# It will require modifications to work:
+# - It may require correct/in-range values for request initialization.
+# - It may require specifying regional endpoints when creating the service
+#   client as shown in:
+#   https://googleapis.dev/python/google-api-core/latest/client_options.html
+from google.cloud import logging_v2
+
+
+async def sample_get_link():
+    # Create a client
+    client = logging_v2.ConfigServiceV2AsyncClient()
+
+    # Initialize request argument(s)
+    request = logging_v2.GetLinkRequest(
+        name="name_value",
+    )
+
+    # Make the request
+    response = await client.get_link(request=request)
+
+    # Handle the response
+    print(response)
+
+# [END logging_v2_generated_ConfigServiceV2_GetLink_async]

--- a/packages/gapic-generator/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_config_service_v2_get_link_sync.py
+++ b/packages/gapic-generator/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_config_service_v2_get_link_sync.py
@@ -1,0 +1,52 @@
+# -*- coding: utf-8 -*-
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Generated code. DO NOT EDIT!
+#
+# Snippet for GetLink
+# NOTE: This snippet has been automatically generated for illustrative purposes only.
+# It may require modifications to work in your environment.
+
+# To install the latest published package dependency, execute the following:
+#   python3 -m pip install google-cloud-logging
+
+
+# [START logging_v2_generated_ConfigServiceV2_GetLink_sync]
+# This snippet has been automatically generated and should be regarded as a
+# code template only.
+# It will require modifications to work:
+# - It may require correct/in-range values for request initialization.
+# - It may require specifying regional endpoints when creating the service
+#   client as shown in:
+#   https://googleapis.dev/python/google-api-core/latest/client_options.html
+from google.cloud import logging_v2
+
+
+def sample_get_link():
+    # Create a client
+    client = logging_v2.ConfigServiceV2Client()
+
+    # Initialize request argument(s)
+    request = logging_v2.GetLinkRequest(
+        name="name_value",
+    )
+
+    # Make the request
+    response = client.get_link(request=request)
+
+    # Handle the response
+    print(response)
+
+# [END logging_v2_generated_ConfigServiceV2_GetLink_sync]

--- a/packages/gapic-generator/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_config_service_v2_get_settings_async.py
+++ b/packages/gapic-generator/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_config_service_v2_get_settings_async.py
@@ -1,0 +1,52 @@
+# -*- coding: utf-8 -*-
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Generated code. DO NOT EDIT!
+#
+# Snippet for GetSettings
+# NOTE: This snippet has been automatically generated for illustrative purposes only.
+# It may require modifications to work in your environment.
+
+# To install the latest published package dependency, execute the following:
+#   python3 -m pip install google-cloud-logging
+
+
+# [START logging_v2_generated_ConfigServiceV2_GetSettings_async]
+# This snippet has been automatically generated and should be regarded as a
+# code template only.
+# It will require modifications to work:
+# - It may require correct/in-range values for request initialization.
+# - It may require specifying regional endpoints when creating the service
+#   client as shown in:
+#   https://googleapis.dev/python/google-api-core/latest/client_options.html
+from google.cloud import logging_v2
+
+
+async def sample_get_settings():
+    # Create a client
+    client = logging_v2.ConfigServiceV2AsyncClient()
+
+    # Initialize request argument(s)
+    request = logging_v2.GetSettingsRequest(
+        name="name_value",
+    )
+
+    # Make the request
+    response = await client.get_settings(request=request)
+
+    # Handle the response
+    print(response)
+
+# [END logging_v2_generated_ConfigServiceV2_GetSettings_async]

--- a/packages/gapic-generator/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_config_service_v2_get_settings_sync.py
+++ b/packages/gapic-generator/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_config_service_v2_get_settings_sync.py
@@ -1,0 +1,52 @@
+# -*- coding: utf-8 -*-
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Generated code. DO NOT EDIT!
+#
+# Snippet for GetSettings
+# NOTE: This snippet has been automatically generated for illustrative purposes only.
+# It may require modifications to work in your environment.
+
+# To install the latest published package dependency, execute the following:
+#   python3 -m pip install google-cloud-logging
+
+
+# [START logging_v2_generated_ConfigServiceV2_GetSettings_sync]
+# This snippet has been automatically generated and should be regarded as a
+# code template only.
+# It will require modifications to work:
+# - It may require correct/in-range values for request initialization.
+# - It may require specifying regional endpoints when creating the service
+#   client as shown in:
+#   https://googleapis.dev/python/google-api-core/latest/client_options.html
+from google.cloud import logging_v2
+
+
+def sample_get_settings():
+    # Create a client
+    client = logging_v2.ConfigServiceV2Client()
+
+    # Initialize request argument(s)
+    request = logging_v2.GetSettingsRequest(
+        name="name_value",
+    )
+
+    # Make the request
+    response = client.get_settings(request=request)
+
+    # Handle the response
+    print(response)
+
+# [END logging_v2_generated_ConfigServiceV2_GetSettings_sync]

--- a/packages/gapic-generator/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_config_service_v2_get_sink_async.py
+++ b/packages/gapic-generator/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_config_service_v2_get_sink_async.py
@@ -1,0 +1,52 @@
+# -*- coding: utf-8 -*-
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Generated code. DO NOT EDIT!
+#
+# Snippet for GetSink
+# NOTE: This snippet has been automatically generated for illustrative purposes only.
+# It may require modifications to work in your environment.
+
+# To install the latest published package dependency, execute the following:
+#   python3 -m pip install google-cloud-logging
+
+
+# [START logging_v2_generated_ConfigServiceV2_GetSink_async]
+# This snippet has been automatically generated and should be regarded as a
+# code template only.
+# It will require modifications to work:
+# - It may require correct/in-range values for request initialization.
+# - It may require specifying regional endpoints when creating the service
+#   client as shown in:
+#   https://googleapis.dev/python/google-api-core/latest/client_options.html
+from google.cloud import logging_v2
+
+
+async def sample_get_sink():
+    # Create a client
+    client = logging_v2.ConfigServiceV2AsyncClient()
+
+    # Initialize request argument(s)
+    request = logging_v2.GetSinkRequest(
+        sink_name="sink_name_value",
+    )
+
+    # Make the request
+    response = await client.get_sink(request=request)
+
+    # Handle the response
+    print(response)
+
+# [END logging_v2_generated_ConfigServiceV2_GetSink_async]

--- a/packages/gapic-generator/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_config_service_v2_get_sink_sync.py
+++ b/packages/gapic-generator/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_config_service_v2_get_sink_sync.py
@@ -1,0 +1,52 @@
+# -*- coding: utf-8 -*-
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Generated code. DO NOT EDIT!
+#
+# Snippet for GetSink
+# NOTE: This snippet has been automatically generated for illustrative purposes only.
+# It may require modifications to work in your environment.
+
+# To install the latest published package dependency, execute the following:
+#   python3 -m pip install google-cloud-logging
+
+
+# [START logging_v2_generated_ConfigServiceV2_GetSink_sync]
+# This snippet has been automatically generated and should be regarded as a
+# code template only.
+# It will require modifications to work:
+# - It may require correct/in-range values for request initialization.
+# - It may require specifying regional endpoints when creating the service
+#   client as shown in:
+#   https://googleapis.dev/python/google-api-core/latest/client_options.html
+from google.cloud import logging_v2
+
+
+def sample_get_sink():
+    # Create a client
+    client = logging_v2.ConfigServiceV2Client()
+
+    # Initialize request argument(s)
+    request = logging_v2.GetSinkRequest(
+        sink_name="sink_name_value",
+    )
+
+    # Make the request
+    response = client.get_sink(request=request)
+
+    # Handle the response
+    print(response)
+
+# [END logging_v2_generated_ConfigServiceV2_GetSink_sync]

--- a/packages/gapic-generator/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_config_service_v2_get_view_async.py
+++ b/packages/gapic-generator/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_config_service_v2_get_view_async.py
@@ -1,0 +1,52 @@
+# -*- coding: utf-8 -*-
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Generated code. DO NOT EDIT!
+#
+# Snippet for GetView
+# NOTE: This snippet has been automatically generated for illustrative purposes only.
+# It may require modifications to work in your environment.
+
+# To install the latest published package dependency, execute the following:
+#   python3 -m pip install google-cloud-logging
+
+
+# [START logging_v2_generated_ConfigServiceV2_GetView_async]
+# This snippet has been automatically generated and should be regarded as a
+# code template only.
+# It will require modifications to work:
+# - It may require correct/in-range values for request initialization.
+# - It may require specifying regional endpoints when creating the service
+#   client as shown in:
+#   https://googleapis.dev/python/google-api-core/latest/client_options.html
+from google.cloud import logging_v2
+
+
+async def sample_get_view():
+    # Create a client
+    client = logging_v2.ConfigServiceV2AsyncClient()
+
+    # Initialize request argument(s)
+    request = logging_v2.GetViewRequest(
+        name="name_value",
+    )
+
+    # Make the request
+    response = await client.get_view(request=request)
+
+    # Handle the response
+    print(response)
+
+# [END logging_v2_generated_ConfigServiceV2_GetView_async]

--- a/packages/gapic-generator/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_config_service_v2_get_view_sync.py
+++ b/packages/gapic-generator/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_config_service_v2_get_view_sync.py
@@ -1,0 +1,52 @@
+# -*- coding: utf-8 -*-
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Generated code. DO NOT EDIT!
+#
+# Snippet for GetView
+# NOTE: This snippet has been automatically generated for illustrative purposes only.
+# It may require modifications to work in your environment.
+
+# To install the latest published package dependency, execute the following:
+#   python3 -m pip install google-cloud-logging
+
+
+# [START logging_v2_generated_ConfigServiceV2_GetView_sync]
+# This snippet has been automatically generated and should be regarded as a
+# code template only.
+# It will require modifications to work:
+# - It may require correct/in-range values for request initialization.
+# - It may require specifying regional endpoints when creating the service
+#   client as shown in:
+#   https://googleapis.dev/python/google-api-core/latest/client_options.html
+from google.cloud import logging_v2
+
+
+def sample_get_view():
+    # Create a client
+    client = logging_v2.ConfigServiceV2Client()
+
+    # Initialize request argument(s)
+    request = logging_v2.GetViewRequest(
+        name="name_value",
+    )
+
+    # Make the request
+    response = client.get_view(request=request)
+
+    # Handle the response
+    print(response)
+
+# [END logging_v2_generated_ConfigServiceV2_GetView_sync]

--- a/packages/gapic-generator/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_config_service_v2_list_exclusions_async.py
+++ b/packages/gapic-generator/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_config_service_v2_list_exclusions_async.py
@@ -1,0 +1,53 @@
+# -*- coding: utf-8 -*-
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Generated code. DO NOT EDIT!
+#
+# Snippet for ListExclusions
+# NOTE: This snippet has been automatically generated for illustrative purposes only.
+# It may require modifications to work in your environment.
+
+# To install the latest published package dependency, execute the following:
+#   python3 -m pip install google-cloud-logging
+
+
+# [START logging_v2_generated_ConfigServiceV2_ListExclusions_async]
+# This snippet has been automatically generated and should be regarded as a
+# code template only.
+# It will require modifications to work:
+# - It may require correct/in-range values for request initialization.
+# - It may require specifying regional endpoints when creating the service
+#   client as shown in:
+#   https://googleapis.dev/python/google-api-core/latest/client_options.html
+from google.cloud import logging_v2
+
+
+async def sample_list_exclusions():
+    # Create a client
+    client = logging_v2.ConfigServiceV2AsyncClient()
+
+    # Initialize request argument(s)
+    request = logging_v2.ListExclusionsRequest(
+        parent="parent_value",
+    )
+
+    # Make the request
+    page_result = client.list_exclusions(request=request)
+
+    # Handle the response
+    async for response in page_result:
+        print(response)
+
+# [END logging_v2_generated_ConfigServiceV2_ListExclusions_async]

--- a/packages/gapic-generator/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_config_service_v2_list_exclusions_sync.py
+++ b/packages/gapic-generator/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_config_service_v2_list_exclusions_sync.py
@@ -1,0 +1,53 @@
+# -*- coding: utf-8 -*-
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Generated code. DO NOT EDIT!
+#
+# Snippet for ListExclusions
+# NOTE: This snippet has been automatically generated for illustrative purposes only.
+# It may require modifications to work in your environment.
+
+# To install the latest published package dependency, execute the following:
+#   python3 -m pip install google-cloud-logging
+
+
+# [START logging_v2_generated_ConfigServiceV2_ListExclusions_sync]
+# This snippet has been automatically generated and should be regarded as a
+# code template only.
+# It will require modifications to work:
+# - It may require correct/in-range values for request initialization.
+# - It may require specifying regional endpoints when creating the service
+#   client as shown in:
+#   https://googleapis.dev/python/google-api-core/latest/client_options.html
+from google.cloud import logging_v2
+
+
+def sample_list_exclusions():
+    # Create a client
+    client = logging_v2.ConfigServiceV2Client()
+
+    # Initialize request argument(s)
+    request = logging_v2.ListExclusionsRequest(
+        parent="parent_value",
+    )
+
+    # Make the request
+    page_result = client.list_exclusions(request=request)
+
+    # Handle the response
+    for response in page_result:
+        print(response)
+
+# [END logging_v2_generated_ConfigServiceV2_ListExclusions_sync]

--- a/packages/gapic-generator/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_config_service_v2_list_links_async.py
+++ b/packages/gapic-generator/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_config_service_v2_list_links_async.py
@@ -1,0 +1,53 @@
+# -*- coding: utf-8 -*-
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Generated code. DO NOT EDIT!
+#
+# Snippet for ListLinks
+# NOTE: This snippet has been automatically generated for illustrative purposes only.
+# It may require modifications to work in your environment.
+
+# To install the latest published package dependency, execute the following:
+#   python3 -m pip install google-cloud-logging
+
+
+# [START logging_v2_generated_ConfigServiceV2_ListLinks_async]
+# This snippet has been automatically generated and should be regarded as a
+# code template only.
+# It will require modifications to work:
+# - It may require correct/in-range values for request initialization.
+# - It may require specifying regional endpoints when creating the service
+#   client as shown in:
+#   https://googleapis.dev/python/google-api-core/latest/client_options.html
+from google.cloud import logging_v2
+
+
+async def sample_list_links():
+    # Create a client
+    client = logging_v2.ConfigServiceV2AsyncClient()
+
+    # Initialize request argument(s)
+    request = logging_v2.ListLinksRequest(
+        parent="parent_value",
+    )
+
+    # Make the request
+    page_result = client.list_links(request=request)
+
+    # Handle the response
+    async for response in page_result:
+        print(response)
+
+# [END logging_v2_generated_ConfigServiceV2_ListLinks_async]

--- a/packages/gapic-generator/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_config_service_v2_list_links_sync.py
+++ b/packages/gapic-generator/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_config_service_v2_list_links_sync.py
@@ -1,0 +1,53 @@
+# -*- coding: utf-8 -*-
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Generated code. DO NOT EDIT!
+#
+# Snippet for ListLinks
+# NOTE: This snippet has been automatically generated for illustrative purposes only.
+# It may require modifications to work in your environment.
+
+# To install the latest published package dependency, execute the following:
+#   python3 -m pip install google-cloud-logging
+
+
+# [START logging_v2_generated_ConfigServiceV2_ListLinks_sync]
+# This snippet has been automatically generated and should be regarded as a
+# code template only.
+# It will require modifications to work:
+# - It may require correct/in-range values for request initialization.
+# - It may require specifying regional endpoints when creating the service
+#   client as shown in:
+#   https://googleapis.dev/python/google-api-core/latest/client_options.html
+from google.cloud import logging_v2
+
+
+def sample_list_links():
+    # Create a client
+    client = logging_v2.ConfigServiceV2Client()
+
+    # Initialize request argument(s)
+    request = logging_v2.ListLinksRequest(
+        parent="parent_value",
+    )
+
+    # Make the request
+    page_result = client.list_links(request=request)
+
+    # Handle the response
+    for response in page_result:
+        print(response)
+
+# [END logging_v2_generated_ConfigServiceV2_ListLinks_sync]

--- a/packages/gapic-generator/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_config_service_v2_list_sinks_async.py
+++ b/packages/gapic-generator/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_config_service_v2_list_sinks_async.py
@@ -1,0 +1,53 @@
+# -*- coding: utf-8 -*-
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Generated code. DO NOT EDIT!
+#
+# Snippet for ListSinks
+# NOTE: This snippet has been automatically generated for illustrative purposes only.
+# It may require modifications to work in your environment.
+
+# To install the latest published package dependency, execute the following:
+#   python3 -m pip install google-cloud-logging
+
+
+# [START logging_v2_generated_ConfigServiceV2_ListSinks_async]
+# This snippet has been automatically generated and should be regarded as a
+# code template only.
+# It will require modifications to work:
+# - It may require correct/in-range values for request initialization.
+# - It may require specifying regional endpoints when creating the service
+#   client as shown in:
+#   https://googleapis.dev/python/google-api-core/latest/client_options.html
+from google.cloud import logging_v2
+
+
+async def sample_list_sinks():
+    # Create a client
+    client = logging_v2.ConfigServiceV2AsyncClient()
+
+    # Initialize request argument(s)
+    request = logging_v2.ListSinksRequest(
+        parent="parent_value",
+    )
+
+    # Make the request
+    page_result = client.list_sinks(request=request)
+
+    # Handle the response
+    async for response in page_result:
+        print(response)
+
+# [END logging_v2_generated_ConfigServiceV2_ListSinks_async]

--- a/packages/gapic-generator/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_config_service_v2_list_sinks_sync.py
+++ b/packages/gapic-generator/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_config_service_v2_list_sinks_sync.py
@@ -1,0 +1,53 @@
+# -*- coding: utf-8 -*-
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Generated code. DO NOT EDIT!
+#
+# Snippet for ListSinks
+# NOTE: This snippet has been automatically generated for illustrative purposes only.
+# It may require modifications to work in your environment.
+
+# To install the latest published package dependency, execute the following:
+#   python3 -m pip install google-cloud-logging
+
+
+# [START logging_v2_generated_ConfigServiceV2_ListSinks_sync]
+# This snippet has been automatically generated and should be regarded as a
+# code template only.
+# It will require modifications to work:
+# - It may require correct/in-range values for request initialization.
+# - It may require specifying regional endpoints when creating the service
+#   client as shown in:
+#   https://googleapis.dev/python/google-api-core/latest/client_options.html
+from google.cloud import logging_v2
+
+
+def sample_list_sinks():
+    # Create a client
+    client = logging_v2.ConfigServiceV2Client()
+
+    # Initialize request argument(s)
+    request = logging_v2.ListSinksRequest(
+        parent="parent_value",
+    )
+
+    # Make the request
+    page_result = client.list_sinks(request=request)
+
+    # Handle the response
+    for response in page_result:
+        print(response)
+
+# [END logging_v2_generated_ConfigServiceV2_ListSinks_sync]

--- a/packages/gapic-generator/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_config_service_v2_list_views_async.py
+++ b/packages/gapic-generator/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_config_service_v2_list_views_async.py
@@ -1,0 +1,53 @@
+# -*- coding: utf-8 -*-
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Generated code. DO NOT EDIT!
+#
+# Snippet for ListViews
+# NOTE: This snippet has been automatically generated for illustrative purposes only.
+# It may require modifications to work in your environment.
+
+# To install the latest published package dependency, execute the following:
+#   python3 -m pip install google-cloud-logging
+
+
+# [START logging_v2_generated_ConfigServiceV2_ListViews_async]
+# This snippet has been automatically generated and should be regarded as a
+# code template only.
+# It will require modifications to work:
+# - It may require correct/in-range values for request initialization.
+# - It may require specifying regional endpoints when creating the service
+#   client as shown in:
+#   https://googleapis.dev/python/google-api-core/latest/client_options.html
+from google.cloud import logging_v2
+
+
+async def sample_list_views():
+    # Create a client
+    client = logging_v2.ConfigServiceV2AsyncClient()
+
+    # Initialize request argument(s)
+    request = logging_v2.ListViewsRequest(
+        parent="parent_value",
+    )
+
+    # Make the request
+    page_result = client.list_views(request=request)
+
+    # Handle the response
+    async for response in page_result:
+        print(response)
+
+# [END logging_v2_generated_ConfigServiceV2_ListViews_async]

--- a/packages/gapic-generator/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_config_service_v2_list_views_sync.py
+++ b/packages/gapic-generator/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_config_service_v2_list_views_sync.py
@@ -1,0 +1,53 @@
+# -*- coding: utf-8 -*-
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Generated code. DO NOT EDIT!
+#
+# Snippet for ListViews
+# NOTE: This snippet has been automatically generated for illustrative purposes only.
+# It may require modifications to work in your environment.
+
+# To install the latest published package dependency, execute the following:
+#   python3 -m pip install google-cloud-logging
+
+
+# [START logging_v2_generated_ConfigServiceV2_ListViews_sync]
+# This snippet has been automatically generated and should be regarded as a
+# code template only.
+# It will require modifications to work:
+# - It may require correct/in-range values for request initialization.
+# - It may require specifying regional endpoints when creating the service
+#   client as shown in:
+#   https://googleapis.dev/python/google-api-core/latest/client_options.html
+from google.cloud import logging_v2
+
+
+def sample_list_views():
+    # Create a client
+    client = logging_v2.ConfigServiceV2Client()
+
+    # Initialize request argument(s)
+    request = logging_v2.ListViewsRequest(
+        parent="parent_value",
+    )
+
+    # Make the request
+    page_result = client.list_views(request=request)
+
+    # Handle the response
+    for response in page_result:
+        print(response)
+
+# [END logging_v2_generated_ConfigServiceV2_ListViews_sync]

--- a/packages/gapic-generator/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_config_service_v2_update_cmek_settings_async.py
+++ b/packages/gapic-generator/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_config_service_v2_update_cmek_settings_async.py
@@ -1,0 +1,52 @@
+# -*- coding: utf-8 -*-
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Generated code. DO NOT EDIT!
+#
+# Snippet for UpdateCmekSettings
+# NOTE: This snippet has been automatically generated for illustrative purposes only.
+# It may require modifications to work in your environment.
+
+# To install the latest published package dependency, execute the following:
+#   python3 -m pip install google-cloud-logging
+
+
+# [START logging_v2_generated_ConfigServiceV2_UpdateCmekSettings_async]
+# This snippet has been automatically generated and should be regarded as a
+# code template only.
+# It will require modifications to work:
+# - It may require correct/in-range values for request initialization.
+# - It may require specifying regional endpoints when creating the service
+#   client as shown in:
+#   https://googleapis.dev/python/google-api-core/latest/client_options.html
+from google.cloud import logging_v2
+
+
+async def sample_update_cmek_settings():
+    # Create a client
+    client = logging_v2.ConfigServiceV2AsyncClient()
+
+    # Initialize request argument(s)
+    request = logging_v2.UpdateCmekSettingsRequest(
+        name="name_value",
+    )
+
+    # Make the request
+    response = await client.update_cmek_settings(request=request)
+
+    # Handle the response
+    print(response)
+
+# [END logging_v2_generated_ConfigServiceV2_UpdateCmekSettings_async]

--- a/packages/gapic-generator/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_config_service_v2_update_cmek_settings_sync.py
+++ b/packages/gapic-generator/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_config_service_v2_update_cmek_settings_sync.py
@@ -1,0 +1,52 @@
+# -*- coding: utf-8 -*-
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Generated code. DO NOT EDIT!
+#
+# Snippet for UpdateCmekSettings
+# NOTE: This snippet has been automatically generated for illustrative purposes only.
+# It may require modifications to work in your environment.
+
+# To install the latest published package dependency, execute the following:
+#   python3 -m pip install google-cloud-logging
+
+
+# [START logging_v2_generated_ConfigServiceV2_UpdateCmekSettings_sync]
+# This snippet has been automatically generated and should be regarded as a
+# code template only.
+# It will require modifications to work:
+# - It may require correct/in-range values for request initialization.
+# - It may require specifying regional endpoints when creating the service
+#   client as shown in:
+#   https://googleapis.dev/python/google-api-core/latest/client_options.html
+from google.cloud import logging_v2
+
+
+def sample_update_cmek_settings():
+    # Create a client
+    client = logging_v2.ConfigServiceV2Client()
+
+    # Initialize request argument(s)
+    request = logging_v2.UpdateCmekSettingsRequest(
+        name="name_value",
+    )
+
+    # Make the request
+    response = client.update_cmek_settings(request=request)
+
+    # Handle the response
+    print(response)
+
+# [END logging_v2_generated_ConfigServiceV2_UpdateCmekSettings_sync]

--- a/packages/gapic-generator/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_config_service_v2_update_exclusion_async.py
+++ b/packages/gapic-generator/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_config_service_v2_update_exclusion_async.py
@@ -1,0 +1,57 @@
+# -*- coding: utf-8 -*-
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Generated code. DO NOT EDIT!
+#
+# Snippet for UpdateExclusion
+# NOTE: This snippet has been automatically generated for illustrative purposes only.
+# It may require modifications to work in your environment.
+
+# To install the latest published package dependency, execute the following:
+#   python3 -m pip install google-cloud-logging
+
+
+# [START logging_v2_generated_ConfigServiceV2_UpdateExclusion_async]
+# This snippet has been automatically generated and should be regarded as a
+# code template only.
+# It will require modifications to work:
+# - It may require correct/in-range values for request initialization.
+# - It may require specifying regional endpoints when creating the service
+#   client as shown in:
+#   https://googleapis.dev/python/google-api-core/latest/client_options.html
+from google.cloud import logging_v2
+
+
+async def sample_update_exclusion():
+    # Create a client
+    client = logging_v2.ConfigServiceV2AsyncClient()
+
+    # Initialize request argument(s)
+    exclusion = logging_v2.LogExclusion()
+    exclusion.name = "name_value"
+    exclusion.filter = "filter_value"
+
+    request = logging_v2.UpdateExclusionRequest(
+        name="name_value",
+        exclusion=exclusion,
+    )
+
+    # Make the request
+    response = await client.update_exclusion(request=request)
+
+    # Handle the response
+    print(response)
+
+# [END logging_v2_generated_ConfigServiceV2_UpdateExclusion_async]

--- a/packages/gapic-generator/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_config_service_v2_update_exclusion_sync.py
+++ b/packages/gapic-generator/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_config_service_v2_update_exclusion_sync.py
@@ -1,0 +1,57 @@
+# -*- coding: utf-8 -*-
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Generated code. DO NOT EDIT!
+#
+# Snippet for UpdateExclusion
+# NOTE: This snippet has been automatically generated for illustrative purposes only.
+# It may require modifications to work in your environment.
+
+# To install the latest published package dependency, execute the following:
+#   python3 -m pip install google-cloud-logging
+
+
+# [START logging_v2_generated_ConfigServiceV2_UpdateExclusion_sync]
+# This snippet has been automatically generated and should be regarded as a
+# code template only.
+# It will require modifications to work:
+# - It may require correct/in-range values for request initialization.
+# - It may require specifying regional endpoints when creating the service
+#   client as shown in:
+#   https://googleapis.dev/python/google-api-core/latest/client_options.html
+from google.cloud import logging_v2
+
+
+def sample_update_exclusion():
+    # Create a client
+    client = logging_v2.ConfigServiceV2Client()
+
+    # Initialize request argument(s)
+    exclusion = logging_v2.LogExclusion()
+    exclusion.name = "name_value"
+    exclusion.filter = "filter_value"
+
+    request = logging_v2.UpdateExclusionRequest(
+        name="name_value",
+        exclusion=exclusion,
+    )
+
+    # Make the request
+    response = client.update_exclusion(request=request)
+
+    # Handle the response
+    print(response)
+
+# [END logging_v2_generated_ConfigServiceV2_UpdateExclusion_sync]

--- a/packages/gapic-generator/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_config_service_v2_update_settings_async.py
+++ b/packages/gapic-generator/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_config_service_v2_update_settings_async.py
@@ -1,0 +1,52 @@
+# -*- coding: utf-8 -*-
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Generated code. DO NOT EDIT!
+#
+# Snippet for UpdateSettings
+# NOTE: This snippet has been automatically generated for illustrative purposes only.
+# It may require modifications to work in your environment.
+
+# To install the latest published package dependency, execute the following:
+#   python3 -m pip install google-cloud-logging
+
+
+# [START logging_v2_generated_ConfigServiceV2_UpdateSettings_async]
+# This snippet has been automatically generated and should be regarded as a
+# code template only.
+# It will require modifications to work:
+# - It may require correct/in-range values for request initialization.
+# - It may require specifying regional endpoints when creating the service
+#   client as shown in:
+#   https://googleapis.dev/python/google-api-core/latest/client_options.html
+from google.cloud import logging_v2
+
+
+async def sample_update_settings():
+    # Create a client
+    client = logging_v2.ConfigServiceV2AsyncClient()
+
+    # Initialize request argument(s)
+    request = logging_v2.UpdateSettingsRequest(
+        name="name_value",
+    )
+
+    # Make the request
+    response = await client.update_settings(request=request)
+
+    # Handle the response
+    print(response)
+
+# [END logging_v2_generated_ConfigServiceV2_UpdateSettings_async]

--- a/packages/gapic-generator/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_config_service_v2_update_settings_sync.py
+++ b/packages/gapic-generator/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_config_service_v2_update_settings_sync.py
@@ -1,0 +1,52 @@
+# -*- coding: utf-8 -*-
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Generated code. DO NOT EDIT!
+#
+# Snippet for UpdateSettings
+# NOTE: This snippet has been automatically generated for illustrative purposes only.
+# It may require modifications to work in your environment.
+
+# To install the latest published package dependency, execute the following:
+#   python3 -m pip install google-cloud-logging
+
+
+# [START logging_v2_generated_ConfigServiceV2_UpdateSettings_sync]
+# This snippet has been automatically generated and should be regarded as a
+# code template only.
+# It will require modifications to work:
+# - It may require correct/in-range values for request initialization.
+# - It may require specifying regional endpoints when creating the service
+#   client as shown in:
+#   https://googleapis.dev/python/google-api-core/latest/client_options.html
+from google.cloud import logging_v2
+
+
+def sample_update_settings():
+    # Create a client
+    client = logging_v2.ConfigServiceV2Client()
+
+    # Initialize request argument(s)
+    request = logging_v2.UpdateSettingsRequest(
+        name="name_value",
+    )
+
+    # Make the request
+    response = client.update_settings(request=request)
+
+    # Handle the response
+    print(response)
+
+# [END logging_v2_generated_ConfigServiceV2_UpdateSettings_sync]

--- a/packages/gapic-generator/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_config_service_v2_update_sink_async.py
+++ b/packages/gapic-generator/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_config_service_v2_update_sink_async.py
@@ -1,0 +1,57 @@
+# -*- coding: utf-8 -*-
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Generated code. DO NOT EDIT!
+#
+# Snippet for UpdateSink
+# NOTE: This snippet has been automatically generated for illustrative purposes only.
+# It may require modifications to work in your environment.
+
+# To install the latest published package dependency, execute the following:
+#   python3 -m pip install google-cloud-logging
+
+
+# [START logging_v2_generated_ConfigServiceV2_UpdateSink_async]
+# This snippet has been automatically generated and should be regarded as a
+# code template only.
+# It will require modifications to work:
+# - It may require correct/in-range values for request initialization.
+# - It may require specifying regional endpoints when creating the service
+#   client as shown in:
+#   https://googleapis.dev/python/google-api-core/latest/client_options.html
+from google.cloud import logging_v2
+
+
+async def sample_update_sink():
+    # Create a client
+    client = logging_v2.ConfigServiceV2AsyncClient()
+
+    # Initialize request argument(s)
+    sink = logging_v2.LogSink()
+    sink.name = "name_value"
+    sink.destination = "destination_value"
+
+    request = logging_v2.UpdateSinkRequest(
+        sink_name="sink_name_value",
+        sink=sink,
+    )
+
+    # Make the request
+    response = await client.update_sink(request=request)
+
+    # Handle the response
+    print(response)
+
+# [END logging_v2_generated_ConfigServiceV2_UpdateSink_async]

--- a/packages/gapic-generator/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_config_service_v2_update_sink_sync.py
+++ b/packages/gapic-generator/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_config_service_v2_update_sink_sync.py
@@ -1,0 +1,57 @@
+# -*- coding: utf-8 -*-
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Generated code. DO NOT EDIT!
+#
+# Snippet for UpdateSink
+# NOTE: This snippet has been automatically generated for illustrative purposes only.
+# It may require modifications to work in your environment.
+
+# To install the latest published package dependency, execute the following:
+#   python3 -m pip install google-cloud-logging
+
+
+# [START logging_v2_generated_ConfigServiceV2_UpdateSink_sync]
+# This snippet has been automatically generated and should be regarded as a
+# code template only.
+# It will require modifications to work:
+# - It may require correct/in-range values for request initialization.
+# - It may require specifying regional endpoints when creating the service
+#   client as shown in:
+#   https://googleapis.dev/python/google-api-core/latest/client_options.html
+from google.cloud import logging_v2
+
+
+def sample_update_sink():
+    # Create a client
+    client = logging_v2.ConfigServiceV2Client()
+
+    # Initialize request argument(s)
+    sink = logging_v2.LogSink()
+    sink.name = "name_value"
+    sink.destination = "destination_value"
+
+    request = logging_v2.UpdateSinkRequest(
+        sink_name="sink_name_value",
+        sink=sink,
+    )
+
+    # Make the request
+    response = client.update_sink(request=request)
+
+    # Handle the response
+    print(response)
+
+# [END logging_v2_generated_ConfigServiceV2_UpdateSink_sync]

--- a/packages/gapic-generator/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_config_service_v2_update_view_async.py
+++ b/packages/gapic-generator/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_config_service_v2_update_view_async.py
@@ -1,0 +1,52 @@
+# -*- coding: utf-8 -*-
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Generated code. DO NOT EDIT!
+#
+# Snippet for UpdateView
+# NOTE: This snippet has been automatically generated for illustrative purposes only.
+# It may require modifications to work in your environment.
+
+# To install the latest published package dependency, execute the following:
+#   python3 -m pip install google-cloud-logging
+
+
+# [START logging_v2_generated_ConfigServiceV2_UpdateView_async]
+# This snippet has been automatically generated and should be regarded as a
+# code template only.
+# It will require modifications to work:
+# - It may require correct/in-range values for request initialization.
+# - It may require specifying regional endpoints when creating the service
+#   client as shown in:
+#   https://googleapis.dev/python/google-api-core/latest/client_options.html
+from google.cloud import logging_v2
+
+
+async def sample_update_view():
+    # Create a client
+    client = logging_v2.ConfigServiceV2AsyncClient()
+
+    # Initialize request argument(s)
+    request = logging_v2.UpdateViewRequest(
+        name="name_value",
+    )
+
+    # Make the request
+    response = await client.update_view(request=request)
+
+    # Handle the response
+    print(response)
+
+# [END logging_v2_generated_ConfigServiceV2_UpdateView_async]

--- a/packages/gapic-generator/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_config_service_v2_update_view_sync.py
+++ b/packages/gapic-generator/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_config_service_v2_update_view_sync.py
@@ -1,0 +1,52 @@
+# -*- coding: utf-8 -*-
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Generated code. DO NOT EDIT!
+#
+# Snippet for UpdateView
+# NOTE: This snippet has been automatically generated for illustrative purposes only.
+# It may require modifications to work in your environment.
+
+# To install the latest published package dependency, execute the following:
+#   python3 -m pip install google-cloud-logging
+
+
+# [START logging_v2_generated_ConfigServiceV2_UpdateView_sync]
+# This snippet has been automatically generated and should be regarded as a
+# code template only.
+# It will require modifications to work:
+# - It may require correct/in-range values for request initialization.
+# - It may require specifying regional endpoints when creating the service
+#   client as shown in:
+#   https://googleapis.dev/python/google-api-core/latest/client_options.html
+from google.cloud import logging_v2
+
+
+def sample_update_view():
+    # Create a client
+    client = logging_v2.ConfigServiceV2Client()
+
+    # Initialize request argument(s)
+    request = logging_v2.UpdateViewRequest(
+        name="name_value",
+    )
+
+    # Make the request
+    response = client.update_view(request=request)
+
+    # Handle the response
+    print(response)
+
+# [END logging_v2_generated_ConfigServiceV2_UpdateView_sync]

--- a/packages/gapic-generator/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_metrics_service_v2_create_log_metric_async.py
+++ b/packages/gapic-generator/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_metrics_service_v2_create_log_metric_async.py
@@ -1,0 +1,57 @@
+# -*- coding: utf-8 -*-
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Generated code. DO NOT EDIT!
+#
+# Snippet for CreateLogMetric
+# NOTE: This snippet has been automatically generated for illustrative purposes only.
+# It may require modifications to work in your environment.
+
+# To install the latest published package dependency, execute the following:
+#   python3 -m pip install google-cloud-logging
+
+
+# [START logging_v2_generated_MetricsServiceV2_CreateLogMetric_async]
+# This snippet has been automatically generated and should be regarded as a
+# code template only.
+# It will require modifications to work:
+# - It may require correct/in-range values for request initialization.
+# - It may require specifying regional endpoints when creating the service
+#   client as shown in:
+#   https://googleapis.dev/python/google-api-core/latest/client_options.html
+from google.cloud import logging_v2
+
+
+async def sample_create_log_metric():
+    # Create a client
+    client = logging_v2.MetricsServiceV2AsyncClient()
+
+    # Initialize request argument(s)
+    metric = logging_v2.LogMetric()
+    metric.name = "name_value"
+    metric.filter = "filter_value"
+
+    request = logging_v2.CreateLogMetricRequest(
+        parent="parent_value",
+        metric=metric,
+    )
+
+    # Make the request
+    response = await client.create_log_metric(request=request)
+
+    # Handle the response
+    print(response)
+
+# [END logging_v2_generated_MetricsServiceV2_CreateLogMetric_async]

--- a/packages/gapic-generator/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_metrics_service_v2_create_log_metric_sync.py
+++ b/packages/gapic-generator/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_metrics_service_v2_create_log_metric_sync.py
@@ -1,0 +1,57 @@
+# -*- coding: utf-8 -*-
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Generated code. DO NOT EDIT!
+#
+# Snippet for CreateLogMetric
+# NOTE: This snippet has been automatically generated for illustrative purposes only.
+# It may require modifications to work in your environment.
+
+# To install the latest published package dependency, execute the following:
+#   python3 -m pip install google-cloud-logging
+
+
+# [START logging_v2_generated_MetricsServiceV2_CreateLogMetric_sync]
+# This snippet has been automatically generated and should be regarded as a
+# code template only.
+# It will require modifications to work:
+# - It may require correct/in-range values for request initialization.
+# - It may require specifying regional endpoints when creating the service
+#   client as shown in:
+#   https://googleapis.dev/python/google-api-core/latest/client_options.html
+from google.cloud import logging_v2
+
+
+def sample_create_log_metric():
+    # Create a client
+    client = logging_v2.MetricsServiceV2Client()
+
+    # Initialize request argument(s)
+    metric = logging_v2.LogMetric()
+    metric.name = "name_value"
+    metric.filter = "filter_value"
+
+    request = logging_v2.CreateLogMetricRequest(
+        parent="parent_value",
+        metric=metric,
+    )
+
+    # Make the request
+    response = client.create_log_metric(request=request)
+
+    # Handle the response
+    print(response)
+
+# [END logging_v2_generated_MetricsServiceV2_CreateLogMetric_sync]

--- a/packages/gapic-generator/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_metrics_service_v2_delete_log_metric_async.py
+++ b/packages/gapic-generator/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_metrics_service_v2_delete_log_metric_async.py
@@ -1,0 +1,50 @@
+# -*- coding: utf-8 -*-
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Generated code. DO NOT EDIT!
+#
+# Snippet for DeleteLogMetric
+# NOTE: This snippet has been automatically generated for illustrative purposes only.
+# It may require modifications to work in your environment.
+
+# To install the latest published package dependency, execute the following:
+#   python3 -m pip install google-cloud-logging
+
+
+# [START logging_v2_generated_MetricsServiceV2_DeleteLogMetric_async]
+# This snippet has been automatically generated and should be regarded as a
+# code template only.
+# It will require modifications to work:
+# - It may require correct/in-range values for request initialization.
+# - It may require specifying regional endpoints when creating the service
+#   client as shown in:
+#   https://googleapis.dev/python/google-api-core/latest/client_options.html
+from google.cloud import logging_v2
+
+
+async def sample_delete_log_metric():
+    # Create a client
+    client = logging_v2.MetricsServiceV2AsyncClient()
+
+    # Initialize request argument(s)
+    request = logging_v2.DeleteLogMetricRequest(
+        metric_name="metric_name_value",
+    )
+
+    # Make the request
+    await client.delete_log_metric(request=request)
+
+
+# [END logging_v2_generated_MetricsServiceV2_DeleteLogMetric_async]

--- a/packages/gapic-generator/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_metrics_service_v2_delete_log_metric_sync.py
+++ b/packages/gapic-generator/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_metrics_service_v2_delete_log_metric_sync.py
@@ -1,0 +1,50 @@
+# -*- coding: utf-8 -*-
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Generated code. DO NOT EDIT!
+#
+# Snippet for DeleteLogMetric
+# NOTE: This snippet has been automatically generated for illustrative purposes only.
+# It may require modifications to work in your environment.
+
+# To install the latest published package dependency, execute the following:
+#   python3 -m pip install google-cloud-logging
+
+
+# [START logging_v2_generated_MetricsServiceV2_DeleteLogMetric_sync]
+# This snippet has been automatically generated and should be regarded as a
+# code template only.
+# It will require modifications to work:
+# - It may require correct/in-range values for request initialization.
+# - It may require specifying regional endpoints when creating the service
+#   client as shown in:
+#   https://googleapis.dev/python/google-api-core/latest/client_options.html
+from google.cloud import logging_v2
+
+
+def sample_delete_log_metric():
+    # Create a client
+    client = logging_v2.MetricsServiceV2Client()
+
+    # Initialize request argument(s)
+    request = logging_v2.DeleteLogMetricRequest(
+        metric_name="metric_name_value",
+    )
+
+    # Make the request
+    client.delete_log_metric(request=request)
+
+
+# [END logging_v2_generated_MetricsServiceV2_DeleteLogMetric_sync]

--- a/packages/gapic-generator/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_metrics_service_v2_get_log_metric_async.py
+++ b/packages/gapic-generator/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_metrics_service_v2_get_log_metric_async.py
@@ -1,0 +1,52 @@
+# -*- coding: utf-8 -*-
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Generated code. DO NOT EDIT!
+#
+# Snippet for GetLogMetric
+# NOTE: This snippet has been automatically generated for illustrative purposes only.
+# It may require modifications to work in your environment.
+
+# To install the latest published package dependency, execute the following:
+#   python3 -m pip install google-cloud-logging
+
+
+# [START logging_v2_generated_MetricsServiceV2_GetLogMetric_async]
+# This snippet has been automatically generated and should be regarded as a
+# code template only.
+# It will require modifications to work:
+# - It may require correct/in-range values for request initialization.
+# - It may require specifying regional endpoints when creating the service
+#   client as shown in:
+#   https://googleapis.dev/python/google-api-core/latest/client_options.html
+from google.cloud import logging_v2
+
+
+async def sample_get_log_metric():
+    # Create a client
+    client = logging_v2.MetricsServiceV2AsyncClient()
+
+    # Initialize request argument(s)
+    request = logging_v2.GetLogMetricRequest(
+        metric_name="metric_name_value",
+    )
+
+    # Make the request
+    response = await client.get_log_metric(request=request)
+
+    # Handle the response
+    print(response)
+
+# [END logging_v2_generated_MetricsServiceV2_GetLogMetric_async]

--- a/packages/gapic-generator/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_metrics_service_v2_get_log_metric_sync.py
+++ b/packages/gapic-generator/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_metrics_service_v2_get_log_metric_sync.py
@@ -1,0 +1,52 @@
+# -*- coding: utf-8 -*-
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Generated code. DO NOT EDIT!
+#
+# Snippet for GetLogMetric
+# NOTE: This snippet has been automatically generated for illustrative purposes only.
+# It may require modifications to work in your environment.
+
+# To install the latest published package dependency, execute the following:
+#   python3 -m pip install google-cloud-logging
+
+
+# [START logging_v2_generated_MetricsServiceV2_GetLogMetric_sync]
+# This snippet has been automatically generated and should be regarded as a
+# code template only.
+# It will require modifications to work:
+# - It may require correct/in-range values for request initialization.
+# - It may require specifying regional endpoints when creating the service
+#   client as shown in:
+#   https://googleapis.dev/python/google-api-core/latest/client_options.html
+from google.cloud import logging_v2
+
+
+def sample_get_log_metric():
+    # Create a client
+    client = logging_v2.MetricsServiceV2Client()
+
+    # Initialize request argument(s)
+    request = logging_v2.GetLogMetricRequest(
+        metric_name="metric_name_value",
+    )
+
+    # Make the request
+    response = client.get_log_metric(request=request)
+
+    # Handle the response
+    print(response)
+
+# [END logging_v2_generated_MetricsServiceV2_GetLogMetric_sync]

--- a/packages/gapic-generator/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_metrics_service_v2_list_log_metrics_async.py
+++ b/packages/gapic-generator/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_metrics_service_v2_list_log_metrics_async.py
@@ -1,0 +1,53 @@
+# -*- coding: utf-8 -*-
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Generated code. DO NOT EDIT!
+#
+# Snippet for ListLogMetrics
+# NOTE: This snippet has been automatically generated for illustrative purposes only.
+# It may require modifications to work in your environment.
+
+# To install the latest published package dependency, execute the following:
+#   python3 -m pip install google-cloud-logging
+
+
+# [START logging_v2_generated_MetricsServiceV2_ListLogMetrics_async]
+# This snippet has been automatically generated and should be regarded as a
+# code template only.
+# It will require modifications to work:
+# - It may require correct/in-range values for request initialization.
+# - It may require specifying regional endpoints when creating the service
+#   client as shown in:
+#   https://googleapis.dev/python/google-api-core/latest/client_options.html
+from google.cloud import logging_v2
+
+
+async def sample_list_log_metrics():
+    # Create a client
+    client = logging_v2.MetricsServiceV2AsyncClient()
+
+    # Initialize request argument(s)
+    request = logging_v2.ListLogMetricsRequest(
+        parent="parent_value",
+    )
+
+    # Make the request
+    page_result = client.list_log_metrics(request=request)
+
+    # Handle the response
+    async for response in page_result:
+        print(response)
+
+# [END logging_v2_generated_MetricsServiceV2_ListLogMetrics_async]

--- a/packages/gapic-generator/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_metrics_service_v2_list_log_metrics_sync.py
+++ b/packages/gapic-generator/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_metrics_service_v2_list_log_metrics_sync.py
@@ -1,0 +1,53 @@
+# -*- coding: utf-8 -*-
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Generated code. DO NOT EDIT!
+#
+# Snippet for ListLogMetrics
+# NOTE: This snippet has been automatically generated for illustrative purposes only.
+# It may require modifications to work in your environment.
+
+# To install the latest published package dependency, execute the following:
+#   python3 -m pip install google-cloud-logging
+
+
+# [START logging_v2_generated_MetricsServiceV2_ListLogMetrics_sync]
+# This snippet has been automatically generated and should be regarded as a
+# code template only.
+# It will require modifications to work:
+# - It may require correct/in-range values for request initialization.
+# - It may require specifying regional endpoints when creating the service
+#   client as shown in:
+#   https://googleapis.dev/python/google-api-core/latest/client_options.html
+from google.cloud import logging_v2
+
+
+def sample_list_log_metrics():
+    # Create a client
+    client = logging_v2.MetricsServiceV2Client()
+
+    # Initialize request argument(s)
+    request = logging_v2.ListLogMetricsRequest(
+        parent="parent_value",
+    )
+
+    # Make the request
+    page_result = client.list_log_metrics(request=request)
+
+    # Handle the response
+    for response in page_result:
+        print(response)
+
+# [END logging_v2_generated_MetricsServiceV2_ListLogMetrics_sync]

--- a/packages/gapic-generator/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_metrics_service_v2_update_log_metric_async.py
+++ b/packages/gapic-generator/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_metrics_service_v2_update_log_metric_async.py
@@ -1,0 +1,57 @@
+# -*- coding: utf-8 -*-
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Generated code. DO NOT EDIT!
+#
+# Snippet for UpdateLogMetric
+# NOTE: This snippet has been automatically generated for illustrative purposes only.
+# It may require modifications to work in your environment.
+
+# To install the latest published package dependency, execute the following:
+#   python3 -m pip install google-cloud-logging
+
+
+# [START logging_v2_generated_MetricsServiceV2_UpdateLogMetric_async]
+# This snippet has been automatically generated and should be regarded as a
+# code template only.
+# It will require modifications to work:
+# - It may require correct/in-range values for request initialization.
+# - It may require specifying regional endpoints when creating the service
+#   client as shown in:
+#   https://googleapis.dev/python/google-api-core/latest/client_options.html
+from google.cloud import logging_v2
+
+
+async def sample_update_log_metric():
+    # Create a client
+    client = logging_v2.MetricsServiceV2AsyncClient()
+
+    # Initialize request argument(s)
+    metric = logging_v2.LogMetric()
+    metric.name = "name_value"
+    metric.filter = "filter_value"
+
+    request = logging_v2.UpdateLogMetricRequest(
+        metric_name="metric_name_value",
+        metric=metric,
+    )
+
+    # Make the request
+    response = await client.update_log_metric(request=request)
+
+    # Handle the response
+    print(response)
+
+# [END logging_v2_generated_MetricsServiceV2_UpdateLogMetric_async]

--- a/packages/gapic-generator/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_metrics_service_v2_update_log_metric_sync.py
+++ b/packages/gapic-generator/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_metrics_service_v2_update_log_metric_sync.py
@@ -1,0 +1,57 @@
+# -*- coding: utf-8 -*-
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Generated code. DO NOT EDIT!
+#
+# Snippet for UpdateLogMetric
+# NOTE: This snippet has been automatically generated for illustrative purposes only.
+# It may require modifications to work in your environment.
+
+# To install the latest published package dependency, execute the following:
+#   python3 -m pip install google-cloud-logging
+
+
+# [START logging_v2_generated_MetricsServiceV2_UpdateLogMetric_sync]
+# This snippet has been automatically generated and should be regarded as a
+# code template only.
+# It will require modifications to work:
+# - It may require correct/in-range values for request initialization.
+# - It may require specifying regional endpoints when creating the service
+#   client as shown in:
+#   https://googleapis.dev/python/google-api-core/latest/client_options.html
+from google.cloud import logging_v2
+
+
+def sample_update_log_metric():
+    # Create a client
+    client = logging_v2.MetricsServiceV2Client()
+
+    # Initialize request argument(s)
+    metric = logging_v2.LogMetric()
+    metric.name = "name_value"
+    metric.filter = "filter_value"
+
+    request = logging_v2.UpdateLogMetricRequest(
+        metric_name="metric_name_value",
+        metric=metric,
+    )
+
+    # Make the request
+    response = client.update_log_metric(request=request)
+
+    # Handle the response
+    print(response)
+
+# [END logging_v2_generated_MetricsServiceV2_UpdateLogMetric_sync]

--- a/packages/gapic-generator/tests/integration/goldens/logging_internal/setup.py
+++ b/packages/gapic-generator/tests/integration/goldens/logging_internal/setup.py
@@ -43,7 +43,7 @@ dependencies = [
     # Exclude incompatible versions of `google-auth`
     # See https://github.com/googleapis/google-cloud-python/issues/12364
     "google-auth >= 2.14.1, <3.0.0,!=2.24.0,!=2.25.0",
-    "grpcio >= 1.44.0, < 2.0.0",
+    "grpcio >= 1.59.0, < 2.0.0",
     "grpcio >= 1.75.1, < 2.0.0; python_version >= '3.14'",
     "proto-plus >= 1.22.3, <2.0.0",
     "proto-plus >= 1.25.0, <2.0.0; python_version >= '3.13'",

--- a/packages/gapic-generator/tests/integration/goldens/logging_internal/testing/constraints-3.10.txt
+++ b/packages/gapic-generator/tests/integration/goldens/logging_internal/testing/constraints-3.10.txt
@@ -6,6 +6,6 @@
 # then this file should have google-cloud-foo==1.14.0
 google-api-core==2.17.1
 google-auth==2.14.1
-grpcio==1.44.0
+grpcio==1.59.0
 proto-plus==1.22.3
 protobuf==4.25.8

--- a/packages/gapic-generator/tests/integration/goldens/logging_internal/tests/unit/gapic/logging_v2/test_config_service_v2.py
+++ b/packages/gapic-generator/tests/integration/goldens/logging_internal/tests/unit/gapic/logging_v2/test_config_service_v2.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 #
 import os
+import asyncio
 from unittest import mock
 from unittest.mock import AsyncMock
 
@@ -94,6 +95,15 @@ def modify_default_endpoint(client):
 # mtls endpoint for endpoint testing purposes.
 def modify_default_endpoint_template(client):
     return "test.{UNIVERSE_DOMAIN}" if ("localhost" in client._DEFAULT_ENDPOINT_TEMPLATE) else client._DEFAULT_ENDPOINT_TEMPLATE
+
+
+@pytest.fixture(autouse=True)
+def set_event_loop():
+    try:
+        asyncio.get_event_loop()
+    except RuntimeError:
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
 
 
 def test__get_default_mtls_endpoint():

--- a/packages/gapic-generator/tests/integration/goldens/logging_internal/tests/unit/gapic/logging_v2/test_logging_service_v2.py
+++ b/packages/gapic-generator/tests/integration/goldens/logging_internal/tests/unit/gapic/logging_v2/test_logging_service_v2.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 #
 import os
+import asyncio
 from unittest import mock
 from unittest.mock import AsyncMock
 
@@ -95,6 +96,15 @@ def modify_default_endpoint(client):
 # mtls endpoint for endpoint testing purposes.
 def modify_default_endpoint_template(client):
     return "test.{UNIVERSE_DOMAIN}" if ("localhost" in client._DEFAULT_ENDPOINT_TEMPLATE) else client._DEFAULT_ENDPOINT_TEMPLATE
+
+
+@pytest.fixture(autouse=True)
+def set_event_loop():
+    try:
+        asyncio.get_event_loop()
+    except RuntimeError:
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
 
 
 def test__get_default_mtls_endpoint():

--- a/packages/gapic-generator/tests/integration/goldens/logging_internal/tests/unit/gapic/logging_v2/test_metrics_service_v2.py
+++ b/packages/gapic-generator/tests/integration/goldens/logging_internal/tests/unit/gapic/logging_v2/test_metrics_service_v2.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 #
 import os
+import asyncio
 from unittest import mock
 from unittest.mock import AsyncMock
 
@@ -93,6 +94,15 @@ def modify_default_endpoint(client):
 # mtls endpoint for endpoint testing purposes.
 def modify_default_endpoint_template(client):
     return "test.{UNIVERSE_DOMAIN}" if ("localhost" in client._DEFAULT_ENDPOINT_TEMPLATE) else client._DEFAULT_ENDPOINT_TEMPLATE
+
+
+@pytest.fixture(autouse=True)
+def set_event_loop():
+    try:
+        asyncio.get_event_loop()
+    except RuntimeError:
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
 
 
 def test__get_default_mtls_endpoint():

--- a/packages/gapic-generator/tests/integration/goldens/redis/noxfile.py
+++ b/packages/gapic-generator/tests/integration/goldens/redis/noxfile.py
@@ -48,7 +48,12 @@ PREVIEW_PYTHON_VERSION = "3.14"
 
 CURRENT_DIRECTORY = pathlib.Path(__file__).parent.absolute()
 
-LOWER_BOUND_CONSTRAINTS_FILE = CURRENT_DIRECTORY / "constraints.txt"
+if (CURRENT_DIRECTORY / "testing").exists():
+    LOWER_BOUND_CONSTRAINTS_FILE = (
+        CURRENT_DIRECTORY / "testing" / f"constraints-{ALL_PYTHON[0]}.txt"
+    )
+else:
+    LOWER_BOUND_CONSTRAINTS_FILE = CURRENT_DIRECTORY / "constraints.txt"
 PACKAGE_NAME = "google-cloud-redis"
 
 UNIT_TEST_STANDARD_DEPENDENCIES = [

--- a/packages/gapic-generator/tests/integration/goldens/redis/setup.py
+++ b/packages/gapic-generator/tests/integration/goldens/redis/setup.py
@@ -43,7 +43,7 @@ dependencies = [
     # Exclude incompatible versions of `google-auth`
     # See https://github.com/googleapis/google-cloud-python/issues/12364
     "google-auth >= 2.14.1, <3.0.0,!=2.24.0,!=2.25.0",
-    "grpcio >= 1.44.0, < 2.0.0",
+    "grpcio >= 1.59.0, < 2.0.0",
     "grpcio >= 1.75.1, < 2.0.0; python_version >= '3.14'",
     "proto-plus >= 1.22.3, <2.0.0",
     "proto-plus >= 1.25.0, <2.0.0; python_version >= '3.13'",

--- a/packages/gapic-generator/tests/integration/goldens/redis/testing/constraints-3.10-async-rest.txt
+++ b/packages/gapic-generator/tests/integration/goldens/redis/testing/constraints-3.10-async-rest.txt
@@ -7,6 +7,6 @@
 # then this file should have google-cloud-foo==1.14.0
 google-api-core==2.21.0
 google-auth==2.35.0
-grpcio==1.44.0
+grpcio==1.59.0
 proto-plus==1.22.3
 protobuf==4.25.8

--- a/packages/gapic-generator/tests/integration/goldens/redis/testing/constraints-3.10.txt
+++ b/packages/gapic-generator/tests/integration/goldens/redis/testing/constraints-3.10.txt
@@ -6,6 +6,6 @@
 # then this file should have google-cloud-foo==1.14.0
 google-api-core==2.17.1
 google-auth==2.14.1
-grpcio==1.44.0
+grpcio==1.59.0
 proto-plus==1.22.3
 protobuf==4.25.8

--- a/packages/gapic-generator/tests/integration/goldens/redis/tests/unit/gapic/redis_v1/test_cloud_redis.py
+++ b/packages/gapic-generator/tests/integration/goldens/redis/tests/unit/gapic/redis_v1/test_cloud_redis.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 #
 import os
+import asyncio
 from unittest import mock
 from unittest.mock import AsyncMock
 
@@ -111,6 +112,15 @@ def modify_default_endpoint(client):
 # mtls endpoint for endpoint testing purposes.
 def modify_default_endpoint_template(client):
     return "test.{UNIVERSE_DOMAIN}" if ("localhost" in client._DEFAULT_ENDPOINT_TEMPLATE) else client._DEFAULT_ENDPOINT_TEMPLATE
+
+
+@pytest.fixture(autouse=True)
+def set_event_loop():
+    try:
+        asyncio.get_event_loop()
+    except RuntimeError:
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
 
 
 def test__get_default_mtls_endpoint():

--- a/packages/gapic-generator/tests/integration/goldens/redis_selective/noxfile.py
+++ b/packages/gapic-generator/tests/integration/goldens/redis_selective/noxfile.py
@@ -48,7 +48,12 @@ PREVIEW_PYTHON_VERSION = "3.14"
 
 CURRENT_DIRECTORY = pathlib.Path(__file__).parent.absolute()
 
-LOWER_BOUND_CONSTRAINTS_FILE = CURRENT_DIRECTORY / "constraints.txt"
+if (CURRENT_DIRECTORY / "testing").exists():
+    LOWER_BOUND_CONSTRAINTS_FILE = (
+        CURRENT_DIRECTORY / "testing" / f"constraints-{ALL_PYTHON[0]}.txt"
+    )
+else:
+    LOWER_BOUND_CONSTRAINTS_FILE = CURRENT_DIRECTORY / "constraints.txt"
 PACKAGE_NAME = "google-cloud-redis"
 
 UNIT_TEST_STANDARD_DEPENDENCIES = [

--- a/packages/gapic-generator/tests/integration/goldens/redis_selective/setup.py
+++ b/packages/gapic-generator/tests/integration/goldens/redis_selective/setup.py
@@ -43,7 +43,7 @@ dependencies = [
     # Exclude incompatible versions of `google-auth`
     # See https://github.com/googleapis/google-cloud-python/issues/12364
     "google-auth >= 2.14.1, <3.0.0,!=2.24.0,!=2.25.0",
-    "grpcio >= 1.44.0, < 2.0.0",
+    "grpcio >= 1.59.0, < 2.0.0",
     "grpcio >= 1.75.1, < 2.0.0; python_version >= '3.14'",
     "proto-plus >= 1.22.3, <2.0.0",
     "proto-plus >= 1.25.0, <2.0.0; python_version >= '3.13'",

--- a/packages/gapic-generator/tests/integration/goldens/redis_selective/testing/constraints-3.10-async-rest.txt
+++ b/packages/gapic-generator/tests/integration/goldens/redis_selective/testing/constraints-3.10-async-rest.txt
@@ -7,6 +7,6 @@
 # then this file should have google-cloud-foo==1.14.0
 google-api-core==2.21.0
 google-auth==2.35.0
-grpcio==1.44.0
+grpcio==1.59.0
 proto-plus==1.22.3
 protobuf==4.25.8

--- a/packages/gapic-generator/tests/integration/goldens/redis_selective/testing/constraints-3.10.txt
+++ b/packages/gapic-generator/tests/integration/goldens/redis_selective/testing/constraints-3.10.txt
@@ -6,6 +6,6 @@
 # then this file should have google-cloud-foo==1.14.0
 google-api-core==2.17.1
 google-auth==2.14.1
-grpcio==1.44.0
+grpcio==1.59.0
 proto-plus==1.22.3
 protobuf==4.25.8

--- a/packages/gapic-generator/tests/integration/goldens/redis_selective/tests/unit/gapic/redis_v1/test_cloud_redis.py
+++ b/packages/gapic-generator/tests/integration/goldens/redis_selective/tests/unit/gapic/redis_v1/test_cloud_redis.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 #
 import os
+import asyncio
 from unittest import mock
 from unittest.mock import AsyncMock
 
@@ -111,6 +112,15 @@ def modify_default_endpoint(client):
 # mtls endpoint for endpoint testing purposes.
 def modify_default_endpoint_template(client):
     return "test.{UNIVERSE_DOMAIN}" if ("localhost" in client._DEFAULT_ENDPOINT_TEMPLATE) else client._DEFAULT_ENDPOINT_TEMPLATE
+
+
+@pytest.fixture(autouse=True)
+def set_event_loop():
+    try:
+        asyncio.get_event_loop()
+    except RuntimeError:
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
 
 
 def test__get_default_mtls_endpoint():

--- a/packages/gapic-generator/tests/integration/goldens/storagebatchoperations/noxfile.py
+++ b/packages/gapic-generator/tests/integration/goldens/storagebatchoperations/noxfile.py
@@ -48,7 +48,12 @@ PREVIEW_PYTHON_VERSION = "3.14"
 
 CURRENT_DIRECTORY = pathlib.Path(__file__).parent.absolute()
 
-LOWER_BOUND_CONSTRAINTS_FILE = CURRENT_DIRECTORY / "constraints.txt"
+if (CURRENT_DIRECTORY / "testing").exists():
+    LOWER_BOUND_CONSTRAINTS_FILE = (
+        CURRENT_DIRECTORY / "testing" / f"constraints-{ALL_PYTHON[0]}.txt"
+    )
+else:
+    LOWER_BOUND_CONSTRAINTS_FILE = CURRENT_DIRECTORY / "constraints.txt"
 PACKAGE_NAME = "google-cloud-storagebatchoperations"
 
 UNIT_TEST_STANDARD_DEPENDENCIES = [

--- a/packages/gapic-generator/tests/integration/goldens/storagebatchoperations/setup.py
+++ b/packages/gapic-generator/tests/integration/goldens/storagebatchoperations/setup.py
@@ -43,7 +43,7 @@ dependencies = [
     # Exclude incompatible versions of `google-auth`
     # See https://github.com/googleapis/google-cloud-python/issues/12364
     "google-auth >= 2.14.1, <3.0.0,!=2.24.0,!=2.25.0",
-    "grpcio >= 1.44.0, < 2.0.0",
+    "grpcio >= 1.59.0, < 2.0.0",
     "grpcio >= 1.75.1, < 2.0.0; python_version >= '3.14'",
     "proto-plus >= 1.22.3, <2.0.0",
     "proto-plus >= 1.25.0, <2.0.0; python_version >= '3.13'",

--- a/packages/gapic-generator/tests/integration/goldens/storagebatchoperations/testing/constraints-3.10.txt
+++ b/packages/gapic-generator/tests/integration/goldens/storagebatchoperations/testing/constraints-3.10.txt
@@ -6,6 +6,6 @@
 # then this file should have google-cloud-foo==1.14.0
 google-api-core==2.17.1
 google-auth==2.14.1
-grpcio==1.44.0
+grpcio==1.59.0
 proto-plus==1.22.3
 protobuf==4.25.8

--- a/packages/gapic-generator/tests/integration/goldens/storagebatchoperations/tests/unit/gapic/storagebatchoperations_v1/test_storage_batch_operations.py
+++ b/packages/gapic-generator/tests/integration/goldens/storagebatchoperations/tests/unit/gapic/storagebatchoperations_v1/test_storage_batch_operations.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 #
 import os
+import asyncio
 import re
 from unittest import mock
 from unittest.mock import AsyncMock
@@ -103,6 +104,15 @@ def modify_default_endpoint(client):
 # mtls endpoint for endpoint testing purposes.
 def modify_default_endpoint_template(client):
     return "test.{UNIVERSE_DOMAIN}" if ("localhost" in client._DEFAULT_ENDPOINT_TEMPLATE) else client._DEFAULT_ENDPOINT_TEMPLATE
+
+
+@pytest.fixture(autouse=True)
+def set_event_loop():
+    try:
+        asyncio.get_event_loop()
+    except RuntimeError:
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
 
 
 def test__get_default_mtls_endpoint():


### PR DESCRIPTION
This PR updates the Python GAPIC generator templates to support modern EOL Python support drops natively across the entire SDK.

### Changes
* **setup.py.j2**: Bumps the baseline minimum `grpcio` dependency requirement to `>= 1.59.0`. This robust minimum requirement resolves the `pytest-asyncio` event loop regressions universally, removing the need for custom `pytest-asyncio` overrides.
* **noxfile.py.j2**: Replaced the hardcoded constraints path with a dynamic constraints file path resolver at runtime, ensuring that monorepos natively resolve to their version-specific constraints files (e.g., `testing/constraints-3.10.txt`).