### PR TITLE
fix(gapic-generator): add pragma to `constants.py` to resolve coverage failure and correct `if` block

### DIFF
--- a/packages/gapic-generator/gapic/templates/tests/unit/gapic/%name_%version/%sub/test_%service.py.j2
+++ b/packages/gapic-generator/gapic/templates/tests/unit/gapic/%name_%version/%sub/test_%service.py.j2
@@ -107,7 +107,7 @@ CRED_INFO_JSON = {
     "principal": "service-account@example.com",
 }
 CRED_INFO_STRING = json.dumps(CRED_INFO_JSON)
-{% if api.all_method_settings.values()|map(attribute="auto_populated_fields", default=[])|list %}
+{% if api.all_method_settings.values()|map(attribute="auto_populated_fields", default=[])|select|list %}
 _UUID4_RE = re.compile(r"{{ uuid4_re }}")
 {% endif %}
 

--- a/packages/gapic-generator/gapic/utils/constants.py
+++ b/packages/gapic-generator/gapic/utils/constants.py
@@ -13,4 +13,4 @@
 # limitations under the License.
 
 # The regex for a UUID4 as specified in AIP-4235.
-UUID4_RE = r"[a-f0-9]{8}-?[a-f0-9]{4}-?4[a-f0-9]{3}-?[89ab][a-f0-9]{3}-?[a-f0-9]{12}"
+UUID4_RE = r"[a-f0-9]{8}-?[a-f0-9]{4}-?4[a-f0-9]{3}-?[89ab][a-f0-9]{3}-?[a-f0-9]{12}"  # pragma: NO COVER


### PR DESCRIPTION
During another PR, a failure in the cover nox session pointed at a lack of unit test coverage for this recent addition to the repo. As a constant, there is little benefit to instituting a unit test here. Adds `# pragma: NO COVER` to `constants.py` to resolve the 100% coverage check failure.

In addition a `select` function was inadvertently left out of an `if` code block to correctly respond when feature does NOT have `auto_populated_fields` during a recent generator update (~ 20260512).
* This error only shows up as an issue when code is generated in packages that do not have `auto_populated_fields` and have been generated very recently. In this case, during updates to `google-cloud-logging`, we ran into this issue.
