### PR TITLE
feat(logging): drop support for Python 3.7, 3.8, and 3.9 runtimes

### DIFF
--- a/.librarian/generator-input/client-post-processing/logging-integration.yaml
+++ b/.librarian/generator-input/client-post-processing/logging-integration.yaml
@@ -45,7 +45,7 @@ replacements:
           "google-cloud-audit-log >= 0.3.1, < 1.0.0",
           "google-cloud-core >= 2.0.0, <3.0.0",
           "grpc-google-iam-v1 >=0.12.4, <1.0.0",
-          "opentelemetry-api >= 1.9.0",
+          "opentelemetry-api >= 1.16.0",
           "grpcio >= 1.59.0, < 2.0.0",
     count: 1
   - paths: [
@@ -60,7 +60,7 @@ replacements:
       google-cloud-audit-log==0.3.1
       google-cloud-core==2.0.0
       grpc-google-iam-v1==0.12.4
-      opentelemetry-api==1.9.0
+      opentelemetry-api==1.16.0
       grpcio==1.59.0
     count: 1
   - paths: [

--- a/.librarian/generator-input/client-post-processing/logging-integration.yaml
+++ b/.librarian/generator-input/client-post-processing/logging-integration.yaml
@@ -38,7 +38,7 @@ replacements:
     ]
     before: |
       "google-auth >= 2.14.1, <3.0.0,!=2.24.0,!=2.25.0",
-      \    "grpcio >= 1.44.0, < 2.0.0",
+          "grpcio >= 1.59.0, < 2.0.0",
     after: |
       "google-auth >= 2.14.1, <3.0.0,!=2.24.0,!=2.25.0",
           "google-cloud-appengine-logging>=0.1.3, <2.0.0",
@@ -46,7 +46,22 @@ replacements:
           "google-cloud-core >= 2.0.0, <3.0.0",
           "grpc-google-iam-v1 >=0.12.4, <1.0.0",
           "opentelemetry-api >= 1.9.0",
-          "grpcio >= 1.44.0, < 2.0.0",
+          "grpcio >= 1.59.0, < 2.0.0",
+    count: 1
+  - paths: [
+      "packages/google-cloud-logging/testing/constraints-3.10.txt"
+    ]
+    before: |
+      google-auth==2.14.1
+      grpcio==1.59.0
+    after: |
+      google-auth==2.14.1
+      google-cloud-appengine-logging==0.1.3
+      google-cloud-audit-log==0.3.1
+      google-cloud-core==2.0.0
+      grpc-google-iam-v1==0.12.4
+      opentelemetry-api==1.9.0
+      grpcio==1.59.0
     count: 1
   - paths: [
       "packages/google-cloud-logging/samples/generated_samples/logging_v2_generated_config_service_v2_copy_log_entries_async.py",

--- a/packages/google-cloud-logging/CONTRIBUTING.rst
+++ b/packages/google-cloud-logging/CONTRIBUTING.rst
@@ -22,7 +22,7 @@ In order to add a feature:
   documentation.
 
 - The feature must work fully on the following CPython versions:
-  3.7, 3.8, 3.9, 3.10, 3.11, 3.12, 3.13 and 3.14 on both UNIX and Windows.
+  3.10, 3.11, 3.12, 3.13 and 3.14 on both UNIX and Windows.
 
 - The feature must not add unnecessary dependencies (where
   "unnecessary" is of course subjective, but new dependencies should
@@ -195,11 +195,11 @@ configure them just like the System Tests.
 
    # Run all tests in a folder
    $ cd samples/snippets
-   $ nox -s py-3.8
+   $ nox -s py-3.10
 
    # Run a single sample test
    $ cd samples/snippets
-   $ nox -s py-3.8 -- -k <name of test>
+   $ nox -s py-3.10 -- -k <name of test>
 
 ********************************************
 Note About ``README`` as it pertains to PyPI
@@ -221,18 +221,12 @@ Supported Python Versions
 
 We support:
 
--  `Python 3.7`_
--  `Python 3.8`_
--  `Python 3.9`_
 -  `Python 3.10`_
 -  `Python 3.11`_
 -  `Python 3.12`_
 -  `Python 3.13`_
 -  `Python 3.14`_
 
-.. _Python 3.7: https://docs.python.org/3.7/
-.. _Python 3.8: https://docs.python.org/3.8/
-.. _Python 3.9: https://docs.python.org/3.9/
 .. _Python 3.10: https://docs.python.org/3.10/
 .. _Python 3.11: https://docs.python.org/3.11/
 .. _Python 3.12: https://docs.python.org/3.12/
@@ -245,17 +239,7 @@ Supported versions can be found in our ``noxfile.py`` `config`_.
 .. _config: https://github.com/googleapis/google-cloud-python/blob/main/noxfile.py
 
 
-We also explicitly decided to support Python 3 beginning with version 3.7.
-Reasons for this include:
-
--  Encouraging use of newest versions of Python 3
--  Taking the lead of `prominent`_ open-source `projects`_
--  `Unicode literal support`_ which allows for a cleaner codebase that
-   works in both Python 2 and Python 3
-
-.. _prominent: https://docs.djangoproject.com/en/1.9/faq/install/#what-python-version-can-i-use-with-django
-.. _projects: http://flask.pocoo.org/docs/0.10/python3/
-.. _Unicode literal support: https://www.python.org/dev/peps/pep-0414/
+We also explicitly decided to support Python 3 beginning with version 3.10.
 
 **********
 Versioning

--- a/packages/google-cloud-logging/constraints.txt
+++ b/packages/google-cloud-logging/constraints.txt
@@ -1,0 +1,12 @@
+google-api-core==2.17.1
+google-auth==2.14.1
+google-cloud-appengine-logging==0.1.3
+google-cloud-audit-log==0.3.1
+google-cloud-core==2.0.0
+grpc-google-iam-v1==0.12.4
+grpcio==1.59.0
+grpcio==1.75.1
+opentelemetry-api==1.16.0
+proto-plus==1.22.3
+proto-plus==1.25.0
+protobuf==4.25.8

--- a/packages/google-cloud-logging/google/cloud/logging_v2/client.py
+++ b/packages/google-cloud-logging/google/cloud/logging_v2/client.py
@@ -383,7 +383,7 @@ class Client(ClientWithProject):
             elif monitored_resource.type == _GKE_RESOURCE_TYPE:
                 return StructuredLogHandler(**kw, project_id=self.project)
             elif monitored_resource.type == _GCF_RESOURCE_TYPE:
-                # __stdout__ stream required to support structured logging on Python 3.7
+                # __stdout__ stream required to support structured logging on Python 3.7  # version-scanner: ignore
                 kw["stream"] = kw.get("stream", sys.__stdout__)
                 return StructuredLogHandler(**kw, project_id=self.project)
             elif monitored_resource.type == _RUN_RESOURCE_TYPE:

--- a/packages/google-cloud-logging/google/cloud/logging_v2/client.py
+++ b/packages/google-cloud-logging/google/cloud/logging_v2/client.py
@@ -383,7 +383,8 @@ class Client(ClientWithProject):
             elif monitored_resource.type == _GKE_RESOURCE_TYPE:
                 return StructuredLogHandler(**kw, project_id=self.project)
             elif monitored_resource.type == _GCF_RESOURCE_TYPE:
-                # __stdout__ stream required to support structured logging on Python 3.7  # version-scanner: ignore
+                # Bypassing redirects via __stdout__ ensures structured logging
+                # works robustly on Google Cloud Functions even if stdout is redirected.
                 kw["stream"] = kw.get("stream", sys.__stdout__)
                 return StructuredLogHandler(**kw, project_id=self.project)
             elif monitored_resource.type == _RUN_RESOURCE_TYPE:

--- a/packages/google-cloud-logging/noxfile.py
+++ b/packages/google-cloud-logging/noxfile.py
@@ -47,7 +47,12 @@ PREVIEW_PYTHON_VERSION = "3.14"
 
 CURRENT_DIRECTORY = pathlib.Path(__file__).parent.absolute()
 
-LOWER_BOUND_CONSTRAINTS_FILE = CURRENT_DIRECTORY / "constraints.txt"
+if (CURRENT_DIRECTORY / "testing").exists():
+    LOWER_BOUND_CONSTRAINTS_FILE = (
+        CURRENT_DIRECTORY / "testing" / f"constraints-{ALL_PYTHON[0]}.txt"
+    )
+else:
+    LOWER_BOUND_CONSTRAINTS_FILE = CURRENT_DIRECTORY / "constraints.txt"
 PACKAGE_NAME = "google-cloud-logging"
 
 UNIT_TEST_STANDARD_DEPENDENCIES = [
@@ -466,14 +471,6 @@ def prerelease_deps(session, protobuf_implementation):
     unit_deps_all = UNIT_TEST_STANDARD_DEPENDENCIES + UNIT_TEST_EXTERNAL_DEPENDENCIES
     session.install(*unit_deps_all)
 
-    # Install dependencies for the system test environment
-    system_deps_all = (
-        SYSTEM_TEST_STANDARD_DEPENDENCIES
-        + SYSTEM_TEST_EXTERNAL_DEPENDENCIES
-        + SYSTEM_TEST_EXTRAS
-    )
-    session.install(*system_deps_all)
-
     # Because we test minimum dependency versions on the minimum Python
     # version, the first version we test with in the unit tests sessions has a
     # constraints file containing all dependencies and extras.
@@ -584,14 +581,6 @@ def core_deps_from_source(session, protobuf_implementation):
     # Install dependencies for the unit test environment
     unit_deps_all = UNIT_TEST_STANDARD_DEPENDENCIES + UNIT_TEST_EXTERNAL_DEPENDENCIES
     session.install(*unit_deps_all)
-
-    # Install dependencies for the system test environment
-    system_deps_all = (
-        SYSTEM_TEST_STANDARD_DEPENDENCIES
-        + SYSTEM_TEST_EXTERNAL_DEPENDENCIES
-        + SYSTEM_TEST_EXTRAS
-    )
-    session.install(*system_deps_all)
 
     # Because we test minimum dependency versions on the minimum Python
     # version, the first version we test with in the unit tests sessions has a

--- a/packages/google-cloud-logging/pytest.ini
+++ b/packages/google-cloud-logging/pytest.ini
@@ -13,14 +13,6 @@ filterwarnings =
     ignore:get_mtls_endpoint_and_cert_source is deprecated.:DeprecationWarning
     # DeprecationWarnings triggered by Flask 1.0 testing by Flask dependencies in test code
     ignore:Importing 'itsdangerous.json' is deprecated and will be removed in ItsDangerous 2.1:DeprecationWarning
-    # 3.7 deprecation warnings, remove after support for Python 3.7 is dropped
-    ignore:After January 1, 2024, new releases of this library will drop support for Python 3.7:DeprecationWarning
-    ignore:Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3,and in 3.9 it will stop working:DeprecationWarning
-    ignore:You are using a non-supported Python version \(3\.7:FutureWarning
-    # 3.8 deprecation warnings, remove after support for Python 3.8 is dropped
-    ignore:You are using a non-supported Python version \(3\.8:FutureWarning
-    # 3.9 deprecation warnings, remove after support for Python 3.9 is dropped
-    ignore:You are using a Python version \(3\.9:FutureWarning
     # 3.10 deprecation warnings, remove after support for Python 3.10 is dropped
     ignore:You are using a Python version \(3\.10:FutureWarning
     ignore:Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3, and in 3.10 it will stop working:DeprecationWarning

--- a/packages/google-cloud-logging/setup.py
+++ b/packages/google-cloud-logging/setup.py
@@ -48,7 +48,7 @@ dependencies = [
     "google-cloud-core >= 2.0.0, <3.0.0",
     "grpc-google-iam-v1 >=0.12.4, <1.0.0",
     "opentelemetry-api >= 1.9.0",
-    "grpcio >= 1.44.0, < 2.0.0",
+    "grpcio >= 1.59.0, < 2.0.0",
     "grpcio >= 1.75.1, < 2.0.0; python_version >= '3.14'",
     "proto-plus >= 1.22.3, <2.0.0",
     "proto-plus >= 1.25.0, <2.0.0; python_version >= '3.13'",

--- a/packages/google-cloud-logging/setup.py
+++ b/packages/google-cloud-logging/setup.py
@@ -47,7 +47,7 @@ dependencies = [
     "google-cloud-audit-log >= 0.3.1, < 1.0.0",
     "google-cloud-core >= 2.0.0, <3.0.0",
     "grpc-google-iam-v1 >=0.12.4, <1.0.0",
-    "opentelemetry-api >= 1.9.0",
+    "opentelemetry-api >= 1.16.0",
     "grpcio >= 1.59.0, < 2.0.0",
     "grpcio >= 1.75.1, < 2.0.0; python_version >= '3.14'",
     "proto-plus >= 1.22.3, <2.0.0",

--- a/packages/google-cloud-logging/testing/constraints-3.10.txt
+++ b/packages/google-cloud-logging/testing/constraints-3.10.txt
@@ -6,6 +6,11 @@
 # then this file should have google-cloud-foo==1.14.0
 google-api-core==2.17.1
 google-auth==2.14.1
-grpcio==1.44.0
+google-cloud-appengine-logging==0.1.3
+google-cloud-audit-log==0.3.1
+google-cloud-core==2.0.0
+grpc-google-iam-v1==0.12.4
+opentelemetry-api==1.9.0
+grpcio==1.59.0
 proto-plus==1.22.3
 protobuf==4.25.8

--- a/packages/google-cloud-logging/testing/constraints-3.10.txt
+++ b/packages/google-cloud-logging/testing/constraints-3.10.txt
@@ -10,7 +10,7 @@ google-cloud-appengine-logging==0.1.3
 google-cloud-audit-log==0.3.1
 google-cloud-core==2.0.0
 grpc-google-iam-v1==0.12.4
-opentelemetry-api==1.9.0
+opentelemetry-api==1.16.0
 grpcio==1.59.0
 proto-plus==1.22.3
 protobuf==4.25.8

--- a/packages/google-cloud-logging/tests/unit/gapic/logging_v2/test_config_service_v2.py
+++ b/packages/google-cloud-logging/tests/unit/gapic/logging_v2/test_config_service_v2.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+import asyncio
 import json
 import math
 import os
@@ -110,6 +111,21 @@ def modify_default_endpoint_template(client):
         if ("localhost" in client._DEFAULT_ENDPOINT_TEMPLATE)
         else client._DEFAULT_ENDPOINT_TEMPLATE
     )
+
+
+@pytest.fixture(autouse=True)
+def set_event_loop():
+    try:
+        asyncio.get_running_loop()
+        yield
+    except RuntimeError:
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+        try:
+            yield
+        finally:
+            loop.close()
+            asyncio.set_event_loop(None)
 
 
 def test__get_default_mtls_endpoint():
@@ -1317,8 +1333,8 @@ def test_config_service_v2_client_create_channel_credentials_file(
 @pytest.mark.parametrize(
     "request_type",
     [
-        logging_config.ListBucketsRequest,
-        dict,
+        logging_config.ListBucketsRequest({}),
+        {},
     ],
 )
 def test_list_buckets(request_type, transport: str = "grpc"):
@@ -1329,7 +1345,7 @@ def test_list_buckets(request_type, transport: str = "grpc"):
 
     # Everything is optional in proto3 as far as the runtime is concerned,
     # and we are mocking out the actual API, so just send an empty request.
-    request = request_type()
+    request = request_type
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(type(client.transport.list_buckets), "__call__") as call:
@@ -1374,10 +1390,11 @@ def test_list_buckets_non_empty_request_with_auto_populated_field():
         client.list_buckets(request=request)
         call.assert_called()
         _, args, _ = call.mock_calls[0]
-        assert args[0] == logging_config.ListBucketsRequest(
+        request_msg = logging_config.ListBucketsRequest(
             parent="parent_value",
             page_token="page_token_value",
         )
+        assert args[0] == request_msg
 
 
 def test_list_buckets_use_cached_wrapped_rpc():
@@ -1458,9 +1475,14 @@ async def test_list_buckets_async_use_cached_wrapped_rpc(
 
 
 @pytest.mark.asyncio
-async def test_list_buckets_async(
-    transport: str = "grpc_asyncio", request_type=logging_config.ListBucketsRequest
-):
+@pytest.mark.parametrize(
+    "request_type",
+    [
+        logging_config.ListBucketsRequest({}),
+        {},
+    ],
+)
+async def test_list_buckets_async(request_type, transport: str = "grpc_asyncio"):
     client = ConfigServiceV2AsyncClient(
         credentials=async_anonymous_credentials(),
         transport=transport,
@@ -1468,7 +1490,7 @@ async def test_list_buckets_async(
 
     # Everything is optional in proto3 as far as the runtime is concerned,
     # and we are mocking out the actual API, so just send an empty request.
-    request = request_type()
+    request = request_type
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(type(client.transport.list_buckets), "__call__") as call:
@@ -1489,11 +1511,6 @@ async def test_list_buckets_async(
     # Establish that the response is the type that we expect.
     assert isinstance(response, pagers.ListBucketsAsyncPager)
     assert response.next_page_token == "next_page_token_value"
-
-
-@pytest.mark.asyncio
-async def test_list_buckets_async_from_dict():
-    await test_list_buckets_async(request_type=dict)
 
 
 def test_list_buckets_field_headers():
@@ -1832,8 +1849,8 @@ async def test_list_buckets_async_pages():
 @pytest.mark.parametrize(
     "request_type",
     [
-        logging_config.GetBucketRequest,
-        dict,
+        logging_config.GetBucketRequest({}),
+        {},
     ],
 )
 def test_get_bucket(request_type, transport: str = "grpc"):
@@ -1844,7 +1861,7 @@ def test_get_bucket(request_type, transport: str = "grpc"):
 
     # Everything is optional in proto3 as far as the runtime is concerned,
     # and we are mocking out the actual API, so just send an empty request.
-    request = request_type()
+    request = request_type
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(type(client.transport.get_bucket), "__call__") as call:
@@ -1900,9 +1917,10 @@ def test_get_bucket_non_empty_request_with_auto_populated_field():
         client.get_bucket(request=request)
         call.assert_called()
         _, args, _ = call.mock_calls[0]
-        assert args[0] == logging_config.GetBucketRequest(
+        request_msg = logging_config.GetBucketRequest(
             name="name_value",
         )
+        assert args[0] == request_msg
 
 
 def test_get_bucket_use_cached_wrapped_rpc():
@@ -1981,9 +1999,14 @@ async def test_get_bucket_async_use_cached_wrapped_rpc(transport: str = "grpc_as
 
 
 @pytest.mark.asyncio
-async def test_get_bucket_async(
-    transport: str = "grpc_asyncio", request_type=logging_config.GetBucketRequest
-):
+@pytest.mark.parametrize(
+    "request_type",
+    [
+        logging_config.GetBucketRequest({}),
+        {},
+    ],
+)
+async def test_get_bucket_async(request_type, transport: str = "grpc_asyncio"):
     client = ConfigServiceV2AsyncClient(
         credentials=async_anonymous_credentials(),
         transport=transport,
@@ -1991,7 +2014,7 @@ async def test_get_bucket_async(
 
     # Everything is optional in proto3 as far as the runtime is concerned,
     # and we are mocking out the actual API, so just send an empty request.
-    request = request_type()
+    request = request_type
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(type(client.transport.get_bucket), "__call__") as call:
@@ -2024,11 +2047,6 @@ async def test_get_bucket_async(
     assert response.lifecycle_state == logging_config.LifecycleState.ACTIVE
     assert response.analytics_enabled is True
     assert response.restricted_fields == ["restricted_fields_value"]
-
-
-@pytest.mark.asyncio
-async def test_get_bucket_async_from_dict():
-    await test_get_bucket_async(request_type=dict)
 
 
 def test_get_bucket_field_headers():
@@ -2095,8 +2113,8 @@ async def test_get_bucket_field_headers_async():
 @pytest.mark.parametrize(
     "request_type",
     [
-        logging_config.CreateBucketRequest,
-        dict,
+        logging_config.CreateBucketRequest({}),
+        {},
     ],
 )
 def test_create_bucket_async(request_type, transport: str = "grpc"):
@@ -2107,7 +2125,7 @@ def test_create_bucket_async(request_type, transport: str = "grpc"):
 
     # Everything is optional in proto3 as far as the runtime is concerned,
     # and we are mocking out the actual API, so just send an empty request.
-    request = request_type()
+    request = request_type
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(
@@ -2153,10 +2171,11 @@ def test_create_bucket_async_non_empty_request_with_auto_populated_field():
         client.create_bucket_async(request=request)
         call.assert_called()
         _, args, _ = call.mock_calls[0]
-        assert args[0] == logging_config.CreateBucketRequest(
+        request_msg = logging_config.CreateBucketRequest(
             parent="parent_value",
             bucket_id="bucket_id_value",
         )
+        assert args[0] == request_msg
 
 
 def test_create_bucket_async_use_cached_wrapped_rpc():
@@ -2251,9 +2270,14 @@ async def test_create_bucket_async_async_use_cached_wrapped_rpc(
 
 
 @pytest.mark.asyncio
-async def test_create_bucket_async_async(
-    transport: str = "grpc_asyncio", request_type=logging_config.CreateBucketRequest
-):
+@pytest.mark.parametrize(
+    "request_type",
+    [
+        logging_config.CreateBucketRequest({}),
+        {},
+    ],
+)
+async def test_create_bucket_async_async(request_type, transport: str = "grpc_asyncio"):
     client = ConfigServiceV2AsyncClient(
         credentials=async_anonymous_credentials(),
         transport=transport,
@@ -2261,7 +2285,7 @@ async def test_create_bucket_async_async(
 
     # Everything is optional in proto3 as far as the runtime is concerned,
     # and we are mocking out the actual API, so just send an empty request.
-    request = request_type()
+    request = request_type
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(
@@ -2281,11 +2305,6 @@ async def test_create_bucket_async_async(
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, future.Future)
-
-
-@pytest.mark.asyncio
-async def test_create_bucket_async_async_from_dict():
-    await test_create_bucket_async_async(request_type=dict)
 
 
 def test_create_bucket_async_field_headers():
@@ -2356,8 +2375,8 @@ async def test_create_bucket_async_field_headers_async():
 @pytest.mark.parametrize(
     "request_type",
     [
-        logging_config.UpdateBucketRequest,
-        dict,
+        logging_config.UpdateBucketRequest({}),
+        {},
     ],
 )
 def test_update_bucket_async(request_type, transport: str = "grpc"):
@@ -2368,7 +2387,7 @@ def test_update_bucket_async(request_type, transport: str = "grpc"):
 
     # Everything is optional in proto3 as far as the runtime is concerned,
     # and we are mocking out the actual API, so just send an empty request.
-    request = request_type()
+    request = request_type
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(
@@ -2413,9 +2432,10 @@ def test_update_bucket_async_non_empty_request_with_auto_populated_field():
         client.update_bucket_async(request=request)
         call.assert_called()
         _, args, _ = call.mock_calls[0]
-        assert args[0] == logging_config.UpdateBucketRequest(
+        request_msg = logging_config.UpdateBucketRequest(
             name="name_value",
         )
+        assert args[0] == request_msg
 
 
 def test_update_bucket_async_use_cached_wrapped_rpc():
@@ -2510,9 +2530,14 @@ async def test_update_bucket_async_async_use_cached_wrapped_rpc(
 
 
 @pytest.mark.asyncio
-async def test_update_bucket_async_async(
-    transport: str = "grpc_asyncio", request_type=logging_config.UpdateBucketRequest
-):
+@pytest.mark.parametrize(
+    "request_type",
+    [
+        logging_config.UpdateBucketRequest({}),
+        {},
+    ],
+)
+async def test_update_bucket_async_async(request_type, transport: str = "grpc_asyncio"):
     client = ConfigServiceV2AsyncClient(
         credentials=async_anonymous_credentials(),
         transport=transport,
@@ -2520,7 +2545,7 @@ async def test_update_bucket_async_async(
 
     # Everything is optional in proto3 as far as the runtime is concerned,
     # and we are mocking out the actual API, so just send an empty request.
-    request = request_type()
+    request = request_type
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(
@@ -2540,11 +2565,6 @@ async def test_update_bucket_async_async(
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, future.Future)
-
-
-@pytest.mark.asyncio
-async def test_update_bucket_async_async_from_dict():
-    await test_update_bucket_async_async(request_type=dict)
 
 
 def test_update_bucket_async_field_headers():
@@ -2615,8 +2635,8 @@ async def test_update_bucket_async_field_headers_async():
 @pytest.mark.parametrize(
     "request_type",
     [
-        logging_config.CreateBucketRequest,
-        dict,
+        logging_config.CreateBucketRequest({}),
+        {},
     ],
 )
 def test_create_bucket(request_type, transport: str = "grpc"):
@@ -2627,7 +2647,7 @@ def test_create_bucket(request_type, transport: str = "grpc"):
 
     # Everything is optional in proto3 as far as the runtime is concerned,
     # and we are mocking out the actual API, so just send an empty request.
-    request = request_type()
+    request = request_type
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(type(client.transport.create_bucket), "__call__") as call:
@@ -2684,10 +2704,11 @@ def test_create_bucket_non_empty_request_with_auto_populated_field():
         client.create_bucket(request=request)
         call.assert_called()
         _, args, _ = call.mock_calls[0]
-        assert args[0] == logging_config.CreateBucketRequest(
+        request_msg = logging_config.CreateBucketRequest(
             parent="parent_value",
             bucket_id="bucket_id_value",
         )
+        assert args[0] == request_msg
 
 
 def test_create_bucket_use_cached_wrapped_rpc():
@@ -2768,9 +2789,14 @@ async def test_create_bucket_async_use_cached_wrapped_rpc(
 
 
 @pytest.mark.asyncio
-async def test_create_bucket_async(
-    transport: str = "grpc_asyncio", request_type=logging_config.CreateBucketRequest
-):
+@pytest.mark.parametrize(
+    "request_type",
+    [
+        logging_config.CreateBucketRequest({}),
+        {},
+    ],
+)
+async def test_create_bucket_async(request_type, transport: str = "grpc_asyncio"):
     client = ConfigServiceV2AsyncClient(
         credentials=async_anonymous_credentials(),
         transport=transport,
@@ -2778,7 +2804,7 @@ async def test_create_bucket_async(
 
     # Everything is optional in proto3 as far as the runtime is concerned,
     # and we are mocking out the actual API, so just send an empty request.
-    request = request_type()
+    request = request_type
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(type(client.transport.create_bucket), "__call__") as call:
@@ -2811,11 +2837,6 @@ async def test_create_bucket_async(
     assert response.lifecycle_state == logging_config.LifecycleState.ACTIVE
     assert response.analytics_enabled is True
     assert response.restricted_fields == ["restricted_fields_value"]
-
-
-@pytest.mark.asyncio
-async def test_create_bucket_async_from_dict():
-    await test_create_bucket_async(request_type=dict)
 
 
 def test_create_bucket_field_headers():
@@ -2882,8 +2903,8 @@ async def test_create_bucket_field_headers_async():
 @pytest.mark.parametrize(
     "request_type",
     [
-        logging_config.UpdateBucketRequest,
-        dict,
+        logging_config.UpdateBucketRequest({}),
+        {},
     ],
 )
 def test_update_bucket(request_type, transport: str = "grpc"):
@@ -2894,7 +2915,7 @@ def test_update_bucket(request_type, transport: str = "grpc"):
 
     # Everything is optional in proto3 as far as the runtime is concerned,
     # and we are mocking out the actual API, so just send an empty request.
-    request = request_type()
+    request = request_type
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(type(client.transport.update_bucket), "__call__") as call:
@@ -2950,9 +2971,10 @@ def test_update_bucket_non_empty_request_with_auto_populated_field():
         client.update_bucket(request=request)
         call.assert_called()
         _, args, _ = call.mock_calls[0]
-        assert args[0] == logging_config.UpdateBucketRequest(
+        request_msg = logging_config.UpdateBucketRequest(
             name="name_value",
         )
+        assert args[0] == request_msg
 
 
 def test_update_bucket_use_cached_wrapped_rpc():
@@ -3033,9 +3055,14 @@ async def test_update_bucket_async_use_cached_wrapped_rpc(
 
 
 @pytest.mark.asyncio
-async def test_update_bucket_async(
-    transport: str = "grpc_asyncio", request_type=logging_config.UpdateBucketRequest
-):
+@pytest.mark.parametrize(
+    "request_type",
+    [
+        logging_config.UpdateBucketRequest({}),
+        {},
+    ],
+)
+async def test_update_bucket_async(request_type, transport: str = "grpc_asyncio"):
     client = ConfigServiceV2AsyncClient(
         credentials=async_anonymous_credentials(),
         transport=transport,
@@ -3043,7 +3070,7 @@ async def test_update_bucket_async(
 
     # Everything is optional in proto3 as far as the runtime is concerned,
     # and we are mocking out the actual API, so just send an empty request.
-    request = request_type()
+    request = request_type
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(type(client.transport.update_bucket), "__call__") as call:
@@ -3076,11 +3103,6 @@ async def test_update_bucket_async(
     assert response.lifecycle_state == logging_config.LifecycleState.ACTIVE
     assert response.analytics_enabled is True
     assert response.restricted_fields == ["restricted_fields_value"]
-
-
-@pytest.mark.asyncio
-async def test_update_bucket_async_from_dict():
-    await test_update_bucket_async(request_type=dict)
 
 
 def test_update_bucket_field_headers():
@@ -3147,8 +3169,8 @@ async def test_update_bucket_field_headers_async():
 @pytest.mark.parametrize(
     "request_type",
     [
-        logging_config.DeleteBucketRequest,
-        dict,
+        logging_config.DeleteBucketRequest({}),
+        {},
     ],
 )
 def test_delete_bucket(request_type, transport: str = "grpc"):
@@ -3159,7 +3181,7 @@ def test_delete_bucket(request_type, transport: str = "grpc"):
 
     # Everything is optional in proto3 as far as the runtime is concerned,
     # and we are mocking out the actual API, so just send an empty request.
-    request = request_type()
+    request = request_type
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(type(client.transport.delete_bucket), "__call__") as call:
@@ -3200,9 +3222,10 @@ def test_delete_bucket_non_empty_request_with_auto_populated_field():
         client.delete_bucket(request=request)
         call.assert_called()
         _, args, _ = call.mock_calls[0]
-        assert args[0] == logging_config.DeleteBucketRequest(
+        request_msg = logging_config.DeleteBucketRequest(
             name="name_value",
         )
+        assert args[0] == request_msg
 
 
 def test_delete_bucket_use_cached_wrapped_rpc():
@@ -3283,9 +3306,14 @@ async def test_delete_bucket_async_use_cached_wrapped_rpc(
 
 
 @pytest.mark.asyncio
-async def test_delete_bucket_async(
-    transport: str = "grpc_asyncio", request_type=logging_config.DeleteBucketRequest
-):
+@pytest.mark.parametrize(
+    "request_type",
+    [
+        logging_config.DeleteBucketRequest({}),
+        {},
+    ],
+)
+async def test_delete_bucket_async(request_type, transport: str = "grpc_asyncio"):
     client = ConfigServiceV2AsyncClient(
         credentials=async_anonymous_credentials(),
         transport=transport,
@@ -3293,7 +3321,7 @@ async def test_delete_bucket_async(
 
     # Everything is optional in proto3 as far as the runtime is concerned,
     # and we are mocking out the actual API, so just send an empty request.
-    request = request_type()
+    request = request_type
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(type(client.transport.delete_bucket), "__call__") as call:
@@ -3309,11 +3337,6 @@ async def test_delete_bucket_async(
 
     # Establish that the response is the type that we expect.
     assert response is None
-
-
-@pytest.mark.asyncio
-async def test_delete_bucket_async_from_dict():
-    await test_delete_bucket_async(request_type=dict)
 
 
 def test_delete_bucket_field_headers():
@@ -3378,8 +3401,8 @@ async def test_delete_bucket_field_headers_async():
 @pytest.mark.parametrize(
     "request_type",
     [
-        logging_config.UndeleteBucketRequest,
-        dict,
+        logging_config.UndeleteBucketRequest({}),
+        {},
     ],
 )
 def test_undelete_bucket(request_type, transport: str = "grpc"):
@@ -3390,7 +3413,7 @@ def test_undelete_bucket(request_type, transport: str = "grpc"):
 
     # Everything is optional in proto3 as far as the runtime is concerned,
     # and we are mocking out the actual API, so just send an empty request.
-    request = request_type()
+    request = request_type
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(type(client.transport.undelete_bucket), "__call__") as call:
@@ -3431,9 +3454,10 @@ def test_undelete_bucket_non_empty_request_with_auto_populated_field():
         client.undelete_bucket(request=request)
         call.assert_called()
         _, args, _ = call.mock_calls[0]
-        assert args[0] == logging_config.UndeleteBucketRequest(
+        request_msg = logging_config.UndeleteBucketRequest(
             name="name_value",
         )
+        assert args[0] == request_msg
 
 
 def test_undelete_bucket_use_cached_wrapped_rpc():
@@ -3514,9 +3538,14 @@ async def test_undelete_bucket_async_use_cached_wrapped_rpc(
 
 
 @pytest.mark.asyncio
-async def test_undelete_bucket_async(
-    transport: str = "grpc_asyncio", request_type=logging_config.UndeleteBucketRequest
-):
+@pytest.mark.parametrize(
+    "request_type",
+    [
+        logging_config.UndeleteBucketRequest({}),
+        {},
+    ],
+)
+async def test_undelete_bucket_async(request_type, transport: str = "grpc_asyncio"):
     client = ConfigServiceV2AsyncClient(
         credentials=async_anonymous_credentials(),
         transport=transport,
@@ -3524,7 +3553,7 @@ async def test_undelete_bucket_async(
 
     # Everything is optional in proto3 as far as the runtime is concerned,
     # and we are mocking out the actual API, so just send an empty request.
-    request = request_type()
+    request = request_type
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(type(client.transport.undelete_bucket), "__call__") as call:
@@ -3540,11 +3569,6 @@ async def test_undelete_bucket_async(
 
     # Establish that the response is the type that we expect.
     assert response is None
-
-
-@pytest.mark.asyncio
-async def test_undelete_bucket_async_from_dict():
-    await test_undelete_bucket_async(request_type=dict)
 
 
 def test_undelete_bucket_field_headers():
@@ -3609,8 +3633,8 @@ async def test_undelete_bucket_field_headers_async():
 @pytest.mark.parametrize(
     "request_type",
     [
-        logging_config.ListViewsRequest,
-        dict,
+        logging_config.ListViewsRequest({}),
+        {},
     ],
 )
 def test_list_views(request_type, transport: str = "grpc"):
@@ -3621,7 +3645,7 @@ def test_list_views(request_type, transport: str = "grpc"):
 
     # Everything is optional in proto3 as far as the runtime is concerned,
     # and we are mocking out the actual API, so just send an empty request.
-    request = request_type()
+    request = request_type
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(type(client.transport.list_views), "__call__") as call:
@@ -3666,10 +3690,11 @@ def test_list_views_non_empty_request_with_auto_populated_field():
         client.list_views(request=request)
         call.assert_called()
         _, args, _ = call.mock_calls[0]
-        assert args[0] == logging_config.ListViewsRequest(
+        request_msg = logging_config.ListViewsRequest(
             parent="parent_value",
             page_token="page_token_value",
         )
+        assert args[0] == request_msg
 
 
 def test_list_views_use_cached_wrapped_rpc():
@@ -3748,9 +3773,14 @@ async def test_list_views_async_use_cached_wrapped_rpc(transport: str = "grpc_as
 
 
 @pytest.mark.asyncio
-async def test_list_views_async(
-    transport: str = "grpc_asyncio", request_type=logging_config.ListViewsRequest
-):
+@pytest.mark.parametrize(
+    "request_type",
+    [
+        logging_config.ListViewsRequest({}),
+        {},
+    ],
+)
+async def test_list_views_async(request_type, transport: str = "grpc_asyncio"):
     client = ConfigServiceV2AsyncClient(
         credentials=async_anonymous_credentials(),
         transport=transport,
@@ -3758,7 +3788,7 @@ async def test_list_views_async(
 
     # Everything is optional in proto3 as far as the runtime is concerned,
     # and we are mocking out the actual API, so just send an empty request.
-    request = request_type()
+    request = request_type
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(type(client.transport.list_views), "__call__") as call:
@@ -3779,11 +3809,6 @@ async def test_list_views_async(
     # Establish that the response is the type that we expect.
     assert isinstance(response, pagers.ListViewsAsyncPager)
     assert response.next_page_token == "next_page_token_value"
-
-
-@pytest.mark.asyncio
-async def test_list_views_async_from_dict():
-    await test_list_views_async(request_type=dict)
 
 
 def test_list_views_field_headers():
@@ -4122,8 +4147,8 @@ async def test_list_views_async_pages():
 @pytest.mark.parametrize(
     "request_type",
     [
-        logging_config.GetViewRequest,
-        dict,
+        logging_config.GetViewRequest({}),
+        {},
     ],
 )
 def test_get_view(request_type, transport: str = "grpc"):
@@ -4134,7 +4159,7 @@ def test_get_view(request_type, transport: str = "grpc"):
 
     # Everything is optional in proto3 as far as the runtime is concerned,
     # and we are mocking out the actual API, so just send an empty request.
-    request = request_type()
+    request = request_type
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(type(client.transport.get_view), "__call__") as call:
@@ -4182,9 +4207,10 @@ def test_get_view_non_empty_request_with_auto_populated_field():
         client.get_view(request=request)
         call.assert_called()
         _, args, _ = call.mock_calls[0]
-        assert args[0] == logging_config.GetViewRequest(
+        request_msg = logging_config.GetViewRequest(
             name="name_value",
         )
+        assert args[0] == request_msg
 
 
 def test_get_view_use_cached_wrapped_rpc():
@@ -4263,9 +4289,14 @@ async def test_get_view_async_use_cached_wrapped_rpc(transport: str = "grpc_asyn
 
 
 @pytest.mark.asyncio
-async def test_get_view_async(
-    transport: str = "grpc_asyncio", request_type=logging_config.GetViewRequest
-):
+@pytest.mark.parametrize(
+    "request_type",
+    [
+        logging_config.GetViewRequest({}),
+        {},
+    ],
+)
+async def test_get_view_async(request_type, transport: str = "grpc_asyncio"):
     client = ConfigServiceV2AsyncClient(
         credentials=async_anonymous_credentials(),
         transport=transport,
@@ -4273,7 +4304,7 @@ async def test_get_view_async(
 
     # Everything is optional in proto3 as far as the runtime is concerned,
     # and we are mocking out the actual API, so just send an empty request.
-    request = request_type()
+    request = request_type
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(type(client.transport.get_view), "__call__") as call:
@@ -4298,11 +4329,6 @@ async def test_get_view_async(
     assert response.name == "name_value"
     assert response.description == "description_value"
     assert response.filter == "filter_value"
-
-
-@pytest.mark.asyncio
-async def test_get_view_async_from_dict():
-    await test_get_view_async(request_type=dict)
 
 
 def test_get_view_field_headers():
@@ -4369,8 +4395,8 @@ async def test_get_view_field_headers_async():
 @pytest.mark.parametrize(
     "request_type",
     [
-        logging_config.CreateViewRequest,
-        dict,
+        logging_config.CreateViewRequest({}),
+        {},
     ],
 )
 def test_create_view(request_type, transport: str = "grpc"):
@@ -4381,7 +4407,7 @@ def test_create_view(request_type, transport: str = "grpc"):
 
     # Everything is optional in proto3 as far as the runtime is concerned,
     # and we are mocking out the actual API, so just send an empty request.
-    request = request_type()
+    request = request_type
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(type(client.transport.create_view), "__call__") as call:
@@ -4430,10 +4456,11 @@ def test_create_view_non_empty_request_with_auto_populated_field():
         client.create_view(request=request)
         call.assert_called()
         _, args, _ = call.mock_calls[0]
-        assert args[0] == logging_config.CreateViewRequest(
+        request_msg = logging_config.CreateViewRequest(
             parent="parent_value",
             view_id="view_id_value",
         )
+        assert args[0] == request_msg
 
 
 def test_create_view_use_cached_wrapped_rpc():
@@ -4514,9 +4541,14 @@ async def test_create_view_async_use_cached_wrapped_rpc(
 
 
 @pytest.mark.asyncio
-async def test_create_view_async(
-    transport: str = "grpc_asyncio", request_type=logging_config.CreateViewRequest
-):
+@pytest.mark.parametrize(
+    "request_type",
+    [
+        logging_config.CreateViewRequest({}),
+        {},
+    ],
+)
+async def test_create_view_async(request_type, transport: str = "grpc_asyncio"):
     client = ConfigServiceV2AsyncClient(
         credentials=async_anonymous_credentials(),
         transport=transport,
@@ -4524,7 +4556,7 @@ async def test_create_view_async(
 
     # Everything is optional in proto3 as far as the runtime is concerned,
     # and we are mocking out the actual API, so just send an empty request.
-    request = request_type()
+    request = request_type
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(type(client.transport.create_view), "__call__") as call:
@@ -4549,11 +4581,6 @@ async def test_create_view_async(
     assert response.name == "name_value"
     assert response.description == "description_value"
     assert response.filter == "filter_value"
-
-
-@pytest.mark.asyncio
-async def test_create_view_async_from_dict():
-    await test_create_view_async(request_type=dict)
 
 
 def test_create_view_field_headers():
@@ -4620,8 +4647,8 @@ async def test_create_view_field_headers_async():
 @pytest.mark.parametrize(
     "request_type",
     [
-        logging_config.UpdateViewRequest,
-        dict,
+        logging_config.UpdateViewRequest({}),
+        {},
     ],
 )
 def test_update_view(request_type, transport: str = "grpc"):
@@ -4632,7 +4659,7 @@ def test_update_view(request_type, transport: str = "grpc"):
 
     # Everything is optional in proto3 as far as the runtime is concerned,
     # and we are mocking out the actual API, so just send an empty request.
-    request = request_type()
+    request = request_type
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(type(client.transport.update_view), "__call__") as call:
@@ -4680,9 +4707,10 @@ def test_update_view_non_empty_request_with_auto_populated_field():
         client.update_view(request=request)
         call.assert_called()
         _, args, _ = call.mock_calls[0]
-        assert args[0] == logging_config.UpdateViewRequest(
+        request_msg = logging_config.UpdateViewRequest(
             name="name_value",
         )
+        assert args[0] == request_msg
 
 
 def test_update_view_use_cached_wrapped_rpc():
@@ -4763,9 +4791,14 @@ async def test_update_view_async_use_cached_wrapped_rpc(
 
 
 @pytest.mark.asyncio
-async def test_update_view_async(
-    transport: str = "grpc_asyncio", request_type=logging_config.UpdateViewRequest
-):
+@pytest.mark.parametrize(
+    "request_type",
+    [
+        logging_config.UpdateViewRequest({}),
+        {},
+    ],
+)
+async def test_update_view_async(request_type, transport: str = "grpc_asyncio"):
     client = ConfigServiceV2AsyncClient(
         credentials=async_anonymous_credentials(),
         transport=transport,
@@ -4773,7 +4806,7 @@ async def test_update_view_async(
 
     # Everything is optional in proto3 as far as the runtime is concerned,
     # and we are mocking out the actual API, so just send an empty request.
-    request = request_type()
+    request = request_type
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(type(client.transport.update_view), "__call__") as call:
@@ -4798,11 +4831,6 @@ async def test_update_view_async(
     assert response.name == "name_value"
     assert response.description == "description_value"
     assert response.filter == "filter_value"
-
-
-@pytest.mark.asyncio
-async def test_update_view_async_from_dict():
-    await test_update_view_async(request_type=dict)
 
 
 def test_update_view_field_headers():
@@ -4869,8 +4897,8 @@ async def test_update_view_field_headers_async():
 @pytest.mark.parametrize(
     "request_type",
     [
-        logging_config.DeleteViewRequest,
-        dict,
+        logging_config.DeleteViewRequest({}),
+        {},
     ],
 )
 def test_delete_view(request_type, transport: str = "grpc"):
@@ -4881,7 +4909,7 @@ def test_delete_view(request_type, transport: str = "grpc"):
 
     # Everything is optional in proto3 as far as the runtime is concerned,
     # and we are mocking out the actual API, so just send an empty request.
-    request = request_type()
+    request = request_type
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(type(client.transport.delete_view), "__call__") as call:
@@ -4922,9 +4950,10 @@ def test_delete_view_non_empty_request_with_auto_populated_field():
         client.delete_view(request=request)
         call.assert_called()
         _, args, _ = call.mock_calls[0]
-        assert args[0] == logging_config.DeleteViewRequest(
+        request_msg = logging_config.DeleteViewRequest(
             name="name_value",
         )
+        assert args[0] == request_msg
 
 
 def test_delete_view_use_cached_wrapped_rpc():
@@ -5005,9 +5034,14 @@ async def test_delete_view_async_use_cached_wrapped_rpc(
 
 
 @pytest.mark.asyncio
-async def test_delete_view_async(
-    transport: str = "grpc_asyncio", request_type=logging_config.DeleteViewRequest
-):
+@pytest.mark.parametrize(
+    "request_type",
+    [
+        logging_config.DeleteViewRequest({}),
+        {},
+    ],
+)
+async def test_delete_view_async(request_type, transport: str = "grpc_asyncio"):
     client = ConfigServiceV2AsyncClient(
         credentials=async_anonymous_credentials(),
         transport=transport,
@@ -5015,7 +5049,7 @@ async def test_delete_view_async(
 
     # Everything is optional in proto3 as far as the runtime is concerned,
     # and we are mocking out the actual API, so just send an empty request.
-    request = request_type()
+    request = request_type
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(type(client.transport.delete_view), "__call__") as call:
@@ -5031,11 +5065,6 @@ async def test_delete_view_async(
 
     # Establish that the response is the type that we expect.
     assert response is None
-
-
-@pytest.mark.asyncio
-async def test_delete_view_async_from_dict():
-    await test_delete_view_async(request_type=dict)
 
 
 def test_delete_view_field_headers():
@@ -5100,8 +5129,8 @@ async def test_delete_view_field_headers_async():
 @pytest.mark.parametrize(
     "request_type",
     [
-        logging_config.ListSinksRequest,
-        dict,
+        logging_config.ListSinksRequest({}),
+        {},
     ],
 )
 def test_list_sinks(request_type, transport: str = "grpc"):
@@ -5112,7 +5141,7 @@ def test_list_sinks(request_type, transport: str = "grpc"):
 
     # Everything is optional in proto3 as far as the runtime is concerned,
     # and we are mocking out the actual API, so just send an empty request.
-    request = request_type()
+    request = request_type
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(type(client.transport.list_sinks), "__call__") as call:
@@ -5157,10 +5186,11 @@ def test_list_sinks_non_empty_request_with_auto_populated_field():
         client.list_sinks(request=request)
         call.assert_called()
         _, args, _ = call.mock_calls[0]
-        assert args[0] == logging_config.ListSinksRequest(
+        request_msg = logging_config.ListSinksRequest(
             parent="parent_value",
             page_token="page_token_value",
         )
+        assert args[0] == request_msg
 
 
 def test_list_sinks_use_cached_wrapped_rpc():
@@ -5239,9 +5269,14 @@ async def test_list_sinks_async_use_cached_wrapped_rpc(transport: str = "grpc_as
 
 
 @pytest.mark.asyncio
-async def test_list_sinks_async(
-    transport: str = "grpc_asyncio", request_type=logging_config.ListSinksRequest
-):
+@pytest.mark.parametrize(
+    "request_type",
+    [
+        logging_config.ListSinksRequest({}),
+        {},
+    ],
+)
+async def test_list_sinks_async(request_type, transport: str = "grpc_asyncio"):
     client = ConfigServiceV2AsyncClient(
         credentials=async_anonymous_credentials(),
         transport=transport,
@@ -5249,7 +5284,7 @@ async def test_list_sinks_async(
 
     # Everything is optional in proto3 as far as the runtime is concerned,
     # and we are mocking out the actual API, so just send an empty request.
-    request = request_type()
+    request = request_type
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(type(client.transport.list_sinks), "__call__") as call:
@@ -5270,11 +5305,6 @@ async def test_list_sinks_async(
     # Establish that the response is the type that we expect.
     assert isinstance(response, pagers.ListSinksAsyncPager)
     assert response.next_page_token == "next_page_token_value"
-
-
-@pytest.mark.asyncio
-async def test_list_sinks_async_from_dict():
-    await test_list_sinks_async(request_type=dict)
 
 
 def test_list_sinks_field_headers():
@@ -5613,8 +5643,8 @@ async def test_list_sinks_async_pages():
 @pytest.mark.parametrize(
     "request_type",
     [
-        logging_config.GetSinkRequest,
-        dict,
+        logging_config.GetSinkRequest({}),
+        {},
     ],
 )
 def test_get_sink(request_type, transport: str = "grpc"):
@@ -5625,7 +5655,7 @@ def test_get_sink(request_type, transport: str = "grpc"):
 
     # Everything is optional in proto3 as far as the runtime is concerned,
     # and we are mocking out the actual API, so just send an empty request.
-    request = request_type()
+    request = request_type
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(type(client.transport.get_sink), "__call__") as call:
@@ -5683,9 +5713,10 @@ def test_get_sink_non_empty_request_with_auto_populated_field():
         client.get_sink(request=request)
         call.assert_called()
         _, args, _ = call.mock_calls[0]
-        assert args[0] == logging_config.GetSinkRequest(
+        request_msg = logging_config.GetSinkRequest(
             sink_name="sink_name_value",
         )
+        assert args[0] == request_msg
 
 
 def test_get_sink_use_cached_wrapped_rpc():
@@ -5764,9 +5795,14 @@ async def test_get_sink_async_use_cached_wrapped_rpc(transport: str = "grpc_asyn
 
 
 @pytest.mark.asyncio
-async def test_get_sink_async(
-    transport: str = "grpc_asyncio", request_type=logging_config.GetSinkRequest
-):
+@pytest.mark.parametrize(
+    "request_type",
+    [
+        logging_config.GetSinkRequest({}),
+        {},
+    ],
+)
+async def test_get_sink_async(request_type, transport: str = "grpc_asyncio"):
     client = ConfigServiceV2AsyncClient(
         credentials=async_anonymous_credentials(),
         transport=transport,
@@ -5774,7 +5810,7 @@ async def test_get_sink_async(
 
     # Everything is optional in proto3 as far as the runtime is concerned,
     # and we are mocking out the actual API, so just send an empty request.
-    request = request_type()
+    request = request_type
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(type(client.transport.get_sink), "__call__") as call:
@@ -5809,11 +5845,6 @@ async def test_get_sink_async(
     assert response.output_version_format == logging_config.LogSink.VersionFormat.V2
     assert response.writer_identity == "writer_identity_value"
     assert response.include_children is True
-
-
-@pytest.mark.asyncio
-async def test_get_sink_async_from_dict():
-    await test_get_sink_async(request_type=dict)
 
 
 def test_get_sink_field_headers():
@@ -5962,8 +5993,8 @@ async def test_get_sink_flattened_error_async():
 @pytest.mark.parametrize(
     "request_type",
     [
-        logging_config.CreateSinkRequest,
-        dict,
+        logging_config.CreateSinkRequest({}),
+        {},
     ],
 )
 def test_create_sink(request_type, transport: str = "grpc"):
@@ -5974,7 +6005,7 @@ def test_create_sink(request_type, transport: str = "grpc"):
 
     # Everything is optional in proto3 as far as the runtime is concerned,
     # and we are mocking out the actual API, so just send an empty request.
-    request = request_type()
+    request = request_type
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(type(client.transport.create_sink), "__call__") as call:
@@ -6032,9 +6063,10 @@ def test_create_sink_non_empty_request_with_auto_populated_field():
         client.create_sink(request=request)
         call.assert_called()
         _, args, _ = call.mock_calls[0]
-        assert args[0] == logging_config.CreateSinkRequest(
+        request_msg = logging_config.CreateSinkRequest(
             parent="parent_value",
         )
+        assert args[0] == request_msg
 
 
 def test_create_sink_use_cached_wrapped_rpc():
@@ -6115,9 +6147,14 @@ async def test_create_sink_async_use_cached_wrapped_rpc(
 
 
 @pytest.mark.asyncio
-async def test_create_sink_async(
-    transport: str = "grpc_asyncio", request_type=logging_config.CreateSinkRequest
-):
+@pytest.mark.parametrize(
+    "request_type",
+    [
+        logging_config.CreateSinkRequest({}),
+        {},
+    ],
+)
+async def test_create_sink_async(request_type, transport: str = "grpc_asyncio"):
     client = ConfigServiceV2AsyncClient(
         credentials=async_anonymous_credentials(),
         transport=transport,
@@ -6125,7 +6162,7 @@ async def test_create_sink_async(
 
     # Everything is optional in proto3 as far as the runtime is concerned,
     # and we are mocking out the actual API, so just send an empty request.
-    request = request_type()
+    request = request_type
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(type(client.transport.create_sink), "__call__") as call:
@@ -6160,11 +6197,6 @@ async def test_create_sink_async(
     assert response.output_version_format == logging_config.LogSink.VersionFormat.V2
     assert response.writer_identity == "writer_identity_value"
     assert response.include_children is True
-
-
-@pytest.mark.asyncio
-async def test_create_sink_async_from_dict():
-    await test_create_sink_async(request_type=dict)
 
 
 def test_create_sink_field_headers():
@@ -6323,8 +6355,8 @@ async def test_create_sink_flattened_error_async():
 @pytest.mark.parametrize(
     "request_type",
     [
-        logging_config.UpdateSinkRequest,
-        dict,
+        logging_config.UpdateSinkRequest({}),
+        {},
     ],
 )
 def test_update_sink(request_type, transport: str = "grpc"):
@@ -6335,7 +6367,7 @@ def test_update_sink(request_type, transport: str = "grpc"):
 
     # Everything is optional in proto3 as far as the runtime is concerned,
     # and we are mocking out the actual API, so just send an empty request.
-    request = request_type()
+    request = request_type
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(type(client.transport.update_sink), "__call__") as call:
@@ -6393,9 +6425,10 @@ def test_update_sink_non_empty_request_with_auto_populated_field():
         client.update_sink(request=request)
         call.assert_called()
         _, args, _ = call.mock_calls[0]
-        assert args[0] == logging_config.UpdateSinkRequest(
+        request_msg = logging_config.UpdateSinkRequest(
             sink_name="sink_name_value",
         )
+        assert args[0] == request_msg
 
 
 def test_update_sink_use_cached_wrapped_rpc():
@@ -6476,9 +6509,14 @@ async def test_update_sink_async_use_cached_wrapped_rpc(
 
 
 @pytest.mark.asyncio
-async def test_update_sink_async(
-    transport: str = "grpc_asyncio", request_type=logging_config.UpdateSinkRequest
-):
+@pytest.mark.parametrize(
+    "request_type",
+    [
+        logging_config.UpdateSinkRequest({}),
+        {},
+    ],
+)
+async def test_update_sink_async(request_type, transport: str = "grpc_asyncio"):
     client = ConfigServiceV2AsyncClient(
         credentials=async_anonymous_credentials(),
         transport=transport,
@@ -6486,7 +6524,7 @@ async def test_update_sink_async(
 
     # Everything is optional in proto3 as far as the runtime is concerned,
     # and we are mocking out the actual API, so just send an empty request.
-    request = request_type()
+    request = request_type
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(type(client.transport.update_sink), "__call__") as call:
@@ -6521,11 +6559,6 @@ async def test_update_sink_async(
     assert response.output_version_format == logging_config.LogSink.VersionFormat.V2
     assert response.writer_identity == "writer_identity_value"
     assert response.include_children is True
-
-
-@pytest.mark.asyncio
-async def test_update_sink_async_from_dict():
-    await test_update_sink_async(request_type=dict)
 
 
 def test_update_sink_field_headers():
@@ -6694,8 +6727,8 @@ async def test_update_sink_flattened_error_async():
 @pytest.mark.parametrize(
     "request_type",
     [
-        logging_config.DeleteSinkRequest,
-        dict,
+        logging_config.DeleteSinkRequest({}),
+        {},
     ],
 )
 def test_delete_sink(request_type, transport: str = "grpc"):
@@ -6706,7 +6739,7 @@ def test_delete_sink(request_type, transport: str = "grpc"):
 
     # Everything is optional in proto3 as far as the runtime is concerned,
     # and we are mocking out the actual API, so just send an empty request.
-    request = request_type()
+    request = request_type
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(type(client.transport.delete_sink), "__call__") as call:
@@ -6747,9 +6780,10 @@ def test_delete_sink_non_empty_request_with_auto_populated_field():
         client.delete_sink(request=request)
         call.assert_called()
         _, args, _ = call.mock_calls[0]
-        assert args[0] == logging_config.DeleteSinkRequest(
+        request_msg = logging_config.DeleteSinkRequest(
             sink_name="sink_name_value",
         )
+        assert args[0] == request_msg
 
 
 def test_delete_sink_use_cached_wrapped_rpc():
@@ -6830,9 +6864,14 @@ async def test_delete_sink_async_use_cached_wrapped_rpc(
 
 
 @pytest.mark.asyncio
-async def test_delete_sink_async(
-    transport: str = "grpc_asyncio", request_type=logging_config.DeleteSinkRequest
-):
+@pytest.mark.parametrize(
+    "request_type",
+    [
+        logging_config.DeleteSinkRequest({}),
+        {},
+    ],
+)
+async def test_delete_sink_async(request_type, transport: str = "grpc_asyncio"):
     client = ConfigServiceV2AsyncClient(
         credentials=async_anonymous_credentials(),
         transport=transport,
@@ -6840,7 +6879,7 @@ async def test_delete_sink_async(
 
     # Everything is optional in proto3 as far as the runtime is concerned,
     # and we are mocking out the actual API, so just send an empty request.
-    request = request_type()
+    request = request_type
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(type(client.transport.delete_sink), "__call__") as call:
@@ -6856,11 +6895,6 @@ async def test_delete_sink_async(
 
     # Establish that the response is the type that we expect.
     assert response is None
-
-
-@pytest.mark.asyncio
-async def test_delete_sink_async_from_dict():
-    await test_delete_sink_async(request_type=dict)
 
 
 def test_delete_sink_field_headers():
@@ -7005,8 +7039,8 @@ async def test_delete_sink_flattened_error_async():
 @pytest.mark.parametrize(
     "request_type",
     [
-        logging_config.CreateLinkRequest,
-        dict,
+        logging_config.CreateLinkRequest({}),
+        {},
     ],
 )
 def test_create_link(request_type, transport: str = "grpc"):
@@ -7017,7 +7051,7 @@ def test_create_link(request_type, transport: str = "grpc"):
 
     # Everything is optional in proto3 as far as the runtime is concerned,
     # and we are mocking out the actual API, so just send an empty request.
-    request = request_type()
+    request = request_type
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(type(client.transport.create_link), "__call__") as call:
@@ -7059,10 +7093,11 @@ def test_create_link_non_empty_request_with_auto_populated_field():
         client.create_link(request=request)
         call.assert_called()
         _, args, _ = call.mock_calls[0]
-        assert args[0] == logging_config.CreateLinkRequest(
+        request_msg = logging_config.CreateLinkRequest(
             parent="parent_value",
             link_id="link_id_value",
         )
+        assert args[0] == request_msg
 
 
 def test_create_link_use_cached_wrapped_rpc():
@@ -7153,9 +7188,14 @@ async def test_create_link_async_use_cached_wrapped_rpc(
 
 
 @pytest.mark.asyncio
-async def test_create_link_async(
-    transport: str = "grpc_asyncio", request_type=logging_config.CreateLinkRequest
-):
+@pytest.mark.parametrize(
+    "request_type",
+    [
+        logging_config.CreateLinkRequest({}),
+        {},
+    ],
+)
+async def test_create_link_async(request_type, transport: str = "grpc_asyncio"):
     client = ConfigServiceV2AsyncClient(
         credentials=async_anonymous_credentials(),
         transport=transport,
@@ -7163,7 +7203,7 @@ async def test_create_link_async(
 
     # Everything is optional in proto3 as far as the runtime is concerned,
     # and we are mocking out the actual API, so just send an empty request.
-    request = request_type()
+    request = request_type
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(type(client.transport.create_link), "__call__") as call:
@@ -7181,11 +7221,6 @@ async def test_create_link_async(
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, future.Future)
-
-
-@pytest.mark.asyncio
-async def test_create_link_async_from_dict():
-    await test_create_link_async(request_type=dict)
 
 
 def test_create_link_field_headers():
@@ -7354,8 +7389,8 @@ async def test_create_link_flattened_error_async():
 @pytest.mark.parametrize(
     "request_type",
     [
-        logging_config.DeleteLinkRequest,
-        dict,
+        logging_config.DeleteLinkRequest({}),
+        {},
     ],
 )
 def test_delete_link(request_type, transport: str = "grpc"):
@@ -7366,7 +7401,7 @@ def test_delete_link(request_type, transport: str = "grpc"):
 
     # Everything is optional in proto3 as far as the runtime is concerned,
     # and we are mocking out the actual API, so just send an empty request.
-    request = request_type()
+    request = request_type
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(type(client.transport.delete_link), "__call__") as call:
@@ -7407,9 +7442,10 @@ def test_delete_link_non_empty_request_with_auto_populated_field():
         client.delete_link(request=request)
         call.assert_called()
         _, args, _ = call.mock_calls[0]
-        assert args[0] == logging_config.DeleteLinkRequest(
+        request_msg = logging_config.DeleteLinkRequest(
             name="name_value",
         )
+        assert args[0] == request_msg
 
 
 def test_delete_link_use_cached_wrapped_rpc():
@@ -7500,9 +7536,14 @@ async def test_delete_link_async_use_cached_wrapped_rpc(
 
 
 @pytest.mark.asyncio
-async def test_delete_link_async(
-    transport: str = "grpc_asyncio", request_type=logging_config.DeleteLinkRequest
-):
+@pytest.mark.parametrize(
+    "request_type",
+    [
+        logging_config.DeleteLinkRequest({}),
+        {},
+    ],
+)
+async def test_delete_link_async(request_type, transport: str = "grpc_asyncio"):
     client = ConfigServiceV2AsyncClient(
         credentials=async_anonymous_credentials(),
         transport=transport,
@@ -7510,7 +7551,7 @@ async def test_delete_link_async(
 
     # Everything is optional in proto3 as far as the runtime is concerned,
     # and we are mocking out the actual API, so just send an empty request.
-    request = request_type()
+    request = request_type
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(type(client.transport.delete_link), "__call__") as call:
@@ -7528,11 +7569,6 @@ async def test_delete_link_async(
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, future.Future)
-
-
-@pytest.mark.asyncio
-async def test_delete_link_async_from_dict():
-    await test_delete_link_async(request_type=dict)
 
 
 def test_delete_link_field_headers():
@@ -7681,8 +7717,8 @@ async def test_delete_link_flattened_error_async():
 @pytest.mark.parametrize(
     "request_type",
     [
-        logging_config.ListLinksRequest,
-        dict,
+        logging_config.ListLinksRequest({}),
+        {},
     ],
 )
 def test_list_links(request_type, transport: str = "grpc"):
@@ -7693,7 +7729,7 @@ def test_list_links(request_type, transport: str = "grpc"):
 
     # Everything is optional in proto3 as far as the runtime is concerned,
     # and we are mocking out the actual API, so just send an empty request.
-    request = request_type()
+    request = request_type
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(type(client.transport.list_links), "__call__") as call:
@@ -7738,10 +7774,11 @@ def test_list_links_non_empty_request_with_auto_populated_field():
         client.list_links(request=request)
         call.assert_called()
         _, args, _ = call.mock_calls[0]
-        assert args[0] == logging_config.ListLinksRequest(
+        request_msg = logging_config.ListLinksRequest(
             parent="parent_value",
             page_token="page_token_value",
         )
+        assert args[0] == request_msg
 
 
 def test_list_links_use_cached_wrapped_rpc():
@@ -7820,9 +7857,14 @@ async def test_list_links_async_use_cached_wrapped_rpc(transport: str = "grpc_as
 
 
 @pytest.mark.asyncio
-async def test_list_links_async(
-    transport: str = "grpc_asyncio", request_type=logging_config.ListLinksRequest
-):
+@pytest.mark.parametrize(
+    "request_type",
+    [
+        logging_config.ListLinksRequest({}),
+        {},
+    ],
+)
+async def test_list_links_async(request_type, transport: str = "grpc_asyncio"):
     client = ConfigServiceV2AsyncClient(
         credentials=async_anonymous_credentials(),
         transport=transport,
@@ -7830,7 +7872,7 @@ async def test_list_links_async(
 
     # Everything is optional in proto3 as far as the runtime is concerned,
     # and we are mocking out the actual API, so just send an empty request.
-    request = request_type()
+    request = request_type
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(type(client.transport.list_links), "__call__") as call:
@@ -7851,11 +7893,6 @@ async def test_list_links_async(
     # Establish that the response is the type that we expect.
     assert isinstance(response, pagers.ListLinksAsyncPager)
     assert response.next_page_token == "next_page_token_value"
-
-
-@pytest.mark.asyncio
-async def test_list_links_async_from_dict():
-    await test_list_links_async(request_type=dict)
 
 
 def test_list_links_field_headers():
@@ -8194,8 +8231,8 @@ async def test_list_links_async_pages():
 @pytest.mark.parametrize(
     "request_type",
     [
-        logging_config.GetLinkRequest,
-        dict,
+        logging_config.GetLinkRequest({}),
+        {},
     ],
 )
 def test_get_link(request_type, transport: str = "grpc"):
@@ -8206,7 +8243,7 @@ def test_get_link(request_type, transport: str = "grpc"):
 
     # Everything is optional in proto3 as far as the runtime is concerned,
     # and we are mocking out the actual API, so just send an empty request.
-    request = request_type()
+    request = request_type
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(type(client.transport.get_link), "__call__") as call:
@@ -8254,9 +8291,10 @@ def test_get_link_non_empty_request_with_auto_populated_field():
         client.get_link(request=request)
         call.assert_called()
         _, args, _ = call.mock_calls[0]
-        assert args[0] == logging_config.GetLinkRequest(
+        request_msg = logging_config.GetLinkRequest(
             name="name_value",
         )
+        assert args[0] == request_msg
 
 
 def test_get_link_use_cached_wrapped_rpc():
@@ -8335,9 +8373,14 @@ async def test_get_link_async_use_cached_wrapped_rpc(transport: str = "grpc_asyn
 
 
 @pytest.mark.asyncio
-async def test_get_link_async(
-    transport: str = "grpc_asyncio", request_type=logging_config.GetLinkRequest
-):
+@pytest.mark.parametrize(
+    "request_type",
+    [
+        logging_config.GetLinkRequest({}),
+        {},
+    ],
+)
+async def test_get_link_async(request_type, transport: str = "grpc_asyncio"):
     client = ConfigServiceV2AsyncClient(
         credentials=async_anonymous_credentials(),
         transport=transport,
@@ -8345,7 +8388,7 @@ async def test_get_link_async(
 
     # Everything is optional in proto3 as far as the runtime is concerned,
     # and we are mocking out the actual API, so just send an empty request.
-    request = request_type()
+    request = request_type
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(type(client.transport.get_link), "__call__") as call:
@@ -8370,11 +8413,6 @@ async def test_get_link_async(
     assert response.name == "name_value"
     assert response.description == "description_value"
     assert response.lifecycle_state == logging_config.LifecycleState.ACTIVE
-
-
-@pytest.mark.asyncio
-async def test_get_link_async_from_dict():
-    await test_get_link_async(request_type=dict)
 
 
 def test_get_link_field_headers():
@@ -8519,8 +8557,8 @@ async def test_get_link_flattened_error_async():
 @pytest.mark.parametrize(
     "request_type",
     [
-        logging_config.ListExclusionsRequest,
-        dict,
+        logging_config.ListExclusionsRequest({}),
+        {},
     ],
 )
 def test_list_exclusions(request_type, transport: str = "grpc"):
@@ -8531,7 +8569,7 @@ def test_list_exclusions(request_type, transport: str = "grpc"):
 
     # Everything is optional in proto3 as far as the runtime is concerned,
     # and we are mocking out the actual API, so just send an empty request.
-    request = request_type()
+    request = request_type
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(type(client.transport.list_exclusions), "__call__") as call:
@@ -8576,10 +8614,11 @@ def test_list_exclusions_non_empty_request_with_auto_populated_field():
         client.list_exclusions(request=request)
         call.assert_called()
         _, args, _ = call.mock_calls[0]
-        assert args[0] == logging_config.ListExclusionsRequest(
+        request_msg = logging_config.ListExclusionsRequest(
             parent="parent_value",
             page_token="page_token_value",
         )
+        assert args[0] == request_msg
 
 
 def test_list_exclusions_use_cached_wrapped_rpc():
@@ -8660,9 +8699,14 @@ async def test_list_exclusions_async_use_cached_wrapped_rpc(
 
 
 @pytest.mark.asyncio
-async def test_list_exclusions_async(
-    transport: str = "grpc_asyncio", request_type=logging_config.ListExclusionsRequest
-):
+@pytest.mark.parametrize(
+    "request_type",
+    [
+        logging_config.ListExclusionsRequest({}),
+        {},
+    ],
+)
+async def test_list_exclusions_async(request_type, transport: str = "grpc_asyncio"):
     client = ConfigServiceV2AsyncClient(
         credentials=async_anonymous_credentials(),
         transport=transport,
@@ -8670,7 +8714,7 @@ async def test_list_exclusions_async(
 
     # Everything is optional in proto3 as far as the runtime is concerned,
     # and we are mocking out the actual API, so just send an empty request.
-    request = request_type()
+    request = request_type
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(type(client.transport.list_exclusions), "__call__") as call:
@@ -8691,11 +8735,6 @@ async def test_list_exclusions_async(
     # Establish that the response is the type that we expect.
     assert isinstance(response, pagers.ListExclusionsAsyncPager)
     assert response.next_page_token == "next_page_token_value"
-
-
-@pytest.mark.asyncio
-async def test_list_exclusions_async_from_dict():
-    await test_list_exclusions_async(request_type=dict)
 
 
 def test_list_exclusions_field_headers():
@@ -9034,8 +9073,8 @@ async def test_list_exclusions_async_pages():
 @pytest.mark.parametrize(
     "request_type",
     [
-        logging_config.GetExclusionRequest,
-        dict,
+        logging_config.GetExclusionRequest({}),
+        {},
     ],
 )
 def test_get_exclusion(request_type, transport: str = "grpc"):
@@ -9046,7 +9085,7 @@ def test_get_exclusion(request_type, transport: str = "grpc"):
 
     # Everything is optional in proto3 as far as the runtime is concerned,
     # and we are mocking out the actual API, so just send an empty request.
-    request = request_type()
+    request = request_type
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(type(client.transport.get_exclusion), "__call__") as call:
@@ -9096,9 +9135,10 @@ def test_get_exclusion_non_empty_request_with_auto_populated_field():
         client.get_exclusion(request=request)
         call.assert_called()
         _, args, _ = call.mock_calls[0]
-        assert args[0] == logging_config.GetExclusionRequest(
+        request_msg = logging_config.GetExclusionRequest(
             name="name_value",
         )
+        assert args[0] == request_msg
 
 
 def test_get_exclusion_use_cached_wrapped_rpc():
@@ -9179,9 +9219,14 @@ async def test_get_exclusion_async_use_cached_wrapped_rpc(
 
 
 @pytest.mark.asyncio
-async def test_get_exclusion_async(
-    transport: str = "grpc_asyncio", request_type=logging_config.GetExclusionRequest
-):
+@pytest.mark.parametrize(
+    "request_type",
+    [
+        logging_config.GetExclusionRequest({}),
+        {},
+    ],
+)
+async def test_get_exclusion_async(request_type, transport: str = "grpc_asyncio"):
     client = ConfigServiceV2AsyncClient(
         credentials=async_anonymous_credentials(),
         transport=transport,
@@ -9189,7 +9234,7 @@ async def test_get_exclusion_async(
 
     # Everything is optional in proto3 as far as the runtime is concerned,
     # and we are mocking out the actual API, so just send an empty request.
-    request = request_type()
+    request = request_type
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(type(client.transport.get_exclusion), "__call__") as call:
@@ -9216,11 +9261,6 @@ async def test_get_exclusion_async(
     assert response.description == "description_value"
     assert response.filter == "filter_value"
     assert response.disabled is True
-
-
-@pytest.mark.asyncio
-async def test_get_exclusion_async_from_dict():
-    await test_get_exclusion_async(request_type=dict)
 
 
 def test_get_exclusion_field_headers():
@@ -9369,8 +9409,8 @@ async def test_get_exclusion_flattened_error_async():
 @pytest.mark.parametrize(
     "request_type",
     [
-        logging_config.CreateExclusionRequest,
-        dict,
+        logging_config.CreateExclusionRequest({}),
+        {},
     ],
 )
 def test_create_exclusion(request_type, transport: str = "grpc"):
@@ -9381,7 +9421,7 @@ def test_create_exclusion(request_type, transport: str = "grpc"):
 
     # Everything is optional in proto3 as far as the runtime is concerned,
     # and we are mocking out the actual API, so just send an empty request.
-    request = request_type()
+    request = request_type
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(type(client.transport.create_exclusion), "__call__") as call:
@@ -9431,9 +9471,10 @@ def test_create_exclusion_non_empty_request_with_auto_populated_field():
         client.create_exclusion(request=request)
         call.assert_called()
         _, args, _ = call.mock_calls[0]
-        assert args[0] == logging_config.CreateExclusionRequest(
+        request_msg = logging_config.CreateExclusionRequest(
             parent="parent_value",
         )
+        assert args[0] == request_msg
 
 
 def test_create_exclusion_use_cached_wrapped_rpc():
@@ -9516,9 +9557,14 @@ async def test_create_exclusion_async_use_cached_wrapped_rpc(
 
 
 @pytest.mark.asyncio
-async def test_create_exclusion_async(
-    transport: str = "grpc_asyncio", request_type=logging_config.CreateExclusionRequest
-):
+@pytest.mark.parametrize(
+    "request_type",
+    [
+        logging_config.CreateExclusionRequest({}),
+        {},
+    ],
+)
+async def test_create_exclusion_async(request_type, transport: str = "grpc_asyncio"):
     client = ConfigServiceV2AsyncClient(
         credentials=async_anonymous_credentials(),
         transport=transport,
@@ -9526,7 +9572,7 @@ async def test_create_exclusion_async(
 
     # Everything is optional in proto3 as far as the runtime is concerned,
     # and we are mocking out the actual API, so just send an empty request.
-    request = request_type()
+    request = request_type
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(type(client.transport.create_exclusion), "__call__") as call:
@@ -9553,11 +9599,6 @@ async def test_create_exclusion_async(
     assert response.description == "description_value"
     assert response.filter == "filter_value"
     assert response.disabled is True
-
-
-@pytest.mark.asyncio
-async def test_create_exclusion_async_from_dict():
-    await test_create_exclusion_async(request_type=dict)
 
 
 def test_create_exclusion_field_headers():
@@ -9716,8 +9757,8 @@ async def test_create_exclusion_flattened_error_async():
 @pytest.mark.parametrize(
     "request_type",
     [
-        logging_config.UpdateExclusionRequest,
-        dict,
+        logging_config.UpdateExclusionRequest({}),
+        {},
     ],
 )
 def test_update_exclusion(request_type, transport: str = "grpc"):
@@ -9728,7 +9769,7 @@ def test_update_exclusion(request_type, transport: str = "grpc"):
 
     # Everything is optional in proto3 as far as the runtime is concerned,
     # and we are mocking out the actual API, so just send an empty request.
-    request = request_type()
+    request = request_type
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(type(client.transport.update_exclusion), "__call__") as call:
@@ -9778,9 +9819,10 @@ def test_update_exclusion_non_empty_request_with_auto_populated_field():
         client.update_exclusion(request=request)
         call.assert_called()
         _, args, _ = call.mock_calls[0]
-        assert args[0] == logging_config.UpdateExclusionRequest(
+        request_msg = logging_config.UpdateExclusionRequest(
             name="name_value",
         )
+        assert args[0] == request_msg
 
 
 def test_update_exclusion_use_cached_wrapped_rpc():
@@ -9863,9 +9905,14 @@ async def test_update_exclusion_async_use_cached_wrapped_rpc(
 
 
 @pytest.mark.asyncio
-async def test_update_exclusion_async(
-    transport: str = "grpc_asyncio", request_type=logging_config.UpdateExclusionRequest
-):
+@pytest.mark.parametrize(
+    "request_type",
+    [
+        logging_config.UpdateExclusionRequest({}),
+        {},
+    ],
+)
+async def test_update_exclusion_async(request_type, transport: str = "grpc_asyncio"):
     client = ConfigServiceV2AsyncClient(
         credentials=async_anonymous_credentials(),
         transport=transport,
@@ -9873,7 +9920,7 @@ async def test_update_exclusion_async(
 
     # Everything is optional in proto3 as far as the runtime is concerned,
     # and we are mocking out the actual API, so just send an empty request.
-    request = request_type()
+    request = request_type
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(type(client.transport.update_exclusion), "__call__") as call:
@@ -9900,11 +9947,6 @@ async def test_update_exclusion_async(
     assert response.description == "description_value"
     assert response.filter == "filter_value"
     assert response.disabled is True
-
-
-@pytest.mark.asyncio
-async def test_update_exclusion_async_from_dict():
-    await test_update_exclusion_async(request_type=dict)
 
 
 def test_update_exclusion_field_headers():
@@ -10073,8 +10115,8 @@ async def test_update_exclusion_flattened_error_async():
 @pytest.mark.parametrize(
     "request_type",
     [
-        logging_config.DeleteExclusionRequest,
-        dict,
+        logging_config.DeleteExclusionRequest({}),
+        {},
     ],
 )
 def test_delete_exclusion(request_type, transport: str = "grpc"):
@@ -10085,7 +10127,7 @@ def test_delete_exclusion(request_type, transport: str = "grpc"):
 
     # Everything is optional in proto3 as far as the runtime is concerned,
     # and we are mocking out the actual API, so just send an empty request.
-    request = request_type()
+    request = request_type
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(type(client.transport.delete_exclusion), "__call__") as call:
@@ -10126,9 +10168,10 @@ def test_delete_exclusion_non_empty_request_with_auto_populated_field():
         client.delete_exclusion(request=request)
         call.assert_called()
         _, args, _ = call.mock_calls[0]
-        assert args[0] == logging_config.DeleteExclusionRequest(
+        request_msg = logging_config.DeleteExclusionRequest(
             name="name_value",
         )
+        assert args[0] == request_msg
 
 
 def test_delete_exclusion_use_cached_wrapped_rpc():
@@ -10211,9 +10254,14 @@ async def test_delete_exclusion_async_use_cached_wrapped_rpc(
 
 
 @pytest.mark.asyncio
-async def test_delete_exclusion_async(
-    transport: str = "grpc_asyncio", request_type=logging_config.DeleteExclusionRequest
-):
+@pytest.mark.parametrize(
+    "request_type",
+    [
+        logging_config.DeleteExclusionRequest({}),
+        {},
+    ],
+)
+async def test_delete_exclusion_async(request_type, transport: str = "grpc_asyncio"):
     client = ConfigServiceV2AsyncClient(
         credentials=async_anonymous_credentials(),
         transport=transport,
@@ -10221,7 +10269,7 @@ async def test_delete_exclusion_async(
 
     # Everything is optional in proto3 as far as the runtime is concerned,
     # and we are mocking out the actual API, so just send an empty request.
-    request = request_type()
+    request = request_type
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(type(client.transport.delete_exclusion), "__call__") as call:
@@ -10237,11 +10285,6 @@ async def test_delete_exclusion_async(
 
     # Establish that the response is the type that we expect.
     assert response is None
-
-
-@pytest.mark.asyncio
-async def test_delete_exclusion_async_from_dict():
-    await test_delete_exclusion_async(request_type=dict)
 
 
 def test_delete_exclusion_field_headers():
@@ -10386,8 +10429,8 @@ async def test_delete_exclusion_flattened_error_async():
 @pytest.mark.parametrize(
     "request_type",
     [
-        logging_config.GetCmekSettingsRequest,
-        dict,
+        logging_config.GetCmekSettingsRequest({}),
+        {},
     ],
 )
 def test_get_cmek_settings(request_type, transport: str = "grpc"):
@@ -10398,7 +10441,7 @@ def test_get_cmek_settings(request_type, transport: str = "grpc"):
 
     # Everything is optional in proto3 as far as the runtime is concerned,
     # and we are mocking out the actual API, so just send an empty request.
-    request = request_type()
+    request = request_type
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(
@@ -10452,9 +10495,10 @@ def test_get_cmek_settings_non_empty_request_with_auto_populated_field():
         client.get_cmek_settings(request=request)
         call.assert_called()
         _, args, _ = call.mock_calls[0]
-        assert args[0] == logging_config.GetCmekSettingsRequest(
+        request_msg = logging_config.GetCmekSettingsRequest(
             name="name_value",
         )
+        assert args[0] == request_msg
 
 
 def test_get_cmek_settings_use_cached_wrapped_rpc():
@@ -10537,9 +10581,14 @@ async def test_get_cmek_settings_async_use_cached_wrapped_rpc(
 
 
 @pytest.mark.asyncio
-async def test_get_cmek_settings_async(
-    transport: str = "grpc_asyncio", request_type=logging_config.GetCmekSettingsRequest
-):
+@pytest.mark.parametrize(
+    "request_type",
+    [
+        logging_config.GetCmekSettingsRequest({}),
+        {},
+    ],
+)
+async def test_get_cmek_settings_async(request_type, transport: str = "grpc_asyncio"):
     client = ConfigServiceV2AsyncClient(
         credentials=async_anonymous_credentials(),
         transport=transport,
@@ -10547,7 +10596,7 @@ async def test_get_cmek_settings_async(
 
     # Everything is optional in proto3 as far as the runtime is concerned,
     # and we are mocking out the actual API, so just send an empty request.
-    request = request_type()
+    request = request_type
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(
@@ -10576,11 +10625,6 @@ async def test_get_cmek_settings_async(
     assert response.kms_key_name == "kms_key_name_value"
     assert response.kms_key_version_name == "kms_key_version_name_value"
     assert response.service_account_id == "service_account_id_value"
-
-
-@pytest.mark.asyncio
-async def test_get_cmek_settings_async_from_dict():
-    await test_get_cmek_settings_async(request_type=dict)
 
 
 def test_get_cmek_settings_field_headers():
@@ -10651,8 +10695,8 @@ async def test_get_cmek_settings_field_headers_async():
 @pytest.mark.parametrize(
     "request_type",
     [
-        logging_config.UpdateCmekSettingsRequest,
-        dict,
+        logging_config.UpdateCmekSettingsRequest({}),
+        {},
     ],
 )
 def test_update_cmek_settings(request_type, transport: str = "grpc"):
@@ -10663,7 +10707,7 @@ def test_update_cmek_settings(request_type, transport: str = "grpc"):
 
     # Everything is optional in proto3 as far as the runtime is concerned,
     # and we are mocking out the actual API, so just send an empty request.
-    request = request_type()
+    request = request_type
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(
@@ -10717,9 +10761,10 @@ def test_update_cmek_settings_non_empty_request_with_auto_populated_field():
         client.update_cmek_settings(request=request)
         call.assert_called()
         _, args, _ = call.mock_calls[0]
-        assert args[0] == logging_config.UpdateCmekSettingsRequest(
+        request_msg = logging_config.UpdateCmekSettingsRequest(
             name="name_value",
         )
+        assert args[0] == request_msg
 
 
 def test_update_cmek_settings_use_cached_wrapped_rpc():
@@ -10804,9 +10849,15 @@ async def test_update_cmek_settings_async_use_cached_wrapped_rpc(
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "request_type",
+    [
+        logging_config.UpdateCmekSettingsRequest({}),
+        {},
+    ],
+)
 async def test_update_cmek_settings_async(
-    transport: str = "grpc_asyncio",
-    request_type=logging_config.UpdateCmekSettingsRequest,
+    request_type, transport: str = "grpc_asyncio"
 ):
     client = ConfigServiceV2AsyncClient(
         credentials=async_anonymous_credentials(),
@@ -10815,7 +10866,7 @@ async def test_update_cmek_settings_async(
 
     # Everything is optional in proto3 as far as the runtime is concerned,
     # and we are mocking out the actual API, so just send an empty request.
-    request = request_type()
+    request = request_type
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(
@@ -10844,11 +10895,6 @@ async def test_update_cmek_settings_async(
     assert response.kms_key_name == "kms_key_name_value"
     assert response.kms_key_version_name == "kms_key_version_name_value"
     assert response.service_account_id == "service_account_id_value"
-
-
-@pytest.mark.asyncio
-async def test_update_cmek_settings_async_from_dict():
-    await test_update_cmek_settings_async(request_type=dict)
 
 
 def test_update_cmek_settings_field_headers():
@@ -10919,8 +10965,8 @@ async def test_update_cmek_settings_field_headers_async():
 @pytest.mark.parametrize(
     "request_type",
     [
-        logging_config.GetSettingsRequest,
-        dict,
+        logging_config.GetSettingsRequest({}),
+        {},
     ],
 )
 def test_get_settings(request_type, transport: str = "grpc"):
@@ -10931,7 +10977,7 @@ def test_get_settings(request_type, transport: str = "grpc"):
 
     # Everything is optional in proto3 as far as the runtime is concerned,
     # and we are mocking out the actual API, so just send an empty request.
-    request = request_type()
+    request = request_type
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(type(client.transport.get_settings), "__call__") as call:
@@ -10983,9 +11029,10 @@ def test_get_settings_non_empty_request_with_auto_populated_field():
         client.get_settings(request=request)
         call.assert_called()
         _, args, _ = call.mock_calls[0]
-        assert args[0] == logging_config.GetSettingsRequest(
+        request_msg = logging_config.GetSettingsRequest(
             name="name_value",
         )
+        assert args[0] == request_msg
 
 
 def test_get_settings_use_cached_wrapped_rpc():
@@ -11066,9 +11113,14 @@ async def test_get_settings_async_use_cached_wrapped_rpc(
 
 
 @pytest.mark.asyncio
-async def test_get_settings_async(
-    transport: str = "grpc_asyncio", request_type=logging_config.GetSettingsRequest
-):
+@pytest.mark.parametrize(
+    "request_type",
+    [
+        logging_config.GetSettingsRequest({}),
+        {},
+    ],
+)
+async def test_get_settings_async(request_type, transport: str = "grpc_asyncio"):
     client = ConfigServiceV2AsyncClient(
         credentials=async_anonymous_credentials(),
         transport=transport,
@@ -11076,7 +11128,7 @@ async def test_get_settings_async(
 
     # Everything is optional in proto3 as far as the runtime is concerned,
     # and we are mocking out the actual API, so just send an empty request.
-    request = request_type()
+    request = request_type
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(type(client.transport.get_settings), "__call__") as call:
@@ -11105,11 +11157,6 @@ async def test_get_settings_async(
     assert response.kms_service_account_id == "kms_service_account_id_value"
     assert response.storage_location == "storage_location_value"
     assert response.disable_default_sink is True
-
-
-@pytest.mark.asyncio
-async def test_get_settings_async_from_dict():
-    await test_get_settings_async(request_type=dict)
 
 
 def test_get_settings_field_headers():
@@ -11258,8 +11305,8 @@ async def test_get_settings_flattened_error_async():
 @pytest.mark.parametrize(
     "request_type",
     [
-        logging_config.UpdateSettingsRequest,
-        dict,
+        logging_config.UpdateSettingsRequest({}),
+        {},
     ],
 )
 def test_update_settings(request_type, transport: str = "grpc"):
@@ -11270,7 +11317,7 @@ def test_update_settings(request_type, transport: str = "grpc"):
 
     # Everything is optional in proto3 as far as the runtime is concerned,
     # and we are mocking out the actual API, so just send an empty request.
-    request = request_type()
+    request = request_type
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(type(client.transport.update_settings), "__call__") as call:
@@ -11322,9 +11369,10 @@ def test_update_settings_non_empty_request_with_auto_populated_field():
         client.update_settings(request=request)
         call.assert_called()
         _, args, _ = call.mock_calls[0]
-        assert args[0] == logging_config.UpdateSettingsRequest(
+        request_msg = logging_config.UpdateSettingsRequest(
             name="name_value",
         )
+        assert args[0] == request_msg
 
 
 def test_update_settings_use_cached_wrapped_rpc():
@@ -11405,9 +11453,14 @@ async def test_update_settings_async_use_cached_wrapped_rpc(
 
 
 @pytest.mark.asyncio
-async def test_update_settings_async(
-    transport: str = "grpc_asyncio", request_type=logging_config.UpdateSettingsRequest
-):
+@pytest.mark.parametrize(
+    "request_type",
+    [
+        logging_config.UpdateSettingsRequest({}),
+        {},
+    ],
+)
+async def test_update_settings_async(request_type, transport: str = "grpc_asyncio"):
     client = ConfigServiceV2AsyncClient(
         credentials=async_anonymous_credentials(),
         transport=transport,
@@ -11415,7 +11468,7 @@ async def test_update_settings_async(
 
     # Everything is optional in proto3 as far as the runtime is concerned,
     # and we are mocking out the actual API, so just send an empty request.
-    request = request_type()
+    request = request_type
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(type(client.transport.update_settings), "__call__") as call:
@@ -11444,11 +11497,6 @@ async def test_update_settings_async(
     assert response.kms_service_account_id == "kms_service_account_id_value"
     assert response.storage_location == "storage_location_value"
     assert response.disable_default_sink is True
-
-
-@pytest.mark.asyncio
-async def test_update_settings_async_from_dict():
-    await test_update_settings_async(request_type=dict)
 
 
 def test_update_settings_field_headers():
@@ -11607,8 +11655,8 @@ async def test_update_settings_flattened_error_async():
 @pytest.mark.parametrize(
     "request_type",
     [
-        logging_config.CopyLogEntriesRequest,
-        dict,
+        logging_config.CopyLogEntriesRequest({}),
+        {},
     ],
 )
 def test_copy_log_entries(request_type, transport: str = "grpc"):
@@ -11619,7 +11667,7 @@ def test_copy_log_entries(request_type, transport: str = "grpc"):
 
     # Everything is optional in proto3 as far as the runtime is concerned,
     # and we are mocking out the actual API, so just send an empty request.
-    request = request_type()
+    request = request_type
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(type(client.transport.copy_log_entries), "__call__") as call:
@@ -11662,11 +11710,12 @@ def test_copy_log_entries_non_empty_request_with_auto_populated_field():
         client.copy_log_entries(request=request)
         call.assert_called()
         _, args, _ = call.mock_calls[0]
-        assert args[0] == logging_config.CopyLogEntriesRequest(
+        request_msg = logging_config.CopyLogEntriesRequest(
             name="name_value",
             filter="filter_value",
             destination="destination_value",
         )
+        assert args[0] == request_msg
 
 
 def test_copy_log_entries_use_cached_wrapped_rpc():
@@ -11759,9 +11808,14 @@ async def test_copy_log_entries_async_use_cached_wrapped_rpc(
 
 
 @pytest.mark.asyncio
-async def test_copy_log_entries_async(
-    transport: str = "grpc_asyncio", request_type=logging_config.CopyLogEntriesRequest
-):
+@pytest.mark.parametrize(
+    "request_type",
+    [
+        logging_config.CopyLogEntriesRequest({}),
+        {},
+    ],
+)
+async def test_copy_log_entries_async(request_type, transport: str = "grpc_asyncio"):
     client = ConfigServiceV2AsyncClient(
         credentials=async_anonymous_credentials(),
         transport=transport,
@@ -11769,7 +11823,7 @@ async def test_copy_log_entries_async(
 
     # Everything is optional in proto3 as far as the runtime is concerned,
     # and we are mocking out the actual API, so just send an empty request.
-    request = request_type()
+    request = request_type
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(type(client.transport.copy_log_entries), "__call__") as call:
@@ -11787,11 +11841,6 @@ async def test_copy_log_entries_async(
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, future.Future)
-
-
-@pytest.mark.asyncio
-async def test_copy_log_entries_async_from_dict():
-    await test_copy_log_entries_async(request_type=dict)
 
 
 def test_credentials_transport_error():
@@ -11916,7 +11965,6 @@ def test_list_buckets_empty_call_grpc():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = logging_config.ListBucketsRequest()
-
         assert args[0] == request_msg
 
 
@@ -11937,7 +11985,6 @@ def test_get_bucket_empty_call_grpc():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = logging_config.GetBucketRequest()
-
         assert args[0] == request_msg
 
 
@@ -11960,7 +12007,6 @@ def test_create_bucket_async_empty_call_grpc():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = logging_config.CreateBucketRequest()
-
         assert args[0] == request_msg
 
 
@@ -11983,7 +12029,6 @@ def test_update_bucket_async_empty_call_grpc():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = logging_config.UpdateBucketRequest()
-
         assert args[0] == request_msg
 
 
@@ -12004,7 +12049,6 @@ def test_create_bucket_empty_call_grpc():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = logging_config.CreateBucketRequest()
-
         assert args[0] == request_msg
 
 
@@ -12025,7 +12069,6 @@ def test_update_bucket_empty_call_grpc():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = logging_config.UpdateBucketRequest()
-
         assert args[0] == request_msg
 
 
@@ -12046,7 +12089,6 @@ def test_delete_bucket_empty_call_grpc():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = logging_config.DeleteBucketRequest()
-
         assert args[0] == request_msg
 
 
@@ -12067,7 +12109,6 @@ def test_undelete_bucket_empty_call_grpc():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = logging_config.UndeleteBucketRequest()
-
         assert args[0] == request_msg
 
 
@@ -12088,7 +12129,6 @@ def test_list_views_empty_call_grpc():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = logging_config.ListViewsRequest()
-
         assert args[0] == request_msg
 
 
@@ -12109,7 +12149,6 @@ def test_get_view_empty_call_grpc():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = logging_config.GetViewRequest()
-
         assert args[0] == request_msg
 
 
@@ -12130,7 +12169,6 @@ def test_create_view_empty_call_grpc():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = logging_config.CreateViewRequest()
-
         assert args[0] == request_msg
 
 
@@ -12151,7 +12189,6 @@ def test_update_view_empty_call_grpc():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = logging_config.UpdateViewRequest()
-
         assert args[0] == request_msg
 
 
@@ -12172,7 +12209,6 @@ def test_delete_view_empty_call_grpc():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = logging_config.DeleteViewRequest()
-
         assert args[0] == request_msg
 
 
@@ -12193,7 +12229,6 @@ def test_list_sinks_empty_call_grpc():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = logging_config.ListSinksRequest()
-
         assert args[0] == request_msg
 
 
@@ -12214,7 +12249,6 @@ def test_get_sink_empty_call_grpc():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = logging_config.GetSinkRequest()
-
         assert args[0] == request_msg
 
 
@@ -12235,7 +12269,6 @@ def test_create_sink_empty_call_grpc():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = logging_config.CreateSinkRequest()
-
         assert args[0] == request_msg
 
 
@@ -12256,7 +12289,6 @@ def test_update_sink_empty_call_grpc():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = logging_config.UpdateSinkRequest()
-
         assert args[0] == request_msg
 
 
@@ -12277,7 +12309,6 @@ def test_delete_sink_empty_call_grpc():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = logging_config.DeleteSinkRequest()
-
         assert args[0] == request_msg
 
 
@@ -12298,7 +12329,6 @@ def test_create_link_empty_call_grpc():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = logging_config.CreateLinkRequest()
-
         assert args[0] == request_msg
 
 
@@ -12319,7 +12349,6 @@ def test_delete_link_empty_call_grpc():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = logging_config.DeleteLinkRequest()
-
         assert args[0] == request_msg
 
 
@@ -12340,7 +12369,6 @@ def test_list_links_empty_call_grpc():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = logging_config.ListLinksRequest()
-
         assert args[0] == request_msg
 
 
@@ -12361,7 +12389,6 @@ def test_get_link_empty_call_grpc():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = logging_config.GetLinkRequest()
-
         assert args[0] == request_msg
 
 
@@ -12382,7 +12409,6 @@ def test_list_exclusions_empty_call_grpc():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = logging_config.ListExclusionsRequest()
-
         assert args[0] == request_msg
 
 
@@ -12403,7 +12429,6 @@ def test_get_exclusion_empty_call_grpc():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = logging_config.GetExclusionRequest()
-
         assert args[0] == request_msg
 
 
@@ -12424,7 +12449,6 @@ def test_create_exclusion_empty_call_grpc():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = logging_config.CreateExclusionRequest()
-
         assert args[0] == request_msg
 
 
@@ -12445,7 +12469,6 @@ def test_update_exclusion_empty_call_grpc():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = logging_config.UpdateExclusionRequest()
-
         assert args[0] == request_msg
 
 
@@ -12466,7 +12489,6 @@ def test_delete_exclusion_empty_call_grpc():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = logging_config.DeleteExclusionRequest()
-
         assert args[0] == request_msg
 
 
@@ -12489,7 +12511,6 @@ def test_get_cmek_settings_empty_call_grpc():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = logging_config.GetCmekSettingsRequest()
-
         assert args[0] == request_msg
 
 
@@ -12512,7 +12533,6 @@ def test_update_cmek_settings_empty_call_grpc():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = logging_config.UpdateCmekSettingsRequest()
-
         assert args[0] == request_msg
 
 
@@ -12533,7 +12553,6 @@ def test_get_settings_empty_call_grpc():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = logging_config.GetSettingsRequest()
-
         assert args[0] == request_msg
 
 
@@ -12554,7 +12573,6 @@ def test_update_settings_empty_call_grpc():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = logging_config.UpdateSettingsRequest()
-
         assert args[0] == request_msg
 
 
@@ -12575,7 +12593,6 @@ def test_copy_log_entries_empty_call_grpc():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = logging_config.CopyLogEntriesRequest()
-
         assert args[0] == request_msg
 
 
@@ -12616,7 +12633,6 @@ async def test_list_buckets_empty_call_grpc_asyncio():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = logging_config.ListBucketsRequest()
-
         assert args[0] == request_msg
 
 
@@ -12649,7 +12665,6 @@ async def test_get_bucket_empty_call_grpc_asyncio():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = logging_config.GetBucketRequest()
-
         assert args[0] == request_msg
 
 
@@ -12676,7 +12691,6 @@ async def test_create_bucket_async_empty_call_grpc_asyncio():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = logging_config.CreateBucketRequest()
-
         assert args[0] == request_msg
 
 
@@ -12703,7 +12717,6 @@ async def test_update_bucket_async_empty_call_grpc_asyncio():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = logging_config.UpdateBucketRequest()
-
         assert args[0] == request_msg
 
 
@@ -12736,7 +12749,6 @@ async def test_create_bucket_empty_call_grpc_asyncio():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = logging_config.CreateBucketRequest()
-
         assert args[0] == request_msg
 
 
@@ -12769,7 +12781,6 @@ async def test_update_bucket_empty_call_grpc_asyncio():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = logging_config.UpdateBucketRequest()
-
         assert args[0] == request_msg
 
 
@@ -12792,7 +12803,6 @@ async def test_delete_bucket_empty_call_grpc_asyncio():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = logging_config.DeleteBucketRequest()
-
         assert args[0] == request_msg
 
 
@@ -12815,7 +12825,6 @@ async def test_undelete_bucket_empty_call_grpc_asyncio():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = logging_config.UndeleteBucketRequest()
-
         assert args[0] == request_msg
 
 
@@ -12842,7 +12851,6 @@ async def test_list_views_empty_call_grpc_asyncio():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = logging_config.ListViewsRequest()
-
         assert args[0] == request_msg
 
 
@@ -12871,7 +12879,6 @@ async def test_get_view_empty_call_grpc_asyncio():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = logging_config.GetViewRequest()
-
         assert args[0] == request_msg
 
 
@@ -12900,7 +12907,6 @@ async def test_create_view_empty_call_grpc_asyncio():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = logging_config.CreateViewRequest()
-
         assert args[0] == request_msg
 
 
@@ -12929,7 +12935,6 @@ async def test_update_view_empty_call_grpc_asyncio():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = logging_config.UpdateViewRequest()
-
         assert args[0] == request_msg
 
 
@@ -12952,7 +12957,6 @@ async def test_delete_view_empty_call_grpc_asyncio():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = logging_config.DeleteViewRequest()
-
         assert args[0] == request_msg
 
 
@@ -12979,7 +12983,6 @@ async def test_list_sinks_empty_call_grpc_asyncio():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = logging_config.ListSinksRequest()
-
         assert args[0] == request_msg
 
 
@@ -13013,7 +13016,6 @@ async def test_get_sink_empty_call_grpc_asyncio():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = logging_config.GetSinkRequest()
-
         assert args[0] == request_msg
 
 
@@ -13047,7 +13049,6 @@ async def test_create_sink_empty_call_grpc_asyncio():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = logging_config.CreateSinkRequest()
-
         assert args[0] == request_msg
 
 
@@ -13081,7 +13082,6 @@ async def test_update_sink_empty_call_grpc_asyncio():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = logging_config.UpdateSinkRequest()
-
         assert args[0] == request_msg
 
 
@@ -13104,7 +13104,6 @@ async def test_delete_sink_empty_call_grpc_asyncio():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = logging_config.DeleteSinkRequest()
-
         assert args[0] == request_msg
 
 
@@ -13129,7 +13128,6 @@ async def test_create_link_empty_call_grpc_asyncio():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = logging_config.CreateLinkRequest()
-
         assert args[0] == request_msg
 
 
@@ -13154,7 +13152,6 @@ async def test_delete_link_empty_call_grpc_asyncio():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = logging_config.DeleteLinkRequest()
-
         assert args[0] == request_msg
 
 
@@ -13181,7 +13178,6 @@ async def test_list_links_empty_call_grpc_asyncio():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = logging_config.ListLinksRequest()
-
         assert args[0] == request_msg
 
 
@@ -13210,7 +13206,6 @@ async def test_get_link_empty_call_grpc_asyncio():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = logging_config.GetLinkRequest()
-
         assert args[0] == request_msg
 
 
@@ -13237,7 +13232,6 @@ async def test_list_exclusions_empty_call_grpc_asyncio():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = logging_config.ListExclusionsRequest()
-
         assert args[0] == request_msg
 
 
@@ -13267,7 +13261,6 @@ async def test_get_exclusion_empty_call_grpc_asyncio():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = logging_config.GetExclusionRequest()
-
         assert args[0] == request_msg
 
 
@@ -13297,7 +13290,6 @@ async def test_create_exclusion_empty_call_grpc_asyncio():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = logging_config.CreateExclusionRequest()
-
         assert args[0] == request_msg
 
 
@@ -13327,7 +13319,6 @@ async def test_update_exclusion_empty_call_grpc_asyncio():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = logging_config.UpdateExclusionRequest()
-
         assert args[0] == request_msg
 
 
@@ -13350,7 +13341,6 @@ async def test_delete_exclusion_empty_call_grpc_asyncio():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = logging_config.DeleteExclusionRequest()
-
         assert args[0] == request_msg
 
 
@@ -13382,7 +13372,6 @@ async def test_get_cmek_settings_empty_call_grpc_asyncio():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = logging_config.GetCmekSettingsRequest()
-
         assert args[0] == request_msg
 
 
@@ -13414,7 +13403,6 @@ async def test_update_cmek_settings_empty_call_grpc_asyncio():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = logging_config.UpdateCmekSettingsRequest()
-
         assert args[0] == request_msg
 
 
@@ -13445,7 +13433,6 @@ async def test_get_settings_empty_call_grpc_asyncio():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = logging_config.GetSettingsRequest()
-
         assert args[0] == request_msg
 
 
@@ -13476,7 +13463,6 @@ async def test_update_settings_empty_call_grpc_asyncio():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = logging_config.UpdateSettingsRequest()
-
         assert args[0] == request_msg
 
 
@@ -13501,7 +13487,6 @@ async def test_copy_log_entries_empty_call_grpc_asyncio():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = logging_config.CopyLogEntriesRequest()
-
         assert args[0] == request_msg
 
 

--- a/packages/google-cloud-logging/tests/unit/gapic/logging_v2/test_logging_service_v2.py
+++ b/packages/google-cloud-logging/tests/unit/gapic/logging_v2/test_logging_service_v2.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+import asyncio
 import json
 import math
 import os
@@ -110,6 +111,21 @@ def modify_default_endpoint_template(client):
         if ("localhost" in client._DEFAULT_ENDPOINT_TEMPLATE)
         else client._DEFAULT_ENDPOINT_TEMPLATE
     )
+
+
+@pytest.fixture(autouse=True)
+def set_event_loop():
+    try:
+        asyncio.get_running_loop()
+        yield
+    except RuntimeError:
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+        try:
+            yield
+        finally:
+            loop.close()
+            asyncio.set_event_loop(None)
 
 
 def test__get_default_mtls_endpoint():
@@ -1319,8 +1335,8 @@ def test_logging_service_v2_client_create_channel_credentials_file(
 @pytest.mark.parametrize(
     "request_type",
     [
-        logging.DeleteLogRequest,
-        dict,
+        logging.DeleteLogRequest({}),
+        {},
     ],
 )
 def test_delete_log(request_type, transport: str = "grpc"):
@@ -1331,7 +1347,7 @@ def test_delete_log(request_type, transport: str = "grpc"):
 
     # Everything is optional in proto3 as far as the runtime is concerned,
     # and we are mocking out the actual API, so just send an empty request.
-    request = request_type()
+    request = request_type
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(type(client.transport.delete_log), "__call__") as call:
@@ -1372,9 +1388,10 @@ def test_delete_log_non_empty_request_with_auto_populated_field():
         client.delete_log(request=request)
         call.assert_called()
         _, args, _ = call.mock_calls[0]
-        assert args[0] == logging.DeleteLogRequest(
+        request_msg = logging.DeleteLogRequest(
             log_name="log_name_value",
         )
+        assert args[0] == request_msg
 
 
 def test_delete_log_use_cached_wrapped_rpc():
@@ -1453,9 +1470,14 @@ async def test_delete_log_async_use_cached_wrapped_rpc(transport: str = "grpc_as
 
 
 @pytest.mark.asyncio
-async def test_delete_log_async(
-    transport: str = "grpc_asyncio", request_type=logging.DeleteLogRequest
-):
+@pytest.mark.parametrize(
+    "request_type",
+    [
+        logging.DeleteLogRequest({}),
+        {},
+    ],
+)
+async def test_delete_log_async(request_type, transport: str = "grpc_asyncio"):
     client = LoggingServiceV2AsyncClient(
         credentials=async_anonymous_credentials(),
         transport=transport,
@@ -1463,7 +1485,7 @@ async def test_delete_log_async(
 
     # Everything is optional in proto3 as far as the runtime is concerned,
     # and we are mocking out the actual API, so just send an empty request.
-    request = request_type()
+    request = request_type
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(type(client.transport.delete_log), "__call__") as call:
@@ -1479,11 +1501,6 @@ async def test_delete_log_async(
 
     # Establish that the response is the type that we expect.
     assert response is None
-
-
-@pytest.mark.asyncio
-async def test_delete_log_async_from_dict():
-    await test_delete_log_async(request_type=dict)
 
 
 def test_delete_log_field_headers():
@@ -1628,8 +1645,8 @@ async def test_delete_log_flattened_error_async():
 @pytest.mark.parametrize(
     "request_type",
     [
-        logging.WriteLogEntriesRequest,
-        dict,
+        logging.WriteLogEntriesRequest({}),
+        {},
     ],
 )
 def test_write_log_entries(request_type, transport: str = "grpc"):
@@ -1640,7 +1657,7 @@ def test_write_log_entries(request_type, transport: str = "grpc"):
 
     # Everything is optional in proto3 as far as the runtime is concerned,
     # and we are mocking out the actual API, so just send an empty request.
-    request = request_type()
+    request = request_type
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(
@@ -1685,9 +1702,10 @@ def test_write_log_entries_non_empty_request_with_auto_populated_field():
         client.write_log_entries(request=request)
         call.assert_called()
         _, args, _ = call.mock_calls[0]
-        assert args[0] == logging.WriteLogEntriesRequest(
+        request_msg = logging.WriteLogEntriesRequest(
             log_name="log_name_value",
         )
+        assert args[0] == request_msg
 
 
 def test_write_log_entries_use_cached_wrapped_rpc():
@@ -1770,9 +1788,14 @@ async def test_write_log_entries_async_use_cached_wrapped_rpc(
 
 
 @pytest.mark.asyncio
-async def test_write_log_entries_async(
-    transport: str = "grpc_asyncio", request_type=logging.WriteLogEntriesRequest
-):
+@pytest.mark.parametrize(
+    "request_type",
+    [
+        logging.WriteLogEntriesRequest({}),
+        {},
+    ],
+)
+async def test_write_log_entries_async(request_type, transport: str = "grpc_asyncio"):
     client = LoggingServiceV2AsyncClient(
         credentials=async_anonymous_credentials(),
         transport=transport,
@@ -1780,7 +1803,7 @@ async def test_write_log_entries_async(
 
     # Everything is optional in proto3 as far as the runtime is concerned,
     # and we are mocking out the actual API, so just send an empty request.
-    request = request_type()
+    request = request_type
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(
@@ -1800,11 +1823,6 @@ async def test_write_log_entries_async(
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, logging.WriteLogEntriesResponse)
-
-
-@pytest.mark.asyncio
-async def test_write_log_entries_async_from_dict():
-    await test_write_log_entries_async(request_type=dict)
 
 
 def test_write_log_entries_flattened():
@@ -1926,8 +1944,8 @@ async def test_write_log_entries_flattened_error_async():
 @pytest.mark.parametrize(
     "request_type",
     [
-        logging.ListLogEntriesRequest,
-        dict,
+        logging.ListLogEntriesRequest({}),
+        {},
     ],
 )
 def test_list_log_entries(request_type, transport: str = "grpc"):
@@ -1938,7 +1956,7 @@ def test_list_log_entries(request_type, transport: str = "grpc"):
 
     # Everything is optional in proto3 as far as the runtime is concerned,
     # and we are mocking out the actual API, so just send an empty request.
-    request = request_type()
+    request = request_type
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(type(client.transport.list_log_entries), "__call__") as call:
@@ -1984,11 +2002,12 @@ def test_list_log_entries_non_empty_request_with_auto_populated_field():
         client.list_log_entries(request=request)
         call.assert_called()
         _, args, _ = call.mock_calls[0]
-        assert args[0] == logging.ListLogEntriesRequest(
+        request_msg = logging.ListLogEntriesRequest(
             filter="filter_value",
             order_by="order_by_value",
             page_token="page_token_value",
         )
+        assert args[0] == request_msg
 
 
 def test_list_log_entries_use_cached_wrapped_rpc():
@@ -2071,9 +2090,14 @@ async def test_list_log_entries_async_use_cached_wrapped_rpc(
 
 
 @pytest.mark.asyncio
-async def test_list_log_entries_async(
-    transport: str = "grpc_asyncio", request_type=logging.ListLogEntriesRequest
-):
+@pytest.mark.parametrize(
+    "request_type",
+    [
+        logging.ListLogEntriesRequest({}),
+        {},
+    ],
+)
+async def test_list_log_entries_async(request_type, transport: str = "grpc_asyncio"):
     client = LoggingServiceV2AsyncClient(
         credentials=async_anonymous_credentials(),
         transport=transport,
@@ -2081,7 +2105,7 @@ async def test_list_log_entries_async(
 
     # Everything is optional in proto3 as far as the runtime is concerned,
     # and we are mocking out the actual API, so just send an empty request.
-    request = request_type()
+    request = request_type
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(type(client.transport.list_log_entries), "__call__") as call:
@@ -2102,11 +2126,6 @@ async def test_list_log_entries_async(
     # Establish that the response is the type that we expect.
     assert isinstance(response, pagers.ListLogEntriesAsyncPager)
     assert response.next_page_token == "next_page_token_value"
-
-
-@pytest.mark.asyncio
-async def test_list_log_entries_async_from_dict():
-    await test_list_log_entries_async(request_type=dict)
 
 
 def test_list_log_entries_flattened():
@@ -2401,8 +2420,8 @@ async def test_list_log_entries_async_pages():
 @pytest.mark.parametrize(
     "request_type",
     [
-        logging.ListMonitoredResourceDescriptorsRequest,
-        dict,
+        logging.ListMonitoredResourceDescriptorsRequest({}),
+        {},
     ],
 )
 def test_list_monitored_resource_descriptors(request_type, transport: str = "grpc"):
@@ -2413,7 +2432,7 @@ def test_list_monitored_resource_descriptors(request_type, transport: str = "grp
 
     # Everything is optional in proto3 as far as the runtime is concerned,
     # and we are mocking out the actual API, so just send an empty request.
-    request = request_type()
+    request = request_type
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(
@@ -2461,9 +2480,10 @@ def test_list_monitored_resource_descriptors_non_empty_request_with_auto_populat
         client.list_monitored_resource_descriptors(request=request)
         call.assert_called()
         _, args, _ = call.mock_calls[0]
-        assert args[0] == logging.ListMonitoredResourceDescriptorsRequest(
+        request_msg = logging.ListMonitoredResourceDescriptorsRequest(
             page_token="page_token_value",
         )
+        assert args[0] == request_msg
 
 
 def test_list_monitored_resource_descriptors_use_cached_wrapped_rpc():
@@ -2549,9 +2569,15 @@ async def test_list_monitored_resource_descriptors_async_use_cached_wrapped_rpc(
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "request_type",
+    [
+        logging.ListMonitoredResourceDescriptorsRequest({}),
+        {},
+    ],
+)
 async def test_list_monitored_resource_descriptors_async(
-    transport: str = "grpc_asyncio",
-    request_type=logging.ListMonitoredResourceDescriptorsRequest,
+    request_type, transport: str = "grpc_asyncio"
 ):
     client = LoggingServiceV2AsyncClient(
         credentials=async_anonymous_credentials(),
@@ -2560,7 +2586,7 @@ async def test_list_monitored_resource_descriptors_async(
 
     # Everything is optional in proto3 as far as the runtime is concerned,
     # and we are mocking out the actual API, so just send an empty request.
-    request = request_type()
+    request = request_type
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(
@@ -2583,11 +2609,6 @@ async def test_list_monitored_resource_descriptors_async(
     # Establish that the response is the type that we expect.
     assert isinstance(response, pagers.ListMonitoredResourceDescriptorsAsyncPager)
     assert response.next_page_token == "next_page_token_value"
-
-
-@pytest.mark.asyncio
-async def test_list_monitored_resource_descriptors_async_from_dict():
-    await test_list_monitored_resource_descriptors_async(request_type=dict)
 
 
 def test_list_monitored_resource_descriptors_pager(transport_name: str = "grpc"):
@@ -2798,8 +2819,8 @@ async def test_list_monitored_resource_descriptors_async_pages():
 @pytest.mark.parametrize(
     "request_type",
     [
-        logging.ListLogsRequest,
-        dict,
+        logging.ListLogsRequest({}),
+        {},
     ],
 )
 def test_list_logs(request_type, transport: str = "grpc"):
@@ -2810,7 +2831,7 @@ def test_list_logs(request_type, transport: str = "grpc"):
 
     # Everything is optional in proto3 as far as the runtime is concerned,
     # and we are mocking out the actual API, so just send an empty request.
-    request = request_type()
+    request = request_type
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(type(client.transport.list_logs), "__call__") as call:
@@ -2857,10 +2878,11 @@ def test_list_logs_non_empty_request_with_auto_populated_field():
         client.list_logs(request=request)
         call.assert_called()
         _, args, _ = call.mock_calls[0]
-        assert args[0] == logging.ListLogsRequest(
+        request_msg = logging.ListLogsRequest(
             parent="parent_value",
             page_token="page_token_value",
         )
+        assert args[0] == request_msg
 
 
 def test_list_logs_use_cached_wrapped_rpc():
@@ -2939,9 +2961,14 @@ async def test_list_logs_async_use_cached_wrapped_rpc(transport: str = "grpc_asy
 
 
 @pytest.mark.asyncio
-async def test_list_logs_async(
-    transport: str = "grpc_asyncio", request_type=logging.ListLogsRequest
-):
+@pytest.mark.parametrize(
+    "request_type",
+    [
+        logging.ListLogsRequest({}),
+        {},
+    ],
+)
+async def test_list_logs_async(request_type, transport: str = "grpc_asyncio"):
     client = LoggingServiceV2AsyncClient(
         credentials=async_anonymous_credentials(),
         transport=transport,
@@ -2949,7 +2976,7 @@ async def test_list_logs_async(
 
     # Everything is optional in proto3 as far as the runtime is concerned,
     # and we are mocking out the actual API, so just send an empty request.
-    request = request_type()
+    request = request_type
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(type(client.transport.list_logs), "__call__") as call:
@@ -2972,11 +2999,6 @@ async def test_list_logs_async(
     assert isinstance(response, pagers.ListLogsAsyncPager)
     assert response.log_names == ["log_names_value"]
     assert response.next_page_token == "next_page_token_value"
-
-
-@pytest.mark.asyncio
-async def test_list_logs_async_from_dict():
-    await test_list_logs_async(request_type=dict)
 
 
 def test_list_logs_field_headers():
@@ -3315,8 +3337,8 @@ async def test_list_logs_async_pages():
 @pytest.mark.parametrize(
     "request_type",
     [
-        logging.TailLogEntriesRequest,
-        dict,
+        logging.TailLogEntriesRequest({}),
+        {},
     ],
 )
 def test_tail_log_entries(request_type, transport: str = "grpc"):
@@ -3327,7 +3349,7 @@ def test_tail_log_entries(request_type, transport: str = "grpc"):
 
     # Everything is optional in proto3 as far as the runtime is concerned,
     # and we are mocking out the actual API, so just send an empty request.
-    request = request_type()
+    request = request_type
     requests = [request]
 
     # Mock the actual call within the gRPC stub, and fake the request.
@@ -3426,9 +3448,14 @@ async def test_tail_log_entries_async_use_cached_wrapped_rpc(
 
 
 @pytest.mark.asyncio
-async def test_tail_log_entries_async(
-    transport: str = "grpc_asyncio", request_type=logging.TailLogEntriesRequest
-):
+@pytest.mark.parametrize(
+    "request_type",
+    [
+        logging.TailLogEntriesRequest({}),
+        {},
+    ],
+)
+async def test_tail_log_entries_async(request_type, transport: str = "grpc_asyncio"):
     client = LoggingServiceV2AsyncClient(
         credentials=async_anonymous_credentials(),
         transport=transport,
@@ -3436,7 +3463,7 @@ async def test_tail_log_entries_async(
 
     # Everything is optional in proto3 as far as the runtime is concerned,
     # and we are mocking out the actual API, so just send an empty request.
-    request = request_type()
+    request = request_type
     requests = [request]
 
     # Mock the actual call within the gRPC stub, and fake the request.
@@ -3456,11 +3483,6 @@ async def test_tail_log_entries_async(
     # Establish that the response is the type that we expect.
     message = await response.read()
     assert isinstance(message, logging.TailLogEntriesResponse)
-
-
-@pytest.mark.asyncio
-async def test_tail_log_entries_async_from_dict():
-    await test_tail_log_entries_async(request_type=dict)
 
 
 def test_credentials_transport_error():
@@ -3585,7 +3607,6 @@ def test_delete_log_empty_call_grpc():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = logging.DeleteLogRequest()
-
         assert args[0] == request_msg
 
 
@@ -3608,7 +3629,6 @@ def test_write_log_entries_empty_call_grpc():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = logging.WriteLogEntriesRequest()
-
         assert args[0] == request_msg
 
 
@@ -3629,7 +3649,6 @@ def test_list_log_entries_empty_call_grpc():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = logging.ListLogEntriesRequest()
-
         assert args[0] == request_msg
 
 
@@ -3652,7 +3671,6 @@ def test_list_monitored_resource_descriptors_empty_call_grpc():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = logging.ListMonitoredResourceDescriptorsRequest()
-
         assert args[0] == request_msg
 
 
@@ -3673,7 +3691,6 @@ def test_list_logs_empty_call_grpc():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = logging.ListLogsRequest()
-
         assert args[0] == request_msg
 
 
@@ -3710,7 +3727,6 @@ async def test_delete_log_empty_call_grpc_asyncio():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = logging.DeleteLogRequest()
-
         assert args[0] == request_msg
 
 
@@ -3737,7 +3753,6 @@ async def test_write_log_entries_empty_call_grpc_asyncio():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = logging.WriteLogEntriesRequest()
-
         assert args[0] == request_msg
 
 
@@ -3764,7 +3779,6 @@ async def test_list_log_entries_empty_call_grpc_asyncio():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = logging.ListLogEntriesRequest()
-
         assert args[0] == request_msg
 
 
@@ -3793,7 +3807,6 @@ async def test_list_monitored_resource_descriptors_empty_call_grpc_asyncio():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = logging.ListMonitoredResourceDescriptorsRequest()
-
         assert args[0] == request_msg
 
 
@@ -3821,7 +3834,6 @@ async def test_list_logs_empty_call_grpc_asyncio():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = logging.ListLogsRequest()
-
         assert args[0] == request_msg
 
 

--- a/packages/google-cloud-logging/tests/unit/gapic/logging_v2/test_metrics_service_v2.py
+++ b/packages/google-cloud-logging/tests/unit/gapic/logging_v2/test_metrics_service_v2.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+import asyncio
 import json
 import math
 import os
@@ -109,6 +110,21 @@ def modify_default_endpoint_template(client):
         if ("localhost" in client._DEFAULT_ENDPOINT_TEMPLATE)
         else client._DEFAULT_ENDPOINT_TEMPLATE
     )
+
+
+@pytest.fixture(autouse=True)
+def set_event_loop():
+    try:
+        asyncio.get_running_loop()
+        yield
+    except RuntimeError:
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+        try:
+            yield
+        finally:
+            loop.close()
+            asyncio.set_event_loop(None)
 
 
 def test__get_default_mtls_endpoint():
@@ -1318,8 +1334,8 @@ def test_metrics_service_v2_client_create_channel_credentials_file(
 @pytest.mark.parametrize(
     "request_type",
     [
-        logging_metrics.ListLogMetricsRequest,
-        dict,
+        logging_metrics.ListLogMetricsRequest({}),
+        {},
     ],
 )
 def test_list_log_metrics(request_type, transport: str = "grpc"):
@@ -1330,7 +1346,7 @@ def test_list_log_metrics(request_type, transport: str = "grpc"):
 
     # Everything is optional in proto3 as far as the runtime is concerned,
     # and we are mocking out the actual API, so just send an empty request.
-    request = request_type()
+    request = request_type
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(type(client.transport.list_log_metrics), "__call__") as call:
@@ -1375,10 +1391,11 @@ def test_list_log_metrics_non_empty_request_with_auto_populated_field():
         client.list_log_metrics(request=request)
         call.assert_called()
         _, args, _ = call.mock_calls[0]
-        assert args[0] == logging_metrics.ListLogMetricsRequest(
+        request_msg = logging_metrics.ListLogMetricsRequest(
             parent="parent_value",
             page_token="page_token_value",
         )
+        assert args[0] == request_msg
 
 
 def test_list_log_metrics_use_cached_wrapped_rpc():
@@ -1461,9 +1478,14 @@ async def test_list_log_metrics_async_use_cached_wrapped_rpc(
 
 
 @pytest.mark.asyncio
-async def test_list_log_metrics_async(
-    transport: str = "grpc_asyncio", request_type=logging_metrics.ListLogMetricsRequest
-):
+@pytest.mark.parametrize(
+    "request_type",
+    [
+        logging_metrics.ListLogMetricsRequest({}),
+        {},
+    ],
+)
+async def test_list_log_metrics_async(request_type, transport: str = "grpc_asyncio"):
     client = MetricsServiceV2AsyncClient(
         credentials=async_anonymous_credentials(),
         transport=transport,
@@ -1471,7 +1493,7 @@ async def test_list_log_metrics_async(
 
     # Everything is optional in proto3 as far as the runtime is concerned,
     # and we are mocking out the actual API, so just send an empty request.
-    request = request_type()
+    request = request_type
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(type(client.transport.list_log_metrics), "__call__") as call:
@@ -1492,11 +1514,6 @@ async def test_list_log_metrics_async(
     # Establish that the response is the type that we expect.
     assert isinstance(response, pagers.ListLogMetricsAsyncPager)
     assert response.next_page_token == "next_page_token_value"
-
-
-@pytest.mark.asyncio
-async def test_list_log_metrics_async_from_dict():
-    await test_list_log_metrics_async(request_type=dict)
 
 
 def test_list_log_metrics_field_headers():
@@ -1835,8 +1852,8 @@ async def test_list_log_metrics_async_pages():
 @pytest.mark.parametrize(
     "request_type",
     [
-        logging_metrics.GetLogMetricRequest,
-        dict,
+        logging_metrics.GetLogMetricRequest({}),
+        {},
     ],
 )
 def test_get_log_metric(request_type, transport: str = "grpc"):
@@ -1847,7 +1864,7 @@ def test_get_log_metric(request_type, transport: str = "grpc"):
 
     # Everything is optional in proto3 as far as the runtime is concerned,
     # and we are mocking out the actual API, so just send an empty request.
-    request = request_type()
+    request = request_type
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(type(client.transport.get_log_metric), "__call__") as call:
@@ -1903,9 +1920,10 @@ def test_get_log_metric_non_empty_request_with_auto_populated_field():
         client.get_log_metric(request=request)
         call.assert_called()
         _, args, _ = call.mock_calls[0]
-        assert args[0] == logging_metrics.GetLogMetricRequest(
+        request_msg = logging_metrics.GetLogMetricRequest(
             metric_name="metric_name_value",
         )
+        assert args[0] == request_msg
 
 
 def test_get_log_metric_use_cached_wrapped_rpc():
@@ -1986,9 +2004,14 @@ async def test_get_log_metric_async_use_cached_wrapped_rpc(
 
 
 @pytest.mark.asyncio
-async def test_get_log_metric_async(
-    transport: str = "grpc_asyncio", request_type=logging_metrics.GetLogMetricRequest
-):
+@pytest.mark.parametrize(
+    "request_type",
+    [
+        logging_metrics.GetLogMetricRequest({}),
+        {},
+    ],
+)
+async def test_get_log_metric_async(request_type, transport: str = "grpc_asyncio"):
     client = MetricsServiceV2AsyncClient(
         credentials=async_anonymous_credentials(),
         transport=transport,
@@ -1996,7 +2019,7 @@ async def test_get_log_metric_async(
 
     # Everything is optional in proto3 as far as the runtime is concerned,
     # and we are mocking out the actual API, so just send an empty request.
-    request = request_type()
+    request = request_type
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(type(client.transport.get_log_metric), "__call__") as call:
@@ -2029,11 +2052,6 @@ async def test_get_log_metric_async(
     assert response.disabled is True
     assert response.value_extractor == "value_extractor_value"
     assert response.version == logging_metrics.LogMetric.ApiVersion.V1
-
-
-@pytest.mark.asyncio
-async def test_get_log_metric_async_from_dict():
-    await test_get_log_metric_async(request_type=dict)
 
 
 def test_get_log_metric_field_headers():
@@ -2182,8 +2200,8 @@ async def test_get_log_metric_flattened_error_async():
 @pytest.mark.parametrize(
     "request_type",
     [
-        logging_metrics.CreateLogMetricRequest,
-        dict,
+        logging_metrics.CreateLogMetricRequest({}),
+        {},
     ],
 )
 def test_create_log_metric(request_type, transport: str = "grpc"):
@@ -2194,7 +2212,7 @@ def test_create_log_metric(request_type, transport: str = "grpc"):
 
     # Everything is optional in proto3 as far as the runtime is concerned,
     # and we are mocking out the actual API, so just send an empty request.
-    request = request_type()
+    request = request_type
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(
@@ -2254,9 +2272,10 @@ def test_create_log_metric_non_empty_request_with_auto_populated_field():
         client.create_log_metric(request=request)
         call.assert_called()
         _, args, _ = call.mock_calls[0]
-        assert args[0] == logging_metrics.CreateLogMetricRequest(
+        request_msg = logging_metrics.CreateLogMetricRequest(
             parent="parent_value",
         )
+        assert args[0] == request_msg
 
 
 def test_create_log_metric_use_cached_wrapped_rpc():
@@ -2339,9 +2358,14 @@ async def test_create_log_metric_async_use_cached_wrapped_rpc(
 
 
 @pytest.mark.asyncio
-async def test_create_log_metric_async(
-    transport: str = "grpc_asyncio", request_type=logging_metrics.CreateLogMetricRequest
-):
+@pytest.mark.parametrize(
+    "request_type",
+    [
+        logging_metrics.CreateLogMetricRequest({}),
+        {},
+    ],
+)
+async def test_create_log_metric_async(request_type, transport: str = "grpc_asyncio"):
     client = MetricsServiceV2AsyncClient(
         credentials=async_anonymous_credentials(),
         transport=transport,
@@ -2349,7 +2373,7 @@ async def test_create_log_metric_async(
 
     # Everything is optional in proto3 as far as the runtime is concerned,
     # and we are mocking out the actual API, so just send an empty request.
-    request = request_type()
+    request = request_type
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(
@@ -2384,11 +2408,6 @@ async def test_create_log_metric_async(
     assert response.disabled is True
     assert response.value_extractor == "value_extractor_value"
     assert response.version == logging_metrics.LogMetric.ApiVersion.V1
-
-
-@pytest.mark.asyncio
-async def test_create_log_metric_async_from_dict():
-    await test_create_log_metric_async(request_type=dict)
 
 
 def test_create_log_metric_field_headers():
@@ -2555,8 +2574,8 @@ async def test_create_log_metric_flattened_error_async():
 @pytest.mark.parametrize(
     "request_type",
     [
-        logging_metrics.UpdateLogMetricRequest,
-        dict,
+        logging_metrics.UpdateLogMetricRequest({}),
+        {},
     ],
 )
 def test_update_log_metric(request_type, transport: str = "grpc"):
@@ -2567,7 +2586,7 @@ def test_update_log_metric(request_type, transport: str = "grpc"):
 
     # Everything is optional in proto3 as far as the runtime is concerned,
     # and we are mocking out the actual API, so just send an empty request.
-    request = request_type()
+    request = request_type
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(
@@ -2627,9 +2646,10 @@ def test_update_log_metric_non_empty_request_with_auto_populated_field():
         client.update_log_metric(request=request)
         call.assert_called()
         _, args, _ = call.mock_calls[0]
-        assert args[0] == logging_metrics.UpdateLogMetricRequest(
+        request_msg = logging_metrics.UpdateLogMetricRequest(
             metric_name="metric_name_value",
         )
+        assert args[0] == request_msg
 
 
 def test_update_log_metric_use_cached_wrapped_rpc():
@@ -2712,9 +2732,14 @@ async def test_update_log_metric_async_use_cached_wrapped_rpc(
 
 
 @pytest.mark.asyncio
-async def test_update_log_metric_async(
-    transport: str = "grpc_asyncio", request_type=logging_metrics.UpdateLogMetricRequest
-):
+@pytest.mark.parametrize(
+    "request_type",
+    [
+        logging_metrics.UpdateLogMetricRequest({}),
+        {},
+    ],
+)
+async def test_update_log_metric_async(request_type, transport: str = "grpc_asyncio"):
     client = MetricsServiceV2AsyncClient(
         credentials=async_anonymous_credentials(),
         transport=transport,
@@ -2722,7 +2747,7 @@ async def test_update_log_metric_async(
 
     # Everything is optional in proto3 as far as the runtime is concerned,
     # and we are mocking out the actual API, so just send an empty request.
-    request = request_type()
+    request = request_type
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(
@@ -2757,11 +2782,6 @@ async def test_update_log_metric_async(
     assert response.disabled is True
     assert response.value_extractor == "value_extractor_value"
     assert response.version == logging_metrics.LogMetric.ApiVersion.V1
-
-
-@pytest.mark.asyncio
-async def test_update_log_metric_async_from_dict():
-    await test_update_log_metric_async(request_type=dict)
 
 
 def test_update_log_metric_field_headers():
@@ -2928,8 +2948,8 @@ async def test_update_log_metric_flattened_error_async():
 @pytest.mark.parametrize(
     "request_type",
     [
-        logging_metrics.DeleteLogMetricRequest,
-        dict,
+        logging_metrics.DeleteLogMetricRequest({}),
+        {},
     ],
 )
 def test_delete_log_metric(request_type, transport: str = "grpc"):
@@ -2940,7 +2960,7 @@ def test_delete_log_metric(request_type, transport: str = "grpc"):
 
     # Everything is optional in proto3 as far as the runtime is concerned,
     # and we are mocking out the actual API, so just send an empty request.
-    request = request_type()
+    request = request_type
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(
@@ -2985,9 +3005,10 @@ def test_delete_log_metric_non_empty_request_with_auto_populated_field():
         client.delete_log_metric(request=request)
         call.assert_called()
         _, args, _ = call.mock_calls[0]
-        assert args[0] == logging_metrics.DeleteLogMetricRequest(
+        request_msg = logging_metrics.DeleteLogMetricRequest(
             metric_name="metric_name_value",
         )
+        assert args[0] == request_msg
 
 
 def test_delete_log_metric_use_cached_wrapped_rpc():
@@ -3070,9 +3091,14 @@ async def test_delete_log_metric_async_use_cached_wrapped_rpc(
 
 
 @pytest.mark.asyncio
-async def test_delete_log_metric_async(
-    transport: str = "grpc_asyncio", request_type=logging_metrics.DeleteLogMetricRequest
-):
+@pytest.mark.parametrize(
+    "request_type",
+    [
+        logging_metrics.DeleteLogMetricRequest({}),
+        {},
+    ],
+)
+async def test_delete_log_metric_async(request_type, transport: str = "grpc_asyncio"):
     client = MetricsServiceV2AsyncClient(
         credentials=async_anonymous_credentials(),
         transport=transport,
@@ -3080,7 +3106,7 @@ async def test_delete_log_metric_async(
 
     # Everything is optional in proto3 as far as the runtime is concerned,
     # and we are mocking out the actual API, so just send an empty request.
-    request = request_type()
+    request = request_type
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(
@@ -3098,11 +3124,6 @@ async def test_delete_log_metric_async(
 
     # Establish that the response is the type that we expect.
     assert response is None
-
-
-@pytest.mark.asyncio
-async def test_delete_log_metric_async_from_dict():
-    await test_delete_log_metric_async(request_type=dict)
 
 
 def test_delete_log_metric_field_headers():
@@ -3374,7 +3395,6 @@ def test_list_log_metrics_empty_call_grpc():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = logging_metrics.ListLogMetricsRequest()
-
         assert args[0] == request_msg
 
 
@@ -3395,7 +3415,6 @@ def test_get_log_metric_empty_call_grpc():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = logging_metrics.GetLogMetricRequest()
-
         assert args[0] == request_msg
 
 
@@ -3418,7 +3437,6 @@ def test_create_log_metric_empty_call_grpc():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = logging_metrics.CreateLogMetricRequest()
-
         assert args[0] == request_msg
 
 
@@ -3441,7 +3459,6 @@ def test_update_log_metric_empty_call_grpc():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = logging_metrics.UpdateLogMetricRequest()
-
         assert args[0] == request_msg
 
 
@@ -3464,7 +3481,6 @@ def test_delete_log_metric_empty_call_grpc():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = logging_metrics.DeleteLogMetricRequest()
-
         assert args[0] == request_msg
 
 
@@ -3505,7 +3521,6 @@ async def test_list_log_metrics_empty_call_grpc_asyncio():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = logging_metrics.ListLogMetricsRequest()
-
         assert args[0] == request_msg
 
 
@@ -3538,7 +3553,6 @@ async def test_get_log_metric_empty_call_grpc_asyncio():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = logging_metrics.GetLogMetricRequest()
-
         assert args[0] == request_msg
 
 
@@ -3573,7 +3587,6 @@ async def test_create_log_metric_empty_call_grpc_asyncio():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = logging_metrics.CreateLogMetricRequest()
-
         assert args[0] == request_msg
 
 
@@ -3608,7 +3621,6 @@ async def test_update_log_metric_empty_call_grpc_asyncio():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = logging_metrics.UpdateLogMetricRequest()
-
         assert args[0] == request_msg
 
 
@@ -3633,7 +3645,6 @@ async def test_delete_log_metric_empty_call_grpc_asyncio():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = logging_metrics.DeleteLogMetricRequest()
-
         assert args[0] == request_msg
 
 

--- a/packages/google-cloud-logging/tests/unit/test_logger.py
+++ b/packages/google-cloud-logging/tests/unit/test_logger.py
@@ -11,14 +11,11 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-import sys
 import unittest
 from copy import deepcopy
 from datetime import datetime, timedelta, timezone
 
 import mock
-import pytest
 
 
 def _make_credentials():
@@ -1773,10 +1770,6 @@ class TestBatch(unittest.TestCase):
         self.assertEqual(list(batch.entries), UNSENT)
         self.assertIsNone(api._write_entries_called_with)
 
-    @pytest.mark.skipif(
-        sys.version_info < (3, 8),
-        reason="InvalidArgument init with details requires python3.8+",
-    )
     def test_append_context_to_error(self):
         """
         If an InvalidArgument exception contains info on the log that threw it,
@@ -1826,10 +1819,6 @@ class TestBatch(unittest.TestCase):
             err.message, starting_message, "message should have been unchanged"
         )
 
-    @pytest.mark.skipif(
-        sys.version_info < (3, 8),
-        reason="InvalidArgument init with details requires python3.8+",
-    )
     def test_batch_error_gets_context(self):
         """
         Simulate an InvalidArgument sent as part of a batch commit, to ensure


### PR DESCRIPTION
This PR updates the `google-cloud-logging` library to drop support for end-of-life Python runtimes (3.7, 3.8, and 3.9) and modernize package metadata and dependency constraints for Python 3.10+.

### Changes
* **Librarian Config**: Edited setup.py replacement in `.librarian/generator-input/client-post-processing/logging-integration.yaml` and added post-processing injection rules for `testing/constraints-3.10.txt`.
* **Regeneration**: Re-compiled GAPIC client services cleanly using `gapic-generator v1.33.0`, natively incorporating the `set_event_loop` autouse asyncio loop fixture inside all service unit tests.
* **Codebase EOL Cleanup**: Removed obsolete warning filters from `pytest.ini` and EOL skips from `test_logger.py` and `CONTRIBUTING.rst`.

🦕
