### PR TITLE
chore: update librarian to v0.15.0

### DIFF
--- a/librarian.yaml
+++ b/librarian.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 language: python
-version: v0.14.1-0.20260522151051-433d9e6211ad
+version: v0.15.0
 repo: googleapis/google-cloud-python
 sources:
   googleapis:


### PR DESCRIPTION
This pull request bumps the Librarian version to v0.15.0.

The generate-all command (`google-cloud-python$ docker run -u $(id -u):$(id -g) -v .:/repo -v ~/.cache:/.cache -w /repo docker.io/library/librarian-python:${V}  generate -v --all`) did not make any code changes.

