### PR TITLE
fix(testutils): support != exclusion constraints in lower-bound-checker

### DIFF
--- a/packages/google-cloud-testutils/test_utils/lower_bound_checker/lower_bound_checker.py
+++ b/packages/google-cloud-testutils/test_utils/lower_bound_checker/lower_bound_checker.py
@@ -121,7 +121,7 @@ def _lower_bound(requirement: Requirement) -> str:
     Returns:
         str: The lower bound for the requirement.
     """
-    spec_set = list(requirement.specifier)
+    spec_set = [s for s in requirement.specifier if s.operator != "!="]
 
     # sort by operator: <, then >=
     spec_set.sort(key=lambda x: x.operator)

--- a/packages/google-cloud-testutils/tests/unit/test_lower_bound_checker.py
+++ b/packages/google-cloud-testutils/tests/unit/test_lower_bound_checker.py
@@ -170,7 +170,7 @@ def test_update_constraints_with_setup_py_missing_lower_bounds():
     assert "setup.py is missing explicit lower bounds" in result.output
 
     invalid_pkg_list = parse_error_msg(result.output)
-    assert set(invalid_pkg_list) == {"requests", "packaging", "wheel"}
+    assert set(invalid_pkg_list) == {"requests", "wheel"}
 
 
 def test_check():
@@ -311,4 +311,16 @@ def test_check_with_setup_py_missing_lower_bounds():
     assert result.exit_code == 2
 
     invalid_pkg_list = parse_error_msg(result.output)
-    assert set(invalid_pkg_list) == {"requests", "packaging", "wheel"}
+    assert set(invalid_pkg_list) == {"requests", "wheel"}
+
+
+def test_lower_bound_with_exclusion():
+    from packaging.requirements import Requirement
+
+    req = Requirement("google-auth>=1.25.0, !=2.24.0")
+    assert lower_bound_checker._lower_bound(req) == "1.25.0"
+
+    # Multiple exclusions
+    req_multiple = Requirement("google-auth>=1.25.0, !=2.24.0, !=2.25.0")
+    assert lower_bound_checker._lower_bound(req_multiple) == "1.25.0"
+


### PR DESCRIPTION
### Problem
The `lower-bound-checker` tool has a parsing limitation in `_lower_bound()` where any dependency specifiers containing exclusion constraints (like `!=2.24.0` in `google-auth`) could cause the parser to raise an `IndeterminableLowerBound` exception and fail.

### Solution
Updated `_lower_bound` in `packages/google-cloud-testutils/test_utils/lower_bound_checker/lower_bound_checker.py` to filter out `!=` exclusion operators from the set of specifiers before determining the lower bound of the package. Since an exclusion operator does not change the lower bound itself, this allows dependencies with exclusions (like `packaging>=14.0, !=15.0` or `google-auth>=1.25.0, !=2.24.0`) to be parsed successfully and their lower bounds resolved correctly.

### Verification
1. Added new direct unit tests to `packages/google-cloud-testutils/tests/unit/test_lower_bound_checker.py` to verify `_lower_bound()` behaves as expected under single and multiple exclusion constraints.
2. Updated existing end-to-end/integration tests in the test suite to reflect the updated expectation (previously, `packaging>=14.0, !=15.0` in the bad package dummy setup.py failed to parse and was in the invalid package list; now, it is successfully parsed, and is no longer in the invalid package list).