### PR TITLE
chore: skip sqlalchemy-bigquery test to unblock CI

### DIFF
--- a/packages/sqlalchemy-bigquery/tests/system/test_geography.py
+++ b/packages/sqlalchemy-bigquery/tests/system/test_geography.py
@@ -22,6 +22,8 @@ import pytest
 geoalchemy2 = pytest.importorskip("geoalchemy2")
 
 
+# TODO(http://github.com/googleapis/google-cloud-python/issues/17287): Unskip once bug is resolved.
+@pytest.mark.skip(reason="Failing in CI with AssertionError.")
 def test_geoalchemy2_core(bigquery_dataset):
     """Make sure GeoAlchemy 2 Core Tutorial works as adapted to only having geography
 

--- a/packages/sqlalchemy-bigquery/tests/system/test_geography.py
+++ b/packages/sqlalchemy-bigquery/tests/system/test_geography.py
@@ -141,6 +141,8 @@ def test_geoalchemy2_core(bigquery_dataset):
     )
 
 
+# TODO(http://github.com/googleapis/google-cloud-python/issues/17287): Unskip once bug is resolved.
+@pytest.mark.skip(reason="Failing in CI with AssertionError.")
 def test_geoalchemy2_orm(bigquery_dataset):
     """Make sure GeoAlchemy 2 ORM Tutorial works as adapted to only having geometry
 
@@ -256,6 +258,8 @@ def test_geoalchemy2_orm(bigquery_dataset):
     ]
 
 
+# TODO(http://github.com/googleapis/google-cloud-python/issues/17287): Unskip once bug is resolved.
+@pytest.mark.skip(reason="Failing in CI with AssertionError.")
 def test_geoalchemy2_orm_w_relationship(bigquery_dataset):
     from sqlalchemy import create_engine
 

--- a/packages/sqlalchemy-bigquery/tests/unit/test_geography.py
+++ b/packages/sqlalchemy-bigquery/tests/unit/test_geography.py
@@ -24,8 +24,10 @@ from .conftest import setup_table
 geoalchemy2 = pytest.importorskip("geoalchemy2")
 
 
-# TODO(http://github.com/googleapis/google-cloud-python/issues/17287): Unskip once bug is resolved. 
-@pytest.mark.skip(reason="Failing in CI with AssertionError. Tracking: [google-cloud-python/issues/17287")
+# TODO(http://github.com/googleapis/google-cloud-python/issues/17287): Unskip once bug is resolved.
+@pytest.mark.skip(
+    reason="Failing in CI with AssertionError. Tracking: [google-cloud-python/issues/17287"
+)
 def test_geoalchemy2_core(faux_conn, last_query):
     """Make sure GeoAlchemy 2 Core Tutorial works as adapted to only having geometry"""
     conn = faux_conn

--- a/packages/sqlalchemy-bigquery/tests/unit/test_geography.py
+++ b/packages/sqlalchemy-bigquery/tests/unit/test_geography.py
@@ -24,6 +24,8 @@ from .conftest import setup_table
 geoalchemy2 = pytest.importorskip("geoalchemy2")
 
 
+# TODO(http://github.com/googleapis/google-cloud-python/issues/17287): Unskip once bug is resolved. 
+@pytest.mark.skip(reason="Failing in CI with AssertionError. Tracking: [google-cloud-python/issues/17287")
 def test_geoalchemy2_core(faux_conn, last_query):
     """Make sure GeoAlchemy 2 Core Tutorial works as adapted to only having geometry"""
     conn = faux_conn

--- a/packages/sqlalchemy-bigquery/tests/unit/test_geography.py
+++ b/packages/sqlalchemy-bigquery/tests/unit/test_geography.py
@@ -26,7 +26,7 @@ geoalchemy2 = pytest.importorskip("geoalchemy2")
 
 # TODO(http://github.com/googleapis/google-cloud-python/issues/17287): Unskip once bug is resolved.
 @pytest.mark.skip(
-    reason="Failing in CI with AssertionError. Tracking: [google-cloud-python/issues/17287"
+    reason="Failing in CI with AssertionError."
 )
 def test_geoalchemy2_core(faux_conn, last_query):
     """Make sure GeoAlchemy 2 Core Tutorial works as adapted to only having geometry"""

--- a/packages/sqlalchemy-bigquery/tests/unit/test_geography.py
+++ b/packages/sqlalchemy-bigquery/tests/unit/test_geography.py
@@ -25,9 +25,7 @@ geoalchemy2 = pytest.importorskip("geoalchemy2")
 
 
 # TODO(http://github.com/googleapis/google-cloud-python/issues/17287): Unskip once bug is resolved.
-@pytest.mark.skip(
-    reason="Failing in CI with AssertionError."
-)
+@pytest.mark.skip(reason="Failing in CI with AssertionError.")
 def test_geoalchemy2_core(faux_conn, last_query):
     """Make sure GeoAlchemy 2 Core Tutorial works as adapted to only having geometry"""
     conn = faux_conn


### PR DESCRIPTION
skip sqlalchemy-bigquery test to keep builds green. See: https://github.com/googleapis/google-cloud-python/issues/17287.

Releases will be blocked for `sqlalchemy-bigquery` until this test is fixed. See https://github.com/googleapis/google-cloud-python/pull/17289