### PR TITLE
fix(bigquery): Fix timestamp scientific notation handling in _helpers.py

### DIFF
--- a/packages/google-cloud-bigquery/google/cloud/bigquery/_helpers.py
+++ b/packages/google-cloud-bigquery/google/cloud/bigquery/_helpers.py
@@ -261,7 +261,7 @@ class CellDataParser:
             return value
         if _not_null(value, field):
             # value will be a integer in seconds, to microsecond precision, in UTC.
-            return _datetime_from_microseconds(int(value))
+            return _datetime_from_microseconds(int(float(value)))
         return None
 
     def datetime_to_py(self, value, field):


### PR DESCRIPTION
Casting to float first handles scientific notation returned by API.   Otherwise its a noop.

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [X] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/google-cloud-python/issues) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [X] Ensure the tests and linter pass
- [X] Code coverage does not decrease (if any source code was changed)
- [X] Appropriate docs were updated (if necessary)

Fixes #17277🦕