### PR TITLE
fix: require protobuf 6.33.5 in Bazel Workspace to address CVE-2026-0994

### DIFF
--- a/.github/workflows/gapic-generator-tests.yml
+++ b/.github/workflows/gapic-generator-tests.yml
@@ -194,8 +194,6 @@ jobs:
           key: ${{ runner.os }}-bazel-20210105-${{ secrets.CACHE_VERSION }}
 
       - name: Run Bazel Integration Tests
-        env:
-          USE_BAZEL_VERSION: 7.7.1
         run: |
           # We need to move into the package directory if the 
           # WORKSPACE file is located there.

--- a/.github/workflows/gapic-generator-tests.yml
+++ b/.github/workflows/gapic-generator-tests.yml
@@ -194,6 +194,8 @@ jobs:
           key: ${{ runner.os }}-bazel-20210105-${{ secrets.CACHE_VERSION }}
 
       - name: Run Bazel Integration Tests
+        env:
+          USE_BAZEL_VERSION: 6.4.0
         run: |
           # We need to move into the package directory if the 
           # WORKSPACE file is located there.

--- a/.github/workflows/gapic-generator-tests.yml
+++ b/.github/workflows/gapic-generator-tests.yml
@@ -195,7 +195,7 @@ jobs:
 
       - name: Run Bazel Integration Tests
         env:
-          USE_BAZEL_VERSION: 6.4.0
+          USE_BAZEL_VERSION: 7.7.1
         run: |
           # We need to move into the package directory if the 
           # WORKSPACE file is located there.

--- a/packages/gapic-generator/.bazeliskrc
+++ b/packages/gapic-generator/.bazeliskrc
@@ -1,2 +1,2 @@
 # See https://github.com/bazelbuild/bazelisk
-USE_BAZEL_VERSION=6.5.0
+USE_BAZEL_VERSION=7.7.1

--- a/packages/gapic-generator/.bazelrc
+++ b/packages/gapic-generator/.bazelrc
@@ -1,2 +1,5 @@
 # New protobuf requires C++17
 build --repo_env=BAZEL_CXXOPTS="-std=c++17"
+
+# Disable SFrame generation to avoid linker errors with newer GCC/binutils
+build --copt=-Wa,--gsframe=no

--- a/packages/gapic-generator/WORKSPACE
+++ b/packages/gapic-generator/WORKSPACE
@@ -82,12 +82,12 @@ http_archive(
     urls = ["https://github.com/protocolbuffers/protobuf/archive/v%s.tar.gz" % _protobuf_version],
 )
 
-# Define a version of Abseil that still contains the `:if_constexpr` target
+# Define the unified version of Abseil compatible with both gRPC and Protobuf 33.5
 http_archive(
     name = "com_google_absl",
-    sha256 = "987ce98f02eefbaf930d6e38ab16aa05737234d7afbab2d5c4ea7adbe50c28ed",
-    strip_prefix = "abseil-cpp-20230802.1",
-    urls = ["https://github.com/abseil/abseil-cpp/archive/refs/tags/20230802.1.tar.gz"],
+    sha256 = "4cf377543506ef2071af274be394b9aa1ef78f65750fc3382c449c285e6cb8f1",
+    strip_prefix = "abseil-cpp-20240116.2",
+    urls = ["https://github.com/abseil/abseil-cpp/archive/refs/tags/20240116.2.tar.gz"],
 )
 
 load("@com_github_grpc_grpc//bazel:grpc_deps.bzl", "grpc_deps")

--- a/packages/gapic-generator/WORKSPACE
+++ b/packages/gapic-generator/WORKSPACE
@@ -2,9 +2,9 @@ workspace(name = "gapic_generator_python")
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
-_bazel_skylib_version = "1.4.0"
+_bazel_skylib_version = "1.7.1"
 
