### PR TITLE
chore(bigframes): add notebook and benchmark Kokoro configs

### DIFF
--- a/.kokoro/continuous/benchmark-bigframes.cfg
+++ b/.kokoro/continuous/benchmark-bigframes.cfg
@@ -1,0 +1,22 @@
+# Format: //devtools/kokoro/config/proto/build.proto
+
+# Only run this nox session.
+env_vars: {
+    key: "NOX_SESSION"
+    value: "benchmark"
+}
+
+env_vars: {
+    key: "BENCHMARK_AND_PUBLISH"
+    value: "true"
+}
+
+env_vars: {
+    key: "GOOGLE_CLOUD_PROJECT"
+    value: "bigframes-benchmarking"
+}
+
+env_vars: {
+    key: "BIGFRAMES_TEST_MODEL_VERTEX_ENDPOINT"
+    value: "https://us-central1-aiplatform.googleapis.com/v1/projects/272725758477/locations/us-central1/endpoints/590545496255234048"
+}

--- a/.kokoro/continuous/continuous-bigframes.cfg
+++ b/.kokoro/continuous/continuous-bigframes.cfg
@@ -3,7 +3,7 @@
 # Only run these nox sessions.
 env_vars: {
     key: "NOX_SESSION"
-    value: "e2e load system_prerelease notebook system_noextras"
+    value: "e2e system_prerelease notebook system_noextras"
 }
 
 env_vars: {

--- a/.kokoro/continuous/notebook-bigframes.cfg
+++ b/.kokoro/continuous/notebook-bigframes.cfg
@@ -1,0 +1,17 @@
+# Format: //devtools/kokoro/config/proto/build.proto
+
+# Only run this nox session.
+env_vars: {
+    key: "NOX_SESSION"
+    value: "notebook"
+}
+
+env_vars: {
+    key: "BENCHMARK_AND_PUBLISH"
+    value: "true"
+}
+
+env_vars: {
+    key: "GOOGLE_CLOUD_PROJECT"
+    value: "bigframes-testing"
+}

--- a/.kokoro/continuous/notebook-bigframes.cfg
+++ b/.kokoro/continuous/notebook-bigframes.cfg
@@ -7,11 +7,6 @@ env_vars: {
 }
 
 env_vars: {
-    key: "BENCHMARK_AND_PUBLISH"
-    value: "true"
-}
-
-env_vars: {
     key: "GOOGLE_CLOUD_PROJECT"
     value: "bigframes-testing"
 }


### PR DESCRIPTION
They are copied from https://github.com/googleapis/python-bigquery-dataframes/tree/main/.kokoro/continuous, and are missing in the current setup.

Also removed "load" command from the `continuous-bigframes` config as we already have a separated config for that test.

internal issue: b/509623551