### PR TITLE
chore(librarian): block release for sqlalchemy-bigquery

### DIFF
--- a/.librarian/config.yaml
+++ b/.librarian/config.yaml
@@ -34,4 +34,8 @@ libraries:
   # Disable automatic releases until system tests are sped up or reorganized.
   - id: "google-cloud-firestore"
     release_blocked: true
+  # TODO(https://github.com/googleapis/google-cloud-python/issues/17287):
+  # Allow releases for sqlalchemy-bigquery once the bug above is fixed.
+  - id: "sqlalchemy-bigquery"
+    release_blocked: true
 

--- a/librarian.yaml
+++ b/librarian.yaml
@@ -2530,6 +2530,7 @@ libraries:
       library_type: CORE
   - name: sqlalchemy-bigquery
     version: 1.17.0
+    skip_release: true
     python:
       library_type: INTEGRATION
   - name: sqlalchemy-spanner


### PR DESCRIPTION
block release for sqlalchemy-bigquery until https://github.com/googleapis/google-cloud-python/issues/17287 is resolved.