-_bazel_skylib_sha256 = "f24ab666394232f834f74d19e2ff142b0af17466ea0c69a3f4c276ee75f6efce"
+_bazel_skylib_sha256 = "bc283cdfcd526a52c3201279cda4bc298652efa898b10b4db0837dc51652756f"
 
 http_archive(
     name = "bazel_skylib",

--- a/packages/gapic-generator/WORKSPACE
+++ b/packages/gapic-generator/WORKSPACE
@@ -81,6 +81,15 @@ http_archive(
     strip_prefix = "protobuf-%s" % _protobuf_version,
     urls = ["https://github.com/protocolbuffers/protobuf/archive/v%s.tar.gz" % _protobuf_version],
 )
+
+# Define a version of Abseil that still contains the `:if_constexpr` target
+http_archive(
+    name = "com_google_absl",
+    sha256 = "371cd4ae271616ba34ed20275cc84bc6066551b99709ec52856230f8ca752e50",
+    strip_prefix = "abseil-cpp-20230802.1",
+    urls = ["https://github.com/abseil/abseil-cpp/archive/refs/tags/20230802.1.tar.gz"],
+)
+
 load("@com_github_grpc_grpc//bazel:grpc_deps.bzl", "grpc_deps")
 
 grpc_deps()

--- a/packages/gapic-generator/WORKSPACE
+++ b/packages/gapic-generator/WORKSPACE
@@ -60,9 +60,9 @@ gapic_generator_python()
 
 gapic_generator_register_toolchains()
 
-_grpc_version = "1.71.0"
+_grpc_version = "1.78.1"
 
-_grpc_sha256 = "9313c3f8f4dd3341597f152d506a50caf571fe40f886e24ea9078891990df285"
+_grpc_sha256 = "f9b1d9fe1648024150593efa077ee0f600f9823a21e9d618b4f304e6c09c9902"
 
 http_archive(
     name = "com_github_grpc_grpc",
@@ -72,9 +72,9 @@ http_archive(
 )
 # instantiated in grpc_deps().
 
-_protobuf_version = "30.2"
+_protobuf_version = "33.5"
 
-_protobuf_sha256 = "07a43d88fe5a38e434c7f94129cad56a4c43a51f99336074d0799c2f7d4e44c5"
+_protobuf_sha256 = "440848dffa209beb8a04e41cc352762e44f8e91342b2a43aab6af9b30713c2f6"
 
 http_archive(
     name = "com_google_protobuf",

--- a/packages/gapic-generator/WORKSPACE
+++ b/packages/gapic-generator/WORKSPACE
@@ -85,7 +85,7 @@ http_archive(
 # Define a version of Abseil that still contains the `:if_constexpr` target
 http_archive(
     name = "com_google_absl",
-    sha256 = "371cd4ae271616ba34ed20275cc84bc6066551b99709ec52856230f8ca752e50",
+    sha256 = "987ce98f02eefbaf930d6e38ab16aa05737234d7afbab2d5c4ea7adbe50c28ed",
     strip_prefix = "abseil-cpp-20230802.1",
     urls = ["https://github.com/abseil/abseil-cpp/archive/refs/tags/20230802.1.tar.gz"],
 )

--- a/packages/gapic-generator/WORKSPACE
+++ b/packages/gapic-generator/WORKSPACE
@@ -22,15 +22,14 @@ http_archive(
     ],
 )
 
-_rules_python_version = "0.26.0"
+_rules_python_version = "1.1.0"
 
-_rules_python_sha256 = "9d04041ac92a0985e344235f5d946f71ac543f1b1565f2cdbc9a2aaee8adf55b"
+_rules_python_sha256 = "663989c748c8868670df5943477176a917056637ef3998a0058b8d960f215bf2"
 
 http_archive(
     name = "rules_python",
-    sha256 = _rules_python_sha256,
     strip_prefix = "rules_python-{}".format(_rules_python_version),
-    url = "https://github.com/bazelbuild/rules_python/archive/{}.tar.gz".format(_rules_python_version),
+    url = "https://github.com/bazelbuild/rules_python/releases/download/{0}/rules_python-{0}.tar.gz".format(_rules_python_version),
 )
 
 load("@rules_python//python:repositories.bzl", "py_repositories")

--- a/packages/gapic-generator/gapic/ads-templates/setup.py.j2
+++ b/packages/gapic-generator/gapic/ads-templates/setup.py.j2
@@ -34,7 +34,7 @@ dependencies = [
     "googleapis-common-protos >= 1.53.0",
     "grpcio >= 1.10.0",
     "proto-plus >= 1.22.3, <2.0.0",
-    "protobuf >= 4.25.8, < 8.0.0",
+    "protobuf >= 6.33.5, < 8.0.0",
     {% if api.requires_package(('google', 'iam', 'v1')) %}
     "grpc-google-iam-v1",
     {% endif %}

--- a/packages/gapic-generator/gapic/ads-templates/setup.py.j2
+++ b/packages/gapic-generator/gapic/ads-templates/setup.py.j2
@@ -29,7 +29,7 @@ else:
     release_status = "Development Status :: 5 - Production/Stable"
 
 dependencies = [
-    "google-api-core[grpc] >= 2.10.0, < 3.0.0",
+    "google-api-core[grpc] >= 2.24.2, < 3.0.0",
     "google-auth >= 2.14.1, <3.0.0",
     "googleapis-common-protos >= 1.53.0",
     "grpcio >= 1.10.0",

--- a/packages/gapic-generator/gapic/templates/%namespace/%name_%version/%sub/__init__.py.j2
+++ b/packages/gapic-generator/gapic/templates/%namespace/%name_%version/%sub/__init__.py.j2
@@ -69,7 +69,7 @@ else:   # pragma: NO COVER
 
         def parse_version_to_tuple(version_string: str):
             """Safely converts a semantic version string to a comparable tuple of integers.
-            Example: "4.25.8" -> (4, 25, 8)
+            Example: "6.33.5" -> (6, 33, 5)
             Ignores non-numeric parts and handles common version formats.
             Args:
                 version_string: Version string in the format "x.y.z" or "x.y.z<suffix>"
@@ -98,9 +98,9 @@ else:   # pragma: NO COVER
                 return (None, "--")
 
         _dependency_package = "google.protobuf"
-        _next_supported_version = "4.25.8"
-        _next_supported_version_tuple = (4, 25, 8)
-        _recommendation = " (we recommend 6.x)"
+        _next_supported_version = "6.33.5"
+        _next_supported_version_tuple = (6, 33, 5)
+        _recommendation = " (we recommend 7.x)"
         (_version_used, _version_used_string) = _get_version(_dependency_package)
         if _version_used and _version_used < _next_supported_version_tuple:
             warnings.warn(f"Package {_package_label} depends on " +

--- a/packages/gapic-generator/gapic/templates/setup.py.j2
+++ b/packages/gapic-generator/gapic/templates/setup.py.j2
@@ -42,7 +42,7 @@ dependencies = [
     "proto-plus >= 1.22.3, <2.0.0",
     "proto-plus >= 1.25.0, <2.0.0; python_version >= '3.13'",
     {# Explicitly exclude protobuf versions mentioned in https://cloud.google.com/support/bulletins#GCP-2022-019 #}
-    "protobuf >= 4.25.8, < 8.0.0",
+    "protobuf >= 6.33.5, < 8.0.0",
     {% for package_tuple, package_info in pypi_packages.items() %}
     {# Quick check to make sure `package_info.package_name` is not the package being generated so we don't circularly include this package in its own constraints file. #}
     {% if api.naming.warehouse_package_name != package_info.package_name %}

--- a/packages/gapic-generator/gapic/templates/setup.py.j2
+++ b/packages/gapic-generator/gapic/templates/setup.py.j2
@@ -33,7 +33,7 @@ else:
     release_status = "Development Status :: 5 - Production/Stable"
 
 dependencies = [
-    "google-api-core[grpc] >= 2.17.1, <3.0.0",
+    "google-api-core[grpc] >= 2.24.2, <3.0.0",
     # Exclude incompatible versions of `google-auth`
     # See https://github.com/googleapis/google-cloud-python/issues/12364
     "google-auth >= 2.14.1, <3.0.0,!=2.24.0,!=2.25.0",
@@ -55,7 +55,6 @@ dependencies = [
 extras = {
 {% if rest_async_io_enabled %}
     "async_rest": [
-        "google-api-core[grpc] >= 2.21.0, < 3.0.0",
         "google-auth[aiohttp] >= 2.35.0, <3.0.0"
     ],
 {% endif %}

--- a/packages/gapic-generator/gapic/templates/testing/constraints-3.10-async-rest.txt.j2
+++ b/packages/gapic-generator/gapic/templates/testing/constraints-3.10-async-rest.txt.j2
@@ -12,7 +12,7 @@ google-api-core==2.21.0
 google-auth==2.35.0
 grpcio==1.44.0
 proto-plus==1.22.3
-protobuf==4.25.8
+protobuf==6.33.5
 {% for package_tuple, package_info in pypi_packages.items() %}
 {# Quick check to make sure `package_info.package_name` is not the package being generated so we don't circularly include this package in its own constraints file. #}
 {% if api.naming.warehouse_package_name != package_info.package_name %}

--- a/packages/gapic-generator/gapic/templates/testing/constraints-3.10-async-rest.txt.j2
+++ b/packages/gapic-generator/gapic/templates/testing/constraints-3.10-async-rest.txt.j2
@@ -8,7 +8,7 @@
 # pinning their versions to their lower bounds.
 # For example, if setup.py has "google-cloud-foo >= 1.14.0, < 2.0.0",
 # then this file should have google-cloud-foo==1.14.0
-google-api-core==2.21.0
+google-api-core==2.24.2
 google-auth==2.35.0
 grpcio==1.44.0
 proto-plus==1.22.3

--- a/packages/gapic-generator/gapic/templates/testing/constraints-3.10.txt.j2
+++ b/packages/gapic-generator/gapic/templates/testing/constraints-3.10.txt.j2
@@ -9,7 +9,7 @@ google-api-core==2.17.1
 google-auth==2.14.1
 grpcio==1.44.0
 proto-plus==1.22.3
-protobuf==4.25.8
+protobuf==6.33.5
 {% for package_tuple, package_info in pypi_packages.items() %}
 {# Quick check to make sure `package_info.package_name` is not the package being generated so we don't circularly include this package in its own constraints file. #}
 {% if api.naming.warehouse_package_name != package_info.package_name %}

--- a/packages/gapic-generator/gapic/templates/testing/constraints-3.10.txt.j2
+++ b/packages/gapic-generator/gapic/templates/testing/constraints-3.10.txt.j2
@@ -5,7 +5,7 @@
 # pinning their versions to their lower bounds.
 # For example, if setup.py has "google-cloud-foo >= 1.14.0, < 2.0.0",
 # then this file should have google-cloud-foo==1.14.0
-google-api-core==2.17.1
+google-api-core==2.24.2
 google-auth==2.14.1
 grpcio==1.44.0
 proto-plus==1.22.3

--- a/packages/gapic-generator/gapic/templates/testing/constraints-3.13.txt.j2
+++ b/packages/gapic-generator/gapic/templates/testing/constraints-3.13.txt.j2
@@ -10,7 +10,7 @@ google-api-core>=2
 google-auth>=2
 grpcio>=1
 proto-plus>=1
-protobuf>=6
+protobuf>=7
 {% for package_tuple, package_info in pypi_packages.items() %}
 {# Quick check to make sure `package_info.package_name` is not the package being generated so we don't circularly include this package in its own constraints file. #}
 {% if api.naming.warehouse_package_name != package_info.package_name %}

--- a/packages/gapic-generator/gapic/templates/testing/constraints-3.14.txt.j2
+++ b/packages/gapic-generator/gapic/templates/testing/constraints-3.14.txt.j2
@@ -10,7 +10,7 @@ google-api-core>=2
 google-auth>=2
 grpcio>=1
 proto-plus>=1
-protobuf>=6
+protobuf>=7
 {% for package_tuple, package_info in pypi_packages.items() %}
 {# Quick check to make sure `package_info.package_name` is not the package being generated so we don't circularly include this package in its own constraints file. #}
 {% if api.naming.warehouse_package_name != package_info.package_name %}

--- a/packages/gapic-generator/requirements.in
+++ b/packages/gapic-generator/requirements.in
@@ -3,7 +3,7 @@ google-api-core
 googleapis-common-protos
 jinja2
 MarkupSafe
-protobuf>=4.25.8
+protobuf>=6.33.5 # for CVE-2026-0994. See https://github.com/advisories/GHSA-7gcm-g887-7qv7 and https://protobuf.dev/support/version-support/#python
 pypandoc
 PyYAML
 grpc-google-iam-v1

--- a/packages/gapic-generator/setup.py
+++ b/packages/gapic-generator/setup.py
@@ -35,7 +35,7 @@ dependencies = [
     # https://jinja.palletsprojects.com/en/3.0.x/templates/#jinja-filters.map
     # https://jinja.palletsprojects.com/en/2.11.x/changelog/#version-2-11-0
     "jinja2 >= 2.11",
-    "protobuf >= 4.25.8, < 8.0.0",
+    "protobuf >= 6.33.5, < 8.0.0",
     "pypandoc >= 1.4",
     "PyYAML >= 5.1.1",
     "grpc-google-iam-v1 >= 0.14.0, < 1.0.0",

--- a/packages/gapic-generator/setup.py
+++ b/packages/gapic-generator/setup.py
@@ -28,9 +28,9 @@ dependencies = [
     # Ensure that the lower bounds of these dependencies match what we have in the
     # templated setup.py.j2: https://github.com/googleapis/gapic-generator-python/blob/main/gapic/templates/setup.py.j2
     "click >= 6.7",
-    "google-api-core[grpc] >= 1.34.1, <3.0.0,!=2.0.*,!=2.1.*,!=2.2.*,!=2.3.*,!=2.4.*,!=2.5.*,!=2.6.*,!=2.7.*,!=2.8.*,!=2.9.*,!=2.10.*",
-    "googleapis-common-protos >= 1.55.0",
-    "grpcio >= 1.24.3",
+    "google-api-core[grpc] >= 2.24.2, < 3.0.0",
+    "googleapis-common-protos >= 1.55.0, < 2.0.0",
+    "grpcio >= 1.24.3, < 2.0.0",
     # 2.11.0 is required which adds the `default` argument to `jinja-filters.map()`
     # https://jinja.palletsprojects.com/en/3.0.x/templates/#jinja-filters.map
     # https://jinja.palletsprojects.com/en/2.11.x/changelog/#version-2-11-0


### PR DESCRIPTION
This PR will be used to debug the changes needed to upgrade Protobuf in the Bazel Workspace. Also see https://github.com/googleapis/google-cloud-python/pull/17349 