### PR TITLE
tests: resolve failure related to unpacking dictionary for protobuf messages

### DIFF
--- a/packages/gapic-generator/gapic/templates/tests/unit/gapic/%name_%version/%sub/test_macros.j2
+++ b/packages/gapic-generator/gapic/templates/tests/unit/gapic/%name_%version/%sub/test_macros.j2
@@ -260,6 +260,8 @@ async def test_{{ method_name }}_async_use_cached_wrapped_rpc(transport: str = "
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
+{% if auto_populated_fields %}
+  # Pure protobuf messages (non-proto-plus) require keyword arguments.
   {{ method.input.ident }}(**{
     {%- for auto_populated_field in auto_populated_fields %}
     "{{ auto_populated_field }}": "{{ auto_populated_field_sample_value }}",
@@ -270,6 +272,10 @@ async def test_{{ method_name }}_async_use_cached_wrapped_rpc(transport: str = "
     "{{ auto_populated_field }}": "{{ auto_populated_field_sample_value }}",
     {%- endfor %}
   },
+{% else %}
+  {{ method.input.ident }}(),
+  {},
+{% endif %}
 ])
 async def test_{{ method_name }}_async(request_type, transport: str = 'grpc_asyncio'):
     client = {{ service.async_client_name }}(

--- a/packages/gapic-generator/gapic/templates/tests/unit/gapic/%name_%version/%sub/test_macros.j2
+++ b/packages/gapic-generator/gapic/templates/tests/unit/gapic/%name_%version/%sub/test_macros.j2
@@ -4,7 +4,7 @@
 {%- set auto_populated_field_sample_value = "explicit value for autopopulate-able field" -%}
 {% with method_name = method.client_method_name|snake_case + "_unary" if method.extended_lro and not full_extended_lro else method.client_method_name|snake_case, method_output = method.extended_lro.operation_type if method.extended_lro and not full_extended_lro else method.output %}
 @pytest.mark.parametrize("request_type", [
-  {{ method.input.ident }}({
+  {{ method.input.ident }}(**{
     {% for auto_populated_field in auto_populated_fields %}
     "{{ auto_populated_field }}": "{{ auto_populated_field_sample_value }}",
     {% endfor %}
@@ -260,7 +260,7 @@ async def test_{{ method_name }}_async_use_cached_wrapped_rpc(transport: str = "
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  {{ method.input.ident }}({
+  {{ method.input.ident }}(**{
     {%- for auto_populated_field in auto_populated_fields %}
     "{{ auto_populated_field }}": "{{ auto_populated_field_sample_value }}",
     {%- endfor %}

--- a/packages/gapic-generator/gapic/templates/tests/unit/gapic/%name_%version/%sub/test_macros.j2
+++ b/packages/gapic-generator/gapic/templates/tests/unit/gapic/%name_%version/%sub/test_macros.j2
@@ -4,6 +4,8 @@
 {%- set auto_populated_field_sample_value = "explicit value for autopopulate-able field" -%}
 {% with method_name = method.client_method_name|snake_case + "_unary" if method.extended_lro and not full_extended_lro else method.client_method_name|snake_case, method_output = method.extended_lro.operation_type if method.extended_lro and not full_extended_lro else method.output %}
 @pytest.mark.parametrize("request_type", [
+{% if auto_populated_fields %}
+  # Pure protobuf messages (non-proto-plus) require keyword arguments.
   {{ method.input.ident }}(**{
     {% for auto_populated_field in auto_populated_fields %}
     "{{ auto_populated_field }}": "{{ auto_populated_field_sample_value }}",
@@ -14,6 +16,10 @@
     "{{ auto_populated_field }}": "{{ auto_populated_field_sample_value }}",
     {% endfor %}
   },
+{% else %}
+  {{ method.input.ident }}(),
+  {},
+{% endif %}
 ])
 def test_{{ method_name }}(request_type, transport: str = 'grpc'):
     client = {{ service.client_name }}(

--- a/packages/gapic-generator/tests/fragments/google/cloud/location/locations.proto
+++ b/packages/gapic-generator/tests/fragments/google/cloud/location/locations.proto
@@ -1,0 +1,108 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package google.cloud.location;
+
+import "google/api/annotations.proto";
+import "google/protobuf/any.proto";
+import "google/api/client.proto";
+
+option cc_enable_arenas = true;
+option go_package = "google.golang.org/genproto/googleapis/cloud/location;location";
+option java_multiple_files = true;
+option java_outer_classname = "LocationsProto";
+option java_package = "com.google.cloud.location";
+
+// An abstract interface that provides location-related information for
+// a service. Service-specific metadata is provided through the
+// [Location.metadata][google.cloud.location.Location.metadata] field.
+service Locations {
+  option (google.api.default_host) = "cloud.googleapis.com";
+  option (google.api.oauth_scopes) = "https://www.googleapis.com/auth/cloud-platform";
+
+  // Lists information about the supported locations for this service.
+  rpc ListLocations(ListLocationsRequest) returns (ListLocationsResponse) {
+    option (google.api.http) = {
+      get: "/v1/{name=locations}"
+      additional_bindings {
+        get: "/v1/{name=projects/*}/locations"
+      }
+    };
+  }
+
+  // Gets information about a location.
+  rpc GetLocation(GetLocationRequest) returns (Location) {
+    option (google.api.http) = {
+      get: "/v1/{name=locations/*}"
+      additional_bindings {
+        get: "/v1/{name=projects/*/locations/*}"
+      }
+    };
+  }
+}
+
+// The request message for [Locations.ListLocations][google.cloud.location.Locations.ListLocations].
+message ListLocationsRequest {
+  // The resource that owns the locations collection, if applicable.
+  string name = 1;
+
+  // The standard list filter.
+  string filter = 2;
+
+  // The standard list page size.
+  int32 page_size = 3;
+
+  // The standard list page token.
+  string page_token = 4;
+}
+
+// The response message for [Locations.ListLocations][google.cloud.location.Locations.ListLocations].
+message ListLocationsResponse {
+  // A list of locations that matches the specified filter in the request.
+  repeated Location locations = 1;
+
+  // The standard List next-page token.
+  string next_page_token = 2;
+}
+
+// The request message for [Locations.GetLocation][google.cloud.location.Locations.GetLocation].
+message GetLocationRequest {
+  // Resource name for the location.
+  string name = 1;
+}
+
+// A resource that represents Google Cloud Platform location.
+message Location {
+  // Resource name for the location, which may vary between implementations.
+  // For example: `"projects/example-project/locations/us-east1"`
+  string name = 1;
+
+  // The canonical id for this location. For example: `"us-east1"`.
+  string location_id = 4;
+
+  // The friendly name for this location, typically a nearby city name.
+  // For example, "Tokyo".
+  string display_name = 5;
+
+  // Cross-service attributes for the location. For example
+  //
+  //     {"cloud.googleapis.com/region": "us-east1"}
+  map<string, string> labels = 2;
+
+  // Service-specific metadata. For example the available capacity at the given
+  // location.
+  google.protobuf.Any metadata = 3;
+}

--- a/packages/gapic-generator/tests/fragments/test_protobuf_type.proto
+++ b/packages/gapic-generator/tests/fragments/test_protobuf_type.proto
@@ -1,0 +1,28 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package google.fragment;
+
+import "google/api/client.proto";
+import "google/cloud/location/locations.proto";
+
+service MockLocationService {
+  option (google.api.default_host) = "locations.example.com";
+
+  rpc GetLocation(google.cloud.location.GetLocationRequest) returns (google.cloud.location.Location) {
+    option (google.api.method_signature) = "name";
+  }
+}

--- a/packages/gapic-generator/tests/integration/goldens/asset/tests/unit/gapic/asset_v1/test_asset_service.py
+++ b/packages/gapic-generator/tests/integration/goldens/asset/tests/unit/gapic/asset_v1/test_asset_service.py
@@ -981,10 +981,8 @@ def test_asset_service_client_create_channel_credentials_file(client_class, tran
 
 
 @pytest.mark.parametrize("request_type", [
-  asset_service.ExportAssetsRequest(**{
-  }),
-  {
-  },
+  asset_service.ExportAssetsRequest(),
+  {},
 ])
 def test_export_assets(request_type, transport: str = 'grpc'):
     client = AssetServiceClient(
@@ -1216,10 +1214,8 @@ async def test_export_assets_field_headers_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  asset_service.ListAssetsRequest(**{
-  }),
-  {
-  },
+  asset_service.ListAssetsRequest(),
+  {},
 ])
 def test_list_assets(request_type, transport: str = 'grpc'):
     client = AssetServiceClient(
@@ -1723,10 +1719,8 @@ async def test_list_assets_async_pages():
             assert page_.raw_page.next_page_token == token
 
 @pytest.mark.parametrize("request_type", [
-  asset_service.BatchGetAssetsHistoryRequest(**{
-  }),
-  {
-  },
+  asset_service.BatchGetAssetsHistoryRequest(),
+  {},
 ])
 def test_batch_get_assets_history(request_type, transport: str = 'grpc'):
     client = AssetServiceClient(
@@ -1948,10 +1942,8 @@ async def test_batch_get_assets_history_field_headers_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  asset_service.CreateFeedRequest(**{
-  }),
-  {
-  },
+  asset_service.CreateFeedRequest(),
+  {},
 ])
 def test_create_feed(request_type, transport: str = 'grpc'):
     client = AssetServiceClient(
@@ -2277,10 +2269,8 @@ async def test_create_feed_flattened_error_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  asset_service.GetFeedRequest(**{
-  }),
-  {
-  },
+  asset_service.GetFeedRequest(),
+  {},
 ])
 def test_get_feed(request_type, transport: str = 'grpc'):
     client = AssetServiceClient(
@@ -2604,10 +2594,8 @@ async def test_get_feed_flattened_error_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  asset_service.ListFeedsRequest(**{
-  }),
-  {
-  },
+  asset_service.ListFeedsRequest(),
+  {},
 ])
 def test_list_feeds(request_type, transport: str = 'grpc'):
     client = AssetServiceClient(
@@ -2911,10 +2899,8 @@ async def test_list_feeds_flattened_error_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  asset_service.UpdateFeedRequest(**{
-  }),
-  {
-  },
+  asset_service.UpdateFeedRequest(),
+  {},
 ])
 def test_update_feed(request_type, transport: str = 'grpc'):
     client = AssetServiceClient(
@@ -3236,10 +3222,8 @@ async def test_update_feed_flattened_error_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  asset_service.DeleteFeedRequest(**{
-  }),
-  {
-  },
+  asset_service.DeleteFeedRequest(),
+  {},
 ])
 def test_delete_feed(request_type, transport: str = 'grpc'):
     client = AssetServiceClient(
@@ -3541,10 +3525,8 @@ async def test_delete_feed_flattened_error_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  asset_service.SearchAllResourcesRequest(**{
-  }),
-  {
-  },
+  asset_service.SearchAllResourcesRequest(),
+  {},
 ])
 def test_search_all_resources(request_type, transport: str = 'grpc'):
     client = AssetServiceClient(
@@ -4072,10 +4054,8 @@ async def test_search_all_resources_async_pages():
             assert page_.raw_page.next_page_token == token
 
 @pytest.mark.parametrize("request_type", [
-  asset_service.SearchAllIamPoliciesRequest(**{
-  }),
-  {
-  },
+  asset_service.SearchAllIamPoliciesRequest(),
+  {},
 ])
 def test_search_all_iam_policies(request_type, transport: str = 'grpc'):
     client = AssetServiceClient(
@@ -4593,10 +4573,8 @@ async def test_search_all_iam_policies_async_pages():
             assert page_.raw_page.next_page_token == token
 
 @pytest.mark.parametrize("request_type", [
-  asset_service.AnalyzeIamPolicyRequest(**{
-  }),
-  {
-  },
+  asset_service.AnalyzeIamPolicyRequest(),
+  {},
 ])
 def test_analyze_iam_policy(request_type, transport: str = 'grpc'):
     client = AssetServiceClient(
@@ -4822,10 +4800,8 @@ async def test_analyze_iam_policy_field_headers_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  asset_service.AnalyzeIamPolicyLongrunningRequest(**{
-  }),
-  {
-  },
+  asset_service.AnalyzeIamPolicyLongrunningRequest(),
+  {},
 ])
 def test_analyze_iam_policy_longrunning(request_type, transport: str = 'grpc'):
     client = AssetServiceClient(
@@ -5057,10 +5033,8 @@ async def test_analyze_iam_policy_longrunning_field_headers_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  asset_service.AnalyzeMoveRequest(**{
-  }),
-  {
-  },
+  asset_service.AnalyzeMoveRequest(),
+  {},
 ])
 def test_analyze_move(request_type, transport: str = 'grpc'):
     client = AssetServiceClient(
@@ -5284,10 +5258,8 @@ async def test_analyze_move_field_headers_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  asset_service.QueryAssetsRequest(**{
-  }),
-  {
-  },
+  asset_service.QueryAssetsRequest(),
+  {},
 ])
 def test_query_assets(request_type, transport: str = 'grpc'):
     client = AssetServiceClient(
@@ -5523,10 +5495,8 @@ async def test_query_assets_field_headers_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  asset_service.CreateSavedQueryRequest(**{
-  }),
-  {
-  },
+  asset_service.CreateSavedQueryRequest(),
+  {},
 ])
 def test_create_saved_query(request_type, transport: str = 'grpc'):
     client = AssetServiceClient(
@@ -5868,10 +5838,8 @@ async def test_create_saved_query_flattened_error_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  asset_service.GetSavedQueryRequest(**{
-  }),
-  {
-  },
+  asset_service.GetSavedQueryRequest(),
+  {},
 ])
 def test_get_saved_query(request_type, transport: str = 'grpc'):
     client = AssetServiceClient(
@@ -6191,10 +6159,8 @@ async def test_get_saved_query_flattened_error_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  asset_service.ListSavedQueriesRequest(**{
-  }),
-  {
-  },
+  asset_service.ListSavedQueriesRequest(),
+  {},
 ])
 def test_list_saved_queries(request_type, transport: str = 'grpc'):
     client = AssetServiceClient(
@@ -6700,10 +6666,8 @@ async def test_list_saved_queries_async_pages():
             assert page_.raw_page.next_page_token == token
 
 @pytest.mark.parametrize("request_type", [
-  asset_service.UpdateSavedQueryRequest(**{
-  }),
-  {
-  },
+  asset_service.UpdateSavedQueryRequest(),
+  {},
 ])
 def test_update_saved_query(request_type, transport: str = 'grpc'):
     client = AssetServiceClient(
@@ -7031,10 +6995,8 @@ async def test_update_saved_query_flattened_error_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  asset_service.DeleteSavedQueryRequest(**{
-  }),
-  {
-  },
+  asset_service.DeleteSavedQueryRequest(),
+  {},
 ])
 def test_delete_saved_query(request_type, transport: str = 'grpc'):
     client = AssetServiceClient(
@@ -7336,10 +7298,8 @@ async def test_delete_saved_query_flattened_error_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  asset_service.BatchGetEffectiveIamPoliciesRequest(**{
-  }),
-  {
-  },
+  asset_service.BatchGetEffectiveIamPoliciesRequest(),
+  {},
 ])
 def test_batch_get_effective_iam_policies(request_type, transport: str = 'grpc'):
     client = AssetServiceClient(
@@ -7561,10 +7521,8 @@ async def test_batch_get_effective_iam_policies_field_headers_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  asset_service.AnalyzeOrgPoliciesRequest(**{
-  }),
-  {
-  },
+  asset_service.AnalyzeOrgPoliciesRequest(),
+  {},
 ])
 def test_analyze_org_policies(request_type, transport: str = 'grpc'):
     client = AssetServiceClient(
@@ -8092,10 +8050,8 @@ async def test_analyze_org_policies_async_pages():
             assert page_.raw_page.next_page_token == token
 
 @pytest.mark.parametrize("request_type", [
-  asset_service.AnalyzeOrgPolicyGovernedContainersRequest(**{
-  }),
-  {
-  },
+  asset_service.AnalyzeOrgPolicyGovernedContainersRequest(),
+  {},
 ])
 def test_analyze_org_policy_governed_containers(request_type, transport: str = 'grpc'):
     client = AssetServiceClient(
@@ -8623,10 +8579,8 @@ async def test_analyze_org_policy_governed_containers_async_pages():
             assert page_.raw_page.next_page_token == token
 
 @pytest.mark.parametrize("request_type", [
-  asset_service.AnalyzeOrgPolicyGovernedAssetsRequest(**{
-  }),
-  {
-  },
+  asset_service.AnalyzeOrgPolicyGovernedAssetsRequest(),
+  {},
 ])
 def test_analyze_org_policy_governed_assets(request_type, transport: str = 'grpc'):
     client = AssetServiceClient(

--- a/packages/gapic-generator/tests/integration/goldens/asset/tests/unit/gapic/asset_v1/test_asset_service.py
+++ b/packages/gapic-generator/tests/integration/goldens/asset/tests/unit/gapic/asset_v1/test_asset_service.py
@@ -1120,8 +1120,8 @@ async def test_export_assets_async_use_cached_wrapped_rpc(transport: str = "grpc
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  asset_service.ExportAssetsRequest(**{  }),
-  {  },
+  asset_service.ExportAssetsRequest(),
+  {},
 ])
 async def test_export_assets_async(request_type, transport: str = 'grpc_asyncio'):
     client = AssetServiceAsyncClient(
@@ -1350,8 +1350,8 @@ async def test_list_assets_async_use_cached_wrapped_rpc(transport: str = "grpc_a
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  asset_service.ListAssetsRequest(**{  }),
-  {  },
+  asset_service.ListAssetsRequest(),
+  {},
 ])
 async def test_list_assets_async(request_type, transport: str = 'grpc_asyncio'):
     client = AssetServiceAsyncClient(
@@ -1853,8 +1853,8 @@ async def test_batch_get_assets_history_async_use_cached_wrapped_rpc(transport: 
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  asset_service.BatchGetAssetsHistoryRequest(**{  }),
-  {  },
+  asset_service.BatchGetAssetsHistoryRequest(),
+  {},
 ])
 async def test_batch_get_assets_history_async(request_type, transport: str = 'grpc_asyncio'):
     client = AssetServiceAsyncClient(
@@ -2090,8 +2090,8 @@ async def test_create_feed_async_use_cached_wrapped_rpc(transport: str = "grpc_a
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  asset_service.CreateFeedRequest(**{  }),
-  {  },
+  asset_service.CreateFeedRequest(),
+  {},
 ])
 async def test_create_feed_async(request_type, transport: str = 'grpc_asyncio'):
     client = AssetServiceAsyncClient(
@@ -2417,8 +2417,8 @@ async def test_get_feed_async_use_cached_wrapped_rpc(transport: str = "grpc_asyn
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  asset_service.GetFeedRequest(**{  }),
-  {  },
+  asset_service.GetFeedRequest(),
+  {},
 ])
 async def test_get_feed_async(request_type, transport: str = 'grpc_asyncio'):
     client = AssetServiceAsyncClient(
@@ -2734,8 +2734,8 @@ async def test_list_feeds_async_use_cached_wrapped_rpc(transport: str = "grpc_as
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  asset_service.ListFeedsRequest(**{  }),
-  {  },
+  asset_service.ListFeedsRequest(),
+  {},
 ])
 async def test_list_feeds_async(request_type, transport: str = 'grpc_asyncio'):
     client = AssetServiceAsyncClient(
@@ -3049,8 +3049,8 @@ async def test_update_feed_async_use_cached_wrapped_rpc(transport: str = "grpc_a
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  asset_service.UpdateFeedRequest(**{  }),
-  {  },
+  asset_service.UpdateFeedRequest(),
+  {},
 ])
 async def test_update_feed_async(request_type, transport: str = 'grpc_asyncio'):
     client = AssetServiceAsyncClient(
@@ -3365,8 +3365,8 @@ async def test_delete_feed_async_use_cached_wrapped_rpc(transport: str = "grpc_a
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  asset_service.DeleteFeedRequest(**{  }),
-  {  },
+  asset_service.DeleteFeedRequest(),
+  {},
 ])
 async def test_delete_feed_async(request_type, transport: str = 'grpc_asyncio'):
     client = AssetServiceAsyncClient(
@@ -3679,8 +3679,8 @@ async def test_search_all_resources_async_use_cached_wrapped_rpc(transport: str 
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  asset_service.SearchAllResourcesRequest(**{  }),
-  {  },
+  asset_service.SearchAllResourcesRequest(),
+  {},
 ])
 async def test_search_all_resources_async(request_type, transport: str = 'grpc_asyncio'):
     client = AssetServiceAsyncClient(
@@ -4210,8 +4210,8 @@ async def test_search_all_iam_policies_async_use_cached_wrapped_rpc(transport: s
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  asset_service.SearchAllIamPoliciesRequest(**{  }),
-  {  },
+  asset_service.SearchAllIamPoliciesRequest(),
+  {},
 ])
 async def test_search_all_iam_policies_async(request_type, transport: str = 'grpc_asyncio'):
     client = AssetServiceAsyncClient(
@@ -4725,8 +4725,8 @@ async def test_analyze_iam_policy_async_use_cached_wrapped_rpc(transport: str = 
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  asset_service.AnalyzeIamPolicyRequest(**{  }),
-  {  },
+  asset_service.AnalyzeIamPolicyRequest(),
+  {},
 ])
 async def test_analyze_iam_policy_async(request_type, transport: str = 'grpc_asyncio'):
     client = AssetServiceAsyncClient(
@@ -4961,8 +4961,8 @@ async def test_analyze_iam_policy_longrunning_async_use_cached_wrapped_rpc(trans
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  asset_service.AnalyzeIamPolicyLongrunningRequest(**{  }),
-  {  },
+  asset_service.AnalyzeIamPolicyLongrunningRequest(),
+  {},
 ])
 async def test_analyze_iam_policy_longrunning_async(request_type, transport: str = 'grpc_asyncio'):
     client = AssetServiceAsyncClient(
@@ -5189,8 +5189,8 @@ async def test_analyze_move_async_use_cached_wrapped_rpc(transport: str = "grpc_
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  asset_service.AnalyzeMoveRequest(**{  }),
-  {  },
+  asset_service.AnalyzeMoveRequest(),
+  {},
 ])
 async def test_analyze_move_async(request_type, transport: str = 'grpc_asyncio'):
     client = AssetServiceAsyncClient(
@@ -5424,8 +5424,8 @@ async def test_query_assets_async_use_cached_wrapped_rpc(transport: str = "grpc_
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  asset_service.QueryAssetsRequest(**{  }),
-  {  },
+  asset_service.QueryAssetsRequest(),
+  {},
 ])
 async def test_query_assets_async(request_type, transport: str = 'grpc_asyncio'):
     client = AssetServiceAsyncClient(
@@ -5663,8 +5663,8 @@ async def test_create_saved_query_async_use_cached_wrapped_rpc(transport: str = 
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  asset_service.CreateSavedQueryRequest(**{  }),
-  {  },
+  asset_service.CreateSavedQueryRequest(),
+  {},
 ])
 async def test_create_saved_query_async(request_type, transport: str = 'grpc_asyncio'):
     client = AssetServiceAsyncClient(
@@ -6006,8 +6006,8 @@ async def test_get_saved_query_async_use_cached_wrapped_rpc(transport: str = "gr
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  asset_service.GetSavedQueryRequest(**{  }),
-  {  },
+  asset_service.GetSavedQueryRequest(),
+  {},
 ])
 async def test_get_saved_query_async(request_type, transport: str = 'grpc_asyncio'):
     client = AssetServiceAsyncClient(
@@ -6327,8 +6327,8 @@ async def test_list_saved_queries_async_use_cached_wrapped_rpc(transport: str = 
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  asset_service.ListSavedQueriesRequest(**{  }),
-  {  },
+  asset_service.ListSavedQueriesRequest(),
+  {},
 ])
 async def test_list_saved_queries_async(request_type, transport: str = 'grpc_asyncio'):
     client = AssetServiceAsyncClient(
@@ -6836,8 +6836,8 @@ async def test_update_saved_query_async_use_cached_wrapped_rpc(transport: str = 
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  asset_service.UpdateSavedQueryRequest(**{  }),
-  {  },
+  asset_service.UpdateSavedQueryRequest(),
+  {},
 ])
 async def test_update_saved_query_async(request_type, transport: str = 'grpc_asyncio'):
     client = AssetServiceAsyncClient(
@@ -7160,8 +7160,8 @@ async def test_delete_saved_query_async_use_cached_wrapped_rpc(transport: str = 
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  asset_service.DeleteSavedQueryRequest(**{  }),
-  {  },
+  asset_service.DeleteSavedQueryRequest(),
+  {},
 ])
 async def test_delete_saved_query_async(request_type, transport: str = 'grpc_asyncio'):
     client = AssetServiceAsyncClient(
@@ -7466,8 +7466,8 @@ async def test_batch_get_effective_iam_policies_async_use_cached_wrapped_rpc(tra
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  asset_service.BatchGetEffectiveIamPoliciesRequest(**{  }),
-  {  },
+  asset_service.BatchGetEffectiveIamPoliciesRequest(),
+  {},
 ])
 async def test_batch_get_effective_iam_policies_async(request_type, transport: str = 'grpc_asyncio'):
     client = AssetServiceAsyncClient(
@@ -7699,8 +7699,8 @@ async def test_analyze_org_policies_async_use_cached_wrapped_rpc(transport: str 
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  asset_service.AnalyzeOrgPoliciesRequest(**{  }),
-  {  },
+  asset_service.AnalyzeOrgPoliciesRequest(),
+  {},
 ])
 async def test_analyze_org_policies_async(request_type, transport: str = 'grpc_asyncio'):
     client = AssetServiceAsyncClient(
@@ -8230,8 +8230,8 @@ async def test_analyze_org_policy_governed_containers_async_use_cached_wrapped_r
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  asset_service.AnalyzeOrgPolicyGovernedContainersRequest(**{  }),
-  {  },
+  asset_service.AnalyzeOrgPolicyGovernedContainersRequest(),
+  {},
 ])
 async def test_analyze_org_policy_governed_containers_async(request_type, transport: str = 'grpc_asyncio'):
     client = AssetServiceAsyncClient(
@@ -8761,8 +8761,8 @@ async def test_analyze_org_policy_governed_assets_async_use_cached_wrapped_rpc(t
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  asset_service.AnalyzeOrgPolicyGovernedAssetsRequest(**{  }),
-  {  },
+  asset_service.AnalyzeOrgPolicyGovernedAssetsRequest(),
+  {},
 ])
 async def test_analyze_org_policy_governed_assets_async(request_type, transport: str = 'grpc_asyncio'):
     client = AssetServiceAsyncClient(

--- a/packages/gapic-generator/tests/integration/goldens/asset/tests/unit/gapic/asset_v1/test_asset_service.py
+++ b/packages/gapic-generator/tests/integration/goldens/asset/tests/unit/gapic/asset_v1/test_asset_service.py
@@ -981,7 +981,7 @@ def test_asset_service_client_create_channel_credentials_file(client_class, tran
 
 
 @pytest.mark.parametrize("request_type", [
-  asset_service.ExportAssetsRequest({
+  asset_service.ExportAssetsRequest(**{
   }),
   {
   },
@@ -1120,7 +1120,7 @@ async def test_export_assets_async_use_cached_wrapped_rpc(transport: str = "grpc
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  asset_service.ExportAssetsRequest({  }),
+  asset_service.ExportAssetsRequest(**{  }),
   {  },
 ])
 async def test_export_assets_async(request_type, transport: str = 'grpc_asyncio'):
@@ -1216,7 +1216,7 @@ async def test_export_assets_field_headers_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  asset_service.ListAssetsRequest({
+  asset_service.ListAssetsRequest(**{
   }),
   {
   },
@@ -1350,7 +1350,7 @@ async def test_list_assets_async_use_cached_wrapped_rpc(transport: str = "grpc_a
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  asset_service.ListAssetsRequest({  }),
+  asset_service.ListAssetsRequest(**{  }),
   {  },
 ])
 async def test_list_assets_async(request_type, transport: str = 'grpc_asyncio'):
@@ -1723,7 +1723,7 @@ async def test_list_assets_async_pages():
             assert page_.raw_page.next_page_token == token
 
 @pytest.mark.parametrize("request_type", [
-  asset_service.BatchGetAssetsHistoryRequest({
+  asset_service.BatchGetAssetsHistoryRequest(**{
   }),
   {
   },
@@ -1853,7 +1853,7 @@ async def test_batch_get_assets_history_async_use_cached_wrapped_rpc(transport: 
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  asset_service.BatchGetAssetsHistoryRequest({  }),
+  asset_service.BatchGetAssetsHistoryRequest(**{  }),
   {  },
 ])
 async def test_batch_get_assets_history_async(request_type, transport: str = 'grpc_asyncio'):
@@ -1948,7 +1948,7 @@ async def test_batch_get_assets_history_field_headers_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  asset_service.CreateFeedRequest({
+  asset_service.CreateFeedRequest(**{
   }),
   {
   },
@@ -2090,7 +2090,7 @@ async def test_create_feed_async_use_cached_wrapped_rpc(transport: str = "grpc_a
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  asset_service.CreateFeedRequest({  }),
+  asset_service.CreateFeedRequest(**{  }),
   {  },
 ])
 async def test_create_feed_async(request_type, transport: str = 'grpc_asyncio'):
@@ -2277,7 +2277,7 @@ async def test_create_feed_flattened_error_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  asset_service.GetFeedRequest({
+  asset_service.GetFeedRequest(**{
   }),
   {
   },
@@ -2417,7 +2417,7 @@ async def test_get_feed_async_use_cached_wrapped_rpc(transport: str = "grpc_asyn
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  asset_service.GetFeedRequest({  }),
+  asset_service.GetFeedRequest(**{  }),
   {  },
 ])
 async def test_get_feed_async(request_type, transport: str = 'grpc_asyncio'):
@@ -2604,7 +2604,7 @@ async def test_get_feed_flattened_error_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  asset_service.ListFeedsRequest({
+  asset_service.ListFeedsRequest(**{
   }),
   {
   },
@@ -2734,7 +2734,7 @@ async def test_list_feeds_async_use_cached_wrapped_rpc(transport: str = "grpc_as
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  asset_service.ListFeedsRequest({  }),
+  asset_service.ListFeedsRequest(**{  }),
   {  },
 ])
 async def test_list_feeds_async(request_type, transport: str = 'grpc_asyncio'):
@@ -2911,7 +2911,7 @@ async def test_list_feeds_flattened_error_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  asset_service.UpdateFeedRequest({
+  asset_service.UpdateFeedRequest(**{
   }),
   {
   },
@@ -3049,7 +3049,7 @@ async def test_update_feed_async_use_cached_wrapped_rpc(transport: str = "grpc_a
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  asset_service.UpdateFeedRequest({  }),
+  asset_service.UpdateFeedRequest(**{  }),
   {  },
 ])
 async def test_update_feed_async(request_type, transport: str = 'grpc_asyncio'):
@@ -3236,7 +3236,7 @@ async def test_update_feed_flattened_error_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  asset_service.DeleteFeedRequest({
+  asset_service.DeleteFeedRequest(**{
   }),
   {
   },
@@ -3365,7 +3365,7 @@ async def test_delete_feed_async_use_cached_wrapped_rpc(transport: str = "grpc_a
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  asset_service.DeleteFeedRequest({  }),
+  asset_service.DeleteFeedRequest(**{  }),
   {  },
 ])
 async def test_delete_feed_async(request_type, transport: str = 'grpc_asyncio'):
@@ -3541,7 +3541,7 @@ async def test_delete_feed_flattened_error_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  asset_service.SearchAllResourcesRequest({
+  asset_service.SearchAllResourcesRequest(**{
   }),
   {
   },
@@ -3679,7 +3679,7 @@ async def test_search_all_resources_async_use_cached_wrapped_rpc(transport: str 
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  asset_service.SearchAllResourcesRequest({  }),
+  asset_service.SearchAllResourcesRequest(**{  }),
   {  },
 ])
 async def test_search_all_resources_async(request_type, transport: str = 'grpc_asyncio'):
@@ -4072,7 +4072,7 @@ async def test_search_all_resources_async_pages():
             assert page_.raw_page.next_page_token == token
 
 @pytest.mark.parametrize("request_type", [
-  asset_service.SearchAllIamPoliciesRequest({
+  asset_service.SearchAllIamPoliciesRequest(**{
   }),
   {
   },
@@ -4210,7 +4210,7 @@ async def test_search_all_iam_policies_async_use_cached_wrapped_rpc(transport: s
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  asset_service.SearchAllIamPoliciesRequest({  }),
+  asset_service.SearchAllIamPoliciesRequest(**{  }),
   {  },
 ])
 async def test_search_all_iam_policies_async(request_type, transport: str = 'grpc_asyncio'):
@@ -4593,7 +4593,7 @@ async def test_search_all_iam_policies_async_pages():
             assert page_.raw_page.next_page_token == token
 
 @pytest.mark.parametrize("request_type", [
-  asset_service.AnalyzeIamPolicyRequest({
+  asset_service.AnalyzeIamPolicyRequest(**{
   }),
   {
   },
@@ -4725,7 +4725,7 @@ async def test_analyze_iam_policy_async_use_cached_wrapped_rpc(transport: str = 
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  asset_service.AnalyzeIamPolicyRequest({  }),
+  asset_service.AnalyzeIamPolicyRequest(**{  }),
   {  },
 ])
 async def test_analyze_iam_policy_async(request_type, transport: str = 'grpc_asyncio'):
@@ -4822,7 +4822,7 @@ async def test_analyze_iam_policy_field_headers_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  asset_service.AnalyzeIamPolicyLongrunningRequest({
+  asset_service.AnalyzeIamPolicyLongrunningRequest(**{
   }),
   {
   },
@@ -4961,7 +4961,7 @@ async def test_analyze_iam_policy_longrunning_async_use_cached_wrapped_rpc(trans
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  asset_service.AnalyzeIamPolicyLongrunningRequest({  }),
+  asset_service.AnalyzeIamPolicyLongrunningRequest(**{  }),
   {  },
 ])
 async def test_analyze_iam_policy_longrunning_async(request_type, transport: str = 'grpc_asyncio'):
@@ -5057,7 +5057,7 @@ async def test_analyze_iam_policy_longrunning_field_headers_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  asset_service.AnalyzeMoveRequest({
+  asset_service.AnalyzeMoveRequest(**{
   }),
   {
   },
@@ -5189,7 +5189,7 @@ async def test_analyze_move_async_use_cached_wrapped_rpc(transport: str = "grpc_
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  asset_service.AnalyzeMoveRequest({  }),
+  asset_service.AnalyzeMoveRequest(**{  }),
   {  },
 ])
 async def test_analyze_move_async(request_type, transport: str = 'grpc_asyncio'):
@@ -5284,7 +5284,7 @@ async def test_analyze_move_field_headers_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  asset_service.QueryAssetsRequest({
+  asset_service.QueryAssetsRequest(**{
   }),
   {
   },
@@ -5424,7 +5424,7 @@ async def test_query_assets_async_use_cached_wrapped_rpc(transport: str = "grpc_
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  asset_service.QueryAssetsRequest({  }),
+  asset_service.QueryAssetsRequest(**{  }),
   {  },
 ])
 async def test_query_assets_async(request_type, transport: str = 'grpc_asyncio'):
@@ -5523,7 +5523,7 @@ async def test_query_assets_field_headers_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  asset_service.CreateSavedQueryRequest({
+  asset_service.CreateSavedQueryRequest(**{
   }),
   {
   },
@@ -5663,7 +5663,7 @@ async def test_create_saved_query_async_use_cached_wrapped_rpc(transport: str = 
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  asset_service.CreateSavedQueryRequest({  }),
+  asset_service.CreateSavedQueryRequest(**{  }),
   {  },
 ])
 async def test_create_saved_query_async(request_type, transport: str = 'grpc_asyncio'):
@@ -5868,7 +5868,7 @@ async def test_create_saved_query_flattened_error_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  asset_service.GetSavedQueryRequest({
+  asset_service.GetSavedQueryRequest(**{
   }),
   {
   },
@@ -6006,7 +6006,7 @@ async def test_get_saved_query_async_use_cached_wrapped_rpc(transport: str = "gr
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  asset_service.GetSavedQueryRequest({  }),
+  asset_service.GetSavedQueryRequest(**{  }),
   {  },
 ])
 async def test_get_saved_query_async(request_type, transport: str = 'grpc_asyncio'):
@@ -6191,7 +6191,7 @@ async def test_get_saved_query_flattened_error_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  asset_service.ListSavedQueriesRequest({
+  asset_service.ListSavedQueriesRequest(**{
   }),
   {
   },
@@ -6327,7 +6327,7 @@ async def test_list_saved_queries_async_use_cached_wrapped_rpc(transport: str = 
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  asset_service.ListSavedQueriesRequest({  }),
+  asset_service.ListSavedQueriesRequest(**{  }),
   {  },
 ])
 async def test_list_saved_queries_async(request_type, transport: str = 'grpc_asyncio'):
@@ -6700,7 +6700,7 @@ async def test_list_saved_queries_async_pages():
             assert page_.raw_page.next_page_token == token
 
 @pytest.mark.parametrize("request_type", [
-  asset_service.UpdateSavedQueryRequest({
+  asset_service.UpdateSavedQueryRequest(**{
   }),
   {
   },
@@ -6836,7 +6836,7 @@ async def test_update_saved_query_async_use_cached_wrapped_rpc(transport: str = 
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  asset_service.UpdateSavedQueryRequest({  }),
+  asset_service.UpdateSavedQueryRequest(**{  }),
   {  },
 ])
 async def test_update_saved_query_async(request_type, transport: str = 'grpc_asyncio'):
@@ -7031,7 +7031,7 @@ async def test_update_saved_query_flattened_error_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  asset_service.DeleteSavedQueryRequest({
+  asset_service.DeleteSavedQueryRequest(**{
   }),
   {
   },
@@ -7160,7 +7160,7 @@ async def test_delete_saved_query_async_use_cached_wrapped_rpc(transport: str = 
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  asset_service.DeleteSavedQueryRequest({  }),
+  asset_service.DeleteSavedQueryRequest(**{  }),
   {  },
 ])
 async def test_delete_saved_query_async(request_type, transport: str = 'grpc_asyncio'):
@@ -7336,7 +7336,7 @@ async def test_delete_saved_query_flattened_error_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  asset_service.BatchGetEffectiveIamPoliciesRequest({
+  asset_service.BatchGetEffectiveIamPoliciesRequest(**{
   }),
   {
   },
@@ -7466,7 +7466,7 @@ async def test_batch_get_effective_iam_policies_async_use_cached_wrapped_rpc(tra
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  asset_service.BatchGetEffectiveIamPoliciesRequest({  }),
+  asset_service.BatchGetEffectiveIamPoliciesRequest(**{  }),
   {  },
 ])
 async def test_batch_get_effective_iam_policies_async(request_type, transport: str = 'grpc_asyncio'):
@@ -7561,7 +7561,7 @@ async def test_batch_get_effective_iam_policies_field_headers_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  asset_service.AnalyzeOrgPoliciesRequest({
+  asset_service.AnalyzeOrgPoliciesRequest(**{
   }),
   {
   },
@@ -7699,7 +7699,7 @@ async def test_analyze_org_policies_async_use_cached_wrapped_rpc(transport: str 
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  asset_service.AnalyzeOrgPoliciesRequest({  }),
+  asset_service.AnalyzeOrgPoliciesRequest(**{  }),
   {  },
 ])
 async def test_analyze_org_policies_async(request_type, transport: str = 'grpc_asyncio'):
@@ -8092,7 +8092,7 @@ async def test_analyze_org_policies_async_pages():
             assert page_.raw_page.next_page_token == token
 
 @pytest.mark.parametrize("request_type", [
-  asset_service.AnalyzeOrgPolicyGovernedContainersRequest({
+  asset_service.AnalyzeOrgPolicyGovernedContainersRequest(**{
   }),
   {
   },
@@ -8230,7 +8230,7 @@ async def test_analyze_org_policy_governed_containers_async_use_cached_wrapped_r
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  asset_service.AnalyzeOrgPolicyGovernedContainersRequest({  }),
+  asset_service.AnalyzeOrgPolicyGovernedContainersRequest(**{  }),
   {  },
 ])
 async def test_analyze_org_policy_governed_containers_async(request_type, transport: str = 'grpc_asyncio'):
@@ -8623,7 +8623,7 @@ async def test_analyze_org_policy_governed_containers_async_pages():
             assert page_.raw_page.next_page_token == token
 
 @pytest.mark.parametrize("request_type", [
-  asset_service.AnalyzeOrgPolicyGovernedAssetsRequest({
+  asset_service.AnalyzeOrgPolicyGovernedAssetsRequest(**{
   }),
   {
   },
@@ -8761,7 +8761,7 @@ async def test_analyze_org_policy_governed_assets_async_use_cached_wrapped_rpc(t
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  asset_service.AnalyzeOrgPolicyGovernedAssetsRequest({  }),
+  asset_service.AnalyzeOrgPolicyGovernedAssetsRequest(**{  }),
   {  },
 ])
 async def test_analyze_org_policy_governed_assets_async(request_type, transport: str = 'grpc_asyncio'):

--- a/packages/gapic-generator/tests/integration/goldens/credentials/tests/unit/gapic/credentials_v1/test_iam_credentials.py
+++ b/packages/gapic-generator/tests/integration/goldens/credentials/tests/unit/gapic/credentials_v1/test_iam_credentials.py
@@ -971,7 +971,7 @@ def test_iam_credentials_client_create_channel_credentials_file(client_class, tr
 
 
 @pytest.mark.parametrize("request_type", [
-  common.GenerateAccessTokenRequest({
+  common.GenerateAccessTokenRequest(**{
   }),
   {
   },
@@ -1103,7 +1103,7 @@ async def test_generate_access_token_async_use_cached_wrapped_rpc(transport: str
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  common.GenerateAccessTokenRequest({  }),
+  common.GenerateAccessTokenRequest(**{  }),
   {  },
 ])
 async def test_generate_access_token_async(request_type, transport: str = 'grpc_asyncio'):
@@ -1308,7 +1308,7 @@ async def test_generate_access_token_flattened_error_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  common.GenerateIdTokenRequest({
+  common.GenerateIdTokenRequest(**{
   }),
   {
   },
@@ -1442,7 +1442,7 @@ async def test_generate_id_token_async_use_cached_wrapped_rpc(transport: str = "
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  common.GenerateIdTokenRequest({  }),
+  common.GenerateIdTokenRequest(**{  }),
   {  },
 ])
 async def test_generate_id_token_async(request_type, transport: str = 'grpc_asyncio'):
@@ -1651,7 +1651,7 @@ async def test_generate_id_token_flattened_error_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  common.SignBlobRequest({
+  common.SignBlobRequest(**{
   }),
   {
   },
@@ -1785,7 +1785,7 @@ async def test_sign_blob_async_use_cached_wrapped_rpc(transport: str = "grpc_asy
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  common.SignBlobRequest({  }),
+  common.SignBlobRequest(**{  }),
   {  },
 ])
 async def test_sign_blob_async(request_type, transport: str = 'grpc_asyncio'):
@@ -1986,7 +1986,7 @@ async def test_sign_blob_flattened_error_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  common.SignJwtRequest({
+  common.SignJwtRequest(**{
   }),
   {
   },
@@ -2122,7 +2122,7 @@ async def test_sign_jwt_async_use_cached_wrapped_rpc(transport: str = "grpc_asyn
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  common.SignJwtRequest({  }),
+  common.SignJwtRequest(**{  }),
   {  },
 ])
 async def test_sign_jwt_async(request_type, transport: str = 'grpc_asyncio'):

--- a/packages/gapic-generator/tests/integration/goldens/credentials/tests/unit/gapic/credentials_v1/test_iam_credentials.py
+++ b/packages/gapic-generator/tests/integration/goldens/credentials/tests/unit/gapic/credentials_v1/test_iam_credentials.py
@@ -971,10 +971,8 @@ def test_iam_credentials_client_create_channel_credentials_file(client_class, tr
 
 
 @pytest.mark.parametrize("request_type", [
-  common.GenerateAccessTokenRequest(**{
-  }),
-  {
-  },
+  common.GenerateAccessTokenRequest(),
+  {},
 ])
 def test_generate_access_token(request_type, transport: str = 'grpc'):
     client = IAMCredentialsClient(
@@ -1308,10 +1306,8 @@ async def test_generate_access_token_flattened_error_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  common.GenerateIdTokenRequest(**{
-  }),
-  {
-  },
+  common.GenerateIdTokenRequest(),
+  {},
 ])
 def test_generate_id_token(request_type, transport: str = 'grpc'):
     client = IAMCredentialsClient(
@@ -1651,10 +1647,8 @@ async def test_generate_id_token_flattened_error_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  common.SignBlobRequest(**{
-  }),
-  {
-  },
+  common.SignBlobRequest(),
+  {},
 ])
 def test_sign_blob(request_type, transport: str = 'grpc'):
     client = IAMCredentialsClient(
@@ -1986,10 +1980,8 @@ async def test_sign_blob_flattened_error_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  common.SignJwtRequest(**{
-  }),
-  {
-  },
+  common.SignJwtRequest(),
+  {},
 ])
 def test_sign_jwt(request_type, transport: str = 'grpc'):
     client = IAMCredentialsClient(

--- a/packages/gapic-generator/tests/integration/goldens/credentials/tests/unit/gapic/credentials_v1/test_iam_credentials.py
+++ b/packages/gapic-generator/tests/integration/goldens/credentials/tests/unit/gapic/credentials_v1/test_iam_credentials.py
@@ -1103,8 +1103,8 @@ async def test_generate_access_token_async_use_cached_wrapped_rpc(transport: str
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  common.GenerateAccessTokenRequest(**{  }),
-  {  },
+  common.GenerateAccessTokenRequest(),
+  {},
 ])
 async def test_generate_access_token_async(request_type, transport: str = 'grpc_asyncio'):
     client = IAMCredentialsAsyncClient(
@@ -1442,8 +1442,8 @@ async def test_generate_id_token_async_use_cached_wrapped_rpc(transport: str = "
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  common.GenerateIdTokenRequest(**{  }),
-  {  },
+  common.GenerateIdTokenRequest(),
+  {},
 ])
 async def test_generate_id_token_async(request_type, transport: str = 'grpc_asyncio'):
     client = IAMCredentialsAsyncClient(
@@ -1785,8 +1785,8 @@ async def test_sign_blob_async_use_cached_wrapped_rpc(transport: str = "grpc_asy
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  common.SignBlobRequest(**{  }),
-  {  },
+  common.SignBlobRequest(),
+  {},
 ])
 async def test_sign_blob_async(request_type, transport: str = 'grpc_asyncio'):
     client = IAMCredentialsAsyncClient(
@@ -2122,8 +2122,8 @@ async def test_sign_jwt_async_use_cached_wrapped_rpc(transport: str = "grpc_asyn
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  common.SignJwtRequest(**{  }),
-  {  },
+  common.SignJwtRequest(),
+  {},
 ])
 async def test_sign_jwt_async(request_type, transport: str = 'grpc_asyncio'):
     client = IAMCredentialsAsyncClient(

--- a/packages/gapic-generator/tests/integration/goldens/eventarc/tests/unit/gapic/eventarc_v1/test_eventarc.py
+++ b/packages/gapic-generator/tests/integration/goldens/eventarc/tests/unit/gapic/eventarc_v1/test_eventarc.py
@@ -1146,8 +1146,8 @@ async def test_get_trigger_async_use_cached_wrapped_rpc(transport: str = "grpc_a
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  eventarc.GetTriggerRequest(**{  }),
-  {  },
+  eventarc.GetTriggerRequest(),
+  {},
 ])
 async def test_get_trigger_async(request_type, transport: str = 'grpc_asyncio'):
     client = EventarcAsyncClient(
@@ -1477,8 +1477,8 @@ async def test_list_triggers_async_use_cached_wrapped_rpc(transport: str = "grpc
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  eventarc.ListTriggersRequest(**{  }),
-  {  },
+  eventarc.ListTriggersRequest(),
+  {},
 ])
 async def test_list_triggers_async(request_type, transport: str = 'grpc_asyncio'):
     client = EventarcAsyncClient(
@@ -1993,8 +1993,8 @@ async def test_create_trigger_async_use_cached_wrapped_rpc(transport: str = "grp
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  eventarc.CreateTriggerRequest(**{  }),
-  {  },
+  eventarc.CreateTriggerRequest(),
+  {},
 ])
 async def test_create_trigger_async(request_type, transport: str = 'grpc_asyncio'):
     client = EventarcAsyncClient(
@@ -2330,8 +2330,8 @@ async def test_update_trigger_async_use_cached_wrapped_rpc(transport: str = "grp
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  eventarc.UpdateTriggerRequest(**{  }),
-  {  },
+  eventarc.UpdateTriggerRequest(),
+  {},
 ])
 async def test_update_trigger_async(request_type, transport: str = 'grpc_asyncio'):
     client = EventarcAsyncClient(
@@ -2671,8 +2671,8 @@ async def test_delete_trigger_async_use_cached_wrapped_rpc(transport: str = "grp
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  eventarc.DeleteTriggerRequest(**{  }),
-  {  },
+  eventarc.DeleteTriggerRequest(),
+  {},
 ])
 async def test_delete_trigger_async(request_type, transport: str = 'grpc_asyncio'):
     client = EventarcAsyncClient(
@@ -3006,8 +3006,8 @@ async def test_get_channel_async_use_cached_wrapped_rpc(transport: str = "grpc_a
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  eventarc.GetChannelRequest(**{  }),
-  {  },
+  eventarc.GetChannelRequest(),
+  {},
 ])
 async def test_get_channel_async(request_type, transport: str = 'grpc_asyncio'):
     client = EventarcAsyncClient(
@@ -3335,8 +3335,8 @@ async def test_list_channels_async_use_cached_wrapped_rpc(transport: str = "grpc
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  eventarc.ListChannelsRequest(**{  }),
-  {  },
+  eventarc.ListChannelsRequest(),
+  {},
 ])
 async def test_list_channels_async(request_type, transport: str = 'grpc_asyncio'):
     client = EventarcAsyncClient(
@@ -3851,8 +3851,8 @@ async def test_create_channel_async_use_cached_wrapped_rpc(transport: str = "grp
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  eventarc.CreateChannelRequest(**{  }),
-  {  },
+  eventarc.CreateChannelRequest(),
+  {},
 ])
 async def test_create_channel_async(request_type, transport: str = 'grpc_asyncio'):
     client = EventarcAsyncClient(
@@ -4188,8 +4188,8 @@ async def test_update_channel_async_use_cached_wrapped_rpc(transport: str = "grp
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  eventarc.UpdateChannelRequest(**{  }),
-  {  },
+  eventarc.UpdateChannelRequest(),
+  {},
 ])
 async def test_update_channel_async(request_type, transport: str = 'grpc_asyncio'):
     client = EventarcAsyncClient(
@@ -4517,8 +4517,8 @@ async def test_delete_channel_async_use_cached_wrapped_rpc(transport: str = "grp
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  eventarc.DeleteChannelRequest(**{  }),
-  {  },
+  eventarc.DeleteChannelRequest(),
+  {},
 ])
 async def test_delete_channel_async(request_type, transport: str = 'grpc_asyncio'):
     client = EventarcAsyncClient(
@@ -4831,8 +4831,8 @@ async def test_get_provider_async_use_cached_wrapped_rpc(transport: str = "grpc_
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  eventarc.GetProviderRequest(**{  }),
-  {  },
+  eventarc.GetProviderRequest(),
+  {},
 ])
 async def test_get_provider_async(request_type, transport: str = 'grpc_asyncio'):
     client = EventarcAsyncClient(
@@ -5152,8 +5152,8 @@ async def test_list_providers_async_use_cached_wrapped_rpc(transport: str = "grp
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  eventarc.ListProvidersRequest(**{  }),
-  {  },
+  eventarc.ListProvidersRequest(),
+  {},
 ])
 async def test_list_providers_async(request_type, transport: str = 'grpc_asyncio'):
     client = EventarcAsyncClient(
@@ -5665,8 +5665,8 @@ async def test_get_channel_connection_async_use_cached_wrapped_rpc(transport: st
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  eventarc.GetChannelConnectionRequest(**{  }),
-  {  },
+  eventarc.GetChannelConnectionRequest(),
+  {},
 ])
 async def test_get_channel_connection_async(request_type, transport: str = 'grpc_asyncio'):
     client = EventarcAsyncClient(
@@ -5986,8 +5986,8 @@ async def test_list_channel_connections_async_use_cached_wrapped_rpc(transport: 
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  eventarc.ListChannelConnectionsRequest(**{  }),
-  {  },
+  eventarc.ListChannelConnectionsRequest(),
+  {},
 ])
 async def test_list_channel_connections_async(request_type, transport: str = 'grpc_asyncio'):
     client = EventarcAsyncClient(
@@ -6502,8 +6502,8 @@ async def test_create_channel_connection_async_use_cached_wrapped_rpc(transport:
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  eventarc.CreateChannelConnectionRequest(**{  }),
-  {  },
+  eventarc.CreateChannelConnectionRequest(),
+  {},
 ])
 async def test_create_channel_connection_async(request_type, transport: str = 'grpc_asyncio'):
     client = EventarcAsyncClient(
@@ -6841,8 +6841,8 @@ async def test_delete_channel_connection_async_use_cached_wrapped_rpc(transport:
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  eventarc.DeleteChannelConnectionRequest(**{  }),
-  {  },
+  eventarc.DeleteChannelConnectionRequest(),
+  {},
 ])
 async def test_delete_channel_connection_async(request_type, transport: str = 'grpc_asyncio'):
     client = EventarcAsyncClient(
@@ -7155,8 +7155,8 @@ async def test_get_google_channel_config_async_use_cached_wrapped_rpc(transport:
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  eventarc.GetGoogleChannelConfigRequest(**{  }),
-  {  },
+  eventarc.GetGoogleChannelConfigRequest(),
+  {},
 ])
 async def test_get_google_channel_config_async(request_type, transport: str = 'grpc_asyncio'):
     client = EventarcAsyncClient(
@@ -7468,8 +7468,8 @@ async def test_update_google_channel_config_async_use_cached_wrapped_rpc(transpo
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  eventarc.UpdateGoogleChannelConfigRequest(**{  }),
-  {  },
+  eventarc.UpdateGoogleChannelConfigRequest(),
+  {},
 ])
 async def test_update_google_channel_config_async(request_type, transport: str = 'grpc_asyncio'):
     client = EventarcAsyncClient(
@@ -7799,8 +7799,8 @@ async def test_get_message_bus_async_use_cached_wrapped_rpc(transport: str = "gr
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  eventarc.GetMessageBusRequest(**{  }),
-  {  },
+  eventarc.GetMessageBusRequest(),
+  {},
 ])
 async def test_get_message_bus_async(request_type, transport: str = 'grpc_asyncio'):
     client = EventarcAsyncClient(
@@ -8126,8 +8126,8 @@ async def test_list_message_buses_async_use_cached_wrapped_rpc(transport: str = 
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  eventarc.ListMessageBusesRequest(**{  }),
-  {  },
+  eventarc.ListMessageBusesRequest(),
+  {},
 ])
 async def test_list_message_buses_async(request_type, transport: str = 'grpc_asyncio'):
     client = EventarcAsyncClient(
@@ -8639,8 +8639,8 @@ async def test_list_message_bus_enrollments_async_use_cached_wrapped_rpc(transpo
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  eventarc.ListMessageBusEnrollmentsRequest(**{  }),
-  {  },
+  eventarc.ListMessageBusEnrollmentsRequest(),
+  {},
 ])
 async def test_list_message_bus_enrollments_async(request_type, transport: str = 'grpc_asyncio'):
     client = EventarcAsyncClient(
@@ -9157,8 +9157,8 @@ async def test_create_message_bus_async_use_cached_wrapped_rpc(transport: str = 
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  eventarc.CreateMessageBusRequest(**{  }),
-  {  },
+  eventarc.CreateMessageBusRequest(),
+  {},
 ])
 async def test_create_message_bus_async(request_type, transport: str = 'grpc_asyncio'):
     client = EventarcAsyncClient(
@@ -9494,8 +9494,8 @@ async def test_update_message_bus_async_use_cached_wrapped_rpc(transport: str = 
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  eventarc.UpdateMessageBusRequest(**{  }),
-  {  },
+  eventarc.UpdateMessageBusRequest(),
+  {},
 ])
 async def test_update_message_bus_async(request_type, transport: str = 'grpc_asyncio'):
     client = EventarcAsyncClient(
@@ -9825,8 +9825,8 @@ async def test_delete_message_bus_async_use_cached_wrapped_rpc(transport: str = 
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  eventarc.DeleteMessageBusRequest(**{  }),
-  {  },
+  eventarc.DeleteMessageBusRequest(),
+  {},
 ])
 async def test_delete_message_bus_async(request_type, transport: str = 'grpc_asyncio'):
     client = EventarcAsyncClient(
@@ -10159,8 +10159,8 @@ async def test_get_enrollment_async_use_cached_wrapped_rpc(transport: str = "grp
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  eventarc.GetEnrollmentRequest(**{  }),
-  {  },
+  eventarc.GetEnrollmentRequest(),
+  {},
 ])
 async def test_get_enrollment_async(request_type, transport: str = 'grpc_asyncio'):
     client = EventarcAsyncClient(
@@ -10490,8 +10490,8 @@ async def test_list_enrollments_async_use_cached_wrapped_rpc(transport: str = "g
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  eventarc.ListEnrollmentsRequest(**{  }),
-  {  },
+  eventarc.ListEnrollmentsRequest(),
+  {},
 ])
 async def test_list_enrollments_async(request_type, transport: str = 'grpc_asyncio'):
     client = EventarcAsyncClient(
@@ -11006,8 +11006,8 @@ async def test_create_enrollment_async_use_cached_wrapped_rpc(transport: str = "
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  eventarc.CreateEnrollmentRequest(**{  }),
-  {  },
+  eventarc.CreateEnrollmentRequest(),
+  {},
 ])
 async def test_create_enrollment_async(request_type, transport: str = 'grpc_asyncio'):
     client = EventarcAsyncClient(
@@ -11343,8 +11343,8 @@ async def test_update_enrollment_async_use_cached_wrapped_rpc(transport: str = "
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  eventarc.UpdateEnrollmentRequest(**{  }),
-  {  },
+  eventarc.UpdateEnrollmentRequest(),
+  {},
 ])
 async def test_update_enrollment_async(request_type, transport: str = 'grpc_asyncio'):
     client = EventarcAsyncClient(
@@ -11674,8 +11674,8 @@ async def test_delete_enrollment_async_use_cached_wrapped_rpc(transport: str = "
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  eventarc.DeleteEnrollmentRequest(**{  }),
-  {  },
+  eventarc.DeleteEnrollmentRequest(),
+  {},
 ])
 async def test_delete_enrollment_async(request_type, transport: str = 'grpc_asyncio'):
     client = EventarcAsyncClient(
@@ -12006,8 +12006,8 @@ async def test_get_pipeline_async_use_cached_wrapped_rpc(transport: str = "grpc_
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  eventarc.GetPipelineRequest(**{  }),
-  {  },
+  eventarc.GetPipelineRequest(),
+  {},
 ])
 async def test_get_pipeline_async(request_type, transport: str = 'grpc_asyncio'):
     client = EventarcAsyncClient(
@@ -12335,8 +12335,8 @@ async def test_list_pipelines_async_use_cached_wrapped_rpc(transport: str = "grp
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  eventarc.ListPipelinesRequest(**{  }),
-  {  },
+  eventarc.ListPipelinesRequest(),
+  {},
 ])
 async def test_list_pipelines_async(request_type, transport: str = 'grpc_asyncio'):
     client = EventarcAsyncClient(
@@ -12851,8 +12851,8 @@ async def test_create_pipeline_async_use_cached_wrapped_rpc(transport: str = "gr
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  eventarc.CreatePipelineRequest(**{  }),
-  {  },
+  eventarc.CreatePipelineRequest(),
+  {},
 ])
 async def test_create_pipeline_async(request_type, transport: str = 'grpc_asyncio'):
     client = EventarcAsyncClient(
@@ -13188,8 +13188,8 @@ async def test_update_pipeline_async_use_cached_wrapped_rpc(transport: str = "gr
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  eventarc.UpdatePipelineRequest(**{  }),
-  {  },
+  eventarc.UpdatePipelineRequest(),
+  {},
 ])
 async def test_update_pipeline_async(request_type, transport: str = 'grpc_asyncio'):
     client = EventarcAsyncClient(
@@ -13519,8 +13519,8 @@ async def test_delete_pipeline_async_use_cached_wrapped_rpc(transport: str = "gr
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  eventarc.DeletePipelineRequest(**{  }),
-  {  },
+  eventarc.DeletePipelineRequest(),
+  {},
 ])
 async def test_delete_pipeline_async(request_type, transport: str = 'grpc_asyncio'):
     client = EventarcAsyncClient(
@@ -13851,8 +13851,8 @@ async def test_get_google_api_source_async_use_cached_wrapped_rpc(transport: str
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  eventarc.GetGoogleApiSourceRequest(**{  }),
-  {  },
+  eventarc.GetGoogleApiSourceRequest(),
+  {},
 ])
 async def test_get_google_api_source_async(request_type, transport: str = 'grpc_asyncio'):
     client = EventarcAsyncClient(
@@ -14180,8 +14180,8 @@ async def test_list_google_api_sources_async_use_cached_wrapped_rpc(transport: s
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  eventarc.ListGoogleApiSourcesRequest(**{  }),
-  {  },
+  eventarc.ListGoogleApiSourcesRequest(),
+  {},
 ])
 async def test_list_google_api_sources_async(request_type, transport: str = 'grpc_asyncio'):
     client = EventarcAsyncClient(
@@ -14696,8 +14696,8 @@ async def test_create_google_api_source_async_use_cached_wrapped_rpc(transport: 
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  eventarc.CreateGoogleApiSourceRequest(**{  }),
-  {  },
+  eventarc.CreateGoogleApiSourceRequest(),
+  {},
 ])
 async def test_create_google_api_source_async(request_type, transport: str = 'grpc_asyncio'):
     client = EventarcAsyncClient(
@@ -15033,8 +15033,8 @@ async def test_update_google_api_source_async_use_cached_wrapped_rpc(transport: 
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  eventarc.UpdateGoogleApiSourceRequest(**{  }),
-  {  },
+  eventarc.UpdateGoogleApiSourceRequest(),
+  {},
 ])
 async def test_update_google_api_source_async(request_type, transport: str = 'grpc_asyncio'):
     client = EventarcAsyncClient(
@@ -15364,8 +15364,8 @@ async def test_delete_google_api_source_async_use_cached_wrapped_rpc(transport: 
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  eventarc.DeleteGoogleApiSourceRequest(**{  }),
-  {  },
+  eventarc.DeleteGoogleApiSourceRequest(),
+  {},
 ])
 async def test_delete_google_api_source_async(request_type, transport: str = 'grpc_asyncio'):
     client = EventarcAsyncClient(

--- a/packages/gapic-generator/tests/integration/goldens/eventarc/tests/unit/gapic/eventarc_v1/test_eventarc.py
+++ b/packages/gapic-generator/tests/integration/goldens/eventarc/tests/unit/gapic/eventarc_v1/test_eventarc.py
@@ -1002,7 +1002,7 @@ def test_eventarc_client_create_channel_credentials_file(client_class, transport
 
 
 @pytest.mark.parametrize("request_type", [
-  eventarc.GetTriggerRequest({
+  eventarc.GetTriggerRequest(**{
   }),
   {
   },
@@ -1146,7 +1146,7 @@ async def test_get_trigger_async_use_cached_wrapped_rpc(transport: str = "grpc_a
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  eventarc.GetTriggerRequest({  }),
+  eventarc.GetTriggerRequest(**{  }),
   {  },
 ])
 async def test_get_trigger_async(request_type, transport: str = 'grpc_asyncio'):
@@ -1337,7 +1337,7 @@ async def test_get_trigger_flattened_error_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  eventarc.ListTriggersRequest({
+  eventarc.ListTriggersRequest(**{
   }),
   {
   },
@@ -1477,7 +1477,7 @@ async def test_list_triggers_async_use_cached_wrapped_rpc(transport: str = "grpc
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  eventarc.ListTriggersRequest({  }),
+  eventarc.ListTriggersRequest(**{  }),
   {  },
 ])
 async def test_list_triggers_async(request_type, transport: str = 'grpc_asyncio'):
@@ -1852,7 +1852,7 @@ async def test_list_triggers_async_pages():
             assert page_.raw_page.next_page_token == token
 
 @pytest.mark.parametrize("request_type", [
-  eventarc.CreateTriggerRequest({
+  eventarc.CreateTriggerRequest(**{
   }),
   {
   },
@@ -1993,7 +1993,7 @@ async def test_create_trigger_async_use_cached_wrapped_rpc(transport: str = "grp
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  eventarc.CreateTriggerRequest({  }),
+  eventarc.CreateTriggerRequest(**{  }),
   {  },
 ])
 async def test_create_trigger_async(request_type, transport: str = 'grpc_asyncio'):
@@ -2193,7 +2193,7 @@ async def test_create_trigger_flattened_error_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  eventarc.UpdateTriggerRequest({
+  eventarc.UpdateTriggerRequest(**{
   }),
   {
   },
@@ -2330,7 +2330,7 @@ async def test_update_trigger_async_use_cached_wrapped_rpc(transport: str = "grp
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  eventarc.UpdateTriggerRequest({  }),
+  eventarc.UpdateTriggerRequest(**{  }),
   {  },
 ])
 async def test_update_trigger_async(request_type, transport: str = 'grpc_asyncio'):
@@ -2530,7 +2530,7 @@ async def test_update_trigger_flattened_error_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  eventarc.DeleteTriggerRequest({
+  eventarc.DeleteTriggerRequest(**{
   }),
   {
   },
@@ -2671,7 +2671,7 @@ async def test_delete_trigger_async_use_cached_wrapped_rpc(transport: str = "grp
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  eventarc.DeleteTriggerRequest({  }),
+  eventarc.DeleteTriggerRequest(**{  }),
   {  },
 ])
 async def test_delete_trigger_async(request_type, transport: str = 'grpc_asyncio'):
@@ -2861,7 +2861,7 @@ async def test_delete_trigger_flattened_error_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  eventarc.GetChannelRequest({
+  eventarc.GetChannelRequest(**{
   }),
   {
   },
@@ -3006,7 +3006,7 @@ async def test_get_channel_async_use_cached_wrapped_rpc(transport: str = "grpc_a
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  eventarc.GetChannelRequest({  }),
+  eventarc.GetChannelRequest(**{  }),
   {  },
 ])
 async def test_get_channel_async(request_type, transport: str = 'grpc_asyncio'):
@@ -3197,7 +3197,7 @@ async def test_get_channel_flattened_error_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  eventarc.ListChannelsRequest({
+  eventarc.ListChannelsRequest(**{
   }),
   {
   },
@@ -3335,7 +3335,7 @@ async def test_list_channels_async_use_cached_wrapped_rpc(transport: str = "grpc
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  eventarc.ListChannelsRequest({  }),
+  eventarc.ListChannelsRequest(**{  }),
   {  },
 ])
 async def test_list_channels_async(request_type, transport: str = 'grpc_asyncio'):
@@ -3710,7 +3710,7 @@ async def test_list_channels_async_pages():
             assert page_.raw_page.next_page_token == token
 
 @pytest.mark.parametrize("request_type", [
-  eventarc.CreateChannelRequest({
+  eventarc.CreateChannelRequest(**{
   }),
   {
   },
@@ -3851,7 +3851,7 @@ async def test_create_channel_async_use_cached_wrapped_rpc(transport: str = "grp
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  eventarc.CreateChannelRequest({  }),
+  eventarc.CreateChannelRequest(**{  }),
   {  },
 ])
 async def test_create_channel_async(request_type, transport: str = 'grpc_asyncio'):
@@ -4051,7 +4051,7 @@ async def test_create_channel_flattened_error_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  eventarc.UpdateChannelRequest({
+  eventarc.UpdateChannelRequest(**{
   }),
   {
   },
@@ -4188,7 +4188,7 @@ async def test_update_channel_async_use_cached_wrapped_rpc(transport: str = "grp
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  eventarc.UpdateChannelRequest({  }),
+  eventarc.UpdateChannelRequest(**{  }),
   {  },
 ])
 async def test_update_channel_async(request_type, transport: str = 'grpc_asyncio'):
@@ -4378,7 +4378,7 @@ async def test_update_channel_flattened_error_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  eventarc.DeleteChannelRequest({
+  eventarc.DeleteChannelRequest(**{
   }),
   {
   },
@@ -4517,7 +4517,7 @@ async def test_delete_channel_async_use_cached_wrapped_rpc(transport: str = "grp
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  eventarc.DeleteChannelRequest({  }),
+  eventarc.DeleteChannelRequest(**{  }),
   {  },
 ])
 async def test_delete_channel_async(request_type, transport: str = 'grpc_asyncio'):
@@ -4697,7 +4697,7 @@ async def test_delete_channel_flattened_error_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  eventarc.GetProviderRequest({
+  eventarc.GetProviderRequest(**{
   }),
   {
   },
@@ -4831,7 +4831,7 @@ async def test_get_provider_async_use_cached_wrapped_rpc(transport: str = "grpc_
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  eventarc.GetProviderRequest({  }),
+  eventarc.GetProviderRequest(**{  }),
   {  },
 ])
 async def test_get_provider_async(request_type, transport: str = 'grpc_asyncio'):
@@ -5012,7 +5012,7 @@ async def test_get_provider_flattened_error_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  eventarc.ListProvidersRequest({
+  eventarc.ListProvidersRequest(**{
   }),
   {
   },
@@ -5152,7 +5152,7 @@ async def test_list_providers_async_use_cached_wrapped_rpc(transport: str = "grp
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  eventarc.ListProvidersRequest({  }),
+  eventarc.ListProvidersRequest(**{  }),
   {  },
 ])
 async def test_list_providers_async(request_type, transport: str = 'grpc_asyncio'):
@@ -5527,7 +5527,7 @@ async def test_list_providers_async_pages():
             assert page_.raw_page.next_page_token == token
 
 @pytest.mark.parametrize("request_type", [
-  eventarc.GetChannelConnectionRequest({
+  eventarc.GetChannelConnectionRequest(**{
   }),
   {
   },
@@ -5665,7 +5665,7 @@ async def test_get_channel_connection_async_use_cached_wrapped_rpc(transport: st
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  eventarc.GetChannelConnectionRequest({  }),
+  eventarc.GetChannelConnectionRequest(**{  }),
   {  },
 ])
 async def test_get_channel_connection_async(request_type, transport: str = 'grpc_asyncio'):
@@ -5850,7 +5850,7 @@ async def test_get_channel_connection_flattened_error_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  eventarc.ListChannelConnectionsRequest({
+  eventarc.ListChannelConnectionsRequest(**{
   }),
   {
   },
@@ -5986,7 +5986,7 @@ async def test_list_channel_connections_async_use_cached_wrapped_rpc(transport: 
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  eventarc.ListChannelConnectionsRequest({  }),
+  eventarc.ListChannelConnectionsRequest(**{  }),
   {  },
 ])
 async def test_list_channel_connections_async(request_type, transport: str = 'grpc_asyncio'):
@@ -6361,7 +6361,7 @@ async def test_list_channel_connections_async_pages():
             assert page_.raw_page.next_page_token == token
 
 @pytest.mark.parametrize("request_type", [
-  eventarc.CreateChannelConnectionRequest({
+  eventarc.CreateChannelConnectionRequest(**{
   }),
   {
   },
@@ -6502,7 +6502,7 @@ async def test_create_channel_connection_async_use_cached_wrapped_rpc(transport:
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  eventarc.CreateChannelConnectionRequest({  }),
+  eventarc.CreateChannelConnectionRequest(**{  }),
   {  },
 ])
 async def test_create_channel_connection_async(request_type, transport: str = 'grpc_asyncio'):
@@ -6702,7 +6702,7 @@ async def test_create_channel_connection_flattened_error_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  eventarc.DeleteChannelConnectionRequest({
+  eventarc.DeleteChannelConnectionRequest(**{
   }),
   {
   },
@@ -6841,7 +6841,7 @@ async def test_delete_channel_connection_async_use_cached_wrapped_rpc(transport:
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  eventarc.DeleteChannelConnectionRequest({  }),
+  eventarc.DeleteChannelConnectionRequest(**{  }),
   {  },
 ])
 async def test_delete_channel_connection_async(request_type, transport: str = 'grpc_asyncio'):
@@ -7021,7 +7021,7 @@ async def test_delete_channel_connection_flattened_error_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  eventarc.GetGoogleChannelConfigRequest({
+  eventarc.GetGoogleChannelConfigRequest(**{
   }),
   {
   },
@@ -7155,7 +7155,7 @@ async def test_get_google_channel_config_async_use_cached_wrapped_rpc(transport:
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  eventarc.GetGoogleChannelConfigRequest({  }),
+  eventarc.GetGoogleChannelConfigRequest(**{  }),
   {  },
 ])
 async def test_get_google_channel_config_async(request_type, transport: str = 'grpc_asyncio'):
@@ -7336,7 +7336,7 @@ async def test_get_google_channel_config_flattened_error_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  eventarc.UpdateGoogleChannelConfigRequest({
+  eventarc.UpdateGoogleChannelConfigRequest(**{
   }),
   {
   },
@@ -7468,7 +7468,7 @@ async def test_update_google_channel_config_async_use_cached_wrapped_rpc(transpo
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  eventarc.UpdateGoogleChannelConfigRequest({  }),
+  eventarc.UpdateGoogleChannelConfigRequest(**{  }),
   {  },
 ])
 async def test_update_google_channel_config_async(request_type, transport: str = 'grpc_asyncio'):
@@ -7659,7 +7659,7 @@ async def test_update_google_channel_config_flattened_error_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  eventarc.GetMessageBusRequest({
+  eventarc.GetMessageBusRequest(**{
   }),
   {
   },
@@ -7799,7 +7799,7 @@ async def test_get_message_bus_async_use_cached_wrapped_rpc(transport: str = "gr
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  eventarc.GetMessageBusRequest({  }),
+  eventarc.GetMessageBusRequest(**{  }),
   {  },
 ])
 async def test_get_message_bus_async(request_type, transport: str = 'grpc_asyncio'):
@@ -7986,7 +7986,7 @@ async def test_get_message_bus_flattened_error_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  eventarc.ListMessageBusesRequest({
+  eventarc.ListMessageBusesRequest(**{
   }),
   {
   },
@@ -8126,7 +8126,7 @@ async def test_list_message_buses_async_use_cached_wrapped_rpc(transport: str = 
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  eventarc.ListMessageBusesRequest({  }),
+  eventarc.ListMessageBusesRequest(**{  }),
   {  },
 ])
 async def test_list_message_buses_async(request_type, transport: str = 'grpc_asyncio'):
@@ -8501,7 +8501,7 @@ async def test_list_message_buses_async_pages():
             assert page_.raw_page.next_page_token == token
 
 @pytest.mark.parametrize("request_type", [
-  eventarc.ListMessageBusEnrollmentsRequest({
+  eventarc.ListMessageBusEnrollmentsRequest(**{
   }),
   {
   },
@@ -8639,7 +8639,7 @@ async def test_list_message_bus_enrollments_async_use_cached_wrapped_rpc(transpo
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  eventarc.ListMessageBusEnrollmentsRequest({  }),
+  eventarc.ListMessageBusEnrollmentsRequest(**{  }),
   {  },
 ])
 async def test_list_message_bus_enrollments_async(request_type, transport: str = 'grpc_asyncio'):
@@ -9016,7 +9016,7 @@ async def test_list_message_bus_enrollments_async_pages():
             assert page_.raw_page.next_page_token == token
 
 @pytest.mark.parametrize("request_type", [
-  eventarc.CreateMessageBusRequest({
+  eventarc.CreateMessageBusRequest(**{
   }),
   {
   },
@@ -9157,7 +9157,7 @@ async def test_create_message_bus_async_use_cached_wrapped_rpc(transport: str = 
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  eventarc.CreateMessageBusRequest({  }),
+  eventarc.CreateMessageBusRequest(**{  }),
   {  },
 ])
 async def test_create_message_bus_async(request_type, transport: str = 'grpc_asyncio'):
@@ -9357,7 +9357,7 @@ async def test_create_message_bus_flattened_error_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  eventarc.UpdateMessageBusRequest({
+  eventarc.UpdateMessageBusRequest(**{
   }),
   {
   },
@@ -9494,7 +9494,7 @@ async def test_update_message_bus_async_use_cached_wrapped_rpc(transport: str = 
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  eventarc.UpdateMessageBusRequest({  }),
+  eventarc.UpdateMessageBusRequest(**{  }),
   {  },
 ])
 async def test_update_message_bus_async(request_type, transport: str = 'grpc_asyncio'):
@@ -9684,7 +9684,7 @@ async def test_update_message_bus_flattened_error_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  eventarc.DeleteMessageBusRequest({
+  eventarc.DeleteMessageBusRequest(**{
   }),
   {
   },
@@ -9825,7 +9825,7 @@ async def test_delete_message_bus_async_use_cached_wrapped_rpc(transport: str = 
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  eventarc.DeleteMessageBusRequest({  }),
+  eventarc.DeleteMessageBusRequest(**{  }),
   {  },
 ])
 async def test_delete_message_bus_async(request_type, transport: str = 'grpc_asyncio'):
@@ -10015,7 +10015,7 @@ async def test_delete_message_bus_flattened_error_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  eventarc.GetEnrollmentRequest({
+  eventarc.GetEnrollmentRequest(**{
   }),
   {
   },
@@ -10159,7 +10159,7 @@ async def test_get_enrollment_async_use_cached_wrapped_rpc(transport: str = "grp
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  eventarc.GetEnrollmentRequest({  }),
+  eventarc.GetEnrollmentRequest(**{  }),
   {  },
 ])
 async def test_get_enrollment_async(request_type, transport: str = 'grpc_asyncio'):
@@ -10350,7 +10350,7 @@ async def test_get_enrollment_flattened_error_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  eventarc.ListEnrollmentsRequest({
+  eventarc.ListEnrollmentsRequest(**{
   }),
   {
   },
@@ -10490,7 +10490,7 @@ async def test_list_enrollments_async_use_cached_wrapped_rpc(transport: str = "g
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  eventarc.ListEnrollmentsRequest({  }),
+  eventarc.ListEnrollmentsRequest(**{  }),
   {  },
 ])
 async def test_list_enrollments_async(request_type, transport: str = 'grpc_asyncio'):
@@ -10865,7 +10865,7 @@ async def test_list_enrollments_async_pages():
             assert page_.raw_page.next_page_token == token
 
 @pytest.mark.parametrize("request_type", [
-  eventarc.CreateEnrollmentRequest({
+  eventarc.CreateEnrollmentRequest(**{
   }),
   {
   },
@@ -11006,7 +11006,7 @@ async def test_create_enrollment_async_use_cached_wrapped_rpc(transport: str = "
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  eventarc.CreateEnrollmentRequest({  }),
+  eventarc.CreateEnrollmentRequest(**{  }),
   {  },
 ])
 async def test_create_enrollment_async(request_type, transport: str = 'grpc_asyncio'):
@@ -11206,7 +11206,7 @@ async def test_create_enrollment_flattened_error_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  eventarc.UpdateEnrollmentRequest({
+  eventarc.UpdateEnrollmentRequest(**{
   }),
   {
   },
@@ -11343,7 +11343,7 @@ async def test_update_enrollment_async_use_cached_wrapped_rpc(transport: str = "
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  eventarc.UpdateEnrollmentRequest({  }),
+  eventarc.UpdateEnrollmentRequest(**{  }),
   {  },
 ])
 async def test_update_enrollment_async(request_type, transport: str = 'grpc_asyncio'):
@@ -11533,7 +11533,7 @@ async def test_update_enrollment_flattened_error_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  eventarc.DeleteEnrollmentRequest({
+  eventarc.DeleteEnrollmentRequest(**{
   }),
   {
   },
@@ -11674,7 +11674,7 @@ async def test_delete_enrollment_async_use_cached_wrapped_rpc(transport: str = "
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  eventarc.DeleteEnrollmentRequest({  }),
+  eventarc.DeleteEnrollmentRequest(**{  }),
   {  },
 ])
 async def test_delete_enrollment_async(request_type, transport: str = 'grpc_asyncio'):
@@ -11864,7 +11864,7 @@ async def test_delete_enrollment_flattened_error_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  eventarc.GetPipelineRequest({
+  eventarc.GetPipelineRequest(**{
   }),
   {
   },
@@ -12006,7 +12006,7 @@ async def test_get_pipeline_async_use_cached_wrapped_rpc(transport: str = "grpc_
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  eventarc.GetPipelineRequest({  }),
+  eventarc.GetPipelineRequest(**{  }),
   {  },
 ])
 async def test_get_pipeline_async(request_type, transport: str = 'grpc_asyncio'):
@@ -12195,7 +12195,7 @@ async def test_get_pipeline_flattened_error_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  eventarc.ListPipelinesRequest({
+  eventarc.ListPipelinesRequest(**{
   }),
   {
   },
@@ -12335,7 +12335,7 @@ async def test_list_pipelines_async_use_cached_wrapped_rpc(transport: str = "grp
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  eventarc.ListPipelinesRequest({  }),
+  eventarc.ListPipelinesRequest(**{  }),
   {  },
 ])
 async def test_list_pipelines_async(request_type, transport: str = 'grpc_asyncio'):
@@ -12710,7 +12710,7 @@ async def test_list_pipelines_async_pages():
             assert page_.raw_page.next_page_token == token
 
 @pytest.mark.parametrize("request_type", [
-  eventarc.CreatePipelineRequest({
+  eventarc.CreatePipelineRequest(**{
   }),
   {
   },
@@ -12851,7 +12851,7 @@ async def test_create_pipeline_async_use_cached_wrapped_rpc(transport: str = "gr
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  eventarc.CreatePipelineRequest({  }),
+  eventarc.CreatePipelineRequest(**{  }),
   {  },
 ])
 async def test_create_pipeline_async(request_type, transport: str = 'grpc_asyncio'):
@@ -13051,7 +13051,7 @@ async def test_create_pipeline_flattened_error_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  eventarc.UpdatePipelineRequest({
+  eventarc.UpdatePipelineRequest(**{
   }),
   {
   },
@@ -13188,7 +13188,7 @@ async def test_update_pipeline_async_use_cached_wrapped_rpc(transport: str = "gr
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  eventarc.UpdatePipelineRequest({  }),
+  eventarc.UpdatePipelineRequest(**{  }),
   {  },
 ])
 async def test_update_pipeline_async(request_type, transport: str = 'grpc_asyncio'):
@@ -13378,7 +13378,7 @@ async def test_update_pipeline_flattened_error_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  eventarc.DeletePipelineRequest({
+  eventarc.DeletePipelineRequest(**{
   }),
   {
   },
@@ -13519,7 +13519,7 @@ async def test_delete_pipeline_async_use_cached_wrapped_rpc(transport: str = "gr
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  eventarc.DeletePipelineRequest({  }),
+  eventarc.DeletePipelineRequest(**{  }),
   {  },
 ])
 async def test_delete_pipeline_async(request_type, transport: str = 'grpc_asyncio'):
@@ -13709,7 +13709,7 @@ async def test_delete_pipeline_flattened_error_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  eventarc.GetGoogleApiSourceRequest({
+  eventarc.GetGoogleApiSourceRequest(**{
   }),
   {
   },
@@ -13851,7 +13851,7 @@ async def test_get_google_api_source_async_use_cached_wrapped_rpc(transport: str
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  eventarc.GetGoogleApiSourceRequest({  }),
+  eventarc.GetGoogleApiSourceRequest(**{  }),
   {  },
 ])
 async def test_get_google_api_source_async(request_type, transport: str = 'grpc_asyncio'):
@@ -14040,7 +14040,7 @@ async def test_get_google_api_source_flattened_error_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  eventarc.ListGoogleApiSourcesRequest({
+  eventarc.ListGoogleApiSourcesRequest(**{
   }),
   {
   },
@@ -14180,7 +14180,7 @@ async def test_list_google_api_sources_async_use_cached_wrapped_rpc(transport: s
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  eventarc.ListGoogleApiSourcesRequest({  }),
+  eventarc.ListGoogleApiSourcesRequest(**{  }),
   {  },
 ])
 async def test_list_google_api_sources_async(request_type, transport: str = 'grpc_asyncio'):
@@ -14555,7 +14555,7 @@ async def test_list_google_api_sources_async_pages():
             assert page_.raw_page.next_page_token == token
 
 @pytest.mark.parametrize("request_type", [
-  eventarc.CreateGoogleApiSourceRequest({
+  eventarc.CreateGoogleApiSourceRequest(**{
   }),
   {
   },
@@ -14696,7 +14696,7 @@ async def test_create_google_api_source_async_use_cached_wrapped_rpc(transport: 
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  eventarc.CreateGoogleApiSourceRequest({  }),
+  eventarc.CreateGoogleApiSourceRequest(**{  }),
   {  },
 ])
 async def test_create_google_api_source_async(request_type, transport: str = 'grpc_asyncio'):
@@ -14896,7 +14896,7 @@ async def test_create_google_api_source_flattened_error_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  eventarc.UpdateGoogleApiSourceRequest({
+  eventarc.UpdateGoogleApiSourceRequest(**{
   }),
   {
   },
@@ -15033,7 +15033,7 @@ async def test_update_google_api_source_async_use_cached_wrapped_rpc(transport: 
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  eventarc.UpdateGoogleApiSourceRequest({  }),
+  eventarc.UpdateGoogleApiSourceRequest(**{  }),
   {  },
 ])
 async def test_update_google_api_source_async(request_type, transport: str = 'grpc_asyncio'):
@@ -15223,7 +15223,7 @@ async def test_update_google_api_source_flattened_error_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  eventarc.DeleteGoogleApiSourceRequest({
+  eventarc.DeleteGoogleApiSourceRequest(**{
   }),
   {
   },
@@ -15364,7 +15364,7 @@ async def test_delete_google_api_source_async_use_cached_wrapped_rpc(transport: 
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  eventarc.DeleteGoogleApiSourceRequest({  }),
+  eventarc.DeleteGoogleApiSourceRequest(**{  }),
   {  },
 ])
 async def test_delete_google_api_source_async(request_type, transport: str = 'grpc_asyncio'):

--- a/packages/gapic-generator/tests/integration/goldens/eventarc/tests/unit/gapic/eventarc_v1/test_eventarc.py
+++ b/packages/gapic-generator/tests/integration/goldens/eventarc/tests/unit/gapic/eventarc_v1/test_eventarc.py
@@ -1002,10 +1002,8 @@ def test_eventarc_client_create_channel_credentials_file(client_class, transport
 
 
 @pytest.mark.parametrize("request_type", [
-  eventarc.GetTriggerRequest(**{
-  }),
-  {
-  },
+  eventarc.GetTriggerRequest(),
+  {},
 ])
 def test_get_trigger(request_type, transport: str = 'grpc'):
     client = EventarcClient(
@@ -1337,10 +1335,8 @@ async def test_get_trigger_flattened_error_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  eventarc.ListTriggersRequest(**{
-  }),
-  {
-  },
+  eventarc.ListTriggersRequest(),
+  {},
 ])
 def test_list_triggers(request_type, transport: str = 'grpc'):
     client = EventarcClient(
@@ -1852,10 +1848,8 @@ async def test_list_triggers_async_pages():
             assert page_.raw_page.next_page_token == token
 
 @pytest.mark.parametrize("request_type", [
-  eventarc.CreateTriggerRequest(**{
-  }),
-  {
-  },
+  eventarc.CreateTriggerRequest(),
+  {},
 ])
 def test_create_trigger(request_type, transport: str = 'grpc'):
     client = EventarcClient(
@@ -2193,10 +2187,8 @@ async def test_create_trigger_flattened_error_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  eventarc.UpdateTriggerRequest(**{
-  }),
-  {
-  },
+  eventarc.UpdateTriggerRequest(),
+  {},
 ])
 def test_update_trigger(request_type, transport: str = 'grpc'):
     client = EventarcClient(
@@ -2530,10 +2522,8 @@ async def test_update_trigger_flattened_error_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  eventarc.DeleteTriggerRequest(**{
-  }),
-  {
-  },
+  eventarc.DeleteTriggerRequest(),
+  {},
 ])
 def test_delete_trigger(request_type, transport: str = 'grpc'):
     client = EventarcClient(
@@ -2861,10 +2851,8 @@ async def test_delete_trigger_flattened_error_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  eventarc.GetChannelRequest(**{
-  }),
-  {
-  },
+  eventarc.GetChannelRequest(),
+  {},
 ])
 def test_get_channel(request_type, transport: str = 'grpc'):
     client = EventarcClient(
@@ -3197,10 +3185,8 @@ async def test_get_channel_flattened_error_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  eventarc.ListChannelsRequest(**{
-  }),
-  {
-  },
+  eventarc.ListChannelsRequest(),
+  {},
 ])
 def test_list_channels(request_type, transport: str = 'grpc'):
     client = EventarcClient(
@@ -3710,10 +3696,8 @@ async def test_list_channels_async_pages():
             assert page_.raw_page.next_page_token == token
 
 @pytest.mark.parametrize("request_type", [
-  eventarc.CreateChannelRequest(**{
-  }),
-  {
-  },
+  eventarc.CreateChannelRequest(),
+  {},
 ])
 def test_create_channel(request_type, transport: str = 'grpc'):
     client = EventarcClient(
@@ -4051,10 +4035,8 @@ async def test_create_channel_flattened_error_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  eventarc.UpdateChannelRequest(**{
-  }),
-  {
-  },
+  eventarc.UpdateChannelRequest(),
+  {},
 ])
 def test_update_channel(request_type, transport: str = 'grpc'):
     client = EventarcClient(
@@ -4378,10 +4360,8 @@ async def test_update_channel_flattened_error_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  eventarc.DeleteChannelRequest(**{
-  }),
-  {
-  },
+  eventarc.DeleteChannelRequest(),
+  {},
 ])
 def test_delete_channel(request_type, transport: str = 'grpc'):
     client = EventarcClient(
@@ -4697,10 +4677,8 @@ async def test_delete_channel_flattened_error_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  eventarc.GetProviderRequest(**{
-  }),
-  {
-  },
+  eventarc.GetProviderRequest(),
+  {},
 ])
 def test_get_provider(request_type, transport: str = 'grpc'):
     client = EventarcClient(
@@ -5012,10 +4990,8 @@ async def test_get_provider_flattened_error_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  eventarc.ListProvidersRequest(**{
-  }),
-  {
-  },
+  eventarc.ListProvidersRequest(),
+  {},
 ])
 def test_list_providers(request_type, transport: str = 'grpc'):
     client = EventarcClient(
@@ -5527,10 +5503,8 @@ async def test_list_providers_async_pages():
             assert page_.raw_page.next_page_token == token
 
 @pytest.mark.parametrize("request_type", [
-  eventarc.GetChannelConnectionRequest(**{
-  }),
-  {
-  },
+  eventarc.GetChannelConnectionRequest(),
+  {},
 ])
 def test_get_channel_connection(request_type, transport: str = 'grpc'):
     client = EventarcClient(
@@ -5850,10 +5824,8 @@ async def test_get_channel_connection_flattened_error_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  eventarc.ListChannelConnectionsRequest(**{
-  }),
-  {
-  },
+  eventarc.ListChannelConnectionsRequest(),
+  {},
 ])
 def test_list_channel_connections(request_type, transport: str = 'grpc'):
     client = EventarcClient(
@@ -6361,10 +6333,8 @@ async def test_list_channel_connections_async_pages():
             assert page_.raw_page.next_page_token == token
 
 @pytest.mark.parametrize("request_type", [
-  eventarc.CreateChannelConnectionRequest(**{
-  }),
-  {
-  },
+  eventarc.CreateChannelConnectionRequest(),
+  {},
 ])
 def test_create_channel_connection(request_type, transport: str = 'grpc'):
     client = EventarcClient(
@@ -6702,10 +6672,8 @@ async def test_create_channel_connection_flattened_error_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  eventarc.DeleteChannelConnectionRequest(**{
-  }),
-  {
-  },
+  eventarc.DeleteChannelConnectionRequest(),
+  {},
 ])
 def test_delete_channel_connection(request_type, transport: str = 'grpc'):
     client = EventarcClient(
@@ -7021,10 +6989,8 @@ async def test_delete_channel_connection_flattened_error_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  eventarc.GetGoogleChannelConfigRequest(**{
-  }),
-  {
-  },
+  eventarc.GetGoogleChannelConfigRequest(),
+  {},
 ])
 def test_get_google_channel_config(request_type, transport: str = 'grpc'):
     client = EventarcClient(
@@ -7336,10 +7302,8 @@ async def test_get_google_channel_config_flattened_error_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  eventarc.UpdateGoogleChannelConfigRequest(**{
-  }),
-  {
-  },
+  eventarc.UpdateGoogleChannelConfigRequest(),
+  {},
 ])
 def test_update_google_channel_config(request_type, transport: str = 'grpc'):
     client = EventarcClient(
@@ -7659,10 +7623,8 @@ async def test_update_google_channel_config_flattened_error_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  eventarc.GetMessageBusRequest(**{
-  }),
-  {
-  },
+  eventarc.GetMessageBusRequest(),
+  {},
 ])
 def test_get_message_bus(request_type, transport: str = 'grpc'):
     client = EventarcClient(
@@ -7986,10 +7948,8 @@ async def test_get_message_bus_flattened_error_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  eventarc.ListMessageBusesRequest(**{
-  }),
-  {
-  },
+  eventarc.ListMessageBusesRequest(),
+  {},
 ])
 def test_list_message_buses(request_type, transport: str = 'grpc'):
     client = EventarcClient(
@@ -8501,10 +8461,8 @@ async def test_list_message_buses_async_pages():
             assert page_.raw_page.next_page_token == token
 
 @pytest.mark.parametrize("request_type", [
-  eventarc.ListMessageBusEnrollmentsRequest(**{
-  }),
-  {
-  },
+  eventarc.ListMessageBusEnrollmentsRequest(),
+  {},
 ])
 def test_list_message_bus_enrollments(request_type, transport: str = 'grpc'):
     client = EventarcClient(
@@ -9016,10 +8974,8 @@ async def test_list_message_bus_enrollments_async_pages():
             assert page_.raw_page.next_page_token == token
 
 @pytest.mark.parametrize("request_type", [
-  eventarc.CreateMessageBusRequest(**{
-  }),
-  {
-  },
+  eventarc.CreateMessageBusRequest(),
+  {},
 ])
 def test_create_message_bus(request_type, transport: str = 'grpc'):
     client = EventarcClient(
@@ -9357,10 +9313,8 @@ async def test_create_message_bus_flattened_error_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  eventarc.UpdateMessageBusRequest(**{
-  }),
-  {
-  },
+  eventarc.UpdateMessageBusRequest(),
+  {},
 ])
 def test_update_message_bus(request_type, transport: str = 'grpc'):
     client = EventarcClient(
@@ -9684,10 +9638,8 @@ async def test_update_message_bus_flattened_error_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  eventarc.DeleteMessageBusRequest(**{
-  }),
-  {
-  },
+  eventarc.DeleteMessageBusRequest(),
+  {},
 ])
 def test_delete_message_bus(request_type, transport: str = 'grpc'):
     client = EventarcClient(
@@ -10015,10 +9967,8 @@ async def test_delete_message_bus_flattened_error_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  eventarc.GetEnrollmentRequest(**{
-  }),
-  {
-  },
+  eventarc.GetEnrollmentRequest(),
+  {},
 ])
 def test_get_enrollment(request_type, transport: str = 'grpc'):
     client = EventarcClient(
@@ -10350,10 +10300,8 @@ async def test_get_enrollment_flattened_error_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  eventarc.ListEnrollmentsRequest(**{
-  }),
-  {
-  },
+  eventarc.ListEnrollmentsRequest(),
+  {},
 ])
 def test_list_enrollments(request_type, transport: str = 'grpc'):
     client = EventarcClient(
@@ -10865,10 +10813,8 @@ async def test_list_enrollments_async_pages():
             assert page_.raw_page.next_page_token == token
 
 @pytest.mark.parametrize("request_type", [
-  eventarc.CreateEnrollmentRequest(**{
-  }),
-  {
-  },
+  eventarc.CreateEnrollmentRequest(),
+  {},
 ])
 def test_create_enrollment(request_type, transport: str = 'grpc'):
     client = EventarcClient(
@@ -11206,10 +11152,8 @@ async def test_create_enrollment_flattened_error_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  eventarc.UpdateEnrollmentRequest(**{
-  }),
-  {
-  },
+  eventarc.UpdateEnrollmentRequest(),
+  {},
 ])
 def test_update_enrollment(request_type, transport: str = 'grpc'):
     client = EventarcClient(
@@ -11533,10 +11477,8 @@ async def test_update_enrollment_flattened_error_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  eventarc.DeleteEnrollmentRequest(**{
-  }),
-  {
-  },
+  eventarc.DeleteEnrollmentRequest(),
+  {},
 ])
 def test_delete_enrollment(request_type, transport: str = 'grpc'):
     client = EventarcClient(
@@ -11864,10 +11806,8 @@ async def test_delete_enrollment_flattened_error_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  eventarc.GetPipelineRequest(**{
-  }),
-  {
-  },
+  eventarc.GetPipelineRequest(),
+  {},
 ])
 def test_get_pipeline(request_type, transport: str = 'grpc'):
     client = EventarcClient(
@@ -12195,10 +12135,8 @@ async def test_get_pipeline_flattened_error_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  eventarc.ListPipelinesRequest(**{
-  }),
-  {
-  },
+  eventarc.ListPipelinesRequest(),
+  {},
 ])
 def test_list_pipelines(request_type, transport: str = 'grpc'):
     client = EventarcClient(
@@ -12710,10 +12648,8 @@ async def test_list_pipelines_async_pages():
             assert page_.raw_page.next_page_token == token
 
 @pytest.mark.parametrize("request_type", [
-  eventarc.CreatePipelineRequest(**{
-  }),
-  {
-  },
+  eventarc.CreatePipelineRequest(),
+  {},
 ])
 def test_create_pipeline(request_type, transport: str = 'grpc'):
     client = EventarcClient(
@@ -13051,10 +12987,8 @@ async def test_create_pipeline_flattened_error_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  eventarc.UpdatePipelineRequest(**{
-  }),
-  {
-  },
+  eventarc.UpdatePipelineRequest(),
+  {},
 ])
 def test_update_pipeline(request_type, transport: str = 'grpc'):
     client = EventarcClient(
@@ -13378,10 +13312,8 @@ async def test_update_pipeline_flattened_error_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  eventarc.DeletePipelineRequest(**{
-  }),
-  {
-  },
+  eventarc.DeletePipelineRequest(),
+  {},
 ])
 def test_delete_pipeline(request_type, transport: str = 'grpc'):
     client = EventarcClient(
@@ -13709,10 +13641,8 @@ async def test_delete_pipeline_flattened_error_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  eventarc.GetGoogleApiSourceRequest(**{
-  }),
-  {
-  },
+  eventarc.GetGoogleApiSourceRequest(),
+  {},
 ])
 def test_get_google_api_source(request_type, transport: str = 'grpc'):
     client = EventarcClient(
@@ -14040,10 +13970,8 @@ async def test_get_google_api_source_flattened_error_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  eventarc.ListGoogleApiSourcesRequest(**{
-  }),
-  {
-  },
+  eventarc.ListGoogleApiSourcesRequest(),
+  {},
 ])
 def test_list_google_api_sources(request_type, transport: str = 'grpc'):
     client = EventarcClient(
@@ -14555,10 +14483,8 @@ async def test_list_google_api_sources_async_pages():
             assert page_.raw_page.next_page_token == token
 
 @pytest.mark.parametrize("request_type", [
-  eventarc.CreateGoogleApiSourceRequest(**{
-  }),
-  {
-  },
+  eventarc.CreateGoogleApiSourceRequest(),
+  {},
 ])
 def test_create_google_api_source(request_type, transport: str = 'grpc'):
     client = EventarcClient(
@@ -14896,10 +14822,8 @@ async def test_create_google_api_source_flattened_error_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  eventarc.UpdateGoogleApiSourceRequest(**{
-  }),
-  {
-  },
+  eventarc.UpdateGoogleApiSourceRequest(),
+  {},
 ])
 def test_update_google_api_source(request_type, transport: str = 'grpc'):
     client = EventarcClient(
@@ -15223,10 +15147,8 @@ async def test_update_google_api_source_flattened_error_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  eventarc.DeleteGoogleApiSourceRequest(**{
-  }),
-  {
-  },
+  eventarc.DeleteGoogleApiSourceRequest(),
+  {},
 ])
 def test_delete_google_api_source(request_type, transport: str = 'grpc'):
     client = EventarcClient(

--- a/packages/gapic-generator/tests/integration/goldens/logging/tests/unit/gapic/logging_v2/test_config_service_v2.py
+++ b/packages/gapic-generator/tests/integration/goldens/logging/tests/unit/gapic/logging_v2/test_config_service_v2.py
@@ -960,7 +960,7 @@ def test_config_service_v2_client_create_channel_credentials_file(client_class, 
 
 
 @pytest.mark.parametrize("request_type", [
-  logging_config.ListBucketsRequest({
+  logging_config.ListBucketsRequest(**{
   }),
   {
   },
@@ -1094,7 +1094,7 @@ async def test_list_buckets_async_use_cached_wrapped_rpc(transport: str = "grpc_
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  logging_config.ListBucketsRequest({  }),
+  logging_config.ListBucketsRequest(**{  }),
   {  },
 ])
 async def test_list_buckets_async(request_type, transport: str = 'grpc_asyncio'):
@@ -1467,7 +1467,7 @@ async def test_list_buckets_async_pages():
             assert page_.raw_page.next_page_token == token
 
 @pytest.mark.parametrize("request_type", [
-  logging_config.GetBucketRequest({
+  logging_config.GetBucketRequest(**{
   }),
   {
   },
@@ -1611,7 +1611,7 @@ async def test_get_bucket_async_use_cached_wrapped_rpc(transport: str = "grpc_as
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  logging_config.GetBucketRequest({  }),
+  logging_config.GetBucketRequest(**{  }),
   {  },
 ])
 async def test_get_bucket_async(request_type, transport: str = 'grpc_asyncio'):
@@ -1720,7 +1720,7 @@ async def test_get_bucket_field_headers_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  logging_config.CreateBucketRequest({
+  logging_config.CreateBucketRequest(**{
   }),
   {
   },
@@ -1861,7 +1861,7 @@ async def test_create_bucket_async_async_use_cached_wrapped_rpc(transport: str =
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  logging_config.CreateBucketRequest({  }),
+  logging_config.CreateBucketRequest(**{  }),
   {  },
 ])
 async def test_create_bucket_async_async(request_type, transport: str = 'grpc_asyncio'):
@@ -1957,7 +1957,7 @@ async def test_create_bucket_async_field_headers_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  logging_config.UpdateBucketRequest({
+  logging_config.UpdateBucketRequest(**{
   }),
   {
   },
@@ -2096,7 +2096,7 @@ async def test_update_bucket_async_async_use_cached_wrapped_rpc(transport: str =
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  logging_config.UpdateBucketRequest({  }),
+  logging_config.UpdateBucketRequest(**{  }),
   {  },
 ])
 async def test_update_bucket_async_async(request_type, transport: str = 'grpc_asyncio'):
@@ -2192,7 +2192,7 @@ async def test_update_bucket_async_field_headers_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  logging_config.CreateBucketRequest({
+  logging_config.CreateBucketRequest(**{
   }),
   {
   },
@@ -2338,7 +2338,7 @@ async def test_create_bucket_async_use_cached_wrapped_rpc(transport: str = "grpc
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  logging_config.CreateBucketRequest({  }),
+  logging_config.CreateBucketRequest(**{  }),
   {  },
 ])
 async def test_create_bucket_async(request_type, transport: str = 'grpc_asyncio'):
@@ -2447,7 +2447,7 @@ async def test_create_bucket_field_headers_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  logging_config.UpdateBucketRequest({
+  logging_config.UpdateBucketRequest(**{
   }),
   {
   },
@@ -2591,7 +2591,7 @@ async def test_update_bucket_async_use_cached_wrapped_rpc(transport: str = "grpc
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  logging_config.UpdateBucketRequest({  }),
+  logging_config.UpdateBucketRequest(**{  }),
   {  },
 ])
 async def test_update_bucket_async(request_type, transport: str = 'grpc_asyncio'):
@@ -2700,7 +2700,7 @@ async def test_update_bucket_field_headers_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  logging_config.DeleteBucketRequest({
+  logging_config.DeleteBucketRequest(**{
   }),
   {
   },
@@ -2829,7 +2829,7 @@ async def test_delete_bucket_async_use_cached_wrapped_rpc(transport: str = "grpc
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  logging_config.DeleteBucketRequest({  }),
+  logging_config.DeleteBucketRequest(**{  }),
   {  },
 ])
 async def test_delete_bucket_async(request_type, transport: str = 'grpc_asyncio'):
@@ -2923,7 +2923,7 @@ async def test_delete_bucket_field_headers_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  logging_config.UndeleteBucketRequest({
+  logging_config.UndeleteBucketRequest(**{
   }),
   {
   },
@@ -3052,7 +3052,7 @@ async def test_undelete_bucket_async_use_cached_wrapped_rpc(transport: str = "gr
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  logging_config.UndeleteBucketRequest({  }),
+  logging_config.UndeleteBucketRequest(**{  }),
   {  },
 ])
 async def test_undelete_bucket_async(request_type, transport: str = 'grpc_asyncio'):
@@ -3146,7 +3146,7 @@ async def test_undelete_bucket_field_headers_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  logging_config.ListViewsRequest({
+  logging_config.ListViewsRequest(**{
   }),
   {
   },
@@ -3280,7 +3280,7 @@ async def test_list_views_async_use_cached_wrapped_rpc(transport: str = "grpc_as
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  logging_config.ListViewsRequest({  }),
+  logging_config.ListViewsRequest(**{  }),
   {  },
 ])
 async def test_list_views_async(request_type, transport: str = 'grpc_asyncio'):
@@ -3653,7 +3653,7 @@ async def test_list_views_async_pages():
             assert page_.raw_page.next_page_token == token
 
 @pytest.mark.parametrize("request_type", [
-  logging_config.GetViewRequest({
+  logging_config.GetViewRequest(**{
   }),
   {
   },
@@ -3789,7 +3789,7 @@ async def test_get_view_async_use_cached_wrapped_rpc(transport: str = "grpc_asyn
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  logging_config.GetViewRequest({  }),
+  logging_config.GetViewRequest(**{  }),
   {  },
 ])
 async def test_get_view_async(request_type, transport: str = 'grpc_asyncio'):
@@ -3890,7 +3890,7 @@ async def test_get_view_field_headers_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  logging_config.CreateViewRequest({
+  logging_config.CreateViewRequest(**{
   }),
   {
   },
@@ -4028,7 +4028,7 @@ async def test_create_view_async_use_cached_wrapped_rpc(transport: str = "grpc_a
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  logging_config.CreateViewRequest({  }),
+  logging_config.CreateViewRequest(**{  }),
   {  },
 ])
 async def test_create_view_async(request_type, transport: str = 'grpc_asyncio'):
@@ -4129,7 +4129,7 @@ async def test_create_view_field_headers_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  logging_config.UpdateViewRequest({
+  logging_config.UpdateViewRequest(**{
   }),
   {
   },
@@ -4265,7 +4265,7 @@ async def test_update_view_async_use_cached_wrapped_rpc(transport: str = "grpc_a
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  logging_config.UpdateViewRequest({  }),
+  logging_config.UpdateViewRequest(**{  }),
   {  },
 ])
 async def test_update_view_async(request_type, transport: str = 'grpc_asyncio'):
@@ -4366,7 +4366,7 @@ async def test_update_view_field_headers_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  logging_config.DeleteViewRequest({
+  logging_config.DeleteViewRequest(**{
   }),
   {
   },
@@ -4495,7 +4495,7 @@ async def test_delete_view_async_use_cached_wrapped_rpc(transport: str = "grpc_a
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  logging_config.DeleteViewRequest({  }),
+  logging_config.DeleteViewRequest(**{  }),
   {  },
 ])
 async def test_delete_view_async(request_type, transport: str = 'grpc_asyncio'):
@@ -4589,7 +4589,7 @@ async def test_delete_view_field_headers_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  logging_config.ListSinksRequest({
+  logging_config.ListSinksRequest(**{
   }),
   {
   },
@@ -4723,7 +4723,7 @@ async def test_list_sinks_async_use_cached_wrapped_rpc(transport: str = "grpc_as
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  logging_config.ListSinksRequest({  }),
+  logging_config.ListSinksRequest(**{  }),
   {  },
 ])
 async def test_list_sinks_async(request_type, transport: str = 'grpc_asyncio'):
@@ -5096,7 +5096,7 @@ async def test_list_sinks_async_pages():
             assert page_.raw_page.next_page_token == token
 
 @pytest.mark.parametrize("request_type", [
-  logging_config.GetSinkRequest({
+  logging_config.GetSinkRequest(**{
   }),
   {
   },
@@ -5242,7 +5242,7 @@ async def test_get_sink_async_use_cached_wrapped_rpc(transport: str = "grpc_asyn
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  logging_config.GetSinkRequest({  }),
+  logging_config.GetSinkRequest(**{  }),
   {  },
 ])
 async def test_get_sink_async(request_type, transport: str = 'grpc_asyncio'):
@@ -5435,7 +5435,7 @@ async def test_get_sink_flattened_error_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  logging_config.CreateSinkRequest({
+  logging_config.CreateSinkRequest(**{
   }),
   {
   },
@@ -5581,7 +5581,7 @@ async def test_create_sink_async_use_cached_wrapped_rpc(transport: str = "grpc_a
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  logging_config.CreateSinkRequest({  }),
+  logging_config.CreateSinkRequest(**{  }),
   {  },
 ])
 async def test_create_sink_async(request_type, transport: str = 'grpc_asyncio'):
@@ -5784,7 +5784,7 @@ async def test_create_sink_flattened_error_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  logging_config.UpdateSinkRequest({
+  logging_config.UpdateSinkRequest(**{
   }),
   {
   },
@@ -5930,7 +5930,7 @@ async def test_update_sink_async_use_cached_wrapped_rpc(transport: str = "grpc_a
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  logging_config.UpdateSinkRequest({  }),
+  logging_config.UpdateSinkRequest(**{  }),
   {  },
 ])
 async def test_update_sink_async(request_type, transport: str = 'grpc_asyncio'):
@@ -6143,7 +6143,7 @@ async def test_update_sink_flattened_error_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  logging_config.DeleteSinkRequest({
+  logging_config.DeleteSinkRequest(**{
   }),
   {
   },
@@ -6272,7 +6272,7 @@ async def test_delete_sink_async_use_cached_wrapped_rpc(transport: str = "grpc_a
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  logging_config.DeleteSinkRequest({  }),
+  logging_config.DeleteSinkRequest(**{  }),
   {  },
 ])
 async def test_delete_sink_async(request_type, transport: str = 'grpc_asyncio'):
@@ -6448,7 +6448,7 @@ async def test_delete_sink_flattened_error_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  logging_config.CreateLinkRequest({
+  logging_config.CreateLinkRequest(**{
   }),
   {
   },
@@ -6589,7 +6589,7 @@ async def test_create_link_async_use_cached_wrapped_rpc(transport: str = "grpc_a
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  logging_config.CreateLinkRequest({  }),
+  logging_config.CreateLinkRequest(**{  }),
   {  },
 ])
 async def test_create_link_async(request_type, transport: str = 'grpc_asyncio'):
@@ -6789,7 +6789,7 @@ async def test_create_link_flattened_error_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  logging_config.DeleteLinkRequest({
+  logging_config.DeleteLinkRequest(**{
   }),
   {
   },
@@ -6928,7 +6928,7 @@ async def test_delete_link_async_use_cached_wrapped_rpc(transport: str = "grpc_a
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  logging_config.DeleteLinkRequest({  }),
+  logging_config.DeleteLinkRequest(**{  }),
   {  },
 ])
 async def test_delete_link_async(request_type, transport: str = 'grpc_asyncio'):
@@ -7108,7 +7108,7 @@ async def test_delete_link_flattened_error_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  logging_config.ListLinksRequest({
+  logging_config.ListLinksRequest(**{
   }),
   {
   },
@@ -7242,7 +7242,7 @@ async def test_list_links_async_use_cached_wrapped_rpc(transport: str = "grpc_as
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  logging_config.ListLinksRequest({  }),
+  logging_config.ListLinksRequest(**{  }),
   {  },
 ])
 async def test_list_links_async(request_type, transport: str = 'grpc_asyncio'):
@@ -7615,7 +7615,7 @@ async def test_list_links_async_pages():
             assert page_.raw_page.next_page_token == token
 
 @pytest.mark.parametrize("request_type", [
-  logging_config.GetLinkRequest({
+  logging_config.GetLinkRequest(**{
   }),
   {
   },
@@ -7751,7 +7751,7 @@ async def test_get_link_async_use_cached_wrapped_rpc(transport: str = "grpc_asyn
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  logging_config.GetLinkRequest({  }),
+  logging_config.GetLinkRequest(**{  }),
   {  },
 ])
 async def test_get_link_async(request_type, transport: str = 'grpc_asyncio'):
@@ -7934,7 +7934,7 @@ async def test_get_link_flattened_error_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  logging_config.ListExclusionsRequest({
+  logging_config.ListExclusionsRequest(**{
   }),
   {
   },
@@ -8068,7 +8068,7 @@ async def test_list_exclusions_async_use_cached_wrapped_rpc(transport: str = "gr
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  logging_config.ListExclusionsRequest({  }),
+  logging_config.ListExclusionsRequest(**{  }),
   {  },
 ])
 async def test_list_exclusions_async(request_type, transport: str = 'grpc_asyncio'):
@@ -8441,7 +8441,7 @@ async def test_list_exclusions_async_pages():
             assert page_.raw_page.next_page_token == token
 
 @pytest.mark.parametrize("request_type", [
-  logging_config.GetExclusionRequest({
+  logging_config.GetExclusionRequest(**{
   }),
   {
   },
@@ -8579,7 +8579,7 @@ async def test_get_exclusion_async_use_cached_wrapped_rpc(transport: str = "grpc
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  logging_config.GetExclusionRequest({  }),
+  logging_config.GetExclusionRequest(**{  }),
   {  },
 ])
 async def test_get_exclusion_async(request_type, transport: str = 'grpc_asyncio'):
@@ -8764,7 +8764,7 @@ async def test_get_exclusion_flattened_error_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  logging_config.CreateExclusionRequest({
+  logging_config.CreateExclusionRequest(**{
   }),
   {
   },
@@ -8902,7 +8902,7 @@ async def test_create_exclusion_async_use_cached_wrapped_rpc(transport: str = "g
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  logging_config.CreateExclusionRequest({  }),
+  logging_config.CreateExclusionRequest(**{  }),
   {  },
 ])
 async def test_create_exclusion_async(request_type, transport: str = 'grpc_asyncio'):
@@ -9097,7 +9097,7 @@ async def test_create_exclusion_flattened_error_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  logging_config.UpdateExclusionRequest({
+  logging_config.UpdateExclusionRequest(**{
   }),
   {
   },
@@ -9235,7 +9235,7 @@ async def test_update_exclusion_async_use_cached_wrapped_rpc(transport: str = "g
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  logging_config.UpdateExclusionRequest({  }),
+  logging_config.UpdateExclusionRequest(**{  }),
   {  },
 ])
 async def test_update_exclusion_async(request_type, transport: str = 'grpc_asyncio'):
@@ -9440,7 +9440,7 @@ async def test_update_exclusion_flattened_error_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  logging_config.DeleteExclusionRequest({
+  logging_config.DeleteExclusionRequest(**{
   }),
   {
   },
@@ -9569,7 +9569,7 @@ async def test_delete_exclusion_async_use_cached_wrapped_rpc(transport: str = "g
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  logging_config.DeleteExclusionRequest({  }),
+  logging_config.DeleteExclusionRequest(**{  }),
   {  },
 ])
 async def test_delete_exclusion_async(request_type, transport: str = 'grpc_asyncio'):
@@ -9745,7 +9745,7 @@ async def test_delete_exclusion_flattened_error_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  logging_config.GetCmekSettingsRequest({
+  logging_config.GetCmekSettingsRequest(**{
   }),
   {
   },
@@ -9883,7 +9883,7 @@ async def test_get_cmek_settings_async_use_cached_wrapped_rpc(transport: str = "
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  logging_config.GetCmekSettingsRequest({  }),
+  logging_config.GetCmekSettingsRequest(**{  }),
   {  },
 ])
 async def test_get_cmek_settings_async(request_type, transport: str = 'grpc_asyncio'):
@@ -9986,7 +9986,7 @@ async def test_get_cmek_settings_field_headers_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  logging_config.UpdateCmekSettingsRequest({
+  logging_config.UpdateCmekSettingsRequest(**{
   }),
   {
   },
@@ -10124,7 +10124,7 @@ async def test_update_cmek_settings_async_use_cached_wrapped_rpc(transport: str 
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  logging_config.UpdateCmekSettingsRequest({  }),
+  logging_config.UpdateCmekSettingsRequest(**{  }),
   {  },
 ])
 async def test_update_cmek_settings_async(request_type, transport: str = 'grpc_asyncio'):
@@ -10227,7 +10227,7 @@ async def test_update_cmek_settings_field_headers_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  logging_config.GetSettingsRequest({
+  logging_config.GetSettingsRequest(**{
   }),
   {
   },
@@ -10367,7 +10367,7 @@ async def test_get_settings_async_use_cached_wrapped_rpc(transport: str = "grpc_
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  logging_config.GetSettingsRequest({  }),
+  logging_config.GetSettingsRequest(**{  }),
   {  },
 ])
 async def test_get_settings_async(request_type, transport: str = 'grpc_asyncio'):
@@ -10554,7 +10554,7 @@ async def test_get_settings_flattened_error_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  logging_config.UpdateSettingsRequest({
+  logging_config.UpdateSettingsRequest(**{
   }),
   {
   },
@@ -10694,7 +10694,7 @@ async def test_update_settings_async_use_cached_wrapped_rpc(transport: str = "gr
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  logging_config.UpdateSettingsRequest({  }),
+  logging_config.UpdateSettingsRequest(**{  }),
   {  },
 ])
 async def test_update_settings_async(request_type, transport: str = 'grpc_asyncio'):
@@ -10891,7 +10891,7 @@ async def test_update_settings_flattened_error_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  logging_config.CopyLogEntriesRequest({
+  logging_config.CopyLogEntriesRequest(**{
   }),
   {
   },
@@ -11034,7 +11034,7 @@ async def test_copy_log_entries_async_use_cached_wrapped_rpc(transport: str = "g
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  logging_config.CopyLogEntriesRequest({  }),
+  logging_config.CopyLogEntriesRequest(**{  }),
   {  },
 ])
 async def test_copy_log_entries_async(request_type, transport: str = 'grpc_asyncio'):

--- a/packages/gapic-generator/tests/integration/goldens/logging/tests/unit/gapic/logging_v2/test_config_service_v2.py
+++ b/packages/gapic-generator/tests/integration/goldens/logging/tests/unit/gapic/logging_v2/test_config_service_v2.py
@@ -1094,8 +1094,8 @@ async def test_list_buckets_async_use_cached_wrapped_rpc(transport: str = "grpc_
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  logging_config.ListBucketsRequest(**{  }),
-  {  },
+  logging_config.ListBucketsRequest(),
+  {},
 ])
 async def test_list_buckets_async(request_type, transport: str = 'grpc_asyncio'):
     client = ConfigServiceV2AsyncClient(
@@ -1611,8 +1611,8 @@ async def test_get_bucket_async_use_cached_wrapped_rpc(transport: str = "grpc_as
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  logging_config.GetBucketRequest(**{  }),
-  {  },
+  logging_config.GetBucketRequest(),
+  {},
 ])
 async def test_get_bucket_async(request_type, transport: str = 'grpc_asyncio'):
     client = ConfigServiceV2AsyncClient(
@@ -1861,8 +1861,8 @@ async def test_create_bucket_async_async_use_cached_wrapped_rpc(transport: str =
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  logging_config.CreateBucketRequest(**{  }),
-  {  },
+  logging_config.CreateBucketRequest(),
+  {},
 ])
 async def test_create_bucket_async_async(request_type, transport: str = 'grpc_asyncio'):
     client = ConfigServiceV2AsyncClient(
@@ -2096,8 +2096,8 @@ async def test_update_bucket_async_async_use_cached_wrapped_rpc(transport: str =
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  logging_config.UpdateBucketRequest(**{  }),
-  {  },
+  logging_config.UpdateBucketRequest(),
+  {},
 ])
 async def test_update_bucket_async_async(request_type, transport: str = 'grpc_asyncio'):
     client = ConfigServiceV2AsyncClient(
@@ -2338,8 +2338,8 @@ async def test_create_bucket_async_use_cached_wrapped_rpc(transport: str = "grpc
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  logging_config.CreateBucketRequest(**{  }),
-  {  },
+  logging_config.CreateBucketRequest(),
+  {},
 ])
 async def test_create_bucket_async(request_type, transport: str = 'grpc_asyncio'):
     client = ConfigServiceV2AsyncClient(
@@ -2591,8 +2591,8 @@ async def test_update_bucket_async_use_cached_wrapped_rpc(transport: str = "grpc
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  logging_config.UpdateBucketRequest(**{  }),
-  {  },
+  logging_config.UpdateBucketRequest(),
+  {},
 ])
 async def test_update_bucket_async(request_type, transport: str = 'grpc_asyncio'):
     client = ConfigServiceV2AsyncClient(
@@ -2829,8 +2829,8 @@ async def test_delete_bucket_async_use_cached_wrapped_rpc(transport: str = "grpc
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  logging_config.DeleteBucketRequest(**{  }),
-  {  },
+  logging_config.DeleteBucketRequest(),
+  {},
 ])
 async def test_delete_bucket_async(request_type, transport: str = 'grpc_asyncio'):
     client = ConfigServiceV2AsyncClient(
@@ -3052,8 +3052,8 @@ async def test_undelete_bucket_async_use_cached_wrapped_rpc(transport: str = "gr
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  logging_config.UndeleteBucketRequest(**{  }),
-  {  },
+  logging_config.UndeleteBucketRequest(),
+  {},
 ])
 async def test_undelete_bucket_async(request_type, transport: str = 'grpc_asyncio'):
     client = ConfigServiceV2AsyncClient(
@@ -3280,8 +3280,8 @@ async def test_list_views_async_use_cached_wrapped_rpc(transport: str = "grpc_as
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  logging_config.ListViewsRequest(**{  }),
-  {  },
+  logging_config.ListViewsRequest(),
+  {},
 ])
 async def test_list_views_async(request_type, transport: str = 'grpc_asyncio'):
     client = ConfigServiceV2AsyncClient(
@@ -3789,8 +3789,8 @@ async def test_get_view_async_use_cached_wrapped_rpc(transport: str = "grpc_asyn
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  logging_config.GetViewRequest(**{  }),
-  {  },
+  logging_config.GetViewRequest(),
+  {},
 ])
 async def test_get_view_async(request_type, transport: str = 'grpc_asyncio'):
     client = ConfigServiceV2AsyncClient(
@@ -4028,8 +4028,8 @@ async def test_create_view_async_use_cached_wrapped_rpc(transport: str = "grpc_a
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  logging_config.CreateViewRequest(**{  }),
-  {  },
+  logging_config.CreateViewRequest(),
+  {},
 ])
 async def test_create_view_async(request_type, transport: str = 'grpc_asyncio'):
     client = ConfigServiceV2AsyncClient(
@@ -4265,8 +4265,8 @@ async def test_update_view_async_use_cached_wrapped_rpc(transport: str = "grpc_a
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  logging_config.UpdateViewRequest(**{  }),
-  {  },
+  logging_config.UpdateViewRequest(),
+  {},
 ])
 async def test_update_view_async(request_type, transport: str = 'grpc_asyncio'):
     client = ConfigServiceV2AsyncClient(
@@ -4495,8 +4495,8 @@ async def test_delete_view_async_use_cached_wrapped_rpc(transport: str = "grpc_a
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  logging_config.DeleteViewRequest(**{  }),
-  {  },
+  logging_config.DeleteViewRequest(),
+  {},
 ])
 async def test_delete_view_async(request_type, transport: str = 'grpc_asyncio'):
     client = ConfigServiceV2AsyncClient(
@@ -4723,8 +4723,8 @@ async def test_list_sinks_async_use_cached_wrapped_rpc(transport: str = "grpc_as
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  logging_config.ListSinksRequest(**{  }),
-  {  },
+  logging_config.ListSinksRequest(),
+  {},
 ])
 async def test_list_sinks_async(request_type, transport: str = 'grpc_asyncio'):
     client = ConfigServiceV2AsyncClient(
@@ -5242,8 +5242,8 @@ async def test_get_sink_async_use_cached_wrapped_rpc(transport: str = "grpc_asyn
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  logging_config.GetSinkRequest(**{  }),
-  {  },
+  logging_config.GetSinkRequest(),
+  {},
 ])
 async def test_get_sink_async(request_type, transport: str = 'grpc_asyncio'):
     client = ConfigServiceV2AsyncClient(
@@ -5581,8 +5581,8 @@ async def test_create_sink_async_use_cached_wrapped_rpc(transport: str = "grpc_a
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  logging_config.CreateSinkRequest(**{  }),
-  {  },
+  logging_config.CreateSinkRequest(),
+  {},
 ])
 async def test_create_sink_async(request_type, transport: str = 'grpc_asyncio'):
     client = ConfigServiceV2AsyncClient(
@@ -5930,8 +5930,8 @@ async def test_update_sink_async_use_cached_wrapped_rpc(transport: str = "grpc_a
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  logging_config.UpdateSinkRequest(**{  }),
-  {  },
+  logging_config.UpdateSinkRequest(),
+  {},
 ])
 async def test_update_sink_async(request_type, transport: str = 'grpc_asyncio'):
     client = ConfigServiceV2AsyncClient(
@@ -6272,8 +6272,8 @@ async def test_delete_sink_async_use_cached_wrapped_rpc(transport: str = "grpc_a
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  logging_config.DeleteSinkRequest(**{  }),
-  {  },
+  logging_config.DeleteSinkRequest(),
+  {},
 ])
 async def test_delete_sink_async(request_type, transport: str = 'grpc_asyncio'):
     client = ConfigServiceV2AsyncClient(
@@ -6589,8 +6589,8 @@ async def test_create_link_async_use_cached_wrapped_rpc(transport: str = "grpc_a
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  logging_config.CreateLinkRequest(**{  }),
-  {  },
+  logging_config.CreateLinkRequest(),
+  {},
 ])
 async def test_create_link_async(request_type, transport: str = 'grpc_asyncio'):
     client = ConfigServiceV2AsyncClient(
@@ -6928,8 +6928,8 @@ async def test_delete_link_async_use_cached_wrapped_rpc(transport: str = "grpc_a
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  logging_config.DeleteLinkRequest(**{  }),
-  {  },
+  logging_config.DeleteLinkRequest(),
+  {},
 ])
 async def test_delete_link_async(request_type, transport: str = 'grpc_asyncio'):
     client = ConfigServiceV2AsyncClient(
@@ -7242,8 +7242,8 @@ async def test_list_links_async_use_cached_wrapped_rpc(transport: str = "grpc_as
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  logging_config.ListLinksRequest(**{  }),
-  {  },
+  logging_config.ListLinksRequest(),
+  {},
 ])
 async def test_list_links_async(request_type, transport: str = 'grpc_asyncio'):
     client = ConfigServiceV2AsyncClient(
@@ -7751,8 +7751,8 @@ async def test_get_link_async_use_cached_wrapped_rpc(transport: str = "grpc_asyn
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  logging_config.GetLinkRequest(**{  }),
-  {  },
+  logging_config.GetLinkRequest(),
+  {},
 ])
 async def test_get_link_async(request_type, transport: str = 'grpc_asyncio'):
     client = ConfigServiceV2AsyncClient(
@@ -8068,8 +8068,8 @@ async def test_list_exclusions_async_use_cached_wrapped_rpc(transport: str = "gr
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  logging_config.ListExclusionsRequest(**{  }),
-  {  },
+  logging_config.ListExclusionsRequest(),
+  {},
 ])
 async def test_list_exclusions_async(request_type, transport: str = 'grpc_asyncio'):
     client = ConfigServiceV2AsyncClient(
@@ -8579,8 +8579,8 @@ async def test_get_exclusion_async_use_cached_wrapped_rpc(transport: str = "grpc
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  logging_config.GetExclusionRequest(**{  }),
-  {  },
+  logging_config.GetExclusionRequest(),
+  {},
 ])
 async def test_get_exclusion_async(request_type, transport: str = 'grpc_asyncio'):
     client = ConfigServiceV2AsyncClient(
@@ -8902,8 +8902,8 @@ async def test_create_exclusion_async_use_cached_wrapped_rpc(transport: str = "g
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  logging_config.CreateExclusionRequest(**{  }),
-  {  },
+  logging_config.CreateExclusionRequest(),
+  {},
 ])
 async def test_create_exclusion_async(request_type, transport: str = 'grpc_asyncio'):
     client = ConfigServiceV2AsyncClient(
@@ -9235,8 +9235,8 @@ async def test_update_exclusion_async_use_cached_wrapped_rpc(transport: str = "g
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  logging_config.UpdateExclusionRequest(**{  }),
-  {  },
+  logging_config.UpdateExclusionRequest(),
+  {},
 ])
 async def test_update_exclusion_async(request_type, transport: str = 'grpc_asyncio'):
     client = ConfigServiceV2AsyncClient(
@@ -9569,8 +9569,8 @@ async def test_delete_exclusion_async_use_cached_wrapped_rpc(transport: str = "g
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  logging_config.DeleteExclusionRequest(**{  }),
-  {  },
+  logging_config.DeleteExclusionRequest(),
+  {},
 ])
 async def test_delete_exclusion_async(request_type, transport: str = 'grpc_asyncio'):
     client = ConfigServiceV2AsyncClient(
@@ -9883,8 +9883,8 @@ async def test_get_cmek_settings_async_use_cached_wrapped_rpc(transport: str = "
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  logging_config.GetCmekSettingsRequest(**{  }),
-  {  },
+  logging_config.GetCmekSettingsRequest(),
+  {},
 ])
 async def test_get_cmek_settings_async(request_type, transport: str = 'grpc_asyncio'):
     client = ConfigServiceV2AsyncClient(
@@ -10124,8 +10124,8 @@ async def test_update_cmek_settings_async_use_cached_wrapped_rpc(transport: str 
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  logging_config.UpdateCmekSettingsRequest(**{  }),
-  {  },
+  logging_config.UpdateCmekSettingsRequest(),
+  {},
 ])
 async def test_update_cmek_settings_async(request_type, transport: str = 'grpc_asyncio'):
     client = ConfigServiceV2AsyncClient(
@@ -10367,8 +10367,8 @@ async def test_get_settings_async_use_cached_wrapped_rpc(transport: str = "grpc_
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  logging_config.GetSettingsRequest(**{  }),
-  {  },
+  logging_config.GetSettingsRequest(),
+  {},
 ])
 async def test_get_settings_async(request_type, transport: str = 'grpc_asyncio'):
     client = ConfigServiceV2AsyncClient(
@@ -10694,8 +10694,8 @@ async def test_update_settings_async_use_cached_wrapped_rpc(transport: str = "gr
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  logging_config.UpdateSettingsRequest(**{  }),
-  {  },
+  logging_config.UpdateSettingsRequest(),
+  {},
 ])
 async def test_update_settings_async(request_type, transport: str = 'grpc_asyncio'):
     client = ConfigServiceV2AsyncClient(
@@ -11034,8 +11034,8 @@ async def test_copy_log_entries_async_use_cached_wrapped_rpc(transport: str = "g
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  logging_config.CopyLogEntriesRequest(**{  }),
-  {  },
+  logging_config.CopyLogEntriesRequest(),
+  {},
 ])
 async def test_copy_log_entries_async(request_type, transport: str = 'grpc_asyncio'):
     client = ConfigServiceV2AsyncClient(

--- a/packages/gapic-generator/tests/integration/goldens/logging/tests/unit/gapic/logging_v2/test_config_service_v2.py
+++ b/packages/gapic-generator/tests/integration/goldens/logging/tests/unit/gapic/logging_v2/test_config_service_v2.py
@@ -960,10 +960,8 @@ def test_config_service_v2_client_create_channel_credentials_file(client_class, 
 
 
 @pytest.mark.parametrize("request_type", [
-  logging_config.ListBucketsRequest(**{
-  }),
-  {
-  },
+  logging_config.ListBucketsRequest(),
+  {},
 ])
 def test_list_buckets(request_type, transport: str = 'grpc'):
     client = ConfigServiceV2Client(
@@ -1467,10 +1465,8 @@ async def test_list_buckets_async_pages():
             assert page_.raw_page.next_page_token == token
 
 @pytest.mark.parametrize("request_type", [
-  logging_config.GetBucketRequest(**{
-  }),
-  {
-  },
+  logging_config.GetBucketRequest(),
+  {},
 ])
 def test_get_bucket(request_type, transport: str = 'grpc'):
     client = ConfigServiceV2Client(
@@ -1720,10 +1716,8 @@ async def test_get_bucket_field_headers_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  logging_config.CreateBucketRequest(**{
-  }),
-  {
-  },
+  logging_config.CreateBucketRequest(),
+  {},
 ])
 def test_create_bucket_async(request_type, transport: str = 'grpc'):
     client = ConfigServiceV2Client(
@@ -1957,10 +1951,8 @@ async def test_create_bucket_async_field_headers_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  logging_config.UpdateBucketRequest(**{
-  }),
-  {
-  },
+  logging_config.UpdateBucketRequest(),
+  {},
 ])
 def test_update_bucket_async(request_type, transport: str = 'grpc'):
     client = ConfigServiceV2Client(
@@ -2192,10 +2184,8 @@ async def test_update_bucket_async_field_headers_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  logging_config.CreateBucketRequest(**{
-  }),
-  {
-  },
+  logging_config.CreateBucketRequest(),
+  {},
 ])
 def test_create_bucket(request_type, transport: str = 'grpc'):
     client = ConfigServiceV2Client(
@@ -2447,10 +2437,8 @@ async def test_create_bucket_field_headers_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  logging_config.UpdateBucketRequest(**{
-  }),
-  {
-  },
+  logging_config.UpdateBucketRequest(),
+  {},
 ])
 def test_update_bucket(request_type, transport: str = 'grpc'):
     client = ConfigServiceV2Client(
@@ -2700,10 +2688,8 @@ async def test_update_bucket_field_headers_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  logging_config.DeleteBucketRequest(**{
-  }),
-  {
-  },
+  logging_config.DeleteBucketRequest(),
+  {},
 ])
 def test_delete_bucket(request_type, transport: str = 'grpc'):
     client = ConfigServiceV2Client(
@@ -2923,10 +2909,8 @@ async def test_delete_bucket_field_headers_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  logging_config.UndeleteBucketRequest(**{
-  }),
-  {
-  },
+  logging_config.UndeleteBucketRequest(),
+  {},
 ])
 def test_undelete_bucket(request_type, transport: str = 'grpc'):
     client = ConfigServiceV2Client(
@@ -3146,10 +3130,8 @@ async def test_undelete_bucket_field_headers_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  logging_config.ListViewsRequest(**{
-  }),
-  {
-  },
+  logging_config.ListViewsRequest(),
+  {},
 ])
 def test_list_views(request_type, transport: str = 'grpc'):
     client = ConfigServiceV2Client(
@@ -3653,10 +3635,8 @@ async def test_list_views_async_pages():
             assert page_.raw_page.next_page_token == token
 
 @pytest.mark.parametrize("request_type", [
-  logging_config.GetViewRequest(**{
-  }),
-  {
-  },
+  logging_config.GetViewRequest(),
+  {},
 ])
 def test_get_view(request_type, transport: str = 'grpc'):
     client = ConfigServiceV2Client(
@@ -3890,10 +3870,8 @@ async def test_get_view_field_headers_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  logging_config.CreateViewRequest(**{
-  }),
-  {
-  },
+  logging_config.CreateViewRequest(),
+  {},
 ])
 def test_create_view(request_type, transport: str = 'grpc'):
     client = ConfigServiceV2Client(
@@ -4129,10 +4107,8 @@ async def test_create_view_field_headers_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  logging_config.UpdateViewRequest(**{
-  }),
-  {
-  },
+  logging_config.UpdateViewRequest(),
+  {},
 ])
 def test_update_view(request_type, transport: str = 'grpc'):
     client = ConfigServiceV2Client(
@@ -4366,10 +4342,8 @@ async def test_update_view_field_headers_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  logging_config.DeleteViewRequest(**{
-  }),
-  {
-  },
+  logging_config.DeleteViewRequest(),
+  {},
 ])
 def test_delete_view(request_type, transport: str = 'grpc'):
     client = ConfigServiceV2Client(
@@ -4589,10 +4563,8 @@ async def test_delete_view_field_headers_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  logging_config.ListSinksRequest(**{
-  }),
-  {
-  },
+  logging_config.ListSinksRequest(),
+  {},
 ])
 def test_list_sinks(request_type, transport: str = 'grpc'):
     client = ConfigServiceV2Client(
@@ -5096,10 +5068,8 @@ async def test_list_sinks_async_pages():
             assert page_.raw_page.next_page_token == token
 
 @pytest.mark.parametrize("request_type", [
-  logging_config.GetSinkRequest(**{
-  }),
-  {
-  },
+  logging_config.GetSinkRequest(),
+  {},
 ])
 def test_get_sink(request_type, transport: str = 'grpc'):
     client = ConfigServiceV2Client(
@@ -5435,10 +5405,8 @@ async def test_get_sink_flattened_error_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  logging_config.CreateSinkRequest(**{
-  }),
-  {
-  },
+  logging_config.CreateSinkRequest(),
+  {},
 ])
 def test_create_sink(request_type, transport: str = 'grpc'):
     client = ConfigServiceV2Client(
@@ -5784,10 +5752,8 @@ async def test_create_sink_flattened_error_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  logging_config.UpdateSinkRequest(**{
-  }),
-  {
-  },
+  logging_config.UpdateSinkRequest(),
+  {},
 ])
 def test_update_sink(request_type, transport: str = 'grpc'):
     client = ConfigServiceV2Client(
@@ -6143,10 +6109,8 @@ async def test_update_sink_flattened_error_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  logging_config.DeleteSinkRequest(**{
-  }),
-  {
-  },
+  logging_config.DeleteSinkRequest(),
+  {},
 ])
 def test_delete_sink(request_type, transport: str = 'grpc'):
     client = ConfigServiceV2Client(
@@ -6448,10 +6412,8 @@ async def test_delete_sink_flattened_error_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  logging_config.CreateLinkRequest(**{
-  }),
-  {
-  },
+  logging_config.CreateLinkRequest(),
+  {},
 ])
 def test_create_link(request_type, transport: str = 'grpc'):
     client = ConfigServiceV2Client(
@@ -6789,10 +6751,8 @@ async def test_create_link_flattened_error_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  logging_config.DeleteLinkRequest(**{
-  }),
-  {
-  },
+  logging_config.DeleteLinkRequest(),
+  {},
 ])
 def test_delete_link(request_type, transport: str = 'grpc'):
     client = ConfigServiceV2Client(
@@ -7108,10 +7068,8 @@ async def test_delete_link_flattened_error_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  logging_config.ListLinksRequest(**{
-  }),
-  {
-  },
+  logging_config.ListLinksRequest(),
+  {},
 ])
 def test_list_links(request_type, transport: str = 'grpc'):
     client = ConfigServiceV2Client(
@@ -7615,10 +7573,8 @@ async def test_list_links_async_pages():
             assert page_.raw_page.next_page_token == token
 
 @pytest.mark.parametrize("request_type", [
-  logging_config.GetLinkRequest(**{
-  }),
-  {
-  },
+  logging_config.GetLinkRequest(),
+  {},
 ])
 def test_get_link(request_type, transport: str = 'grpc'):
     client = ConfigServiceV2Client(
@@ -7934,10 +7890,8 @@ async def test_get_link_flattened_error_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  logging_config.ListExclusionsRequest(**{
-  }),
-  {
-  },
+  logging_config.ListExclusionsRequest(),
+  {},
 ])
 def test_list_exclusions(request_type, transport: str = 'grpc'):
     client = ConfigServiceV2Client(
@@ -8441,10 +8395,8 @@ async def test_list_exclusions_async_pages():
             assert page_.raw_page.next_page_token == token
 
 @pytest.mark.parametrize("request_type", [
-  logging_config.GetExclusionRequest(**{
-  }),
-  {
-  },
+  logging_config.GetExclusionRequest(),
+  {},
 ])
 def test_get_exclusion(request_type, transport: str = 'grpc'):
     client = ConfigServiceV2Client(
@@ -8764,10 +8716,8 @@ async def test_get_exclusion_flattened_error_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  logging_config.CreateExclusionRequest(**{
-  }),
-  {
-  },
+  logging_config.CreateExclusionRequest(),
+  {},
 ])
 def test_create_exclusion(request_type, transport: str = 'grpc'):
     client = ConfigServiceV2Client(
@@ -9097,10 +9047,8 @@ async def test_create_exclusion_flattened_error_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  logging_config.UpdateExclusionRequest(**{
-  }),
-  {
-  },
+  logging_config.UpdateExclusionRequest(),
+  {},
 ])
 def test_update_exclusion(request_type, transport: str = 'grpc'):
     client = ConfigServiceV2Client(
@@ -9440,10 +9388,8 @@ async def test_update_exclusion_flattened_error_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  logging_config.DeleteExclusionRequest(**{
-  }),
-  {
-  },
+  logging_config.DeleteExclusionRequest(),
+  {},
 ])
 def test_delete_exclusion(request_type, transport: str = 'grpc'):
     client = ConfigServiceV2Client(
@@ -9745,10 +9691,8 @@ async def test_delete_exclusion_flattened_error_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  logging_config.GetCmekSettingsRequest(**{
-  }),
-  {
-  },
+  logging_config.GetCmekSettingsRequest(),
+  {},
 ])
 def test_get_cmek_settings(request_type, transport: str = 'grpc'):
     client = ConfigServiceV2Client(
@@ -9986,10 +9930,8 @@ async def test_get_cmek_settings_field_headers_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  logging_config.UpdateCmekSettingsRequest(**{
-  }),
-  {
-  },
+  logging_config.UpdateCmekSettingsRequest(),
+  {},
 ])
 def test_update_cmek_settings(request_type, transport: str = 'grpc'):
     client = ConfigServiceV2Client(
@@ -10227,10 +10169,8 @@ async def test_update_cmek_settings_field_headers_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  logging_config.GetSettingsRequest(**{
-  }),
-  {
-  },
+  logging_config.GetSettingsRequest(),
+  {},
 ])
 def test_get_settings(request_type, transport: str = 'grpc'):
     client = ConfigServiceV2Client(
@@ -10554,10 +10494,8 @@ async def test_get_settings_flattened_error_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  logging_config.UpdateSettingsRequest(**{
-  }),
-  {
-  },
+  logging_config.UpdateSettingsRequest(),
+  {},
 ])
 def test_update_settings(request_type, transport: str = 'grpc'):
     client = ConfigServiceV2Client(
@@ -10891,10 +10829,8 @@ async def test_update_settings_flattened_error_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  logging_config.CopyLogEntriesRequest(**{
-  }),
-  {
-  },
+  logging_config.CopyLogEntriesRequest(),
+  {},
 ])
 def test_copy_log_entries(request_type, transport: str = 'grpc'):
     client = ConfigServiceV2Client(

--- a/packages/gapic-generator/tests/integration/goldens/logging/tests/unit/gapic/logging_v2/test_logging_service_v2.py
+++ b/packages/gapic-generator/tests/integration/goldens/logging/tests/unit/gapic/logging_v2/test_logging_service_v2.py
@@ -962,7 +962,7 @@ def test_logging_service_v2_client_create_channel_credentials_file(client_class,
 
 
 @pytest.mark.parametrize("request_type", [
-  logging.DeleteLogRequest({
+  logging.DeleteLogRequest(**{
   }),
   {
   },
@@ -1091,7 +1091,7 @@ async def test_delete_log_async_use_cached_wrapped_rpc(transport: str = "grpc_as
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  logging.DeleteLogRequest({  }),
+  logging.DeleteLogRequest(**{  }),
   {  },
 ])
 async def test_delete_log_async(request_type, transport: str = 'grpc_asyncio'):
@@ -1267,7 +1267,7 @@ async def test_delete_log_flattened_error_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  logging.WriteLogEntriesRequest({
+  logging.WriteLogEntriesRequest(**{
   }),
   {
   },
@@ -1397,7 +1397,7 @@ async def test_write_log_entries_async_use_cached_wrapped_rpc(transport: str = "
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  logging.WriteLogEntriesRequest({  }),
+  logging.WriteLogEntriesRequest(**{  }),
   {  },
 ])
 async def test_write_log_entries_async(request_type, transport: str = 'grpc_asyncio'):
@@ -1542,7 +1542,7 @@ async def test_write_log_entries_flattened_error_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  logging.ListLogEntriesRequest({
+  logging.ListLogEntriesRequest(**{
   }),
   {
   },
@@ -1678,7 +1678,7 @@ async def test_list_log_entries_async_use_cached_wrapped_rpc(transport: str = "g
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  logging.ListLogEntriesRequest({  }),
+  logging.ListLogEntriesRequest(**{  }),
   {  },
 ])
 async def test_list_log_entries_async(request_type, transport: str = 'grpc_asyncio'):
@@ -2004,7 +2004,7 @@ async def test_list_log_entries_async_pages():
             assert page_.raw_page.next_page_token == token
 
 @pytest.mark.parametrize("request_type", [
-  logging.ListMonitoredResourceDescriptorsRequest({
+  logging.ListMonitoredResourceDescriptorsRequest(**{
   }),
   {
   },
@@ -2136,7 +2136,7 @@ async def test_list_monitored_resource_descriptors_async_use_cached_wrapped_rpc(
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  logging.ListMonitoredResourceDescriptorsRequest({  }),
+  logging.ListMonitoredResourceDescriptorsRequest(**{  }),
   {  },
 ])
 async def test_list_monitored_resource_descriptors_async(request_type, transport: str = 'grpc_asyncio'):
@@ -2360,7 +2360,7 @@ async def test_list_monitored_resource_descriptors_async_pages():
             assert page_.raw_page.next_page_token == token
 
 @pytest.mark.parametrize("request_type", [
-  logging.ListLogsRequest({
+  logging.ListLogsRequest(**{
   }),
   {
   },
@@ -2496,7 +2496,7 @@ async def test_list_logs_async_use_cached_wrapped_rpc(transport: str = "grpc_asy
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  logging.ListLogsRequest({  }),
+  logging.ListLogsRequest(**{  }),
   {  },
 ])
 async def test_list_logs_async(request_type, transport: str = 'grpc_asyncio'):
@@ -2871,7 +2871,7 @@ async def test_list_logs_async_pages():
             assert page_.raw_page.next_page_token == token
 
 @pytest.mark.parametrize("request_type", [
-  logging.TailLogEntriesRequest({
+  logging.TailLogEntriesRequest(**{
   }),
   {
   },
@@ -2972,7 +2972,7 @@ async def test_tail_log_entries_async_use_cached_wrapped_rpc(transport: str = "g
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  logging.TailLogEntriesRequest({  }),
+  logging.TailLogEntriesRequest(**{  }),
   {  },
 ])
 async def test_tail_log_entries_async(request_type, transport: str = 'grpc_asyncio'):

--- a/packages/gapic-generator/tests/integration/goldens/logging/tests/unit/gapic/logging_v2/test_logging_service_v2.py
+++ b/packages/gapic-generator/tests/integration/goldens/logging/tests/unit/gapic/logging_v2/test_logging_service_v2.py
@@ -1091,8 +1091,8 @@ async def test_delete_log_async_use_cached_wrapped_rpc(transport: str = "grpc_as
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  logging.DeleteLogRequest(**{  }),
-  {  },
+  logging.DeleteLogRequest(),
+  {},
 ])
 async def test_delete_log_async(request_type, transport: str = 'grpc_asyncio'):
     client = LoggingServiceV2AsyncClient(
@@ -1397,8 +1397,8 @@ async def test_write_log_entries_async_use_cached_wrapped_rpc(transport: str = "
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  logging.WriteLogEntriesRequest(**{  }),
-  {  },
+  logging.WriteLogEntriesRequest(),
+  {},
 ])
 async def test_write_log_entries_async(request_type, transport: str = 'grpc_asyncio'):
     client = LoggingServiceV2AsyncClient(
@@ -1678,8 +1678,8 @@ async def test_list_log_entries_async_use_cached_wrapped_rpc(transport: str = "g
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  logging.ListLogEntriesRequest(**{  }),
-  {  },
+  logging.ListLogEntriesRequest(),
+  {},
 ])
 async def test_list_log_entries_async(request_type, transport: str = 'grpc_asyncio'):
     client = LoggingServiceV2AsyncClient(
@@ -2136,8 +2136,8 @@ async def test_list_monitored_resource_descriptors_async_use_cached_wrapped_rpc(
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  logging.ListMonitoredResourceDescriptorsRequest(**{  }),
-  {  },
+  logging.ListMonitoredResourceDescriptorsRequest(),
+  {},
 ])
 async def test_list_monitored_resource_descriptors_async(request_type, transport: str = 'grpc_asyncio'):
     client = LoggingServiceV2AsyncClient(
@@ -2496,8 +2496,8 @@ async def test_list_logs_async_use_cached_wrapped_rpc(transport: str = "grpc_asy
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  logging.ListLogsRequest(**{  }),
-  {  },
+  logging.ListLogsRequest(),
+  {},
 ])
 async def test_list_logs_async(request_type, transport: str = 'grpc_asyncio'):
     client = LoggingServiceV2AsyncClient(
@@ -2972,8 +2972,8 @@ async def test_tail_log_entries_async_use_cached_wrapped_rpc(transport: str = "g
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  logging.TailLogEntriesRequest(**{  }),
-  {  },
+  logging.TailLogEntriesRequest(),
+  {},
 ])
 async def test_tail_log_entries_async(request_type, transport: str = 'grpc_asyncio'):
     client = LoggingServiceV2AsyncClient(

--- a/packages/gapic-generator/tests/integration/goldens/logging/tests/unit/gapic/logging_v2/test_logging_service_v2.py
+++ b/packages/gapic-generator/tests/integration/goldens/logging/tests/unit/gapic/logging_v2/test_logging_service_v2.py
@@ -962,10 +962,8 @@ def test_logging_service_v2_client_create_channel_credentials_file(client_class,
 
 
 @pytest.mark.parametrize("request_type", [
-  logging.DeleteLogRequest(**{
-  }),
-  {
-  },
+  logging.DeleteLogRequest(),
+  {},
 ])
 def test_delete_log(request_type, transport: str = 'grpc'):
     client = LoggingServiceV2Client(
@@ -1267,10 +1265,8 @@ async def test_delete_log_flattened_error_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  logging.WriteLogEntriesRequest(**{
-  }),
-  {
-  },
+  logging.WriteLogEntriesRequest(),
+  {},
 ])
 def test_write_log_entries(request_type, transport: str = 'grpc'):
     client = LoggingServiceV2Client(
@@ -1542,10 +1538,8 @@ async def test_write_log_entries_flattened_error_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  logging.ListLogEntriesRequest(**{
-  }),
-  {
-  },
+  logging.ListLogEntriesRequest(),
+  {},
 ])
 def test_list_log_entries(request_type, transport: str = 'grpc'):
     client = LoggingServiceV2Client(
@@ -2004,10 +1998,8 @@ async def test_list_log_entries_async_pages():
             assert page_.raw_page.next_page_token == token
 
 @pytest.mark.parametrize("request_type", [
-  logging.ListMonitoredResourceDescriptorsRequest(**{
-  }),
-  {
-  },
+  logging.ListMonitoredResourceDescriptorsRequest(),
+  {},
 ])
 def test_list_monitored_resource_descriptors(request_type, transport: str = 'grpc'):
     client = LoggingServiceV2Client(
@@ -2360,10 +2352,8 @@ async def test_list_monitored_resource_descriptors_async_pages():
             assert page_.raw_page.next_page_token == token
 
 @pytest.mark.parametrize("request_type", [
-  logging.ListLogsRequest(**{
-  }),
-  {
-  },
+  logging.ListLogsRequest(),
+  {},
 ])
 def test_list_logs(request_type, transport: str = 'grpc'):
     client = LoggingServiceV2Client(
@@ -2871,10 +2861,8 @@ async def test_list_logs_async_pages():
             assert page_.raw_page.next_page_token == token
 
 @pytest.mark.parametrize("request_type", [
-  logging.TailLogEntriesRequest(**{
-  }),
-  {
-  },
+  logging.TailLogEntriesRequest(),
+  {},
 ])
 def test_tail_log_entries(request_type, transport: str = 'grpc'):
     client = LoggingServiceV2Client(

--- a/packages/gapic-generator/tests/integration/goldens/logging/tests/unit/gapic/logging_v2/test_metrics_service_v2.py
+++ b/packages/gapic-generator/tests/integration/goldens/logging/tests/unit/gapic/logging_v2/test_metrics_service_v2.py
@@ -1094,8 +1094,8 @@ async def test_list_log_metrics_async_use_cached_wrapped_rpc(transport: str = "g
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  logging_metrics.ListLogMetricsRequest(**{  }),
-  {  },
+  logging_metrics.ListLogMetricsRequest(),
+  {},
 ])
 async def test_list_log_metrics_async(request_type, transport: str = 'grpc_asyncio'):
     client = MetricsServiceV2AsyncClient(
@@ -1611,8 +1611,8 @@ async def test_get_log_metric_async_use_cached_wrapped_rpc(transport: str = "grp
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  logging_metrics.GetLogMetricRequest(**{  }),
-  {  },
+  logging_metrics.GetLogMetricRequest(),
+  {},
 ])
 async def test_get_log_metric_async(request_type, transport: str = 'grpc_asyncio'):
     client = MetricsServiceV2AsyncClient(
@@ -1946,8 +1946,8 @@ async def test_create_log_metric_async_use_cached_wrapped_rpc(transport: str = "
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  logging_metrics.CreateLogMetricRequest(**{  }),
-  {  },
+  logging_metrics.CreateLogMetricRequest(),
+  {},
 ])
 async def test_create_log_metric_async(request_type, transport: str = 'grpc_asyncio'):
     client = MetricsServiceV2AsyncClient(
@@ -2291,8 +2291,8 @@ async def test_update_log_metric_async_use_cached_wrapped_rpc(transport: str = "
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  logging_metrics.UpdateLogMetricRequest(**{  }),
-  {  },
+  logging_metrics.UpdateLogMetricRequest(),
+  {},
 ])
 async def test_update_log_metric_async(request_type, transport: str = 'grpc_asyncio'):
     client = MetricsServiceV2AsyncClient(
@@ -2621,8 +2621,8 @@ async def test_delete_log_metric_async_use_cached_wrapped_rpc(transport: str = "
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  logging_metrics.DeleteLogMetricRequest(**{  }),
-  {  },
+  logging_metrics.DeleteLogMetricRequest(),
+  {},
 ])
 async def test_delete_log_metric_async(request_type, transport: str = 'grpc_asyncio'):
     client = MetricsServiceV2AsyncClient(

--- a/packages/gapic-generator/tests/integration/goldens/logging/tests/unit/gapic/logging_v2/test_metrics_service_v2.py
+++ b/packages/gapic-generator/tests/integration/goldens/logging/tests/unit/gapic/logging_v2/test_metrics_service_v2.py
@@ -960,7 +960,7 @@ def test_metrics_service_v2_client_create_channel_credentials_file(client_class,
 
 
 @pytest.mark.parametrize("request_type", [
-  logging_metrics.ListLogMetricsRequest({
+  logging_metrics.ListLogMetricsRequest(**{
   }),
   {
   },
@@ -1094,7 +1094,7 @@ async def test_list_log_metrics_async_use_cached_wrapped_rpc(transport: str = "g
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  logging_metrics.ListLogMetricsRequest({  }),
+  logging_metrics.ListLogMetricsRequest(**{  }),
   {  },
 ])
 async def test_list_log_metrics_async(request_type, transport: str = 'grpc_asyncio'):
@@ -1467,7 +1467,7 @@ async def test_list_log_metrics_async_pages():
             assert page_.raw_page.next_page_token == token
 
 @pytest.mark.parametrize("request_type", [
-  logging_metrics.GetLogMetricRequest({
+  logging_metrics.GetLogMetricRequest(**{
   }),
   {
   },
@@ -1611,7 +1611,7 @@ async def test_get_log_metric_async_use_cached_wrapped_rpc(transport: str = "grp
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  logging_metrics.GetLogMetricRequest({  }),
+  logging_metrics.GetLogMetricRequest(**{  }),
   {  },
 ])
 async def test_get_log_metric_async(request_type, transport: str = 'grpc_asyncio'):
@@ -1802,7 +1802,7 @@ async def test_get_log_metric_flattened_error_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  logging_metrics.CreateLogMetricRequest({
+  logging_metrics.CreateLogMetricRequest(**{
   }),
   {
   },
@@ -1946,7 +1946,7 @@ async def test_create_log_metric_async_use_cached_wrapped_rpc(transport: str = "
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  logging_metrics.CreateLogMetricRequest({  }),
+  logging_metrics.CreateLogMetricRequest(**{  }),
   {  },
 ])
 async def test_create_log_metric_async(request_type, transport: str = 'grpc_asyncio'):
@@ -2147,7 +2147,7 @@ async def test_create_log_metric_flattened_error_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  logging_metrics.UpdateLogMetricRequest({
+  logging_metrics.UpdateLogMetricRequest(**{
   }),
   {
   },
@@ -2291,7 +2291,7 @@ async def test_update_log_metric_async_use_cached_wrapped_rpc(transport: str = "
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  logging_metrics.UpdateLogMetricRequest({  }),
+  logging_metrics.UpdateLogMetricRequest(**{  }),
   {  },
 ])
 async def test_update_log_metric_async(request_type, transport: str = 'grpc_asyncio'):
@@ -2492,7 +2492,7 @@ async def test_update_log_metric_flattened_error_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  logging_metrics.DeleteLogMetricRequest({
+  logging_metrics.DeleteLogMetricRequest(**{
   }),
   {
   },
@@ -2621,7 +2621,7 @@ async def test_delete_log_metric_async_use_cached_wrapped_rpc(transport: str = "
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  logging_metrics.DeleteLogMetricRequest({  }),
+  logging_metrics.DeleteLogMetricRequest(**{  }),
   {  },
 ])
 async def test_delete_log_metric_async(request_type, transport: str = 'grpc_asyncio'):

--- a/packages/gapic-generator/tests/integration/goldens/logging/tests/unit/gapic/logging_v2/test_metrics_service_v2.py
+++ b/packages/gapic-generator/tests/integration/goldens/logging/tests/unit/gapic/logging_v2/test_metrics_service_v2.py
@@ -960,10 +960,8 @@ def test_metrics_service_v2_client_create_channel_credentials_file(client_class,
 
 
 @pytest.mark.parametrize("request_type", [
-  logging_metrics.ListLogMetricsRequest(**{
-  }),
-  {
-  },
+  logging_metrics.ListLogMetricsRequest(),
+  {},
 ])
 def test_list_log_metrics(request_type, transport: str = 'grpc'):
     client = MetricsServiceV2Client(
@@ -1467,10 +1465,8 @@ async def test_list_log_metrics_async_pages():
             assert page_.raw_page.next_page_token == token
 
 @pytest.mark.parametrize("request_type", [
-  logging_metrics.GetLogMetricRequest(**{
-  }),
-  {
-  },
+  logging_metrics.GetLogMetricRequest(),
+  {},
 ])
 def test_get_log_metric(request_type, transport: str = 'grpc'):
     client = MetricsServiceV2Client(
@@ -1802,10 +1798,8 @@ async def test_get_log_metric_flattened_error_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  logging_metrics.CreateLogMetricRequest(**{
-  }),
-  {
-  },
+  logging_metrics.CreateLogMetricRequest(),
+  {},
 ])
 def test_create_log_metric(request_type, transport: str = 'grpc'):
     client = MetricsServiceV2Client(
@@ -2147,10 +2141,8 @@ async def test_create_log_metric_flattened_error_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  logging_metrics.UpdateLogMetricRequest(**{
-  }),
-  {
-  },
+  logging_metrics.UpdateLogMetricRequest(),
+  {},
 ])
 def test_update_log_metric(request_type, transport: str = 'grpc'):
     client = MetricsServiceV2Client(
@@ -2492,10 +2484,8 @@ async def test_update_log_metric_flattened_error_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  logging_metrics.DeleteLogMetricRequest(**{
-  }),
-  {
-  },
+  logging_metrics.DeleteLogMetricRequest(),
+  {},
 ])
 def test_delete_log_metric(request_type, transport: str = 'grpc'):
     client = MetricsServiceV2Client(

--- a/packages/gapic-generator/tests/integration/goldens/logging_internal/tests/unit/gapic/logging_v2/test_config_service_v2.py
+++ b/packages/gapic-generator/tests/integration/goldens/logging_internal/tests/unit/gapic/logging_v2/test_config_service_v2.py
@@ -960,10 +960,8 @@ def test_base_config_service_v2_client_create_channel_credentials_file(client_cl
 
 
 @pytest.mark.parametrize("request_type", [
-  logging_config.ListBucketsRequest(**{
-  }),
-  {
-  },
+  logging_config.ListBucketsRequest(),
+  {},
 ])
 def test_list_buckets(request_type, transport: str = 'grpc'):
     client = BaseConfigServiceV2Client(
@@ -1467,10 +1465,8 @@ async def test_list_buckets_async_pages():
             assert page_.raw_page.next_page_token == token
 
 @pytest.mark.parametrize("request_type", [
-  logging_config.GetBucketRequest(**{
-  }),
-  {
-  },
+  logging_config.GetBucketRequest(),
+  {},
 ])
 def test_get_bucket(request_type, transport: str = 'grpc'):
     client = BaseConfigServiceV2Client(
@@ -1720,10 +1716,8 @@ async def test_get_bucket_field_headers_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  logging_config.CreateBucketRequest(**{
-  }),
-  {
-  },
+  logging_config.CreateBucketRequest(),
+  {},
 ])
 def test_create_bucket_async(request_type, transport: str = 'grpc'):
     client = BaseConfigServiceV2Client(
@@ -1957,10 +1951,8 @@ async def test_create_bucket_async_field_headers_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  logging_config.UpdateBucketRequest(**{
-  }),
-  {
-  },
+  logging_config.UpdateBucketRequest(),
+  {},
 ])
 def test_update_bucket_async(request_type, transport: str = 'grpc'):
     client = BaseConfigServiceV2Client(
@@ -2192,10 +2184,8 @@ async def test_update_bucket_async_field_headers_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  logging_config.CreateBucketRequest(**{
-  }),
-  {
-  },
+  logging_config.CreateBucketRequest(),
+  {},
 ])
 def test_create_bucket(request_type, transport: str = 'grpc'):
     client = BaseConfigServiceV2Client(
@@ -2447,10 +2437,8 @@ async def test_create_bucket_field_headers_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  logging_config.UpdateBucketRequest(**{
-  }),
-  {
-  },
+  logging_config.UpdateBucketRequest(),
+  {},
 ])
 def test_update_bucket(request_type, transport: str = 'grpc'):
     client = BaseConfigServiceV2Client(
@@ -2700,10 +2688,8 @@ async def test_update_bucket_field_headers_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  logging_config.DeleteBucketRequest(**{
-  }),
-  {
-  },
+  logging_config.DeleteBucketRequest(),
+  {},
 ])
 def test_delete_bucket(request_type, transport: str = 'grpc'):
     client = BaseConfigServiceV2Client(
@@ -2923,10 +2909,8 @@ async def test_delete_bucket_field_headers_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  logging_config.UndeleteBucketRequest(**{
-  }),
-  {
-  },
+  logging_config.UndeleteBucketRequest(),
+  {},
 ])
 def test_undelete_bucket(request_type, transport: str = 'grpc'):
     client = BaseConfigServiceV2Client(
@@ -3146,10 +3130,8 @@ async def test_undelete_bucket_field_headers_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  logging_config.ListViewsRequest(**{
-  }),
-  {
-  },
+  logging_config.ListViewsRequest(),
+  {},
 ])
 def test__list_views(request_type, transport: str = 'grpc'):
     client = BaseConfigServiceV2Client(
@@ -3653,10 +3635,8 @@ async def test__list_views_async_pages():
             assert page_.raw_page.next_page_token == token
 
 @pytest.mark.parametrize("request_type", [
-  logging_config.GetViewRequest(**{
-  }),
-  {
-  },
+  logging_config.GetViewRequest(),
+  {},
 ])
 def test__get_view(request_type, transport: str = 'grpc'):
     client = BaseConfigServiceV2Client(
@@ -3890,10 +3870,8 @@ async def test__get_view_field_headers_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  logging_config.CreateViewRequest(**{
-  }),
-  {
-  },
+  logging_config.CreateViewRequest(),
+  {},
 ])
 def test__create_view(request_type, transport: str = 'grpc'):
     client = BaseConfigServiceV2Client(
@@ -4129,10 +4107,8 @@ async def test__create_view_field_headers_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  logging_config.UpdateViewRequest(**{
-  }),
-  {
-  },
+  logging_config.UpdateViewRequest(),
+  {},
 ])
 def test__update_view(request_type, transport: str = 'grpc'):
     client = BaseConfigServiceV2Client(
@@ -4366,10 +4342,8 @@ async def test__update_view_field_headers_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  logging_config.DeleteViewRequest(**{
-  }),
-  {
-  },
+  logging_config.DeleteViewRequest(),
+  {},
 ])
 def test__delete_view(request_type, transport: str = 'grpc'):
     client = BaseConfigServiceV2Client(
@@ -4589,10 +4563,8 @@ async def test__delete_view_field_headers_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  logging_config.ListSinksRequest(**{
-  }),
-  {
-  },
+  logging_config.ListSinksRequest(),
+  {},
 ])
 def test__list_sinks(request_type, transport: str = 'grpc'):
     client = BaseConfigServiceV2Client(
@@ -5096,10 +5068,8 @@ async def test__list_sinks_async_pages():
             assert page_.raw_page.next_page_token == token
 
 @pytest.mark.parametrize("request_type", [
-  logging_config.GetSinkRequest(**{
-  }),
-  {
-  },
+  logging_config.GetSinkRequest(),
+  {},
 ])
 def test__get_sink(request_type, transport: str = 'grpc'):
     client = BaseConfigServiceV2Client(
@@ -5435,10 +5405,8 @@ async def test__get_sink_flattened_error_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  logging_config.CreateSinkRequest(**{
-  }),
-  {
-  },
+  logging_config.CreateSinkRequest(),
+  {},
 ])
 def test__create_sink(request_type, transport: str = 'grpc'):
     client = BaseConfigServiceV2Client(
@@ -5784,10 +5752,8 @@ async def test__create_sink_flattened_error_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  logging_config.UpdateSinkRequest(**{
-  }),
-  {
-  },
+  logging_config.UpdateSinkRequest(),
+  {},
 ])
 def test__update_sink(request_type, transport: str = 'grpc'):
     client = BaseConfigServiceV2Client(
@@ -6143,10 +6109,8 @@ async def test__update_sink_flattened_error_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  logging_config.DeleteSinkRequest(**{
-  }),
-  {
-  },
+  logging_config.DeleteSinkRequest(),
+  {},
 ])
 def test__delete_sink(request_type, transport: str = 'grpc'):
     client = BaseConfigServiceV2Client(
@@ -6448,10 +6412,8 @@ async def test__delete_sink_flattened_error_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  logging_config.CreateLinkRequest(**{
-  }),
-  {
-  },
+  logging_config.CreateLinkRequest(),
+  {},
 ])
 def test__create_link(request_type, transport: str = 'grpc'):
     client = BaseConfigServiceV2Client(
@@ -6789,10 +6751,8 @@ async def test__create_link_flattened_error_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  logging_config.DeleteLinkRequest(**{
-  }),
-  {
-  },
+  logging_config.DeleteLinkRequest(),
+  {},
 ])
 def test__delete_link(request_type, transport: str = 'grpc'):
     client = BaseConfigServiceV2Client(
@@ -7108,10 +7068,8 @@ async def test__delete_link_flattened_error_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  logging_config.ListLinksRequest(**{
-  }),
-  {
-  },
+  logging_config.ListLinksRequest(),
+  {},
 ])
 def test__list_links(request_type, transport: str = 'grpc'):
     client = BaseConfigServiceV2Client(
@@ -7615,10 +7573,8 @@ async def test__list_links_async_pages():
             assert page_.raw_page.next_page_token == token
 
 @pytest.mark.parametrize("request_type", [
-  logging_config.GetLinkRequest(**{
-  }),
-  {
-  },
+  logging_config.GetLinkRequest(),
+  {},
 ])
 def test__get_link(request_type, transport: str = 'grpc'):
     client = BaseConfigServiceV2Client(
@@ -7934,10 +7890,8 @@ async def test__get_link_flattened_error_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  logging_config.ListExclusionsRequest(**{
-  }),
-  {
-  },
+  logging_config.ListExclusionsRequest(),
+  {},
 ])
 def test__list_exclusions(request_type, transport: str = 'grpc'):
     client = BaseConfigServiceV2Client(
@@ -8441,10 +8395,8 @@ async def test__list_exclusions_async_pages():
             assert page_.raw_page.next_page_token == token
 
 @pytest.mark.parametrize("request_type", [
-  logging_config.GetExclusionRequest(**{
-  }),
-  {
-  },
+  logging_config.GetExclusionRequest(),
+  {},
 ])
 def test__get_exclusion(request_type, transport: str = 'grpc'):
     client = BaseConfigServiceV2Client(
@@ -8764,10 +8716,8 @@ async def test__get_exclusion_flattened_error_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  logging_config.CreateExclusionRequest(**{
-  }),
-  {
-  },
+  logging_config.CreateExclusionRequest(),
+  {},
 ])
 def test__create_exclusion(request_type, transport: str = 'grpc'):
     client = BaseConfigServiceV2Client(
@@ -9097,10 +9047,8 @@ async def test__create_exclusion_flattened_error_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  logging_config.UpdateExclusionRequest(**{
-  }),
-  {
-  },
+  logging_config.UpdateExclusionRequest(),
+  {},
 ])
 def test__update_exclusion(request_type, transport: str = 'grpc'):
     client = BaseConfigServiceV2Client(
@@ -9440,10 +9388,8 @@ async def test__update_exclusion_flattened_error_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  logging_config.DeleteExclusionRequest(**{
-  }),
-  {
-  },
+  logging_config.DeleteExclusionRequest(),
+  {},
 ])
 def test__delete_exclusion(request_type, transport: str = 'grpc'):
     client = BaseConfigServiceV2Client(
@@ -9745,10 +9691,8 @@ async def test__delete_exclusion_flattened_error_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  logging_config.GetCmekSettingsRequest(**{
-  }),
-  {
-  },
+  logging_config.GetCmekSettingsRequest(),
+  {},
 ])
 def test__get_cmek_settings(request_type, transport: str = 'grpc'):
     client = BaseConfigServiceV2Client(
@@ -9986,10 +9930,8 @@ async def test__get_cmek_settings_field_headers_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  logging_config.UpdateCmekSettingsRequest(**{
-  }),
-  {
-  },
+  logging_config.UpdateCmekSettingsRequest(),
+  {},
 ])
 def test__update_cmek_settings(request_type, transport: str = 'grpc'):
     client = BaseConfigServiceV2Client(
@@ -10227,10 +10169,8 @@ async def test__update_cmek_settings_field_headers_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  logging_config.GetSettingsRequest(**{
-  }),
-  {
-  },
+  logging_config.GetSettingsRequest(),
+  {},
 ])
 def test__get_settings(request_type, transport: str = 'grpc'):
     client = BaseConfigServiceV2Client(
@@ -10554,10 +10494,8 @@ async def test__get_settings_flattened_error_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  logging_config.UpdateSettingsRequest(**{
-  }),
-  {
-  },
+  logging_config.UpdateSettingsRequest(),
+  {},
 ])
 def test__update_settings(request_type, transport: str = 'grpc'):
     client = BaseConfigServiceV2Client(
@@ -10891,10 +10829,8 @@ async def test__update_settings_flattened_error_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  logging_config.CopyLogEntriesRequest(**{
-  }),
-  {
-  },
+  logging_config.CopyLogEntriesRequest(),
+  {},
 ])
 def test__copy_log_entries(request_type, transport: str = 'grpc'):
     client = BaseConfigServiceV2Client(

--- a/packages/gapic-generator/tests/integration/goldens/logging_internal/tests/unit/gapic/logging_v2/test_config_service_v2.py
+++ b/packages/gapic-generator/tests/integration/goldens/logging_internal/tests/unit/gapic/logging_v2/test_config_service_v2.py
@@ -960,7 +960,7 @@ def test_base_config_service_v2_client_create_channel_credentials_file(client_cl
 
 
 @pytest.mark.parametrize("request_type", [
-  logging_config.ListBucketsRequest({
+  logging_config.ListBucketsRequest(**{
   }),
   {
   },
@@ -1094,7 +1094,7 @@ async def test_list_buckets_async_use_cached_wrapped_rpc(transport: str = "grpc_
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  logging_config.ListBucketsRequest({  }),
+  logging_config.ListBucketsRequest(**{  }),
   {  },
 ])
 async def test_list_buckets_async(request_type, transport: str = 'grpc_asyncio'):
@@ -1467,7 +1467,7 @@ async def test_list_buckets_async_pages():
             assert page_.raw_page.next_page_token == token
 
 @pytest.mark.parametrize("request_type", [
-  logging_config.GetBucketRequest({
+  logging_config.GetBucketRequest(**{
   }),
   {
   },
@@ -1611,7 +1611,7 @@ async def test_get_bucket_async_use_cached_wrapped_rpc(transport: str = "grpc_as
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  logging_config.GetBucketRequest({  }),
+  logging_config.GetBucketRequest(**{  }),
   {  },
 ])
 async def test_get_bucket_async(request_type, transport: str = 'grpc_asyncio'):
@@ -1720,7 +1720,7 @@ async def test_get_bucket_field_headers_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  logging_config.CreateBucketRequest({
+  logging_config.CreateBucketRequest(**{
   }),
   {
   },
@@ -1861,7 +1861,7 @@ async def test_create_bucket_async_async_use_cached_wrapped_rpc(transport: str =
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  logging_config.CreateBucketRequest({  }),
+  logging_config.CreateBucketRequest(**{  }),
   {  },
 ])
 async def test_create_bucket_async_async(request_type, transport: str = 'grpc_asyncio'):
@@ -1957,7 +1957,7 @@ async def test_create_bucket_async_field_headers_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  logging_config.UpdateBucketRequest({
+  logging_config.UpdateBucketRequest(**{
   }),
   {
   },
@@ -2096,7 +2096,7 @@ async def test_update_bucket_async_async_use_cached_wrapped_rpc(transport: str =
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  logging_config.UpdateBucketRequest({  }),
+  logging_config.UpdateBucketRequest(**{  }),
   {  },
 ])
 async def test_update_bucket_async_async(request_type, transport: str = 'grpc_asyncio'):
@@ -2192,7 +2192,7 @@ async def test_update_bucket_async_field_headers_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  logging_config.CreateBucketRequest({
+  logging_config.CreateBucketRequest(**{
   }),
   {
   },
@@ -2338,7 +2338,7 @@ async def test_create_bucket_async_use_cached_wrapped_rpc(transport: str = "grpc
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  logging_config.CreateBucketRequest({  }),
+  logging_config.CreateBucketRequest(**{  }),
   {  },
 ])
 async def test_create_bucket_async(request_type, transport: str = 'grpc_asyncio'):
@@ -2447,7 +2447,7 @@ async def test_create_bucket_field_headers_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  logging_config.UpdateBucketRequest({
+  logging_config.UpdateBucketRequest(**{
   }),
   {
   },
@@ -2591,7 +2591,7 @@ async def test_update_bucket_async_use_cached_wrapped_rpc(transport: str = "grpc
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  logging_config.UpdateBucketRequest({  }),
+  logging_config.UpdateBucketRequest(**{  }),
   {  },
 ])
 async def test_update_bucket_async(request_type, transport: str = 'grpc_asyncio'):
@@ -2700,7 +2700,7 @@ async def test_update_bucket_field_headers_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  logging_config.DeleteBucketRequest({
+  logging_config.DeleteBucketRequest(**{
   }),
   {
   },
@@ -2829,7 +2829,7 @@ async def test_delete_bucket_async_use_cached_wrapped_rpc(transport: str = "grpc
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  logging_config.DeleteBucketRequest({  }),
+  logging_config.DeleteBucketRequest(**{  }),
   {  },
 ])
 async def test_delete_bucket_async(request_type, transport: str = 'grpc_asyncio'):
@@ -2923,7 +2923,7 @@ async def test_delete_bucket_field_headers_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  logging_config.UndeleteBucketRequest({
+  logging_config.UndeleteBucketRequest(**{
   }),
   {
   },
@@ -3052,7 +3052,7 @@ async def test_undelete_bucket_async_use_cached_wrapped_rpc(transport: str = "gr
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  logging_config.UndeleteBucketRequest({  }),
+  logging_config.UndeleteBucketRequest(**{  }),
   {  },
 ])
 async def test_undelete_bucket_async(request_type, transport: str = 'grpc_asyncio'):
@@ -3146,7 +3146,7 @@ async def test_undelete_bucket_field_headers_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  logging_config.ListViewsRequest({
+  logging_config.ListViewsRequest(**{
   }),
   {
   },
@@ -3280,7 +3280,7 @@ async def test__list_views_async_use_cached_wrapped_rpc(transport: str = "grpc_a
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  logging_config.ListViewsRequest({  }),
+  logging_config.ListViewsRequest(**{  }),
   {  },
 ])
 async def test__list_views_async(request_type, transport: str = 'grpc_asyncio'):
@@ -3653,7 +3653,7 @@ async def test__list_views_async_pages():
             assert page_.raw_page.next_page_token == token
 
 @pytest.mark.parametrize("request_type", [
-  logging_config.GetViewRequest({
+  logging_config.GetViewRequest(**{
   }),
   {
   },
@@ -3789,7 +3789,7 @@ async def test__get_view_async_use_cached_wrapped_rpc(transport: str = "grpc_asy
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  logging_config.GetViewRequest({  }),
+  logging_config.GetViewRequest(**{  }),
   {  },
 ])
 async def test__get_view_async(request_type, transport: str = 'grpc_asyncio'):
@@ -3890,7 +3890,7 @@ async def test__get_view_field_headers_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  logging_config.CreateViewRequest({
+  logging_config.CreateViewRequest(**{
   }),
   {
   },
@@ -4028,7 +4028,7 @@ async def test__create_view_async_use_cached_wrapped_rpc(transport: str = "grpc_
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  logging_config.CreateViewRequest({  }),
+  logging_config.CreateViewRequest(**{  }),
   {  },
 ])
 async def test__create_view_async(request_type, transport: str = 'grpc_asyncio'):
@@ -4129,7 +4129,7 @@ async def test__create_view_field_headers_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  logging_config.UpdateViewRequest({
+  logging_config.UpdateViewRequest(**{
   }),
   {
   },
@@ -4265,7 +4265,7 @@ async def test__update_view_async_use_cached_wrapped_rpc(transport: str = "grpc_
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  logging_config.UpdateViewRequest({  }),
+  logging_config.UpdateViewRequest(**{  }),
   {  },
 ])
 async def test__update_view_async(request_type, transport: str = 'grpc_asyncio'):
@@ -4366,7 +4366,7 @@ async def test__update_view_field_headers_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  logging_config.DeleteViewRequest({
+  logging_config.DeleteViewRequest(**{
   }),
   {
   },
@@ -4495,7 +4495,7 @@ async def test__delete_view_async_use_cached_wrapped_rpc(transport: str = "grpc_
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  logging_config.DeleteViewRequest({  }),
+  logging_config.DeleteViewRequest(**{  }),
   {  },
 ])
 async def test__delete_view_async(request_type, transport: str = 'grpc_asyncio'):
@@ -4589,7 +4589,7 @@ async def test__delete_view_field_headers_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  logging_config.ListSinksRequest({
+  logging_config.ListSinksRequest(**{
   }),
   {
   },
@@ -4723,7 +4723,7 @@ async def test__list_sinks_async_use_cached_wrapped_rpc(transport: str = "grpc_a
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  logging_config.ListSinksRequest({  }),
+  logging_config.ListSinksRequest(**{  }),
   {  },
 ])
 async def test__list_sinks_async(request_type, transport: str = 'grpc_asyncio'):
@@ -5096,7 +5096,7 @@ async def test__list_sinks_async_pages():
             assert page_.raw_page.next_page_token == token
 
 @pytest.mark.parametrize("request_type", [
-  logging_config.GetSinkRequest({
+  logging_config.GetSinkRequest(**{
   }),
   {
   },
@@ -5242,7 +5242,7 @@ async def test__get_sink_async_use_cached_wrapped_rpc(transport: str = "grpc_asy
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  logging_config.GetSinkRequest({  }),
+  logging_config.GetSinkRequest(**{  }),
   {  },
 ])
 async def test__get_sink_async(request_type, transport: str = 'grpc_asyncio'):
@@ -5435,7 +5435,7 @@ async def test__get_sink_flattened_error_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  logging_config.CreateSinkRequest({
+  logging_config.CreateSinkRequest(**{
   }),
   {
   },
@@ -5581,7 +5581,7 @@ async def test__create_sink_async_use_cached_wrapped_rpc(transport: str = "grpc_
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  logging_config.CreateSinkRequest({  }),
+  logging_config.CreateSinkRequest(**{  }),
   {  },
 ])
 async def test__create_sink_async(request_type, transport: str = 'grpc_asyncio'):
@@ -5784,7 +5784,7 @@ async def test__create_sink_flattened_error_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  logging_config.UpdateSinkRequest({
+  logging_config.UpdateSinkRequest(**{
   }),
   {
   },
@@ -5930,7 +5930,7 @@ async def test__update_sink_async_use_cached_wrapped_rpc(transport: str = "grpc_
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  logging_config.UpdateSinkRequest({  }),
+  logging_config.UpdateSinkRequest(**{  }),
   {  },
 ])
 async def test__update_sink_async(request_type, transport: str = 'grpc_asyncio'):
@@ -6143,7 +6143,7 @@ async def test__update_sink_flattened_error_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  logging_config.DeleteSinkRequest({
+  logging_config.DeleteSinkRequest(**{
   }),
   {
   },
@@ -6272,7 +6272,7 @@ async def test__delete_sink_async_use_cached_wrapped_rpc(transport: str = "grpc_
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  logging_config.DeleteSinkRequest({  }),
+  logging_config.DeleteSinkRequest(**{  }),
   {  },
 ])
 async def test__delete_sink_async(request_type, transport: str = 'grpc_asyncio'):
@@ -6448,7 +6448,7 @@ async def test__delete_sink_flattened_error_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  logging_config.CreateLinkRequest({
+  logging_config.CreateLinkRequest(**{
   }),
   {
   },
@@ -6589,7 +6589,7 @@ async def test__create_link_async_use_cached_wrapped_rpc(transport: str = "grpc_
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  logging_config.CreateLinkRequest({  }),
+  logging_config.CreateLinkRequest(**{  }),
   {  },
 ])
 async def test__create_link_async(request_type, transport: str = 'grpc_asyncio'):
@@ -6789,7 +6789,7 @@ async def test__create_link_flattened_error_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  logging_config.DeleteLinkRequest({
+  logging_config.DeleteLinkRequest(**{
   }),
   {
   },
@@ -6928,7 +6928,7 @@ async def test__delete_link_async_use_cached_wrapped_rpc(transport: str = "grpc_
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  logging_config.DeleteLinkRequest({  }),
+  logging_config.DeleteLinkRequest(**{  }),
   {  },
 ])
 async def test__delete_link_async(request_type, transport: str = 'grpc_asyncio'):
@@ -7108,7 +7108,7 @@ async def test__delete_link_flattened_error_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  logging_config.ListLinksRequest({
+  logging_config.ListLinksRequest(**{
   }),
   {
   },
@@ -7242,7 +7242,7 @@ async def test__list_links_async_use_cached_wrapped_rpc(transport: str = "grpc_a
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  logging_config.ListLinksRequest({  }),
+  logging_config.ListLinksRequest(**{  }),
   {  },
 ])
 async def test__list_links_async(request_type, transport: str = 'grpc_asyncio'):
@@ -7615,7 +7615,7 @@ async def test__list_links_async_pages():
             assert page_.raw_page.next_page_token == token
 
 @pytest.mark.parametrize("request_type", [
-  logging_config.GetLinkRequest({
+  logging_config.GetLinkRequest(**{
   }),
   {
   },
@@ -7751,7 +7751,7 @@ async def test__get_link_async_use_cached_wrapped_rpc(transport: str = "grpc_asy
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  logging_config.GetLinkRequest({  }),
+  logging_config.GetLinkRequest(**{  }),
   {  },
 ])
 async def test__get_link_async(request_type, transport: str = 'grpc_asyncio'):
@@ -7934,7 +7934,7 @@ async def test__get_link_flattened_error_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  logging_config.ListExclusionsRequest({
+  logging_config.ListExclusionsRequest(**{
   }),
   {
   },
@@ -8068,7 +8068,7 @@ async def test__list_exclusions_async_use_cached_wrapped_rpc(transport: str = "g
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  logging_config.ListExclusionsRequest({  }),
+  logging_config.ListExclusionsRequest(**{  }),
   {  },
 ])
 async def test__list_exclusions_async(request_type, transport: str = 'grpc_asyncio'):
@@ -8441,7 +8441,7 @@ async def test__list_exclusions_async_pages():
             assert page_.raw_page.next_page_token == token
 
 @pytest.mark.parametrize("request_type", [
-  logging_config.GetExclusionRequest({
+  logging_config.GetExclusionRequest(**{
   }),
   {
   },
@@ -8579,7 +8579,7 @@ async def test__get_exclusion_async_use_cached_wrapped_rpc(transport: str = "grp
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  logging_config.GetExclusionRequest({  }),
+  logging_config.GetExclusionRequest(**{  }),
   {  },
 ])
 async def test__get_exclusion_async(request_type, transport: str = 'grpc_asyncio'):
@@ -8764,7 +8764,7 @@ async def test__get_exclusion_flattened_error_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  logging_config.CreateExclusionRequest({
+  logging_config.CreateExclusionRequest(**{
   }),
   {
   },
@@ -8902,7 +8902,7 @@ async def test__create_exclusion_async_use_cached_wrapped_rpc(transport: str = "
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  logging_config.CreateExclusionRequest({  }),
+  logging_config.CreateExclusionRequest(**{  }),
   {  },
 ])
 async def test__create_exclusion_async(request_type, transport: str = 'grpc_asyncio'):
@@ -9097,7 +9097,7 @@ async def test__create_exclusion_flattened_error_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  logging_config.UpdateExclusionRequest({
+  logging_config.UpdateExclusionRequest(**{
   }),
   {
   },
@@ -9235,7 +9235,7 @@ async def test__update_exclusion_async_use_cached_wrapped_rpc(transport: str = "
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  logging_config.UpdateExclusionRequest({  }),
+  logging_config.UpdateExclusionRequest(**{  }),
   {  },
 ])
 async def test__update_exclusion_async(request_type, transport: str = 'grpc_asyncio'):
@@ -9440,7 +9440,7 @@ async def test__update_exclusion_flattened_error_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  logging_config.DeleteExclusionRequest({
+  logging_config.DeleteExclusionRequest(**{
   }),
   {
   },
@@ -9569,7 +9569,7 @@ async def test__delete_exclusion_async_use_cached_wrapped_rpc(transport: str = "
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  logging_config.DeleteExclusionRequest({  }),
+  logging_config.DeleteExclusionRequest(**{  }),
   {  },
 ])
 async def test__delete_exclusion_async(request_type, transport: str = 'grpc_asyncio'):
@@ -9745,7 +9745,7 @@ async def test__delete_exclusion_flattened_error_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  logging_config.GetCmekSettingsRequest({
+  logging_config.GetCmekSettingsRequest(**{
   }),
   {
   },
@@ -9883,7 +9883,7 @@ async def test__get_cmek_settings_async_use_cached_wrapped_rpc(transport: str = 
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  logging_config.GetCmekSettingsRequest({  }),
+  logging_config.GetCmekSettingsRequest(**{  }),
   {  },
 ])
 async def test__get_cmek_settings_async(request_type, transport: str = 'grpc_asyncio'):
@@ -9986,7 +9986,7 @@ async def test__get_cmek_settings_field_headers_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  logging_config.UpdateCmekSettingsRequest({
+  logging_config.UpdateCmekSettingsRequest(**{
   }),
   {
   },
@@ -10124,7 +10124,7 @@ async def test__update_cmek_settings_async_use_cached_wrapped_rpc(transport: str
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  logging_config.UpdateCmekSettingsRequest({  }),
+  logging_config.UpdateCmekSettingsRequest(**{  }),
   {  },
 ])
 async def test__update_cmek_settings_async(request_type, transport: str = 'grpc_asyncio'):
@@ -10227,7 +10227,7 @@ async def test__update_cmek_settings_field_headers_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  logging_config.GetSettingsRequest({
+  logging_config.GetSettingsRequest(**{
   }),
   {
   },
@@ -10367,7 +10367,7 @@ async def test__get_settings_async_use_cached_wrapped_rpc(transport: str = "grpc
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  logging_config.GetSettingsRequest({  }),
+  logging_config.GetSettingsRequest(**{  }),
   {  },
 ])
 async def test__get_settings_async(request_type, transport: str = 'grpc_asyncio'):
@@ -10554,7 +10554,7 @@ async def test__get_settings_flattened_error_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  logging_config.UpdateSettingsRequest({
+  logging_config.UpdateSettingsRequest(**{
   }),
   {
   },
@@ -10694,7 +10694,7 @@ async def test__update_settings_async_use_cached_wrapped_rpc(transport: str = "g
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  logging_config.UpdateSettingsRequest({  }),
+  logging_config.UpdateSettingsRequest(**{  }),
   {  },
 ])
 async def test__update_settings_async(request_type, transport: str = 'grpc_asyncio'):
@@ -10891,7 +10891,7 @@ async def test__update_settings_flattened_error_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  logging_config.CopyLogEntriesRequest({
+  logging_config.CopyLogEntriesRequest(**{
   }),
   {
   },
@@ -11034,7 +11034,7 @@ async def test__copy_log_entries_async_use_cached_wrapped_rpc(transport: str = "
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  logging_config.CopyLogEntriesRequest({  }),
+  logging_config.CopyLogEntriesRequest(**{  }),
   {  },
 ])
 async def test__copy_log_entries_async(request_type, transport: str = 'grpc_asyncio'):

--- a/packages/gapic-generator/tests/integration/goldens/logging_internal/tests/unit/gapic/logging_v2/test_config_service_v2.py
+++ b/packages/gapic-generator/tests/integration/goldens/logging_internal/tests/unit/gapic/logging_v2/test_config_service_v2.py
@@ -1094,8 +1094,8 @@ async def test_list_buckets_async_use_cached_wrapped_rpc(transport: str = "grpc_
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  logging_config.ListBucketsRequest(**{  }),
-  {  },
+  logging_config.ListBucketsRequest(),
+  {},
 ])
 async def test_list_buckets_async(request_type, transport: str = 'grpc_asyncio'):
     client = BaseConfigServiceV2AsyncClient(
@@ -1611,8 +1611,8 @@ async def test_get_bucket_async_use_cached_wrapped_rpc(transport: str = "grpc_as
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  logging_config.GetBucketRequest(**{  }),
-  {  },
+  logging_config.GetBucketRequest(),
+  {},
 ])
 async def test_get_bucket_async(request_type, transport: str = 'grpc_asyncio'):
     client = BaseConfigServiceV2AsyncClient(
@@ -1861,8 +1861,8 @@ async def test_create_bucket_async_async_use_cached_wrapped_rpc(transport: str =
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  logging_config.CreateBucketRequest(**{  }),
-  {  },
+  logging_config.CreateBucketRequest(),
+  {},
 ])
 async def test_create_bucket_async_async(request_type, transport: str = 'grpc_asyncio'):
     client = BaseConfigServiceV2AsyncClient(
@@ -2096,8 +2096,8 @@ async def test_update_bucket_async_async_use_cached_wrapped_rpc(transport: str =
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  logging_config.UpdateBucketRequest(**{  }),
-  {  },
+  logging_config.UpdateBucketRequest(),
+  {},
 ])
 async def test_update_bucket_async_async(request_type, transport: str = 'grpc_asyncio'):
     client = BaseConfigServiceV2AsyncClient(
@@ -2338,8 +2338,8 @@ async def test_create_bucket_async_use_cached_wrapped_rpc(transport: str = "grpc
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  logging_config.CreateBucketRequest(**{  }),
-  {  },
+  logging_config.CreateBucketRequest(),
+  {},
 ])
 async def test_create_bucket_async(request_type, transport: str = 'grpc_asyncio'):
     client = BaseConfigServiceV2AsyncClient(
@@ -2591,8 +2591,8 @@ async def test_update_bucket_async_use_cached_wrapped_rpc(transport: str = "grpc
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  logging_config.UpdateBucketRequest(**{  }),
-  {  },
+  logging_config.UpdateBucketRequest(),
+  {},
 ])
 async def test_update_bucket_async(request_type, transport: str = 'grpc_asyncio'):
     client = BaseConfigServiceV2AsyncClient(
@@ -2829,8 +2829,8 @@ async def test_delete_bucket_async_use_cached_wrapped_rpc(transport: str = "grpc
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  logging_config.DeleteBucketRequest(**{  }),
-  {  },
+  logging_config.DeleteBucketRequest(),
+  {},
 ])
 async def test_delete_bucket_async(request_type, transport: str = 'grpc_asyncio'):
     client = BaseConfigServiceV2AsyncClient(
@@ -3052,8 +3052,8 @@ async def test_undelete_bucket_async_use_cached_wrapped_rpc(transport: str = "gr
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  logging_config.UndeleteBucketRequest(**{  }),
-  {  },
+  logging_config.UndeleteBucketRequest(),
+  {},
 ])
 async def test_undelete_bucket_async(request_type, transport: str = 'grpc_asyncio'):
     client = BaseConfigServiceV2AsyncClient(
@@ -3280,8 +3280,8 @@ async def test__list_views_async_use_cached_wrapped_rpc(transport: str = "grpc_a
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  logging_config.ListViewsRequest(**{  }),
-  {  },
+  logging_config.ListViewsRequest(),
+  {},
 ])
 async def test__list_views_async(request_type, transport: str = 'grpc_asyncio'):
     client = BaseConfigServiceV2AsyncClient(
@@ -3789,8 +3789,8 @@ async def test__get_view_async_use_cached_wrapped_rpc(transport: str = "grpc_asy
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  logging_config.GetViewRequest(**{  }),
-  {  },
+  logging_config.GetViewRequest(),
+  {},
 ])
 async def test__get_view_async(request_type, transport: str = 'grpc_asyncio'):
     client = BaseConfigServiceV2AsyncClient(
@@ -4028,8 +4028,8 @@ async def test__create_view_async_use_cached_wrapped_rpc(transport: str = "grpc_
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  logging_config.CreateViewRequest(**{  }),
-  {  },
+  logging_config.CreateViewRequest(),
+  {},
 ])
 async def test__create_view_async(request_type, transport: str = 'grpc_asyncio'):
     client = BaseConfigServiceV2AsyncClient(
@@ -4265,8 +4265,8 @@ async def test__update_view_async_use_cached_wrapped_rpc(transport: str = "grpc_
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  logging_config.UpdateViewRequest(**{  }),
-  {  },
+  logging_config.UpdateViewRequest(),
+  {},
 ])
 async def test__update_view_async(request_type, transport: str = 'grpc_asyncio'):
     client = BaseConfigServiceV2AsyncClient(
@@ -4495,8 +4495,8 @@ async def test__delete_view_async_use_cached_wrapped_rpc(transport: str = "grpc_
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  logging_config.DeleteViewRequest(**{  }),
-  {  },
+  logging_config.DeleteViewRequest(),
+  {},
 ])
 async def test__delete_view_async(request_type, transport: str = 'grpc_asyncio'):
     client = BaseConfigServiceV2AsyncClient(
@@ -4723,8 +4723,8 @@ async def test__list_sinks_async_use_cached_wrapped_rpc(transport: str = "grpc_a
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  logging_config.ListSinksRequest(**{  }),
-  {  },
+  logging_config.ListSinksRequest(),
+  {},
 ])
 async def test__list_sinks_async(request_type, transport: str = 'grpc_asyncio'):
     client = BaseConfigServiceV2AsyncClient(
@@ -5242,8 +5242,8 @@ async def test__get_sink_async_use_cached_wrapped_rpc(transport: str = "grpc_asy
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  logging_config.GetSinkRequest(**{  }),
-  {  },
+  logging_config.GetSinkRequest(),
+  {},
 ])
 async def test__get_sink_async(request_type, transport: str = 'grpc_asyncio'):
     client = BaseConfigServiceV2AsyncClient(
@@ -5581,8 +5581,8 @@ async def test__create_sink_async_use_cached_wrapped_rpc(transport: str = "grpc_
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  logging_config.CreateSinkRequest(**{  }),
-  {  },
+  logging_config.CreateSinkRequest(),
+  {},
 ])
 async def test__create_sink_async(request_type, transport: str = 'grpc_asyncio'):
     client = BaseConfigServiceV2AsyncClient(
@@ -5930,8 +5930,8 @@ async def test__update_sink_async_use_cached_wrapped_rpc(transport: str = "grpc_
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  logging_config.UpdateSinkRequest(**{  }),
-  {  },
+  logging_config.UpdateSinkRequest(),
+  {},
 ])
 async def test__update_sink_async(request_type, transport: str = 'grpc_asyncio'):
     client = BaseConfigServiceV2AsyncClient(
@@ -6272,8 +6272,8 @@ async def test__delete_sink_async_use_cached_wrapped_rpc(transport: str = "grpc_
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  logging_config.DeleteSinkRequest(**{  }),
-  {  },
+  logging_config.DeleteSinkRequest(),
+  {},
 ])
 async def test__delete_sink_async(request_type, transport: str = 'grpc_asyncio'):
     client = BaseConfigServiceV2AsyncClient(
@@ -6589,8 +6589,8 @@ async def test__create_link_async_use_cached_wrapped_rpc(transport: str = "grpc_
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  logging_config.CreateLinkRequest(**{  }),
-  {  },
+  logging_config.CreateLinkRequest(),
+  {},
 ])
 async def test__create_link_async(request_type, transport: str = 'grpc_asyncio'):
     client = BaseConfigServiceV2AsyncClient(
@@ -6928,8 +6928,8 @@ async def test__delete_link_async_use_cached_wrapped_rpc(transport: str = "grpc_
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  logging_config.DeleteLinkRequest(**{  }),
-  {  },
+  logging_config.DeleteLinkRequest(),
+  {},
 ])
 async def test__delete_link_async(request_type, transport: str = 'grpc_asyncio'):
     client = BaseConfigServiceV2AsyncClient(
@@ -7242,8 +7242,8 @@ async def test__list_links_async_use_cached_wrapped_rpc(transport: str = "grpc_a
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  logging_config.ListLinksRequest(**{  }),
-  {  },
+  logging_config.ListLinksRequest(),
+  {},
 ])
 async def test__list_links_async(request_type, transport: str = 'grpc_asyncio'):
     client = BaseConfigServiceV2AsyncClient(
@@ -7751,8 +7751,8 @@ async def test__get_link_async_use_cached_wrapped_rpc(transport: str = "grpc_asy
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  logging_config.GetLinkRequest(**{  }),
-  {  },
+  logging_config.GetLinkRequest(),
+  {},
 ])
 async def test__get_link_async(request_type, transport: str = 'grpc_asyncio'):
     client = BaseConfigServiceV2AsyncClient(
@@ -8068,8 +8068,8 @@ async def test__list_exclusions_async_use_cached_wrapped_rpc(transport: str = "g
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  logging_config.ListExclusionsRequest(**{  }),
-  {  },
+  logging_config.ListExclusionsRequest(),
+  {},
 ])
 async def test__list_exclusions_async(request_type, transport: str = 'grpc_asyncio'):
     client = BaseConfigServiceV2AsyncClient(
@@ -8579,8 +8579,8 @@ async def test__get_exclusion_async_use_cached_wrapped_rpc(transport: str = "grp
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  logging_config.GetExclusionRequest(**{  }),
-  {  },
+  logging_config.GetExclusionRequest(),
+  {},
 ])
 async def test__get_exclusion_async(request_type, transport: str = 'grpc_asyncio'):
     client = BaseConfigServiceV2AsyncClient(
@@ -8902,8 +8902,8 @@ async def test__create_exclusion_async_use_cached_wrapped_rpc(transport: str = "
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  logging_config.CreateExclusionRequest(**{  }),
-  {  },
+  logging_config.CreateExclusionRequest(),
+  {},
 ])
 async def test__create_exclusion_async(request_type, transport: str = 'grpc_asyncio'):
     client = BaseConfigServiceV2AsyncClient(
@@ -9235,8 +9235,8 @@ async def test__update_exclusion_async_use_cached_wrapped_rpc(transport: str = "
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  logging_config.UpdateExclusionRequest(**{  }),
-  {  },
+  logging_config.UpdateExclusionRequest(),
+  {},
 ])
 async def test__update_exclusion_async(request_type, transport: str = 'grpc_asyncio'):
     client = BaseConfigServiceV2AsyncClient(
@@ -9569,8 +9569,8 @@ async def test__delete_exclusion_async_use_cached_wrapped_rpc(transport: str = "
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  logging_config.DeleteExclusionRequest(**{  }),
-  {  },
+  logging_config.DeleteExclusionRequest(),
+  {},
 ])
 async def test__delete_exclusion_async(request_type, transport: str = 'grpc_asyncio'):
     client = BaseConfigServiceV2AsyncClient(
@@ -9883,8 +9883,8 @@ async def test__get_cmek_settings_async_use_cached_wrapped_rpc(transport: str = 
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  logging_config.GetCmekSettingsRequest(**{  }),
-  {  },
+  logging_config.GetCmekSettingsRequest(),
+  {},
 ])
 async def test__get_cmek_settings_async(request_type, transport: str = 'grpc_asyncio'):
     client = BaseConfigServiceV2AsyncClient(
@@ -10124,8 +10124,8 @@ async def test__update_cmek_settings_async_use_cached_wrapped_rpc(transport: str
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  logging_config.UpdateCmekSettingsRequest(**{  }),
-  {  },
+  logging_config.UpdateCmekSettingsRequest(),
+  {},
 ])
 async def test__update_cmek_settings_async(request_type, transport: str = 'grpc_asyncio'):
     client = BaseConfigServiceV2AsyncClient(
@@ -10367,8 +10367,8 @@ async def test__get_settings_async_use_cached_wrapped_rpc(transport: str = "grpc
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  logging_config.GetSettingsRequest(**{  }),
-  {  },
+  logging_config.GetSettingsRequest(),
+  {},
 ])
 async def test__get_settings_async(request_type, transport: str = 'grpc_asyncio'):
     client = BaseConfigServiceV2AsyncClient(
@@ -10694,8 +10694,8 @@ async def test__update_settings_async_use_cached_wrapped_rpc(transport: str = "g
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  logging_config.UpdateSettingsRequest(**{  }),
-  {  },
+  logging_config.UpdateSettingsRequest(),
+  {},
 ])
 async def test__update_settings_async(request_type, transport: str = 'grpc_asyncio'):
     client = BaseConfigServiceV2AsyncClient(
@@ -11034,8 +11034,8 @@ async def test__copy_log_entries_async_use_cached_wrapped_rpc(transport: str = "
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  logging_config.CopyLogEntriesRequest(**{  }),
-  {  },
+  logging_config.CopyLogEntriesRequest(),
+  {},
 ])
 async def test__copy_log_entries_async(request_type, transport: str = 'grpc_asyncio'):
     client = BaseConfigServiceV2AsyncClient(

--- a/packages/gapic-generator/tests/integration/goldens/logging_internal/tests/unit/gapic/logging_v2/test_logging_service_v2.py
+++ b/packages/gapic-generator/tests/integration/goldens/logging_internal/tests/unit/gapic/logging_v2/test_logging_service_v2.py
@@ -962,7 +962,7 @@ def test_logging_service_v2_client_create_channel_credentials_file(client_class,
 
 
 @pytest.mark.parametrize("request_type", [
-  logging.DeleteLogRequest({
+  logging.DeleteLogRequest(**{
   }),
   {
   },
@@ -1091,7 +1091,7 @@ async def test_delete_log_async_use_cached_wrapped_rpc(transport: str = "grpc_as
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  logging.DeleteLogRequest({  }),
+  logging.DeleteLogRequest(**{  }),
   {  },
 ])
 async def test_delete_log_async(request_type, transport: str = 'grpc_asyncio'):
@@ -1267,7 +1267,7 @@ async def test_delete_log_flattened_error_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  logging.WriteLogEntriesRequest({
+  logging.WriteLogEntriesRequest(**{
   }),
   {
   },
@@ -1397,7 +1397,7 @@ async def test_write_log_entries_async_use_cached_wrapped_rpc(transport: str = "
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  logging.WriteLogEntriesRequest({  }),
+  logging.WriteLogEntriesRequest(**{  }),
   {  },
 ])
 async def test_write_log_entries_async(request_type, transport: str = 'grpc_asyncio'):
@@ -1542,7 +1542,7 @@ async def test_write_log_entries_flattened_error_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  logging.ListLogEntriesRequest({
+  logging.ListLogEntriesRequest(**{
   }),
   {
   },
@@ -1678,7 +1678,7 @@ async def test_list_log_entries_async_use_cached_wrapped_rpc(transport: str = "g
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  logging.ListLogEntriesRequest({  }),
+  logging.ListLogEntriesRequest(**{  }),
   {  },
 ])
 async def test_list_log_entries_async(request_type, transport: str = 'grpc_asyncio'):
@@ -2004,7 +2004,7 @@ async def test_list_log_entries_async_pages():
             assert page_.raw_page.next_page_token == token
 
 @pytest.mark.parametrize("request_type", [
-  logging.ListMonitoredResourceDescriptorsRequest({
+  logging.ListMonitoredResourceDescriptorsRequest(**{
   }),
   {
   },
@@ -2136,7 +2136,7 @@ async def test_list_monitored_resource_descriptors_async_use_cached_wrapped_rpc(
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  logging.ListMonitoredResourceDescriptorsRequest({  }),
+  logging.ListMonitoredResourceDescriptorsRequest(**{  }),
   {  },
 ])
 async def test_list_monitored_resource_descriptors_async(request_type, transport: str = 'grpc_asyncio'):
@@ -2360,7 +2360,7 @@ async def test_list_monitored_resource_descriptors_async_pages():
             assert page_.raw_page.next_page_token == token
 
 @pytest.mark.parametrize("request_type", [
-  logging.ListLogsRequest({
+  logging.ListLogsRequest(**{
   }),
   {
   },
@@ -2496,7 +2496,7 @@ async def test_list_logs_async_use_cached_wrapped_rpc(transport: str = "grpc_asy
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  logging.ListLogsRequest({  }),
+  logging.ListLogsRequest(**{  }),
   {  },
 ])
 async def test_list_logs_async(request_type, transport: str = 'grpc_asyncio'):
@@ -2871,7 +2871,7 @@ async def test_list_logs_async_pages():
             assert page_.raw_page.next_page_token == token
 
 @pytest.mark.parametrize("request_type", [
-  logging.TailLogEntriesRequest({
+  logging.TailLogEntriesRequest(**{
   }),
   {
   },
@@ -2972,7 +2972,7 @@ async def test_tail_log_entries_async_use_cached_wrapped_rpc(transport: str = "g
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  logging.TailLogEntriesRequest({  }),
+  logging.TailLogEntriesRequest(**{  }),
   {  },
 ])
 async def test_tail_log_entries_async(request_type, transport: str = 'grpc_asyncio'):

--- a/packages/gapic-generator/tests/integration/goldens/logging_internal/tests/unit/gapic/logging_v2/test_logging_service_v2.py
+++ b/packages/gapic-generator/tests/integration/goldens/logging_internal/tests/unit/gapic/logging_v2/test_logging_service_v2.py
@@ -1091,8 +1091,8 @@ async def test_delete_log_async_use_cached_wrapped_rpc(transport: str = "grpc_as
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  logging.DeleteLogRequest(**{  }),
-  {  },
+  logging.DeleteLogRequest(),
+  {},
 ])
 async def test_delete_log_async(request_type, transport: str = 'grpc_asyncio'):
     client = LoggingServiceV2AsyncClient(
@@ -1397,8 +1397,8 @@ async def test_write_log_entries_async_use_cached_wrapped_rpc(transport: str = "
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  logging.WriteLogEntriesRequest(**{  }),
-  {  },
+  logging.WriteLogEntriesRequest(),
+  {},
 ])
 async def test_write_log_entries_async(request_type, transport: str = 'grpc_asyncio'):
     client = LoggingServiceV2AsyncClient(
@@ -1678,8 +1678,8 @@ async def test_list_log_entries_async_use_cached_wrapped_rpc(transport: str = "g
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  logging.ListLogEntriesRequest(**{  }),
-  {  },
+  logging.ListLogEntriesRequest(),
+  {},
 ])
 async def test_list_log_entries_async(request_type, transport: str = 'grpc_asyncio'):
     client = LoggingServiceV2AsyncClient(
@@ -2136,8 +2136,8 @@ async def test_list_monitored_resource_descriptors_async_use_cached_wrapped_rpc(
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  logging.ListMonitoredResourceDescriptorsRequest(**{  }),
-  {  },
+  logging.ListMonitoredResourceDescriptorsRequest(),
+  {},
 ])
 async def test_list_monitored_resource_descriptors_async(request_type, transport: str = 'grpc_asyncio'):
     client = LoggingServiceV2AsyncClient(
@@ -2496,8 +2496,8 @@ async def test_list_logs_async_use_cached_wrapped_rpc(transport: str = "grpc_asy
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  logging.ListLogsRequest(**{  }),
-  {  },
+  logging.ListLogsRequest(),
+  {},
 ])
 async def test_list_logs_async(request_type, transport: str = 'grpc_asyncio'):
     client = LoggingServiceV2AsyncClient(
@@ -2972,8 +2972,8 @@ async def test_tail_log_entries_async_use_cached_wrapped_rpc(transport: str = "g
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  logging.TailLogEntriesRequest(**{  }),
-  {  },
+  logging.TailLogEntriesRequest(),
+  {},
 ])
 async def test_tail_log_entries_async(request_type, transport: str = 'grpc_asyncio'):
     client = LoggingServiceV2AsyncClient(

--- a/packages/gapic-generator/tests/integration/goldens/logging_internal/tests/unit/gapic/logging_v2/test_logging_service_v2.py
+++ b/packages/gapic-generator/tests/integration/goldens/logging_internal/tests/unit/gapic/logging_v2/test_logging_service_v2.py
@@ -962,10 +962,8 @@ def test_logging_service_v2_client_create_channel_credentials_file(client_class,
 
 
 @pytest.mark.parametrize("request_type", [
-  logging.DeleteLogRequest(**{
-  }),
-  {
-  },
+  logging.DeleteLogRequest(),
+  {},
 ])
 def test_delete_log(request_type, transport: str = 'grpc'):
     client = LoggingServiceV2Client(
@@ -1267,10 +1265,8 @@ async def test_delete_log_flattened_error_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  logging.WriteLogEntriesRequest(**{
-  }),
-  {
-  },
+  logging.WriteLogEntriesRequest(),
+  {},
 ])
 def test_write_log_entries(request_type, transport: str = 'grpc'):
     client = LoggingServiceV2Client(
@@ -1542,10 +1538,8 @@ async def test_write_log_entries_flattened_error_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  logging.ListLogEntriesRequest(**{
-  }),
-  {
-  },
+  logging.ListLogEntriesRequest(),
+  {},
 ])
 def test_list_log_entries(request_type, transport: str = 'grpc'):
     client = LoggingServiceV2Client(
@@ -2004,10 +1998,8 @@ async def test_list_log_entries_async_pages():
             assert page_.raw_page.next_page_token == token
 
 @pytest.mark.parametrize("request_type", [
-  logging.ListMonitoredResourceDescriptorsRequest(**{
-  }),
-  {
-  },
+  logging.ListMonitoredResourceDescriptorsRequest(),
+  {},
 ])
 def test_list_monitored_resource_descriptors(request_type, transport: str = 'grpc'):
     client = LoggingServiceV2Client(
@@ -2360,10 +2352,8 @@ async def test_list_monitored_resource_descriptors_async_pages():
             assert page_.raw_page.next_page_token == token
 
 @pytest.mark.parametrize("request_type", [
-  logging.ListLogsRequest(**{
-  }),
-  {
-  },
+  logging.ListLogsRequest(),
+  {},
 ])
 def test_list_logs(request_type, transport: str = 'grpc'):
     client = LoggingServiceV2Client(
@@ -2871,10 +2861,8 @@ async def test_list_logs_async_pages():
             assert page_.raw_page.next_page_token == token
 
 @pytest.mark.parametrize("request_type", [
-  logging.TailLogEntriesRequest(**{
-  }),
-  {
-  },
+  logging.TailLogEntriesRequest(),
+  {},
 ])
 def test_tail_log_entries(request_type, transport: str = 'grpc'):
     client = LoggingServiceV2Client(

--- a/packages/gapic-generator/tests/integration/goldens/logging_internal/tests/unit/gapic/logging_v2/test_metrics_service_v2.py
+++ b/packages/gapic-generator/tests/integration/goldens/logging_internal/tests/unit/gapic/logging_v2/test_metrics_service_v2.py
@@ -960,7 +960,7 @@ def test_base_metrics_service_v2_client_create_channel_credentials_file(client_c
 
 
 @pytest.mark.parametrize("request_type", [
-  logging_metrics.ListLogMetricsRequest({
+  logging_metrics.ListLogMetricsRequest(**{
   }),
   {
   },
@@ -1094,7 +1094,7 @@ async def test__list_log_metrics_async_use_cached_wrapped_rpc(transport: str = "
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  logging_metrics.ListLogMetricsRequest({  }),
+  logging_metrics.ListLogMetricsRequest(**{  }),
   {  },
 ])
 async def test__list_log_metrics_async(request_type, transport: str = 'grpc_asyncio'):
@@ -1467,7 +1467,7 @@ async def test__list_log_metrics_async_pages():
             assert page_.raw_page.next_page_token == token
 
 @pytest.mark.parametrize("request_type", [
-  logging_metrics.GetLogMetricRequest({
+  logging_metrics.GetLogMetricRequest(**{
   }),
   {
   },
@@ -1611,7 +1611,7 @@ async def test__get_log_metric_async_use_cached_wrapped_rpc(transport: str = "gr
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  logging_metrics.GetLogMetricRequest({  }),
+  logging_metrics.GetLogMetricRequest(**{  }),
   {  },
 ])
 async def test__get_log_metric_async(request_type, transport: str = 'grpc_asyncio'):
@@ -1802,7 +1802,7 @@ async def test__get_log_metric_flattened_error_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  logging_metrics.CreateLogMetricRequest({
+  logging_metrics.CreateLogMetricRequest(**{
   }),
   {
   },
@@ -1946,7 +1946,7 @@ async def test__create_log_metric_async_use_cached_wrapped_rpc(transport: str = 
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  logging_metrics.CreateLogMetricRequest({  }),
+  logging_metrics.CreateLogMetricRequest(**{  }),
   {  },
 ])
 async def test__create_log_metric_async(request_type, transport: str = 'grpc_asyncio'):
@@ -2147,7 +2147,7 @@ async def test__create_log_metric_flattened_error_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  logging_metrics.UpdateLogMetricRequest({
+  logging_metrics.UpdateLogMetricRequest(**{
   }),
   {
   },
@@ -2291,7 +2291,7 @@ async def test__update_log_metric_async_use_cached_wrapped_rpc(transport: str = 
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  logging_metrics.UpdateLogMetricRequest({  }),
+  logging_metrics.UpdateLogMetricRequest(**{  }),
   {  },
 ])
 async def test__update_log_metric_async(request_type, transport: str = 'grpc_asyncio'):
@@ -2492,7 +2492,7 @@ async def test__update_log_metric_flattened_error_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  logging_metrics.DeleteLogMetricRequest({
+  logging_metrics.DeleteLogMetricRequest(**{
   }),
   {
   },
@@ -2621,7 +2621,7 @@ async def test__delete_log_metric_async_use_cached_wrapped_rpc(transport: str = 
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  logging_metrics.DeleteLogMetricRequest({  }),
+  logging_metrics.DeleteLogMetricRequest(**{  }),
   {  },
 ])
 async def test__delete_log_metric_async(request_type, transport: str = 'grpc_asyncio'):

--- a/packages/gapic-generator/tests/integration/goldens/logging_internal/tests/unit/gapic/logging_v2/test_metrics_service_v2.py
+++ b/packages/gapic-generator/tests/integration/goldens/logging_internal/tests/unit/gapic/logging_v2/test_metrics_service_v2.py
@@ -960,10 +960,8 @@ def test_base_metrics_service_v2_client_create_channel_credentials_file(client_c
 
 
 @pytest.mark.parametrize("request_type", [
-  logging_metrics.ListLogMetricsRequest(**{
-  }),
-  {
-  },
+  logging_metrics.ListLogMetricsRequest(),
+  {},
 ])
 def test__list_log_metrics(request_type, transport: str = 'grpc'):
     client = BaseMetricsServiceV2Client(
@@ -1467,10 +1465,8 @@ async def test__list_log_metrics_async_pages():
             assert page_.raw_page.next_page_token == token
 
 @pytest.mark.parametrize("request_type", [
-  logging_metrics.GetLogMetricRequest(**{
-  }),
-  {
-  },
+  logging_metrics.GetLogMetricRequest(),
+  {},
 ])
 def test__get_log_metric(request_type, transport: str = 'grpc'):
     client = BaseMetricsServiceV2Client(
@@ -1802,10 +1798,8 @@ async def test__get_log_metric_flattened_error_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  logging_metrics.CreateLogMetricRequest(**{
-  }),
-  {
-  },
+  logging_metrics.CreateLogMetricRequest(),
+  {},
 ])
 def test__create_log_metric(request_type, transport: str = 'grpc'):
     client = BaseMetricsServiceV2Client(
@@ -2147,10 +2141,8 @@ async def test__create_log_metric_flattened_error_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  logging_metrics.UpdateLogMetricRequest(**{
-  }),
-  {
-  },
+  logging_metrics.UpdateLogMetricRequest(),
+  {},
 ])
 def test__update_log_metric(request_type, transport: str = 'grpc'):
     client = BaseMetricsServiceV2Client(
@@ -2492,10 +2484,8 @@ async def test__update_log_metric_flattened_error_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  logging_metrics.DeleteLogMetricRequest(**{
-  }),
-  {
-  },
+  logging_metrics.DeleteLogMetricRequest(),
+  {},
 ])
 def test__delete_log_metric(request_type, transport: str = 'grpc'):
     client = BaseMetricsServiceV2Client(

--- a/packages/gapic-generator/tests/integration/goldens/logging_internal/tests/unit/gapic/logging_v2/test_metrics_service_v2.py
+++ b/packages/gapic-generator/tests/integration/goldens/logging_internal/tests/unit/gapic/logging_v2/test_metrics_service_v2.py
@@ -1094,8 +1094,8 @@ async def test__list_log_metrics_async_use_cached_wrapped_rpc(transport: str = "
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  logging_metrics.ListLogMetricsRequest(**{  }),
-  {  },
+  logging_metrics.ListLogMetricsRequest(),
+  {},
 ])
 async def test__list_log_metrics_async(request_type, transport: str = 'grpc_asyncio'):
     client = BaseMetricsServiceV2AsyncClient(
@@ -1611,8 +1611,8 @@ async def test__get_log_metric_async_use_cached_wrapped_rpc(transport: str = "gr
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  logging_metrics.GetLogMetricRequest(**{  }),
-  {  },
+  logging_metrics.GetLogMetricRequest(),
+  {},
 ])
 async def test__get_log_metric_async(request_type, transport: str = 'grpc_asyncio'):
     client = BaseMetricsServiceV2AsyncClient(
@@ -1946,8 +1946,8 @@ async def test__create_log_metric_async_use_cached_wrapped_rpc(transport: str = 
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  logging_metrics.CreateLogMetricRequest(**{  }),
-  {  },
+  logging_metrics.CreateLogMetricRequest(),
+  {},
 ])
 async def test__create_log_metric_async(request_type, transport: str = 'grpc_asyncio'):
     client = BaseMetricsServiceV2AsyncClient(
@@ -2291,8 +2291,8 @@ async def test__update_log_metric_async_use_cached_wrapped_rpc(transport: str = 
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  logging_metrics.UpdateLogMetricRequest(**{  }),
-  {  },
+  logging_metrics.UpdateLogMetricRequest(),
+  {},
 ])
 async def test__update_log_metric_async(request_type, transport: str = 'grpc_asyncio'):
     client = BaseMetricsServiceV2AsyncClient(
@@ -2621,8 +2621,8 @@ async def test__delete_log_metric_async_use_cached_wrapped_rpc(transport: str = 
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  logging_metrics.DeleteLogMetricRequest(**{  }),
-  {  },
+  logging_metrics.DeleteLogMetricRequest(),
+  {},
 ])
 async def test__delete_log_metric_async(request_type, transport: str = 'grpc_asyncio'):
     client = BaseMetricsServiceV2AsyncClient(

--- a/packages/gapic-generator/tests/integration/goldens/redis/tests/unit/gapic/redis_v1/test_cloud_redis.py
+++ b/packages/gapic-generator/tests/integration/goldens/redis/tests/unit/gapic/redis_v1/test_cloud_redis.py
@@ -989,7 +989,7 @@ def test_cloud_redis_client_create_channel_credentials_file(client_class, transp
 
 
 @pytest.mark.parametrize("request_type", [
-  cloud_redis.ListInstancesRequest({
+  cloud_redis.ListInstancesRequest(**{
   }),
   {
   },
@@ -1125,7 +1125,7 @@ async def test_list_instances_async_use_cached_wrapped_rpc(transport: str = "grp
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  cloud_redis.ListInstancesRequest({  }),
+  cloud_redis.ListInstancesRequest(**{  }),
   {  },
 ])
 async def test_list_instances_async(request_type, transport: str = 'grpc_asyncio'):
@@ -1500,7 +1500,7 @@ async def test_list_instances_async_pages():
             assert page_.raw_page.next_page_token == token
 
 @pytest.mark.parametrize("request_type", [
-  cloud_redis.GetInstanceRequest({
+  cloud_redis.GetInstanceRequest(**{
   }),
   {
   },
@@ -1684,7 +1684,7 @@ async def test_get_instance_async_use_cached_wrapped_rpc(transport: str = "grpc_
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  cloud_redis.GetInstanceRequest({  }),
+  cloud_redis.GetInstanceRequest(**{  }),
   {  },
 ])
 async def test_get_instance_async(request_type, transport: str = 'grpc_asyncio'):
@@ -1915,7 +1915,7 @@ async def test_get_instance_flattened_error_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  cloud_redis.GetInstanceAuthStringRequest({
+  cloud_redis.GetInstanceAuthStringRequest(**{
   }),
   {
   },
@@ -2047,7 +2047,7 @@ async def test_get_instance_auth_string_async_use_cached_wrapped_rpc(transport: 
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  cloud_redis.GetInstanceAuthStringRequest({  }),
+  cloud_redis.GetInstanceAuthStringRequest(**{  }),
   {  },
 ])
 async def test_get_instance_auth_string_async(request_type, transport: str = 'grpc_asyncio'):
@@ -2226,7 +2226,7 @@ async def test_get_instance_auth_string_flattened_error_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  cloud_redis.CreateInstanceRequest({
+  cloud_redis.CreateInstanceRequest(**{
   }),
   {
   },
@@ -2367,7 +2367,7 @@ async def test_create_instance_async_use_cached_wrapped_rpc(transport: str = "gr
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  cloud_redis.CreateInstanceRequest({  }),
+  cloud_redis.CreateInstanceRequest(**{  }),
   {  },
 ])
 async def test_create_instance_async(request_type, transport: str = 'grpc_asyncio'):
@@ -2567,7 +2567,7 @@ async def test_create_instance_flattened_error_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  cloud_redis.UpdateInstanceRequest({
+  cloud_redis.UpdateInstanceRequest(**{
   }),
   {
   },
@@ -2704,7 +2704,7 @@ async def test_update_instance_async_use_cached_wrapped_rpc(transport: str = "gr
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  cloud_redis.UpdateInstanceRequest({  }),
+  cloud_redis.UpdateInstanceRequest(**{  }),
   {  },
 ])
 async def test_update_instance_async(request_type, transport: str = 'grpc_asyncio'):
@@ -2894,7 +2894,7 @@ async def test_update_instance_flattened_error_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  cloud_redis.UpgradeInstanceRequest({
+  cloud_redis.UpgradeInstanceRequest(**{
   }),
   {
   },
@@ -3035,7 +3035,7 @@ async def test_upgrade_instance_async_use_cached_wrapped_rpc(transport: str = "g
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  cloud_redis.UpgradeInstanceRequest({  }),
+  cloud_redis.UpgradeInstanceRequest(**{  }),
   {  },
 ])
 async def test_upgrade_instance_async(request_type, transport: str = 'grpc_asyncio'):
@@ -3225,7 +3225,7 @@ async def test_upgrade_instance_flattened_error_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  cloud_redis.ImportInstanceRequest({
+  cloud_redis.ImportInstanceRequest(**{
   }),
   {
   },
@@ -3364,7 +3364,7 @@ async def test_import_instance_async_use_cached_wrapped_rpc(transport: str = "gr
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  cloud_redis.ImportInstanceRequest({  }),
+  cloud_redis.ImportInstanceRequest(**{  }),
   {  },
 ])
 async def test_import_instance_async(request_type, transport: str = 'grpc_asyncio'):
@@ -3554,7 +3554,7 @@ async def test_import_instance_flattened_error_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  cloud_redis.ExportInstanceRequest({
+  cloud_redis.ExportInstanceRequest(**{
   }),
   {
   },
@@ -3693,7 +3693,7 @@ async def test_export_instance_async_use_cached_wrapped_rpc(transport: str = "gr
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  cloud_redis.ExportInstanceRequest({  }),
+  cloud_redis.ExportInstanceRequest(**{  }),
   {  },
 ])
 async def test_export_instance_async(request_type, transport: str = 'grpc_asyncio'):
@@ -3883,7 +3883,7 @@ async def test_export_instance_flattened_error_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  cloud_redis.FailoverInstanceRequest({
+  cloud_redis.FailoverInstanceRequest(**{
   }),
   {
   },
@@ -4022,7 +4022,7 @@ async def test_failover_instance_async_use_cached_wrapped_rpc(transport: str = "
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  cloud_redis.FailoverInstanceRequest({  }),
+  cloud_redis.FailoverInstanceRequest(**{  }),
   {  },
 ])
 async def test_failover_instance_async(request_type, transport: str = 'grpc_asyncio'):
@@ -4212,7 +4212,7 @@ async def test_failover_instance_flattened_error_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  cloud_redis.DeleteInstanceRequest({
+  cloud_redis.DeleteInstanceRequest(**{
   }),
   {
   },
@@ -4351,7 +4351,7 @@ async def test_delete_instance_async_use_cached_wrapped_rpc(transport: str = "gr
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  cloud_redis.DeleteInstanceRequest({  }),
+  cloud_redis.DeleteInstanceRequest(**{  }),
   {  },
 ])
 async def test_delete_instance_async(request_type, transport: str = 'grpc_asyncio'):
@@ -4531,7 +4531,7 @@ async def test_delete_instance_flattened_error_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  cloud_redis.RescheduleMaintenanceRequest({
+  cloud_redis.RescheduleMaintenanceRequest(**{
   }),
   {
   },
@@ -4670,7 +4670,7 @@ async def test_reschedule_maintenance_async_use_cached_wrapped_rpc(transport: st
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  cloud_redis.RescheduleMaintenanceRequest({  }),
+  cloud_redis.RescheduleMaintenanceRequest(**{  }),
   {  },
 ])
 async def test_reschedule_maintenance_async(request_type, transport: str = 'grpc_asyncio'):

--- a/packages/gapic-generator/tests/integration/goldens/redis/tests/unit/gapic/redis_v1/test_cloud_redis.py
+++ b/packages/gapic-generator/tests/integration/goldens/redis/tests/unit/gapic/redis_v1/test_cloud_redis.py
@@ -989,10 +989,8 @@ def test_cloud_redis_client_create_channel_credentials_file(client_class, transp
 
 
 @pytest.mark.parametrize("request_type", [
-  cloud_redis.ListInstancesRequest(**{
-  }),
-  {
-  },
+  cloud_redis.ListInstancesRequest(),
+  {},
 ])
 def test_list_instances(request_type, transport: str = 'grpc'):
     client = CloudRedisClient(
@@ -1500,10 +1498,8 @@ async def test_list_instances_async_pages():
             assert page_.raw_page.next_page_token == token
 
 @pytest.mark.parametrize("request_type", [
-  cloud_redis.GetInstanceRequest(**{
-  }),
-  {
-  },
+  cloud_redis.GetInstanceRequest(),
+  {},
 ])
 def test_get_instance(request_type, transport: str = 'grpc'):
     client = CloudRedisClient(
@@ -1915,10 +1911,8 @@ async def test_get_instance_flattened_error_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  cloud_redis.GetInstanceAuthStringRequest(**{
-  }),
-  {
-  },
+  cloud_redis.GetInstanceAuthStringRequest(),
+  {},
 ])
 def test_get_instance_auth_string(request_type, transport: str = 'grpc'):
     client = CloudRedisClient(
@@ -2226,10 +2220,8 @@ async def test_get_instance_auth_string_flattened_error_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  cloud_redis.CreateInstanceRequest(**{
-  }),
-  {
-  },
+  cloud_redis.CreateInstanceRequest(),
+  {},
 ])
 def test_create_instance(request_type, transport: str = 'grpc'):
     client = CloudRedisClient(
@@ -2567,10 +2559,8 @@ async def test_create_instance_flattened_error_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  cloud_redis.UpdateInstanceRequest(**{
-  }),
-  {
-  },
+  cloud_redis.UpdateInstanceRequest(),
+  {},
 ])
 def test_update_instance(request_type, transport: str = 'grpc'):
     client = CloudRedisClient(
@@ -2894,10 +2884,8 @@ async def test_update_instance_flattened_error_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  cloud_redis.UpgradeInstanceRequest(**{
-  }),
-  {
-  },
+  cloud_redis.UpgradeInstanceRequest(),
+  {},
 ])
 def test_upgrade_instance(request_type, transport: str = 'grpc'):
     client = CloudRedisClient(
@@ -3225,10 +3213,8 @@ async def test_upgrade_instance_flattened_error_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  cloud_redis.ImportInstanceRequest(**{
-  }),
-  {
-  },
+  cloud_redis.ImportInstanceRequest(),
+  {},
 ])
 def test_import_instance(request_type, transport: str = 'grpc'):
     client = CloudRedisClient(
@@ -3554,10 +3540,8 @@ async def test_import_instance_flattened_error_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  cloud_redis.ExportInstanceRequest(**{
-  }),
-  {
-  },
+  cloud_redis.ExportInstanceRequest(),
+  {},
 ])
 def test_export_instance(request_type, transport: str = 'grpc'):
     client = CloudRedisClient(
@@ -3883,10 +3867,8 @@ async def test_export_instance_flattened_error_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  cloud_redis.FailoverInstanceRequest(**{
-  }),
-  {
-  },
+  cloud_redis.FailoverInstanceRequest(),
+  {},
 ])
 def test_failover_instance(request_type, transport: str = 'grpc'):
     client = CloudRedisClient(
@@ -4212,10 +4194,8 @@ async def test_failover_instance_flattened_error_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  cloud_redis.DeleteInstanceRequest(**{
-  }),
-  {
-  },
+  cloud_redis.DeleteInstanceRequest(),
+  {},
 ])
 def test_delete_instance(request_type, transport: str = 'grpc'):
     client = CloudRedisClient(
@@ -4531,10 +4511,8 @@ async def test_delete_instance_flattened_error_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  cloud_redis.RescheduleMaintenanceRequest(**{
-  }),
-  {
-  },
+  cloud_redis.RescheduleMaintenanceRequest(),
+  {},
 ])
 def test_reschedule_maintenance(request_type, transport: str = 'grpc'):
     client = CloudRedisClient(

--- a/packages/gapic-generator/tests/integration/goldens/redis/tests/unit/gapic/redis_v1/test_cloud_redis.py
+++ b/packages/gapic-generator/tests/integration/goldens/redis/tests/unit/gapic/redis_v1/test_cloud_redis.py
@@ -1125,8 +1125,8 @@ async def test_list_instances_async_use_cached_wrapped_rpc(transport: str = "grp
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  cloud_redis.ListInstancesRequest(**{  }),
-  {  },
+  cloud_redis.ListInstancesRequest(),
+  {},
 ])
 async def test_list_instances_async(request_type, transport: str = 'grpc_asyncio'):
     client = CloudRedisAsyncClient(
@@ -1684,8 +1684,8 @@ async def test_get_instance_async_use_cached_wrapped_rpc(transport: str = "grpc_
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  cloud_redis.GetInstanceRequest(**{  }),
-  {  },
+  cloud_redis.GetInstanceRequest(),
+  {},
 ])
 async def test_get_instance_async(request_type, transport: str = 'grpc_asyncio'):
     client = CloudRedisAsyncClient(
@@ -2047,8 +2047,8 @@ async def test_get_instance_auth_string_async_use_cached_wrapped_rpc(transport: 
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  cloud_redis.GetInstanceAuthStringRequest(**{  }),
-  {  },
+  cloud_redis.GetInstanceAuthStringRequest(),
+  {},
 ])
 async def test_get_instance_auth_string_async(request_type, transport: str = 'grpc_asyncio'):
     client = CloudRedisAsyncClient(
@@ -2367,8 +2367,8 @@ async def test_create_instance_async_use_cached_wrapped_rpc(transport: str = "gr
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  cloud_redis.CreateInstanceRequest(**{  }),
-  {  },
+  cloud_redis.CreateInstanceRequest(),
+  {},
 ])
 async def test_create_instance_async(request_type, transport: str = 'grpc_asyncio'):
     client = CloudRedisAsyncClient(
@@ -2704,8 +2704,8 @@ async def test_update_instance_async_use_cached_wrapped_rpc(transport: str = "gr
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  cloud_redis.UpdateInstanceRequest(**{  }),
-  {  },
+  cloud_redis.UpdateInstanceRequest(),
+  {},
 ])
 async def test_update_instance_async(request_type, transport: str = 'grpc_asyncio'):
     client = CloudRedisAsyncClient(
@@ -3035,8 +3035,8 @@ async def test_upgrade_instance_async_use_cached_wrapped_rpc(transport: str = "g
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  cloud_redis.UpgradeInstanceRequest(**{  }),
-  {  },
+  cloud_redis.UpgradeInstanceRequest(),
+  {},
 ])
 async def test_upgrade_instance_async(request_type, transport: str = 'grpc_asyncio'):
     client = CloudRedisAsyncClient(
@@ -3364,8 +3364,8 @@ async def test_import_instance_async_use_cached_wrapped_rpc(transport: str = "gr
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  cloud_redis.ImportInstanceRequest(**{  }),
-  {  },
+  cloud_redis.ImportInstanceRequest(),
+  {},
 ])
 async def test_import_instance_async(request_type, transport: str = 'grpc_asyncio'):
     client = CloudRedisAsyncClient(
@@ -3693,8 +3693,8 @@ async def test_export_instance_async_use_cached_wrapped_rpc(transport: str = "gr
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  cloud_redis.ExportInstanceRequest(**{  }),
-  {  },
+  cloud_redis.ExportInstanceRequest(),
+  {},
 ])
 async def test_export_instance_async(request_type, transport: str = 'grpc_asyncio'):
     client = CloudRedisAsyncClient(
@@ -4022,8 +4022,8 @@ async def test_failover_instance_async_use_cached_wrapped_rpc(transport: str = "
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  cloud_redis.FailoverInstanceRequest(**{  }),
-  {  },
+  cloud_redis.FailoverInstanceRequest(),
+  {},
 ])
 async def test_failover_instance_async(request_type, transport: str = 'grpc_asyncio'):
     client = CloudRedisAsyncClient(
@@ -4351,8 +4351,8 @@ async def test_delete_instance_async_use_cached_wrapped_rpc(transport: str = "gr
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  cloud_redis.DeleteInstanceRequest(**{  }),
-  {  },
+  cloud_redis.DeleteInstanceRequest(),
+  {},
 ])
 async def test_delete_instance_async(request_type, transport: str = 'grpc_asyncio'):
     client = CloudRedisAsyncClient(
@@ -4670,8 +4670,8 @@ async def test_reschedule_maintenance_async_use_cached_wrapped_rpc(transport: st
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  cloud_redis.RescheduleMaintenanceRequest(**{  }),
-  {  },
+  cloud_redis.RescheduleMaintenanceRequest(),
+  {},
 ])
 async def test_reschedule_maintenance_async(request_type, transport: str = 'grpc_asyncio'):
     client = CloudRedisAsyncClient(

--- a/packages/gapic-generator/tests/integration/goldens/redis_selective/tests/unit/gapic/redis_v1/test_cloud_redis.py
+++ b/packages/gapic-generator/tests/integration/goldens/redis_selective/tests/unit/gapic/redis_v1/test_cloud_redis.py
@@ -989,7 +989,7 @@ def test_cloud_redis_client_create_channel_credentials_file(client_class, transp
 
 
 @pytest.mark.parametrize("request_type", [
-  cloud_redis.ListInstancesRequest({
+  cloud_redis.ListInstancesRequest(**{
   }),
   {
   },
@@ -1125,7 +1125,7 @@ async def test_list_instances_async_use_cached_wrapped_rpc(transport: str = "grp
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  cloud_redis.ListInstancesRequest({  }),
+  cloud_redis.ListInstancesRequest(**{  }),
   {  },
 ])
 async def test_list_instances_async(request_type, transport: str = 'grpc_asyncio'):
@@ -1500,7 +1500,7 @@ async def test_list_instances_async_pages():
             assert page_.raw_page.next_page_token == token
 
 @pytest.mark.parametrize("request_type", [
-  cloud_redis.GetInstanceRequest({
+  cloud_redis.GetInstanceRequest(**{
   }),
   {
   },
@@ -1684,7 +1684,7 @@ async def test_get_instance_async_use_cached_wrapped_rpc(transport: str = "grpc_
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  cloud_redis.GetInstanceRequest({  }),
+  cloud_redis.GetInstanceRequest(**{  }),
   {  },
 ])
 async def test_get_instance_async(request_type, transport: str = 'grpc_asyncio'):
@@ -1915,7 +1915,7 @@ async def test_get_instance_flattened_error_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  cloud_redis.CreateInstanceRequest({
+  cloud_redis.CreateInstanceRequest(**{
   }),
   {
   },
@@ -2056,7 +2056,7 @@ async def test_create_instance_async_use_cached_wrapped_rpc(transport: str = "gr
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  cloud_redis.CreateInstanceRequest({  }),
+  cloud_redis.CreateInstanceRequest(**{  }),
   {  },
 ])
 async def test_create_instance_async(request_type, transport: str = 'grpc_asyncio'):
@@ -2256,7 +2256,7 @@ async def test_create_instance_flattened_error_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  cloud_redis.UpdateInstanceRequest({
+  cloud_redis.UpdateInstanceRequest(**{
   }),
   {
   },
@@ -2393,7 +2393,7 @@ async def test_update_instance_async_use_cached_wrapped_rpc(transport: str = "gr
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  cloud_redis.UpdateInstanceRequest({  }),
+  cloud_redis.UpdateInstanceRequest(**{  }),
   {  },
 ])
 async def test_update_instance_async(request_type, transport: str = 'grpc_asyncio'):
@@ -2583,7 +2583,7 @@ async def test_update_instance_flattened_error_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  cloud_redis.DeleteInstanceRequest({
+  cloud_redis.DeleteInstanceRequest(**{
   }),
   {
   },
@@ -2722,7 +2722,7 @@ async def test_delete_instance_async_use_cached_wrapped_rpc(transport: str = "gr
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  cloud_redis.DeleteInstanceRequest({  }),
+  cloud_redis.DeleteInstanceRequest(**{  }),
   {  },
 ])
 async def test_delete_instance_async(request_type, transport: str = 'grpc_asyncio'):

--- a/packages/gapic-generator/tests/integration/goldens/redis_selective/tests/unit/gapic/redis_v1/test_cloud_redis.py
+++ b/packages/gapic-generator/tests/integration/goldens/redis_selective/tests/unit/gapic/redis_v1/test_cloud_redis.py
@@ -989,10 +989,8 @@ def test_cloud_redis_client_create_channel_credentials_file(client_class, transp
 
 
 @pytest.mark.parametrize("request_type", [
-  cloud_redis.ListInstancesRequest(**{
-  }),
-  {
-  },
+  cloud_redis.ListInstancesRequest(),
+  {},
 ])
 def test_list_instances(request_type, transport: str = 'grpc'):
     client = CloudRedisClient(
@@ -1500,10 +1498,8 @@ async def test_list_instances_async_pages():
             assert page_.raw_page.next_page_token == token
 
 @pytest.mark.parametrize("request_type", [
-  cloud_redis.GetInstanceRequest(**{
-  }),
-  {
-  },
+  cloud_redis.GetInstanceRequest(),
+  {},
 ])
 def test_get_instance(request_type, transport: str = 'grpc'):
     client = CloudRedisClient(
@@ -1915,10 +1911,8 @@ async def test_get_instance_flattened_error_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  cloud_redis.CreateInstanceRequest(**{
-  }),
-  {
-  },
+  cloud_redis.CreateInstanceRequest(),
+  {},
 ])
 def test_create_instance(request_type, transport: str = 'grpc'):
     client = CloudRedisClient(
@@ -2256,10 +2250,8 @@ async def test_create_instance_flattened_error_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  cloud_redis.UpdateInstanceRequest(**{
-  }),
-  {
-  },
+  cloud_redis.UpdateInstanceRequest(),
+  {},
 ])
 def test_update_instance(request_type, transport: str = 'grpc'):
     client = CloudRedisClient(
@@ -2583,10 +2575,8 @@ async def test_update_instance_flattened_error_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  cloud_redis.DeleteInstanceRequest(**{
-  }),
-  {
-  },
+  cloud_redis.DeleteInstanceRequest(),
+  {},
 ])
 def test_delete_instance(request_type, transport: str = 'grpc'):
     client = CloudRedisClient(

--- a/packages/gapic-generator/tests/integration/goldens/redis_selective/tests/unit/gapic/redis_v1/test_cloud_redis.py
+++ b/packages/gapic-generator/tests/integration/goldens/redis_selective/tests/unit/gapic/redis_v1/test_cloud_redis.py
@@ -1125,8 +1125,8 @@ async def test_list_instances_async_use_cached_wrapped_rpc(transport: str = "grp
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  cloud_redis.ListInstancesRequest(**{  }),
-  {  },
+  cloud_redis.ListInstancesRequest(),
+  {},
 ])
 async def test_list_instances_async(request_type, transport: str = 'grpc_asyncio'):
     client = CloudRedisAsyncClient(
@@ -1684,8 +1684,8 @@ async def test_get_instance_async_use_cached_wrapped_rpc(transport: str = "grpc_
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  cloud_redis.GetInstanceRequest(**{  }),
-  {  },
+  cloud_redis.GetInstanceRequest(),
+  {},
 ])
 async def test_get_instance_async(request_type, transport: str = 'grpc_asyncio'):
     client = CloudRedisAsyncClient(
@@ -2056,8 +2056,8 @@ async def test_create_instance_async_use_cached_wrapped_rpc(transport: str = "gr
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  cloud_redis.CreateInstanceRequest(**{  }),
-  {  },
+  cloud_redis.CreateInstanceRequest(),
+  {},
 ])
 async def test_create_instance_async(request_type, transport: str = 'grpc_asyncio'):
     client = CloudRedisAsyncClient(
@@ -2393,8 +2393,8 @@ async def test_update_instance_async_use_cached_wrapped_rpc(transport: str = "gr
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  cloud_redis.UpdateInstanceRequest(**{  }),
-  {  },
+  cloud_redis.UpdateInstanceRequest(),
+  {},
 ])
 async def test_update_instance_async(request_type, transport: str = 'grpc_asyncio'):
     client = CloudRedisAsyncClient(
@@ -2722,8 +2722,8 @@ async def test_delete_instance_async_use_cached_wrapped_rpc(transport: str = "gr
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  cloud_redis.DeleteInstanceRequest(**{  }),
-  {  },
+  cloud_redis.DeleteInstanceRequest(),
+  {},
 ])
 async def test_delete_instance_async(request_type, transport: str = 'grpc_asyncio'):
     client = CloudRedisAsyncClient(

--- a/packages/gapic-generator/tests/integration/goldens/storagebatchoperations/tests/unit/gapic/storagebatchoperations_v1/test_storage_batch_operations.py
+++ b/packages/gapic-generator/tests/integration/goldens/storagebatchoperations/tests/unit/gapic/storagebatchoperations_v1/test_storage_batch_operations.py
@@ -1057,7 +1057,7 @@ def test_storage_batch_operations_client_create_channel_credentials_file(client_
 
 
 @pytest.mark.parametrize("request_type", [
-  storage_batch_operations.ListJobsRequest({
+  storage_batch_operations.ListJobsRequest(**{
   }),
   {
   },
@@ -1197,7 +1197,7 @@ async def test_list_jobs_async_use_cached_wrapped_rpc(transport: str = "grpc_asy
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  storage_batch_operations.ListJobsRequest({  }),
+  storage_batch_operations.ListJobsRequest(**{  }),
   {  },
 ])
 async def test_list_jobs_async(request_type, transport: str = 'grpc_asyncio'):
@@ -1572,7 +1572,7 @@ async def test_list_jobs_async_pages():
             assert page_.raw_page.next_page_token == token
 
 @pytest.mark.parametrize("request_type", [
-  storage_batch_operations.GetJobRequest({
+  storage_batch_operations.GetJobRequest(**{
   }),
   {
   },
@@ -1712,7 +1712,7 @@ async def test_get_job_async_use_cached_wrapped_rpc(transport: str = "grpc_async
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  storage_batch_operations.GetJobRequest({  }),
+  storage_batch_operations.GetJobRequest(**{  }),
   {  },
 ])
 async def test_get_job_async(request_type, transport: str = 'grpc_asyncio'):
@@ -1899,7 +1899,7 @@ async def test_get_job_flattened_error_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  storage_batch_operations.CreateJobRequest({
+  storage_batch_operations.CreateJobRequest(**{
     "request_id": "explicit value for autopopulate-able field",
   }),
   {
@@ -2046,7 +2046,7 @@ async def test_create_job_async_use_cached_wrapped_rpc(transport: str = "grpc_as
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  storage_batch_operations.CreateJobRequest({    "request_id": "explicit value for autopopulate-able field",  }),
+  storage_batch_operations.CreateJobRequest(**{    "request_id": "explicit value for autopopulate-able field",  }),
   {    "request_id": "explicit value for autopopulate-able field",  },
 ])
 async def test_create_job_async(request_type, transport: str = 'grpc_asyncio'):
@@ -2247,7 +2247,7 @@ async def test_create_job_flattened_error_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  storage_batch_operations.DeleteJobRequest({
+  storage_batch_operations.DeleteJobRequest(**{
     "request_id": "explicit value for autopopulate-able field",
   }),
   {
@@ -2382,7 +2382,7 @@ async def test_delete_job_async_use_cached_wrapped_rpc(transport: str = "grpc_as
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  storage_batch_operations.DeleteJobRequest({    "request_id": "explicit value for autopopulate-able field",  }),
+  storage_batch_operations.DeleteJobRequest(**{    "request_id": "explicit value for autopopulate-able field",  }),
   {    "request_id": "explicit value for autopopulate-able field",  },
 ])
 async def test_delete_job_async(request_type, transport: str = 'grpc_asyncio'):
@@ -2559,7 +2559,7 @@ async def test_delete_job_flattened_error_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  storage_batch_operations.CancelJobRequest({
+  storage_batch_operations.CancelJobRequest(**{
     "request_id": "explicit value for autopopulate-able field",
   }),
   {
@@ -2695,7 +2695,7 @@ async def test_cancel_job_async_use_cached_wrapped_rpc(transport: str = "grpc_as
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  storage_batch_operations.CancelJobRequest({    "request_id": "explicit value for autopopulate-able field",  }),
+  storage_batch_operations.CancelJobRequest(**{    "request_id": "explicit value for autopopulate-able field",  }),
   {    "request_id": "explicit value for autopopulate-able field",  },
 ])
 async def test_cancel_job_async(request_type, transport: str = 'grpc_asyncio'):
@@ -2873,7 +2873,7 @@ async def test_cancel_job_flattened_error_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  storage_batch_operations.ListBucketOperationsRequest({
+  storage_batch_operations.ListBucketOperationsRequest(**{
   }),
   {
   },
@@ -3013,7 +3013,7 @@ async def test_list_bucket_operations_async_use_cached_wrapped_rpc(transport: st
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  storage_batch_operations.ListBucketOperationsRequest({  }),
+  storage_batch_operations.ListBucketOperationsRequest(**{  }),
   {  },
 ])
 async def test_list_bucket_operations_async(request_type, transport: str = 'grpc_asyncio'):
@@ -3388,7 +3388,7 @@ async def test_list_bucket_operations_async_pages():
             assert page_.raw_page.next_page_token == token
 
 @pytest.mark.parametrize("request_type", [
-  storage_batch_operations.GetBucketOperationRequest({
+  storage_batch_operations.GetBucketOperationRequest(**{
   }),
   {
   },
@@ -3524,7 +3524,7 @@ async def test_get_bucket_operation_async_use_cached_wrapped_rpc(transport: str 
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  storage_batch_operations.GetBucketOperationRequest({  }),
+  storage_batch_operations.GetBucketOperationRequest(**{  }),
   {  },
 ])
 async def test_get_bucket_operation_async(request_type, transport: str = 'grpc_asyncio'):

--- a/packages/gapic-generator/tests/integration/goldens/storagebatchoperations/tests/unit/gapic/storagebatchoperations_v1/test_storage_batch_operations.py
+++ b/packages/gapic-generator/tests/integration/goldens/storagebatchoperations/tests/unit/gapic/storagebatchoperations_v1/test_storage_batch_operations.py
@@ -1197,8 +1197,8 @@ async def test_list_jobs_async_use_cached_wrapped_rpc(transport: str = "grpc_asy
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  storage_batch_operations.ListJobsRequest(**{  }),
-  {  },
+  storage_batch_operations.ListJobsRequest(),
+  {},
 ])
 async def test_list_jobs_async(request_type, transport: str = 'grpc_asyncio'):
     client = StorageBatchOperationsAsyncClient(
@@ -1712,8 +1712,8 @@ async def test_get_job_async_use_cached_wrapped_rpc(transport: str = "grpc_async
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  storage_batch_operations.GetJobRequest(**{  }),
-  {  },
+  storage_batch_operations.GetJobRequest(),
+  {},
 ])
 async def test_get_job_async(request_type, transport: str = 'grpc_asyncio'):
     client = StorageBatchOperationsAsyncClient(
@@ -2046,6 +2046,7 @@ async def test_create_job_async_use_cached_wrapped_rpc(transport: str = "grpc_as
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
+  # Pure protobuf messages (non-proto-plus) require keyword arguments.
   storage_batch_operations.CreateJobRequest(**{    "request_id": "explicit value for autopopulate-able field",  }),
   {    "request_id": "explicit value for autopopulate-able field",  },
 ])
@@ -2382,6 +2383,7 @@ async def test_delete_job_async_use_cached_wrapped_rpc(transport: str = "grpc_as
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
+  # Pure protobuf messages (non-proto-plus) require keyword arguments.
   storage_batch_operations.DeleteJobRequest(**{    "request_id": "explicit value for autopopulate-able field",  }),
   {    "request_id": "explicit value for autopopulate-able field",  },
 ])
@@ -2695,6 +2697,7 @@ async def test_cancel_job_async_use_cached_wrapped_rpc(transport: str = "grpc_as
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
+  # Pure protobuf messages (non-proto-plus) require keyword arguments.
   storage_batch_operations.CancelJobRequest(**{    "request_id": "explicit value for autopopulate-able field",  }),
   {    "request_id": "explicit value for autopopulate-able field",  },
 ])
@@ -3013,8 +3016,8 @@ async def test_list_bucket_operations_async_use_cached_wrapped_rpc(transport: st
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  storage_batch_operations.ListBucketOperationsRequest(**{  }),
-  {  },
+  storage_batch_operations.ListBucketOperationsRequest(),
+  {},
 ])
 async def test_list_bucket_operations_async(request_type, transport: str = 'grpc_asyncio'):
     client = StorageBatchOperationsAsyncClient(
@@ -3524,8 +3527,8 @@ async def test_get_bucket_operation_async_use_cached_wrapped_rpc(transport: str 
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("request_type", [
-  storage_batch_operations.GetBucketOperationRequest(**{  }),
-  {  },
+  storage_batch_operations.GetBucketOperationRequest(),
+  {},
 ])
 async def test_get_bucket_operation_async(request_type, transport: str = 'grpc_asyncio'):
     client = StorageBatchOperationsAsyncClient(

--- a/packages/gapic-generator/tests/integration/goldens/storagebatchoperations/tests/unit/gapic/storagebatchoperations_v1/test_storage_batch_operations.py
+++ b/packages/gapic-generator/tests/integration/goldens/storagebatchoperations/tests/unit/gapic/storagebatchoperations_v1/test_storage_batch_operations.py
@@ -1057,10 +1057,8 @@ def test_storage_batch_operations_client_create_channel_credentials_file(client_
 
 
 @pytest.mark.parametrize("request_type", [
-  storage_batch_operations.ListJobsRequest(**{
-  }),
-  {
-  },
+  storage_batch_operations.ListJobsRequest(),
+  {},
 ])
 def test_list_jobs(request_type, transport: str = 'grpc'):
     client = StorageBatchOperationsClient(
@@ -1572,10 +1570,8 @@ async def test_list_jobs_async_pages():
             assert page_.raw_page.next_page_token == token
 
 @pytest.mark.parametrize("request_type", [
-  storage_batch_operations.GetJobRequest(**{
-  }),
-  {
-  },
+  storage_batch_operations.GetJobRequest(),
+  {},
 ])
 def test_get_job(request_type, transport: str = 'grpc'):
     client = StorageBatchOperationsClient(
@@ -1899,6 +1895,7 @@ async def test_get_job_flattened_error_async():
 
 
 @pytest.mark.parametrize("request_type", [
+  # Pure protobuf messages (non-proto-plus) require keyword arguments.
   storage_batch_operations.CreateJobRequest(**{
     "request_id": "explicit value for autopopulate-able field",
   }),
@@ -2248,6 +2245,7 @@ async def test_create_job_flattened_error_async():
 
 
 @pytest.mark.parametrize("request_type", [
+  # Pure protobuf messages (non-proto-plus) require keyword arguments.
   storage_batch_operations.DeleteJobRequest(**{
     "request_id": "explicit value for autopopulate-able field",
   }),
@@ -2561,6 +2559,7 @@ async def test_delete_job_flattened_error_async():
 
 
 @pytest.mark.parametrize("request_type", [
+  # Pure protobuf messages (non-proto-plus) require keyword arguments.
   storage_batch_operations.CancelJobRequest(**{
     "request_id": "explicit value for autopopulate-able field",
   }),
@@ -2876,10 +2875,8 @@ async def test_cancel_job_flattened_error_async():
 
 
 @pytest.mark.parametrize("request_type", [
-  storage_batch_operations.ListBucketOperationsRequest(**{
-  }),
-  {
-  },
+  storage_batch_operations.ListBucketOperationsRequest(),
+  {},
 ])
 def test_list_bucket_operations(request_type, transport: str = 'grpc'):
     client = StorageBatchOperationsClient(
@@ -3391,10 +3388,8 @@ async def test_list_bucket_operations_async_pages():
             assert page_.raw_page.next_page_token == token
 
 @pytest.mark.parametrize("request_type", [
-  storage_batch_operations.GetBucketOperationRequest(**{
-  }),
-  {
-  },
+  storage_batch_operations.GetBucketOperationRequest(),
+  {},
 ])
 def test_get_bucket_operation(request_type, transport: str = 'grpc'):
     client = StorageBatchOperationsClient(


### PR DESCRIPTION
This PR resolves the following failure in https://github.com/googleapis/google-cloud-python/pull/17245/ ([build log](https://github.com/googleapis/google-cloud-python/actions/runs/26527262176/job/78134171625?pr=17245))

```
==================================== ERRORS ====================================
_ ERROR collecting tests/unit/gapic/bigtable_admin_v2/test_bigtable_instance_admin.py _
tests/unit/gapic/bigtable_admin_v2/test_bigtable_instance_admin.py:7259: in <module>
    iam_policy_pb2.GetIamPolicyRequest({}),
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
E   TypeError: _AddInitMethod.<locals>.init() takes 1 positional argument but 2 were given
_ ERROR collecting tests/unit/gapic/bigtable_admin_v2/test_bigtable_table_admin.py _
tests/unit/gapic/bigtable_admin_v2/test_bigtable_table_admin.py:11222: in <module>
    iam_policy_pb2.GetIamPolicyRequest({}),
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
E   TypeError: _AddInitMethod.<locals>.init() takes 1 positional argument but 2 were given
```


To resolve the issue, this PR adds `**` to unpack fields as keyword arguments, maintaining compatibility with both proto-plus and pure protobuf messages.