### PR TITLE
chore: librarian release pull request: 20260527T155946Z

### DIFF
--- a/.librarian/state.yaml
+++ b/.librarian/state.yaml
@@ -74,7 +74,7 @@ libraries:
       - packages/django-google-spanner/docs/
     tag_format: '{id}-v{version}'
   - id: gapic-generator
-    version: 1.33.0
+    version: 1.34.0
     last_generated_commit: ""
     apis: []
     source_roots:

--- a/librarian.yaml
+++ b/librarian.yaml
@@ -67,7 +67,7 @@ libraries:
     python:
       library_type: INTEGRATION
   - name: gapic-generator
-    version: 1.33.0
+    version: 1.34.0
     python:
       library_type: CORE
   - name: gcp-sphinx-docfx-yaml

--- a/packages/gapic-generator/CHANGELOG.md
+++ b/packages/gapic-generator/CHANGELOG.md
@@ -4,6 +4,14 @@
 
 [1]: https://pypi.org/project/gapic-generator/#history
 
+## [1.34.0](https://github.com/googleapis/google-cloud-python/compare/gapic-generator-v1.33.0...gapic-generator-v1.34.0) (2026-05-27)
+
+
+### Bug Fixes
+
+* add pragma to `constants.py` to resolve coverage failure and correct `if` block (#17268) ([1436a23c923e799f9909d039e1f418435845565d](https://github.com/googleapis/google-cloud-python/commit/1436a23c923e799f9909d039e1f418435845565d))
+* update incorrect urls in setup.py to point at monorepo vs splitrepo (#17237) ([eaed04baf3cd356c3811c66e64c277c8841c7563](https://github.com/googleapis/google-cloud-python/commit/eaed04baf3cd356c3811c66e64c277c8841c7563))
+
 ## [1.33.0](https://github.com/googleapis/google-cloud-python/compare/gapic-generator-v1.32.0...gapic-generator-v1.33.0) (2026-05-21)
 
 

--- a/packages/gapic-generator/setup.py
+++ b/packages/gapic-generator/setup.py
@@ -22,7 +22,7 @@ import setuptools
 name = "gapic-generator"
 description = "Google API Client Generator for Python"
 url = "https://github.com/googleapis/google-cloud-python/tree/main/packages/gapic-generator"
-version = "1.33.0"
+version = "1.34.0"
 release_status = "Development Status :: 5 - Production/Stable"
 dependencies = [
     # Ensure that the lower bounds of these dependencies match what we have in the


### PR DESCRIPTION
PR created by the Librarian CLI to initialize a release. Merging this PR will auto trigger a release.

Librarian Version: v0.15.0
Language Image: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/python-librarian-generator@sha256:234b9d1f2ddb057ed7ac6a38db0bf8163d839c65c6cf88ade52530cddebce59e
<details><summary>gapic-generator: v1.34.0</summary>

## [v1.34.0](https://github.com/googleapis/google-cloud-python/compare/gapic-generator-v1.33.0...gapic-generator-v1.34.0) (2026-05-27)

### Bug Fixes

* add pragma to `constants.py` to resolve coverage failure and correct `if` block (#17268) ([1436a23c](https://github.com/googleapis/google-cloud-python/commit/1436a23c))

* update incorrect urls in setup.py to point at monorepo vs splitrepo (#17237) ([eaed04ba](https://github.com/googleapis/google-cloud-python/commit/eaed04ba))

</details>