### PR TITLE
chore: librarian release pull request: librarian-20260528T204829Z

### DIFF
--- a/.librarian/state.yaml
+++ b/.librarian/state.yaml
@@ -2805,7 +2805,7 @@ libraries:
       - packages/google-cloud-gdchardwaremanagement/docs/
     tag_format: '{id}-v{version}'
   - id: google-cloud-geminidataanalytics
-    version: 0.12.0
+    version: 0.13.0
     last_generated_commit: 6df3ecf4fd43b64826de6a477d1a535ec18b0d7c
     apis:
       - path: google/cloud/geminidataanalytics/v1beta

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,7 +98,7 @@ Changelogs
 - [google-cloud-financialservices==0.4.0](https://github.com/googleapis/google-cloud-python/tree/main/packages/google-cloud-financialservices/CHANGELOG.md)
 - [google-cloud-functions==1.23.0](https://github.com/googleapis/google-cloud-python/tree/main/packages/google-cloud-functions/CHANGELOG.md)
 - [google-cloud-gdchardwaremanagement==0.5.0](https://github.com/googleapis/google-cloud-python/tree/main/packages/google-cloud-gdchardwaremanagement/CHANGELOG.md)
-- [google-cloud-geminidataanalytics==0.12.0](https://github.com/googleapis/google-cloud-python/tree/main/packages/google-cloud-geminidataanalytics/CHANGELOG.md)
+- [google-cloud-geminidataanalytics==0.13.0](https://github.com/googleapis/google-cloud-python/tree/main/packages/google-cloud-geminidataanalytics/CHANGELOG.md)
 - [google-cloud-gke-backup==0.8.0](https://github.com/googleapis/google-cloud-python/tree/main/packages/google-cloud-gke-backup/CHANGELOG.md)
 - [google-cloud-gke-connect-gateway==0.13.0](https://github.com/googleapis/google-cloud-python/tree/main/packages/google-cloud-gke-connect-gateway/CHANGELOG.md)
 - [google-cloud-gke-hub==1.24.0](https://github.com/googleapis/google-cloud-python/tree/main/packages/google-cloud-gke-hub/CHANGELOG.md)

--- a/librarian.yaml
+++ b/librarian.yaml
@@ -1150,7 +1150,7 @@ libraries:
     python:
       default_version: v1alpha
   - name: google-cloud-geminidataanalytics
-    version: 0.12.0
+    version: 0.13.0
     apis:
       - path: google/cloud/geminidataanalytics/v1
       - path: google/cloud/geminidataanalytics/v1beta

--- a/packages/google-cloud-geminidataanalytics/CHANGELOG.md
+++ b/packages/google-cloud-geminidataanalytics/CHANGELOG.md
@@ -4,6 +4,13 @@
 
 [1]: https://pypi.org/project/google-cloud-geminidataanalytics/#history
 
+## [0.13.0](https://github.com/googleapis/google-cloud-python/compare/google-cloud-geminidataanalytics-v0.12.0...google-cloud-geminidataanalytics-v0.13.0) (2026-05-28)
+
+
+### Bug Fixes
+
+* generate and default to v1 (#17007) ([3820d9d3b5c201ea9ba6ce129fd7064cba02e23c](https://github.com/googleapis/google-cloud-python/commit/3820d9d3b5c201ea9ba6ce129fd7064cba02e23c))
+
 ## [0.12.0](https://github.com/googleapis/google-cloud-python/compare/google-cloud-geminidataanalytics-v0.11.0...google-cloud-geminidataanalytics-v0.12.0) (2026-03-26)
 
 

--- a/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics/gapic_version.py
+++ b/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics/gapic_version.py
@@ -13,4 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-__version__ = "0.12.0"  # {x-release-please-version}
+__version__ = "0.13.0"  # {x-release-please-version}

--- a/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1/gapic_version.py
+++ b/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1/gapic_version.py
@@ -13,4 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-__version__ = "0.12.0"  # {x-release-please-version}
+__version__ = "0.13.0"  # {x-release-please-version}

--- a/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1alpha/gapic_version.py
+++ b/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1alpha/gapic_version.py
@@ -13,4 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-__version__ = "0.12.0"  # {x-release-please-version}
+__version__ = "0.13.0"  # {x-release-please-version}

--- a/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1beta/gapic_version.py
+++ b/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1beta/gapic_version.py
@@ -13,4 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-__version__ = "0.12.0"  # {x-release-please-version}
+__version__ = "0.13.0"  # {x-release-please-version}

--- a/packages/google-cloud-geminidataanalytics/noxfile.py
+++ b/packages/google-cloud-geminidataanalytics/noxfile.py
@@ -47,7 +47,12 @@ PREVIEW_PYTHON_VERSION = "3.14"
 
 CURRENT_DIRECTORY = pathlib.Path(__file__).parent.absolute()
 
-LOWER_BOUND_CONSTRAINTS_FILE = CURRENT_DIRECTORY / "constraints.txt"
+if (CURRENT_DIRECTORY / "testing").exists():
+    LOWER_BOUND_CONSTRAINTS_FILE = (
+        CURRENT_DIRECTORY / "testing" / f"constraints-{ALL_PYTHON[0]}.txt"
+    )
+else:
+    LOWER_BOUND_CONSTRAINTS_FILE = CURRENT_DIRECTORY / "constraints.txt"
 PACKAGE_NAME = "google-cloud-geminidataanalytics"
 
 UNIT_TEST_STANDARD_DEPENDENCIES = [
@@ -467,14 +472,6 @@ def prerelease_deps(session, protobuf_implementation):
     unit_deps_all = UNIT_TEST_STANDARD_DEPENDENCIES + UNIT_TEST_EXTERNAL_DEPENDENCIES
     session.install(*unit_deps_all)
 
-    # Install dependencies for the system test environment
-    system_deps_all = (
-        SYSTEM_TEST_STANDARD_DEPENDENCIES
-        + SYSTEM_TEST_EXTERNAL_DEPENDENCIES
-        + SYSTEM_TEST_EXTRAS
-    )
-    session.install(*system_deps_all)
-
     # Because we test minimum dependency versions on the minimum Python
     # version, the first version we test with in the unit tests sessions has a
     # constraints file containing all dependencies and extras.
@@ -585,14 +582,6 @@ def core_deps_from_source(session, protobuf_implementation):
     # Install dependencies for the unit test environment
     unit_deps_all = UNIT_TEST_STANDARD_DEPENDENCIES + UNIT_TEST_EXTERNAL_DEPENDENCIES
     session.install(*unit_deps_all)
-
-    # Install dependencies for the system test environment
-    system_deps_all = (
-        SYSTEM_TEST_STANDARD_DEPENDENCIES
-        + SYSTEM_TEST_EXTERNAL_DEPENDENCIES
-        + SYSTEM_TEST_EXTRAS
-    )
-    session.install(*system_deps_all)
 
     # Because we test minimum dependency versions on the minimum Python
     # version, the first version we test with in the unit tests sessions has a

--- a/packages/google-cloud-geminidataanalytics/samples/generated_samples/snippet_metadata_google.cloud.geminidataanalytics.v1.json
+++ b/packages/google-cloud-geminidataanalytics/samples/generated_samples/snippet_metadata_google.cloud.geminidataanalytics.v1.json
@@ -8,7 +8,7 @@
     ],
     "language": "PYTHON",
     "name": "google-cloud-geminidataanalytics",
-    "version": "0.12.0"
+    "version": "0.13.0"
   },
   "snippets": [
     {

--- a/packages/google-cloud-geminidataanalytics/samples/generated_samples/snippet_metadata_google.cloud.geminidataanalytics.v1alpha.json
+++ b/packages/google-cloud-geminidataanalytics/samples/generated_samples/snippet_metadata_google.cloud.geminidataanalytics.v1alpha.json
@@ -8,7 +8,7 @@
     ],
     "language": "PYTHON",
     "name": "google-cloud-geminidataanalytics",
-    "version": "0.12.0"
+    "version": "0.13.0"
   },
   "snippets": [
     {

--- a/packages/google-cloud-geminidataanalytics/samples/generated_samples/snippet_metadata_google.cloud.geminidataanalytics.v1beta.json
+++ b/packages/google-cloud-geminidataanalytics/samples/generated_samples/snippet_metadata_google.cloud.geminidataanalytics.v1beta.json
@@ -8,7 +8,7 @@
     ],
     "language": "PYTHON",
     "name": "google-cloud-geminidataanalytics",
-    "version": "0.12.0"
+    "version": "0.13.0"
   },
   "snippets": [
     {

--- a/packages/google-cloud-geminidataanalytics/setup.py
+++ b/packages/google-cloud-geminidataanalytics/setup.py
@@ -45,7 +45,7 @@ dependencies = [
     # Exclude incompatible versions of `google-auth`
     # See https://github.com/googleapis/google-cloud-python/issues/12364
     "google-auth >= 2.14.1, <3.0.0,!=2.24.0,!=2.25.0",
-    "grpcio >= 1.44.0, < 2.0.0",
+    "grpcio >= 1.59.0, < 2.0.0",
     "grpcio >= 1.75.1, < 2.0.0; python_version >= '3.14'",
     "proto-plus >= 1.22.3, <2.0.0",
     "proto-plus >= 1.25.0, <2.0.0; python_version >= '3.13'",

--- a/packages/google-cloud-geminidataanalytics/testing/constraints-3.10.txt
+++ b/packages/google-cloud-geminidataanalytics/testing/constraints-3.10.txt
@@ -6,7 +6,7 @@
 # then this file should have google-cloud-foo==1.14.0
 google-api-core==2.17.1
 google-auth==2.14.1
-grpcio==1.44.0
+grpcio==1.59.0
 proto-plus==1.22.3
 protobuf==4.25.8
 grpc-google-iam-v1==0.14.0

--- a/packages/google-cloud-geminidataanalytics/tests/unit/gapic/geminidataanalytics_v1/test_data_agent_service.py
+++ b/packages/google-cloud-geminidataanalytics/tests/unit/gapic/geminidataanalytics_v1/test_data_agent_service.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+import asyncio
 import json
 import math
 import os
@@ -126,6 +127,21 @@ def modify_default_endpoint_template(client):
         if ("localhost" in client._DEFAULT_ENDPOINT_TEMPLATE)
         else client._DEFAULT_ENDPOINT_TEMPLATE
     )
+
+
+@pytest.fixture(autouse=True)
+def set_event_loop():
+    try:
+        asyncio.get_running_loop()
+        yield
+    except RuntimeError:
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+        try:
+            yield
+        finally:
+            loop.close()
+            asyncio.set_event_loop(None)
 
 
 def test__get_default_mtls_endpoint():
@@ -1361,8 +1377,8 @@ def test_data_agent_service_client_create_channel_credentials_file(
 @pytest.mark.parametrize(
     "request_type",
     [
-        data_agent_service.ListDataAgentsRequest,
-        dict,
+        data_agent_service.ListDataAgentsRequest(),
+        {},
     ],
 )
 def test_list_data_agents(request_type, transport: str = "grpc"):
@@ -1373,7 +1389,7 @@ def test_list_data_agents(request_type, transport: str = "grpc"):
 
     # Everything is optional in proto3 as far as the runtime is concerned,
     # and we are mocking out the actual API, so just send an empty request.
-    request = request_type()
+    request = request_type
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(type(client.transport.list_data_agents), "__call__") as call:
@@ -1422,12 +1438,13 @@ def test_list_data_agents_non_empty_request_with_auto_populated_field():
         client.list_data_agents(request=request)
         call.assert_called()
         _, args, _ = call.mock_calls[0]
-        assert args[0] == data_agent_service.ListDataAgentsRequest(
+        request_msg = data_agent_service.ListDataAgentsRequest(
             parent="parent_value",
             page_token="page_token_value",
             filter="filter_value",
             order_by="order_by_value",
         )
+        assert args[0] == request_msg
 
 
 def test_list_data_agents_use_cached_wrapped_rpc():
@@ -1510,10 +1527,14 @@ async def test_list_data_agents_async_use_cached_wrapped_rpc(
 
 
 @pytest.mark.asyncio
-async def test_list_data_agents_async(
-    transport: str = "grpc_asyncio",
-    request_type=data_agent_service.ListDataAgentsRequest,
-):
+@pytest.mark.parametrize(
+    "request_type",
+    [
+        data_agent_service.ListDataAgentsRequest(),
+        {},
+    ],
+)
+async def test_list_data_agents_async(request_type, transport: str = "grpc_asyncio"):
     client = DataAgentServiceAsyncClient(
         credentials=async_anonymous_credentials(),
         transport=transport,
@@ -1521,7 +1542,7 @@ async def test_list_data_agents_async(
 
     # Everything is optional in proto3 as far as the runtime is concerned,
     # and we are mocking out the actual API, so just send an empty request.
-    request = request_type()
+    request = request_type
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(type(client.transport.list_data_agents), "__call__") as call:
@@ -1544,11 +1565,6 @@ async def test_list_data_agents_async(
     assert isinstance(response, pagers.ListDataAgentsAsyncPager)
     assert response.next_page_token == "next_page_token_value"
     assert response.unreachable == ["unreachable_value"]
-
-
-@pytest.mark.asyncio
-async def test_list_data_agents_async_from_dict():
-    await test_list_data_agents_async(request_type=dict)
 
 
 def test_list_data_agents_field_headers():
@@ -1887,8 +1903,8 @@ async def test_list_data_agents_async_pages():
 @pytest.mark.parametrize(
     "request_type",
     [
-        data_agent_service.ListAccessibleDataAgentsRequest,
-        dict,
+        data_agent_service.ListAccessibleDataAgentsRequest(),
+        {},
     ],
 )
 def test_list_accessible_data_agents(request_type, transport: str = "grpc"):
@@ -1899,7 +1915,7 @@ def test_list_accessible_data_agents(request_type, transport: str = "grpc"):
 
     # Everything is optional in proto3 as far as the runtime is concerned,
     # and we are mocking out the actual API, so just send an empty request.
-    request = request_type()
+    request = request_type
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(
@@ -1952,12 +1968,13 @@ def test_list_accessible_data_agents_non_empty_request_with_auto_populated_field
         client.list_accessible_data_agents(request=request)
         call.assert_called()
         _, args, _ = call.mock_calls[0]
-        assert args[0] == data_agent_service.ListAccessibleDataAgentsRequest(
+        request_msg = data_agent_service.ListAccessibleDataAgentsRequest(
             parent="parent_value",
             page_token="page_token_value",
             filter="filter_value",
             order_by="order_by_value",
         )
+        assert args[0] == request_msg
 
 
 def test_list_accessible_data_agents_use_cached_wrapped_rpc():
@@ -2043,9 +2060,15 @@ async def test_list_accessible_data_agents_async_use_cached_wrapped_rpc(
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "request_type",
+    [
+        data_agent_service.ListAccessibleDataAgentsRequest(),
+        {},
+    ],
+)
 async def test_list_accessible_data_agents_async(
-    transport: str = "grpc_asyncio",
-    request_type=data_agent_service.ListAccessibleDataAgentsRequest,
+    request_type, transport: str = "grpc_asyncio"
 ):
     client = DataAgentServiceAsyncClient(
         credentials=async_anonymous_credentials(),
@@ -2054,7 +2077,7 @@ async def test_list_accessible_data_agents_async(
 
     # Everything is optional in proto3 as far as the runtime is concerned,
     # and we are mocking out the actual API, so just send an empty request.
-    request = request_type()
+    request = request_type
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(
@@ -2079,11 +2102,6 @@ async def test_list_accessible_data_agents_async(
     assert isinstance(response, pagers.ListAccessibleDataAgentsAsyncPager)
     assert response.next_page_token == "next_page_token_value"
     assert response.unreachable == ["unreachable_value"]
-
-
-@pytest.mark.asyncio
-async def test_list_accessible_data_agents_async_from_dict():
-    await test_list_accessible_data_agents_async(request_type=dict)
 
 
 def test_list_accessible_data_agents_field_headers():
@@ -2440,8 +2458,8 @@ async def test_list_accessible_data_agents_async_pages():
 @pytest.mark.parametrize(
     "request_type",
     [
-        data_agent_service.GetDataAgentRequest,
-        dict,
+        data_agent_service.GetDataAgentRequest(),
+        {},
     ],
 )
 def test_get_data_agent(request_type, transport: str = "grpc"):
@@ -2452,7 +2470,7 @@ def test_get_data_agent(request_type, transport: str = "grpc"):
 
     # Everything is optional in proto3 as far as the runtime is concerned,
     # and we are mocking out the actual API, so just send an empty request.
-    request = request_type()
+    request = request_type
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(type(client.transport.get_data_agent), "__call__") as call:
@@ -2502,9 +2520,10 @@ def test_get_data_agent_non_empty_request_with_auto_populated_field():
         client.get_data_agent(request=request)
         call.assert_called()
         _, args, _ = call.mock_calls[0]
-        assert args[0] == data_agent_service.GetDataAgentRequest(
+        request_msg = data_agent_service.GetDataAgentRequest(
             name="name_value",
         )
+        assert args[0] == request_msg
 
 
 def test_get_data_agent_use_cached_wrapped_rpc():
@@ -2585,9 +2604,14 @@ async def test_get_data_agent_async_use_cached_wrapped_rpc(
 
 
 @pytest.mark.asyncio
-async def test_get_data_agent_async(
-    transport: str = "grpc_asyncio", request_type=data_agent_service.GetDataAgentRequest
-):
+@pytest.mark.parametrize(
+    "request_type",
+    [
+        data_agent_service.GetDataAgentRequest(),
+        {},
+    ],
+)
+async def test_get_data_agent_async(request_type, transport: str = "grpc_asyncio"):
     client = DataAgentServiceAsyncClient(
         credentials=async_anonymous_credentials(),
         transport=transport,
@@ -2595,7 +2619,7 @@ async def test_get_data_agent_async(
 
     # Everything is optional in proto3 as far as the runtime is concerned,
     # and we are mocking out the actual API, so just send an empty request.
-    request = request_type()
+    request = request_type
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(type(client.transport.get_data_agent), "__call__") as call:
@@ -2622,11 +2646,6 @@ async def test_get_data_agent_async(
     assert response.display_name == "display_name_value"
     assert response.description == "description_value"
     assert response.kms_key == "kms_key_value"
-
-
-@pytest.mark.asyncio
-async def test_get_data_agent_async_from_dict():
-    await test_get_data_agent_async(request_type=dict)
 
 
 def test_get_data_agent_field_headers():
@@ -2775,8 +2794,8 @@ async def test_get_data_agent_flattened_error_async():
 @pytest.mark.parametrize(
     "request_type",
     [
-        data_agent_service.CreateDataAgentRequest,
-        dict,
+        data_agent_service.CreateDataAgentRequest(),
+        {},
     ],
 )
 def test_create_data_agent(request_type, transport: str = "grpc"):
@@ -2787,7 +2806,7 @@ def test_create_data_agent(request_type, transport: str = "grpc"):
 
     # Everything is optional in proto3 as far as the runtime is concerned,
     # and we are mocking out the actual API, so just send an empty request.
-    request = request_type()
+    request = request_type
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(
@@ -2833,10 +2852,11 @@ def test_create_data_agent_non_empty_request_with_auto_populated_field():
         client.create_data_agent(request=request)
         call.assert_called()
         _, args, _ = call.mock_calls[0]
-        assert args[0] == data_agent_service.CreateDataAgentRequest(
+        request_msg = data_agent_service.CreateDataAgentRequest(
             parent="parent_value",
             data_agent_id="data_agent_id_value",
         )
+        assert args[0] == request_msg
 
 
 def test_create_data_agent_use_cached_wrapped_rpc():
@@ -2929,10 +2949,14 @@ async def test_create_data_agent_async_use_cached_wrapped_rpc(
 
 
 @pytest.mark.asyncio
-async def test_create_data_agent_async(
-    transport: str = "grpc_asyncio",
-    request_type=data_agent_service.CreateDataAgentRequest,
-):
+@pytest.mark.parametrize(
+    "request_type",
+    [
+        data_agent_service.CreateDataAgentRequest(),
+        {},
+    ],
+)
+async def test_create_data_agent_async(request_type, transport: str = "grpc_asyncio"):
     client = DataAgentServiceAsyncClient(
         credentials=async_anonymous_credentials(),
         transport=transport,
@@ -2940,7 +2964,7 @@ async def test_create_data_agent_async(
 
     # Everything is optional in proto3 as far as the runtime is concerned,
     # and we are mocking out the actual API, so just send an empty request.
-    request = request_type()
+    request = request_type
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(
@@ -2960,11 +2984,6 @@ async def test_create_data_agent_async(
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, future.Future)
-
-
-@pytest.mark.asyncio
-async def test_create_data_agent_async_from_dict():
-    await test_create_data_agent_async(request_type=dict)
 
 
 def test_create_data_agent_field_headers():
@@ -3177,8 +3196,8 @@ async def test_create_data_agent_flattened_error_async():
 @pytest.mark.parametrize(
     "request_type",
     [
-        data_agent_service.CreateDataAgentRequest,
-        dict,
+        data_agent_service.CreateDataAgentRequest(),
+        {},
     ],
 )
 def test_create_data_agent_sync(request_type, transport: str = "grpc"):
@@ -3189,7 +3208,7 @@ def test_create_data_agent_sync(request_type, transport: str = "grpc"):
 
     # Everything is optional in proto3 as far as the runtime is concerned,
     # and we are mocking out the actual API, so just send an empty request.
-    request = request_type()
+    request = request_type
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(
@@ -3244,10 +3263,11 @@ def test_create_data_agent_sync_non_empty_request_with_auto_populated_field():
         client.create_data_agent_sync(request=request)
         call.assert_called()
         _, args, _ = call.mock_calls[0]
-        assert args[0] == data_agent_service.CreateDataAgentRequest(
+        request_msg = data_agent_service.CreateDataAgentRequest(
             parent="parent_value",
             data_agent_id="data_agent_id_value",
         )
+        assert args[0] == request_msg
 
 
 def test_create_data_agent_sync_use_cached_wrapped_rpc():
@@ -3333,9 +3353,15 @@ async def test_create_data_agent_sync_async_use_cached_wrapped_rpc(
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "request_type",
+    [
+        data_agent_service.CreateDataAgentRequest(),
+        {},
+    ],
+)
 async def test_create_data_agent_sync_async(
-    transport: str = "grpc_asyncio",
-    request_type=data_agent_service.CreateDataAgentRequest,
+    request_type, transport: str = "grpc_asyncio"
 ):
     client = DataAgentServiceAsyncClient(
         credentials=async_anonymous_credentials(),
@@ -3344,7 +3370,7 @@ async def test_create_data_agent_sync_async(
 
     # Everything is optional in proto3 as far as the runtime is concerned,
     # and we are mocking out the actual API, so just send an empty request.
-    request = request_type()
+    request = request_type
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(
@@ -3373,11 +3399,6 @@ async def test_create_data_agent_sync_async(
     assert response.display_name == "display_name_value"
     assert response.description == "description_value"
     assert response.kms_key == "kms_key_value"
-
-
-@pytest.mark.asyncio
-async def test_create_data_agent_sync_async_from_dict():
-    await test_create_data_agent_sync_async(request_type=dict)
 
 
 def test_create_data_agent_sync_field_headers():
@@ -3590,8 +3611,8 @@ async def test_create_data_agent_sync_flattened_error_async():
 @pytest.mark.parametrize(
     "request_type",
     [
-        data_agent_service.UpdateDataAgentRequest,
-        dict,
+        data_agent_service.UpdateDataAgentRequest(),
+        {},
     ],
 )
 def test_update_data_agent(request_type, transport: str = "grpc"):
@@ -3602,7 +3623,7 @@ def test_update_data_agent(request_type, transport: str = "grpc"):
 
     # Everything is optional in proto3 as far as the runtime is concerned,
     # and we are mocking out the actual API, so just send an empty request.
-    request = request_type()
+    request = request_type
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(
@@ -3645,7 +3666,8 @@ def test_update_data_agent_non_empty_request_with_auto_populated_field():
         client.update_data_agent(request=request)
         call.assert_called()
         _, args, _ = call.mock_calls[0]
-        assert args[0] == data_agent_service.UpdateDataAgentRequest()
+        request_msg = data_agent_service.UpdateDataAgentRequest()
+        assert args[0] == request_msg
 
 
 def test_update_data_agent_use_cached_wrapped_rpc():
@@ -3738,10 +3760,14 @@ async def test_update_data_agent_async_use_cached_wrapped_rpc(
 
 
 @pytest.mark.asyncio
-async def test_update_data_agent_async(
-    transport: str = "grpc_asyncio",
-    request_type=data_agent_service.UpdateDataAgentRequest,
-):
+@pytest.mark.parametrize(
+    "request_type",
+    [
+        data_agent_service.UpdateDataAgentRequest(),
+        {},
+    ],
+)
+async def test_update_data_agent_async(request_type, transport: str = "grpc_asyncio"):
     client = DataAgentServiceAsyncClient(
         credentials=async_anonymous_credentials(),
         transport=transport,
@@ -3749,7 +3775,7 @@ async def test_update_data_agent_async(
 
     # Everything is optional in proto3 as far as the runtime is concerned,
     # and we are mocking out the actual API, so just send an empty request.
-    request = request_type()
+    request = request_type
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(
@@ -3769,11 +3795,6 @@ async def test_update_data_agent_async(
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, future.Future)
-
-
-@pytest.mark.asyncio
-async def test_update_data_agent_async_from_dict():
-    await test_update_data_agent_async(request_type=dict)
 
 
 def test_update_data_agent_field_headers():
@@ -3976,8 +3997,8 @@ async def test_update_data_agent_flattened_error_async():
 @pytest.mark.parametrize(
     "request_type",
     [
-        data_agent_service.UpdateDataAgentRequest,
-        dict,
+        data_agent_service.UpdateDataAgentRequest(),
+        {},
     ],
 )
 def test_update_data_agent_sync(request_type, transport: str = "grpc"):
@@ -3988,7 +4009,7 @@ def test_update_data_agent_sync(request_type, transport: str = "grpc"):
 
     # Everything is optional in proto3 as far as the runtime is concerned,
     # and we are mocking out the actual API, so just send an empty request.
-    request = request_type()
+    request = request_type
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(
@@ -4040,7 +4061,8 @@ def test_update_data_agent_sync_non_empty_request_with_auto_populated_field():
         client.update_data_agent_sync(request=request)
         call.assert_called()
         _, args, _ = call.mock_calls[0]
-        assert args[0] == data_agent_service.UpdateDataAgentRequest()
+        request_msg = data_agent_service.UpdateDataAgentRequest()
+        assert args[0] == request_msg
 
 
 def test_update_data_agent_sync_use_cached_wrapped_rpc():
@@ -4126,9 +4148,15 @@ async def test_update_data_agent_sync_async_use_cached_wrapped_rpc(
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "request_type",
+    [
+        data_agent_service.UpdateDataAgentRequest(),
+        {},
+    ],
+)
 async def test_update_data_agent_sync_async(
-    transport: str = "grpc_asyncio",
-    request_type=data_agent_service.UpdateDataAgentRequest,
+    request_type, transport: str = "grpc_asyncio"
 ):
     client = DataAgentServiceAsyncClient(
         credentials=async_anonymous_credentials(),
@@ -4137,7 +4165,7 @@ async def test_update_data_agent_sync_async(
 
     # Everything is optional in proto3 as far as the runtime is concerned,
     # and we are mocking out the actual API, so just send an empty request.
-    request = request_type()
+    request = request_type
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(
@@ -4166,11 +4194,6 @@ async def test_update_data_agent_sync_async(
     assert response.display_name == "display_name_value"
     assert response.description == "description_value"
     assert response.kms_key == "kms_key_value"
-
-
-@pytest.mark.asyncio
-async def test_update_data_agent_sync_async_from_dict():
-    await test_update_data_agent_sync_async(request_type=dict)
 
 
 def test_update_data_agent_sync_field_headers():
@@ -4373,8 +4396,8 @@ async def test_update_data_agent_sync_flattened_error_async():
 @pytest.mark.parametrize(
     "request_type",
     [
-        data_agent_service.DeleteDataAgentRequest,
-        dict,
+        data_agent_service.DeleteDataAgentRequest(),
+        {},
     ],
 )
 def test_delete_data_agent(request_type, transport: str = "grpc"):
@@ -4385,7 +4408,7 @@ def test_delete_data_agent(request_type, transport: str = "grpc"):
 
     # Everything is optional in proto3 as far as the runtime is concerned,
     # and we are mocking out the actual API, so just send an empty request.
-    request = request_type()
+    request = request_type
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(
@@ -4430,9 +4453,10 @@ def test_delete_data_agent_non_empty_request_with_auto_populated_field():
         client.delete_data_agent(request=request)
         call.assert_called()
         _, args, _ = call.mock_calls[0]
-        assert args[0] == data_agent_service.DeleteDataAgentRequest(
+        request_msg = data_agent_service.DeleteDataAgentRequest(
             name="name_value",
         )
+        assert args[0] == request_msg
 
 
 def test_delete_data_agent_use_cached_wrapped_rpc():
@@ -4525,10 +4549,14 @@ async def test_delete_data_agent_async_use_cached_wrapped_rpc(
 
 
 @pytest.mark.asyncio
-async def test_delete_data_agent_async(
-    transport: str = "grpc_asyncio",
-    request_type=data_agent_service.DeleteDataAgentRequest,
-):
+@pytest.mark.parametrize(
+    "request_type",
+    [
+        data_agent_service.DeleteDataAgentRequest(),
+        {},
+    ],
+)
+async def test_delete_data_agent_async(request_type, transport: str = "grpc_asyncio"):
     client = DataAgentServiceAsyncClient(
         credentials=async_anonymous_credentials(),
         transport=transport,
@@ -4536,7 +4564,7 @@ async def test_delete_data_agent_async(
 
     # Everything is optional in proto3 as far as the runtime is concerned,
     # and we are mocking out the actual API, so just send an empty request.
-    request = request_type()
+    request = request_type
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(
@@ -4556,11 +4584,6 @@ async def test_delete_data_agent_async(
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, future.Future)
-
-
-@pytest.mark.asyncio
-async def test_delete_data_agent_async_from_dict():
-    await test_delete_data_agent_async(request_type=dict)
 
 
 def test_delete_data_agent_field_headers():
@@ -4717,8 +4740,8 @@ async def test_delete_data_agent_flattened_error_async():
 @pytest.mark.parametrize(
     "request_type",
     [
-        data_agent_service.DeleteDataAgentRequest,
-        dict,
+        data_agent_service.DeleteDataAgentRequest(),
+        {},
     ],
 )
 def test_delete_data_agent_sync(request_type, transport: str = "grpc"):
@@ -4729,7 +4752,7 @@ def test_delete_data_agent_sync(request_type, transport: str = "grpc"):
 
     # Everything is optional in proto3 as far as the runtime is concerned,
     # and we are mocking out the actual API, so just send an empty request.
-    request = request_type()
+    request = request_type
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(
@@ -4774,9 +4797,10 @@ def test_delete_data_agent_sync_non_empty_request_with_auto_populated_field():
         client.delete_data_agent_sync(request=request)
         call.assert_called()
         _, args, _ = call.mock_calls[0]
-        assert args[0] == data_agent_service.DeleteDataAgentRequest(
+        request_msg = data_agent_service.DeleteDataAgentRequest(
             name="name_value",
         )
+        assert args[0] == request_msg
 
 
 def test_delete_data_agent_sync_use_cached_wrapped_rpc():
@@ -4862,9 +4886,15 @@ async def test_delete_data_agent_sync_async_use_cached_wrapped_rpc(
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "request_type",
+    [
+        data_agent_service.DeleteDataAgentRequest(),
+        {},
+    ],
+)
 async def test_delete_data_agent_sync_async(
-    transport: str = "grpc_asyncio",
-    request_type=data_agent_service.DeleteDataAgentRequest,
+    request_type, transport: str = "grpc_asyncio"
 ):
     client = DataAgentServiceAsyncClient(
         credentials=async_anonymous_credentials(),
@@ -4873,7 +4903,7 @@ async def test_delete_data_agent_sync_async(
 
     # Everything is optional in proto3 as far as the runtime is concerned,
     # and we are mocking out the actual API, so just send an empty request.
-    request = request_type()
+    request = request_type
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(
@@ -4891,11 +4921,6 @@ async def test_delete_data_agent_sync_async(
 
     # Establish that the response is the type that we expect.
     assert response is None
-
-
-@pytest.mark.asyncio
-async def test_delete_data_agent_sync_async_from_dict():
-    await test_delete_data_agent_sync_async(request_type=dict)
 
 
 def test_delete_data_agent_sync_field_headers():
@@ -5048,8 +5073,8 @@ async def test_delete_data_agent_sync_flattened_error_async():
 @pytest.mark.parametrize(
     "request_type",
     [
-        iam_policy_pb2.GetIamPolicyRequest,
-        dict,
+        iam_policy_pb2.GetIamPolicyRequest(),
+        {},
     ],
 )
 def test_get_iam_policy(request_type, transport: str = "grpc"):
@@ -5060,7 +5085,7 @@ def test_get_iam_policy(request_type, transport: str = "grpc"):
 
     # Everything is optional in proto3 as far as the runtime is concerned,
     # and we are mocking out the actual API, so just send an empty request.
-    request = request_type()
+    request = request_type
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(type(client.transport.get_iam_policy), "__call__") as call:
@@ -5106,9 +5131,10 @@ def test_get_iam_policy_non_empty_request_with_auto_populated_field():
         client.get_iam_policy(request=request)
         call.assert_called()
         _, args, _ = call.mock_calls[0]
-        assert args[0] == iam_policy_pb2.GetIamPolicyRequest(
+        request_msg = iam_policy_pb2.GetIamPolicyRequest(
             resource="resource_value",
         )
+        assert args[0] == request_msg
 
 
 def test_get_iam_policy_use_cached_wrapped_rpc():
@@ -5189,9 +5215,14 @@ async def test_get_iam_policy_async_use_cached_wrapped_rpc(
 
 
 @pytest.mark.asyncio
-async def test_get_iam_policy_async(
-    transport: str = "grpc_asyncio", request_type=iam_policy_pb2.GetIamPolicyRequest
-):
+@pytest.mark.parametrize(
+    "request_type",
+    [
+        iam_policy_pb2.GetIamPolicyRequest(),
+        {},
+    ],
+)
+async def test_get_iam_policy_async(request_type, transport: str = "grpc_asyncio"):
     client = DataAgentServiceAsyncClient(
         credentials=async_anonymous_credentials(),
         transport=transport,
@@ -5199,7 +5230,7 @@ async def test_get_iam_policy_async(
 
     # Everything is optional in proto3 as far as the runtime is concerned,
     # and we are mocking out the actual API, so just send an empty request.
-    request = request_type()
+    request = request_type
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(type(client.transport.get_iam_policy), "__call__") as call:
@@ -5222,11 +5253,6 @@ async def test_get_iam_policy_async(
     assert isinstance(response, policy_pb2.Policy)
     assert response.version == 774
     assert response.etag == b"etag_blob"
-
-
-@pytest.mark.asyncio
-async def test_get_iam_policy_async_from_dict():
-    await test_get_iam_policy_async(request_type=dict)
 
 
 def test_get_iam_policy_field_headers():
@@ -5388,8 +5414,8 @@ async def test_get_iam_policy_flattened_error_async():
 @pytest.mark.parametrize(
     "request_type",
     [
-        iam_policy_pb2.SetIamPolicyRequest,
-        dict,
+        iam_policy_pb2.SetIamPolicyRequest(),
+        {},
     ],
 )
 def test_set_iam_policy(request_type, transport: str = "grpc"):
@@ -5400,7 +5426,7 @@ def test_set_iam_policy(request_type, transport: str = "grpc"):
 
     # Everything is optional in proto3 as far as the runtime is concerned,
     # and we are mocking out the actual API, so just send an empty request.
-    request = request_type()
+    request = request_type
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(type(client.transport.set_iam_policy), "__call__") as call:
@@ -5446,9 +5472,10 @@ def test_set_iam_policy_non_empty_request_with_auto_populated_field():
         client.set_iam_policy(request=request)
         call.assert_called()
         _, args, _ = call.mock_calls[0]
-        assert args[0] == iam_policy_pb2.SetIamPolicyRequest(
+        request_msg = iam_policy_pb2.SetIamPolicyRequest(
             resource="resource_value",
         )
+        assert args[0] == request_msg
 
 
 def test_set_iam_policy_use_cached_wrapped_rpc():
@@ -5529,9 +5556,14 @@ async def test_set_iam_policy_async_use_cached_wrapped_rpc(
 
 
 @pytest.mark.asyncio
-async def test_set_iam_policy_async(
-    transport: str = "grpc_asyncio", request_type=iam_policy_pb2.SetIamPolicyRequest
-):
+@pytest.mark.parametrize(
+    "request_type",
+    [
+        iam_policy_pb2.SetIamPolicyRequest(),
+        {},
+    ],
+)
+async def test_set_iam_policy_async(request_type, transport: str = "grpc_asyncio"):
     client = DataAgentServiceAsyncClient(
         credentials=async_anonymous_credentials(),
         transport=transport,
@@ -5539,7 +5571,7 @@ async def test_set_iam_policy_async(
 
     # Everything is optional in proto3 as far as the runtime is concerned,
     # and we are mocking out the actual API, so just send an empty request.
-    request = request_type()
+    request = request_type
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(type(client.transport.set_iam_policy), "__call__") as call:
@@ -5562,11 +5594,6 @@ async def test_set_iam_policy_async(
     assert isinstance(response, policy_pb2.Policy)
     assert response.version == 774
     assert response.etag == b"etag_blob"
-
-
-@pytest.mark.asyncio
-async def test_set_iam_policy_async_from_dict():
-    await test_set_iam_policy_async(request_type=dict)
 
 
 def test_set_iam_policy_field_headers():
@@ -8146,7 +8173,6 @@ def test_list_data_agents_empty_call_grpc():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = data_agent_service.ListDataAgentsRequest()
-
         assert args[0] == request_msg
 
 
@@ -8169,7 +8195,6 @@ def test_list_accessible_data_agents_empty_call_grpc():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = data_agent_service.ListAccessibleDataAgentsRequest()
-
         assert args[0] == request_msg
 
 
@@ -8190,7 +8215,6 @@ def test_get_data_agent_empty_call_grpc():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = data_agent_service.GetDataAgentRequest()
-
         assert args[0] == request_msg
 
 
@@ -8213,7 +8237,6 @@ def test_create_data_agent_empty_call_grpc():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = data_agent_service.CreateDataAgentRequest()
-
         assert args[0] == request_msg
 
 
@@ -8236,7 +8259,6 @@ def test_create_data_agent_sync_empty_call_grpc():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = data_agent_service.CreateDataAgentRequest()
-
         assert args[0] == request_msg
 
 
@@ -8259,7 +8281,6 @@ def test_update_data_agent_empty_call_grpc():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = data_agent_service.UpdateDataAgentRequest()
-
         assert args[0] == request_msg
 
 
@@ -8282,7 +8303,6 @@ def test_update_data_agent_sync_empty_call_grpc():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = data_agent_service.UpdateDataAgentRequest()
-
         assert args[0] == request_msg
 
 
@@ -8305,7 +8325,6 @@ def test_delete_data_agent_empty_call_grpc():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = data_agent_service.DeleteDataAgentRequest()
-
         assert args[0] == request_msg
 
 
@@ -8328,7 +8347,6 @@ def test_delete_data_agent_sync_empty_call_grpc():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = data_agent_service.DeleteDataAgentRequest()
-
         assert args[0] == request_msg
 
 
@@ -8349,7 +8367,6 @@ def test_get_iam_policy_empty_call_grpc():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = iam_policy_pb2.GetIamPolicyRequest()
-
         assert args[0] == request_msg
 
 
@@ -8370,7 +8387,6 @@ def test_set_iam_policy_empty_call_grpc():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = iam_policy_pb2.SetIamPolicyRequest()
-
         assert args[0] == request_msg
 
 
@@ -8412,7 +8428,6 @@ async def test_list_data_agents_empty_call_grpc_asyncio():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = data_agent_service.ListDataAgentsRequest()
-
         assert args[0] == request_msg
 
 
@@ -8442,7 +8457,6 @@ async def test_list_accessible_data_agents_empty_call_grpc_asyncio():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = data_agent_service.ListAccessibleDataAgentsRequest()
-
         assert args[0] == request_msg
 
 
@@ -8472,7 +8486,6 @@ async def test_get_data_agent_empty_call_grpc_asyncio():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = data_agent_service.GetDataAgentRequest()
-
         assert args[0] == request_msg
 
 
@@ -8499,7 +8512,6 @@ async def test_create_data_agent_empty_call_grpc_asyncio():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = data_agent_service.CreateDataAgentRequest()
-
         assert args[0] == request_msg
 
 
@@ -8531,7 +8543,6 @@ async def test_create_data_agent_sync_empty_call_grpc_asyncio():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = data_agent_service.CreateDataAgentRequest()
-
         assert args[0] == request_msg
 
 
@@ -8558,7 +8569,6 @@ async def test_update_data_agent_empty_call_grpc_asyncio():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = data_agent_service.UpdateDataAgentRequest()
-
         assert args[0] == request_msg
 
 
@@ -8590,7 +8600,6 @@ async def test_update_data_agent_sync_empty_call_grpc_asyncio():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = data_agent_service.UpdateDataAgentRequest()
-
         assert args[0] == request_msg
 
 
@@ -8617,7 +8626,6 @@ async def test_delete_data_agent_empty_call_grpc_asyncio():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = data_agent_service.DeleteDataAgentRequest()
-
         assert args[0] == request_msg
 
 
@@ -8642,7 +8650,6 @@ async def test_delete_data_agent_sync_empty_call_grpc_asyncio():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = data_agent_service.DeleteDataAgentRequest()
-
         assert args[0] == request_msg
 
 
@@ -8670,7 +8677,6 @@ async def test_get_iam_policy_empty_call_grpc_asyncio():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = iam_policy_pb2.GetIamPolicyRequest()
-
         assert args[0] == request_msg
 
 
@@ -8698,7 +8704,6 @@ async def test_set_iam_policy_empty_call_grpc_asyncio():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = iam_policy_pb2.SetIamPolicyRequest()
-
         assert args[0] == request_msg
 
 
@@ -11389,7 +11394,6 @@ def test_list_data_agents_empty_call_rest():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = data_agent_service.ListDataAgentsRequest()
-
         assert args[0] == request_msg
 
 
@@ -11411,7 +11415,6 @@ def test_list_accessible_data_agents_empty_call_rest():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = data_agent_service.ListAccessibleDataAgentsRequest()
-
         assert args[0] == request_msg
 
 
@@ -11431,7 +11434,6 @@ def test_get_data_agent_empty_call_rest():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = data_agent_service.GetDataAgentRequest()
-
         assert args[0] == request_msg
 
 
@@ -11453,7 +11455,6 @@ def test_create_data_agent_empty_call_rest():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = data_agent_service.CreateDataAgentRequest()
-
         assert args[0] == request_msg
 
 
@@ -11475,7 +11476,6 @@ def test_create_data_agent_sync_empty_call_rest():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = data_agent_service.CreateDataAgentRequest()
-
         assert args[0] == request_msg
 
 
@@ -11497,7 +11497,6 @@ def test_update_data_agent_empty_call_rest():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = data_agent_service.UpdateDataAgentRequest()
-
         assert args[0] == request_msg
 
 
@@ -11519,7 +11518,6 @@ def test_update_data_agent_sync_empty_call_rest():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = data_agent_service.UpdateDataAgentRequest()
-
         assert args[0] == request_msg
 
 
@@ -11541,7 +11539,6 @@ def test_delete_data_agent_empty_call_rest():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = data_agent_service.DeleteDataAgentRequest()
-
         assert args[0] == request_msg
 
 
@@ -11563,7 +11560,6 @@ def test_delete_data_agent_sync_empty_call_rest():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = data_agent_service.DeleteDataAgentRequest()
-
         assert args[0] == request_msg
 
 
@@ -11583,7 +11579,6 @@ def test_get_iam_policy_empty_call_rest():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = iam_policy_pb2.GetIamPolicyRequest()
-
         assert args[0] == request_msg
 
 
@@ -11603,7 +11598,6 @@ def test_set_iam_policy_empty_call_rest():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = iam_policy_pb2.SetIamPolicyRequest()
-
         assert args[0] == request_msg
 
 

--- a/packages/google-cloud-geminidataanalytics/tests/unit/gapic/geminidataanalytics_v1/test_data_chat_service.py
+++ b/packages/google-cloud-geminidataanalytics/tests/unit/gapic/geminidataanalytics_v1/test_data_chat_service.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+import asyncio
 import json
 import math
 import os
@@ -117,6 +118,21 @@ def modify_default_endpoint_template(client):
         if ("localhost" in client._DEFAULT_ENDPOINT_TEMPLATE)
         else client._DEFAULT_ENDPOINT_TEMPLATE
     )
+
+
+@pytest.fixture(autouse=True)
+def set_event_loop():
+    try:
+        asyncio.get_running_loop()
+        yield
+    except RuntimeError:
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+        try:
+            yield
+        finally:
+            loop.close()
+            asyncio.set_event_loop(None)
 
 
 def test__get_default_mtls_endpoint():
@@ -1346,8 +1362,8 @@ def test_data_chat_service_client_create_channel_credentials_file(
 @pytest.mark.parametrize(
     "request_type",
     [
-        data_chat_service.ChatRequest,
-        dict,
+        data_chat_service.ChatRequest(),
+        {},
     ],
 )
 def test_chat(request_type, transport: str = "grpc"):
@@ -1358,7 +1374,7 @@ def test_chat(request_type, transport: str = "grpc"):
 
     # Everything is optional in proto3 as far as the runtime is concerned,
     # and we are mocking out the actual API, so just send an empty request.
-    request = request_type()
+    request = request_type
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(type(client.transport.chat), "__call__") as call:
@@ -1400,9 +1416,10 @@ def test_chat_non_empty_request_with_auto_populated_field():
         client.chat(request=request)
         call.assert_called()
         _, args, _ = call.mock_calls[0]
-        assert args[0] == data_chat_service.ChatRequest(
+        request_msg = data_chat_service.ChatRequest(
             parent="parent_value",
         )
+        assert args[0] == request_msg
 
 
 def test_chat_use_cached_wrapped_rpc():
@@ -1480,9 +1497,14 @@ async def test_chat_async_use_cached_wrapped_rpc(transport: str = "grpc_asyncio"
 
 
 @pytest.mark.asyncio
-async def test_chat_async(
-    transport: str = "grpc_asyncio", request_type=data_chat_service.ChatRequest
-):
+@pytest.mark.parametrize(
+    "request_type",
+    [
+        data_chat_service.ChatRequest(),
+        {},
+    ],
+)
+async def test_chat_async(request_type, transport: str = "grpc_asyncio"):
     client = DataChatServiceAsyncClient(
         credentials=async_anonymous_credentials(),
         transport=transport,
@@ -1490,7 +1512,7 @@ async def test_chat_async(
 
     # Everything is optional in proto3 as far as the runtime is concerned,
     # and we are mocking out the actual API, so just send an empty request.
-    request = request_type()
+    request = request_type
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(type(client.transport.chat), "__call__") as call:
@@ -1510,11 +1532,6 @@ async def test_chat_async(
     # Establish that the response is the type that we expect.
     message = await response.read()
     assert isinstance(message, data_chat_service.Message)
-
-
-@pytest.mark.asyncio
-async def test_chat_async_from_dict():
-    await test_chat_async(request_type=dict)
 
 
 def test_chat_field_headers():
@@ -1582,8 +1599,8 @@ async def test_chat_field_headers_async():
 @pytest.mark.parametrize(
     "request_type",
     [
-        gcg_conversation.CreateConversationRequest,
-        dict,
+        gcg_conversation.CreateConversationRequest(),
+        {},
     ],
 )
 def test_create_conversation(request_type, transport: str = "grpc"):
@@ -1594,7 +1611,7 @@ def test_create_conversation(request_type, transport: str = "grpc"):
 
     # Everything is optional in proto3 as far as the runtime is concerned,
     # and we are mocking out the actual API, so just send an empty request.
-    request = request_type()
+    request = request_type
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(
@@ -1649,10 +1666,11 @@ def test_create_conversation_non_empty_request_with_auto_populated_field():
         client.create_conversation(request=request)
         call.assert_called()
         _, args, _ = call.mock_calls[0]
-        assert args[0] == gcg_conversation.CreateConversationRequest(
+        request_msg = gcg_conversation.CreateConversationRequest(
             parent="parent_value",
             conversation_id="conversation_id_value",
         )
+        assert args[0] == request_msg
 
 
 def test_create_conversation_use_cached_wrapped_rpc():
@@ -1737,10 +1755,14 @@ async def test_create_conversation_async_use_cached_wrapped_rpc(
 
 
 @pytest.mark.asyncio
-async def test_create_conversation_async(
-    transport: str = "grpc_asyncio",
-    request_type=gcg_conversation.CreateConversationRequest,
-):
+@pytest.mark.parametrize(
+    "request_type",
+    [
+        gcg_conversation.CreateConversationRequest(),
+        {},
+    ],
+)
+async def test_create_conversation_async(request_type, transport: str = "grpc_asyncio"):
     client = DataChatServiceAsyncClient(
         credentials=async_anonymous_credentials(),
         transport=transport,
@@ -1748,7 +1770,7 @@ async def test_create_conversation_async(
 
     # Everything is optional in proto3 as far as the runtime is concerned,
     # and we are mocking out the actual API, so just send an empty request.
-    request = request_type()
+    request = request_type
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(
@@ -1777,11 +1799,6 @@ async def test_create_conversation_async(
     assert response.agents == ["agents_value"]
     assert response.kms_key == "kms_key_value"
     assert response.memory_paused is True
-
-
-@pytest.mark.asyncio
-async def test_create_conversation_async_from_dict():
-    await test_create_conversation_async(request_type=dict)
 
 
 def test_create_conversation_field_headers():
@@ -1958,8 +1975,8 @@ async def test_create_conversation_flattened_error_async():
 @pytest.mark.parametrize(
     "request_type",
     [
-        conversation.DeleteConversationRequest,
-        dict,
+        conversation.DeleteConversationRequest(),
+        {},
     ],
 )
 def test_delete_conversation(request_type, transport: str = "grpc"):
@@ -1970,7 +1987,7 @@ def test_delete_conversation(request_type, transport: str = "grpc"):
 
     # Everything is optional in proto3 as far as the runtime is concerned,
     # and we are mocking out the actual API, so just send an empty request.
-    request = request_type()
+    request = request_type
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(
@@ -2015,9 +2032,10 @@ def test_delete_conversation_non_empty_request_with_auto_populated_field():
         client.delete_conversation(request=request)
         call.assert_called()
         _, args, _ = call.mock_calls[0]
-        assert args[0] == conversation.DeleteConversationRequest(
+        request_msg = conversation.DeleteConversationRequest(
             name="name_value",
         )
+        assert args[0] == request_msg
 
 
 def test_delete_conversation_use_cached_wrapped_rpc():
@@ -2102,9 +2120,14 @@ async def test_delete_conversation_async_use_cached_wrapped_rpc(
 
 
 @pytest.mark.asyncio
-async def test_delete_conversation_async(
-    transport: str = "grpc_asyncio", request_type=conversation.DeleteConversationRequest
-):
+@pytest.mark.parametrize(
+    "request_type",
+    [
+        conversation.DeleteConversationRequest(),
+        {},
+    ],
+)
+async def test_delete_conversation_async(request_type, transport: str = "grpc_asyncio"):
     client = DataChatServiceAsyncClient(
         credentials=async_anonymous_credentials(),
         transport=transport,
@@ -2112,7 +2135,7 @@ async def test_delete_conversation_async(
 
     # Everything is optional in proto3 as far as the runtime is concerned,
     # and we are mocking out the actual API, so just send an empty request.
-    request = request_type()
+    request = request_type
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(
@@ -2130,11 +2153,6 @@ async def test_delete_conversation_async(
 
     # Establish that the response is the type that we expect.
     assert response is None
-
-
-@pytest.mark.asyncio
-async def test_delete_conversation_async_from_dict():
-    await test_delete_conversation_async(request_type=dict)
 
 
 def test_delete_conversation_field_headers():
@@ -2287,8 +2305,8 @@ async def test_delete_conversation_flattened_error_async():
 @pytest.mark.parametrize(
     "request_type",
     [
-        conversation.GetConversationRequest,
-        dict,
+        conversation.GetConversationRequest(),
+        {},
     ],
 )
 def test_get_conversation(request_type, transport: str = "grpc"):
@@ -2299,7 +2317,7 @@ def test_get_conversation(request_type, transport: str = "grpc"):
 
     # Everything is optional in proto3 as far as the runtime is concerned,
     # and we are mocking out the actual API, so just send an empty request.
-    request = request_type()
+    request = request_type
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(type(client.transport.get_conversation), "__call__") as call:
@@ -2349,9 +2367,10 @@ def test_get_conversation_non_empty_request_with_auto_populated_field():
         client.get_conversation(request=request)
         call.assert_called()
         _, args, _ = call.mock_calls[0]
-        assert args[0] == conversation.GetConversationRequest(
+        request_msg = conversation.GetConversationRequest(
             name="name_value",
         )
+        assert args[0] == request_msg
 
 
 def test_get_conversation_use_cached_wrapped_rpc():
@@ -2434,9 +2453,14 @@ async def test_get_conversation_async_use_cached_wrapped_rpc(
 
 
 @pytest.mark.asyncio
-async def test_get_conversation_async(
-    transport: str = "grpc_asyncio", request_type=conversation.GetConversationRequest
-):
+@pytest.mark.parametrize(
+    "request_type",
+    [
+        conversation.GetConversationRequest(),
+        {},
+    ],
+)
+async def test_get_conversation_async(request_type, transport: str = "grpc_asyncio"):
     client = DataChatServiceAsyncClient(
         credentials=async_anonymous_credentials(),
         transport=transport,
@@ -2444,7 +2468,7 @@ async def test_get_conversation_async(
 
     # Everything is optional in proto3 as far as the runtime is concerned,
     # and we are mocking out the actual API, so just send an empty request.
-    request = request_type()
+    request = request_type
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(type(client.transport.get_conversation), "__call__") as call:
@@ -2471,11 +2495,6 @@ async def test_get_conversation_async(
     assert response.agents == ["agents_value"]
     assert response.kms_key == "kms_key_value"
     assert response.memory_paused is True
-
-
-@pytest.mark.asyncio
-async def test_get_conversation_async_from_dict():
-    await test_get_conversation_async(request_type=dict)
 
 
 def test_get_conversation_field_headers():
@@ -2624,8 +2643,8 @@ async def test_get_conversation_flattened_error_async():
 @pytest.mark.parametrize(
     "request_type",
     [
-        conversation.ListConversationsRequest,
-        dict,
+        conversation.ListConversationsRequest(),
+        {},
     ],
 )
 def test_list_conversations(request_type, transport: str = "grpc"):
@@ -2636,7 +2655,7 @@ def test_list_conversations(request_type, transport: str = "grpc"):
 
     # Everything is optional in proto3 as far as the runtime is concerned,
     # and we are mocking out the actual API, so just send an empty request.
-    request = request_type()
+    request = request_type
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(
@@ -2686,11 +2705,12 @@ def test_list_conversations_non_empty_request_with_auto_populated_field():
         client.list_conversations(request=request)
         call.assert_called()
         _, args, _ = call.mock_calls[0]
-        assert args[0] == conversation.ListConversationsRequest(
+        request_msg = conversation.ListConversationsRequest(
             parent="parent_value",
             page_token="page_token_value",
             filter="filter_value",
         )
+        assert args[0] == request_msg
 
 
 def test_list_conversations_use_cached_wrapped_rpc():
@@ -2775,9 +2795,14 @@ async def test_list_conversations_async_use_cached_wrapped_rpc(
 
 
 @pytest.mark.asyncio
-async def test_list_conversations_async(
-    transport: str = "grpc_asyncio", request_type=conversation.ListConversationsRequest
-):
+@pytest.mark.parametrize(
+    "request_type",
+    [
+        conversation.ListConversationsRequest(),
+        {},
+    ],
+)
+async def test_list_conversations_async(request_type, transport: str = "grpc_asyncio"):
     client = DataChatServiceAsyncClient(
         credentials=async_anonymous_credentials(),
         transport=transport,
@@ -2785,7 +2810,7 @@ async def test_list_conversations_async(
 
     # Everything is optional in proto3 as far as the runtime is concerned,
     # and we are mocking out the actual API, so just send an empty request.
-    request = request_type()
+    request = request_type
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(
@@ -2808,11 +2833,6 @@ async def test_list_conversations_async(
     # Establish that the response is the type that we expect.
     assert isinstance(response, pagers.ListConversationsAsyncPager)
     assert response.next_page_token == "next_page_token_value"
-
-
-@pytest.mark.asyncio
-async def test_list_conversations_async_from_dict():
-    await test_list_conversations_async(request_type=dict)
 
 
 def test_list_conversations_field_headers():
@@ -3167,8 +3187,8 @@ async def test_list_conversations_async_pages():
 @pytest.mark.parametrize(
     "request_type",
     [
-        data_chat_service.ListMessagesRequest,
-        dict,
+        data_chat_service.ListMessagesRequest(),
+        {},
     ],
 )
 def test_list_messages(request_type, transport: str = "grpc"):
@@ -3179,7 +3199,7 @@ def test_list_messages(request_type, transport: str = "grpc"):
 
     # Everything is optional in proto3 as far as the runtime is concerned,
     # and we are mocking out the actual API, so just send an empty request.
-    request = request_type()
+    request = request_type
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(type(client.transport.list_messages), "__call__") as call:
@@ -3225,11 +3245,12 @@ def test_list_messages_non_empty_request_with_auto_populated_field():
         client.list_messages(request=request)
         call.assert_called()
         _, args, _ = call.mock_calls[0]
-        assert args[0] == data_chat_service.ListMessagesRequest(
+        request_msg = data_chat_service.ListMessagesRequest(
             parent="parent_value",
             page_token="page_token_value",
             filter="filter_value",
         )
+        assert args[0] == request_msg
 
 
 def test_list_messages_use_cached_wrapped_rpc():
@@ -3310,9 +3331,14 @@ async def test_list_messages_async_use_cached_wrapped_rpc(
 
 
 @pytest.mark.asyncio
-async def test_list_messages_async(
-    transport: str = "grpc_asyncio", request_type=data_chat_service.ListMessagesRequest
-):
+@pytest.mark.parametrize(
+    "request_type",
+    [
+        data_chat_service.ListMessagesRequest(),
+        {},
+    ],
+)
+async def test_list_messages_async(request_type, transport: str = "grpc_asyncio"):
     client = DataChatServiceAsyncClient(
         credentials=async_anonymous_credentials(),
         transport=transport,
@@ -3320,7 +3346,7 @@ async def test_list_messages_async(
 
     # Everything is optional in proto3 as far as the runtime is concerned,
     # and we are mocking out the actual API, so just send an empty request.
-    request = request_type()
+    request = request_type
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(type(client.transport.list_messages), "__call__") as call:
@@ -3341,11 +3367,6 @@ async def test_list_messages_async(
     # Establish that the response is the type that we expect.
     assert isinstance(response, pagers.ListMessagesAsyncPager)
     assert response.next_page_token == "next_page_token_value"
-
-
-@pytest.mark.asyncio
-async def test_list_messages_async_from_dict():
-    await test_list_messages_async(request_type=dict)
 
 
 def test_list_messages_field_headers():
@@ -5026,7 +5047,6 @@ def test_chat_empty_call_grpc():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = data_chat_service.ChatRequest()
-
         assert args[0] == request_msg
 
 
@@ -5049,7 +5069,6 @@ def test_create_conversation_empty_call_grpc():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = gcg_conversation.CreateConversationRequest()
-
         assert args[0] == request_msg
 
 
@@ -5072,7 +5091,6 @@ def test_delete_conversation_empty_call_grpc():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = conversation.DeleteConversationRequest()
-
         assert args[0] == request_msg
 
 
@@ -5093,7 +5111,6 @@ def test_get_conversation_empty_call_grpc():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = conversation.GetConversationRequest()
-
         assert args[0] == request_msg
 
 
@@ -5116,7 +5133,6 @@ def test_list_conversations_empty_call_grpc():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = conversation.ListConversationsRequest()
-
         assert args[0] == request_msg
 
 
@@ -5137,7 +5153,6 @@ def test_list_messages_empty_call_grpc():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = data_chat_service.ListMessagesRequest()
-
         assert args[0] == request_msg
 
 
@@ -5177,7 +5192,6 @@ async def test_chat_empty_call_grpc_asyncio():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = data_chat_service.ChatRequest()
-
         assert args[0] == request_msg
 
 
@@ -5209,7 +5223,6 @@ async def test_create_conversation_empty_call_grpc_asyncio():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = gcg_conversation.CreateConversationRequest()
-
         assert args[0] == request_msg
 
 
@@ -5234,7 +5247,6 @@ async def test_delete_conversation_empty_call_grpc_asyncio():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = conversation.DeleteConversationRequest()
-
         assert args[0] == request_msg
 
 
@@ -5264,7 +5276,6 @@ async def test_get_conversation_empty_call_grpc_asyncio():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = conversation.GetConversationRequest()
-
         assert args[0] == request_msg
 
 
@@ -5293,7 +5304,6 @@ async def test_list_conversations_empty_call_grpc_asyncio():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = conversation.ListConversationsRequest()
-
         assert args[0] == request_msg
 
 
@@ -5320,7 +5330,6 @@ async def test_list_messages_empty_call_grpc_asyncio():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = data_chat_service.ListMessagesRequest()
-
         assert args[0] == request_msg
 
 
@@ -6594,7 +6603,6 @@ def test_chat_empty_call_rest():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = data_chat_service.ChatRequest()
-
         assert args[0] == request_msg
 
 
@@ -6616,7 +6624,6 @@ def test_create_conversation_empty_call_rest():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = gcg_conversation.CreateConversationRequest()
-
         assert args[0] == request_msg
 
 
@@ -6638,7 +6645,6 @@ def test_delete_conversation_empty_call_rest():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = conversation.DeleteConversationRequest()
-
         assert args[0] == request_msg
 
 
@@ -6658,7 +6664,6 @@ def test_get_conversation_empty_call_rest():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = conversation.GetConversationRequest()
-
         assert args[0] == request_msg
 
 
@@ -6680,7 +6685,6 @@ def test_list_conversations_empty_call_rest():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = conversation.ListConversationsRequest()
-
         assert args[0] == request_msg
 
 
@@ -6700,7 +6704,6 @@ def test_list_messages_empty_call_rest():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = data_chat_service.ListMessagesRequest()
-
         assert args[0] == request_msg
 
 

--- a/packages/google-cloud-geminidataanalytics/tests/unit/gapic/geminidataanalytics_v1alpha/test_data_agent_service.py
+++ b/packages/google-cloud-geminidataanalytics/tests/unit/gapic/geminidataanalytics_v1alpha/test_data_agent_service.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+import asyncio
 import json
 import math
 import os
@@ -128,6 +129,21 @@ def modify_default_endpoint_template(client):
         if ("localhost" in client._DEFAULT_ENDPOINT_TEMPLATE)
         else client._DEFAULT_ENDPOINT_TEMPLATE
     )
+
+
+@pytest.fixture(autouse=True)
+def set_event_loop():
+    try:
+        asyncio.get_running_loop()
+        yield
+    except RuntimeError:
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+        try:
+            yield
+        finally:
+            loop.close()
+            asyncio.set_event_loop(None)
 
 
 def test__get_default_mtls_endpoint():
@@ -1363,8 +1379,8 @@ def test_data_agent_service_client_create_channel_credentials_file(
 @pytest.mark.parametrize(
     "request_type",
     [
-        data_agent_service.ListDataAgentsRequest,
-        dict,
+        data_agent_service.ListDataAgentsRequest(),
+        {},
     ],
 )
 def test_list_data_agents(request_type, transport: str = "grpc"):
@@ -1375,7 +1391,7 @@ def test_list_data_agents(request_type, transport: str = "grpc"):
 
     # Everything is optional in proto3 as far as the runtime is concerned,
     # and we are mocking out the actual API, so just send an empty request.
-    request = request_type()
+    request = request_type
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(type(client.transport.list_data_agents), "__call__") as call:
@@ -1424,12 +1440,13 @@ def test_list_data_agents_non_empty_request_with_auto_populated_field():
         client.list_data_agents(request=request)
         call.assert_called()
         _, args, _ = call.mock_calls[0]
-        assert args[0] == data_agent_service.ListDataAgentsRequest(
+        request_msg = data_agent_service.ListDataAgentsRequest(
             parent="parent_value",
             page_token="page_token_value",
             filter="filter_value",
             order_by="order_by_value",
         )
+        assert args[0] == request_msg
 
 
 def test_list_data_agents_use_cached_wrapped_rpc():
@@ -1512,10 +1529,14 @@ async def test_list_data_agents_async_use_cached_wrapped_rpc(
 
 
 @pytest.mark.asyncio
-async def test_list_data_agents_async(
-    transport: str = "grpc_asyncio",
-    request_type=data_agent_service.ListDataAgentsRequest,
-):
+@pytest.mark.parametrize(
+    "request_type",
+    [
+        data_agent_service.ListDataAgentsRequest(),
+        {},
+    ],
+)
+async def test_list_data_agents_async(request_type, transport: str = "grpc_asyncio"):
     client = DataAgentServiceAsyncClient(
         credentials=async_anonymous_credentials(),
         transport=transport,
@@ -1523,7 +1544,7 @@ async def test_list_data_agents_async(
 
     # Everything is optional in proto3 as far as the runtime is concerned,
     # and we are mocking out the actual API, so just send an empty request.
-    request = request_type()
+    request = request_type
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(type(client.transport.list_data_agents), "__call__") as call:
@@ -1546,11 +1567,6 @@ async def test_list_data_agents_async(
     assert isinstance(response, pagers.ListDataAgentsAsyncPager)
     assert response.next_page_token == "next_page_token_value"
     assert response.unreachable == ["unreachable_value"]
-
-
-@pytest.mark.asyncio
-async def test_list_data_agents_async_from_dict():
-    await test_list_data_agents_async(request_type=dict)
 
 
 def test_list_data_agents_field_headers():
@@ -1889,8 +1905,8 @@ async def test_list_data_agents_async_pages():
 @pytest.mark.parametrize(
     "request_type",
     [
-        data_agent_service.ListAccessibleDataAgentsRequest,
-        dict,
+        data_agent_service.ListAccessibleDataAgentsRequest(),
+        {},
     ],
 )
 def test_list_accessible_data_agents(request_type, transport: str = "grpc"):
@@ -1901,7 +1917,7 @@ def test_list_accessible_data_agents(request_type, transport: str = "grpc"):
 
     # Everything is optional in proto3 as far as the runtime is concerned,
     # and we are mocking out the actual API, so just send an empty request.
-    request = request_type()
+    request = request_type
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(
@@ -1954,12 +1970,13 @@ def test_list_accessible_data_agents_non_empty_request_with_auto_populated_field
         client.list_accessible_data_agents(request=request)
         call.assert_called()
         _, args, _ = call.mock_calls[0]
-        assert args[0] == data_agent_service.ListAccessibleDataAgentsRequest(
+        request_msg = data_agent_service.ListAccessibleDataAgentsRequest(
             parent="parent_value",
             page_token="page_token_value",
             filter="filter_value",
             order_by="order_by_value",
         )
+        assert args[0] == request_msg
 
 
 def test_list_accessible_data_agents_use_cached_wrapped_rpc():
@@ -2045,9 +2062,15 @@ async def test_list_accessible_data_agents_async_use_cached_wrapped_rpc(
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "request_type",
+    [
+        data_agent_service.ListAccessibleDataAgentsRequest(),
+        {},
+    ],
+)
 async def test_list_accessible_data_agents_async(
-    transport: str = "grpc_asyncio",
-    request_type=data_agent_service.ListAccessibleDataAgentsRequest,
+    request_type, transport: str = "grpc_asyncio"
 ):
     client = DataAgentServiceAsyncClient(
         credentials=async_anonymous_credentials(),
@@ -2056,7 +2079,7 @@ async def test_list_accessible_data_agents_async(
 
     # Everything is optional in proto3 as far as the runtime is concerned,
     # and we are mocking out the actual API, so just send an empty request.
-    request = request_type()
+    request = request_type
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(
@@ -2081,11 +2104,6 @@ async def test_list_accessible_data_agents_async(
     assert isinstance(response, pagers.ListAccessibleDataAgentsAsyncPager)
     assert response.next_page_token == "next_page_token_value"
     assert response.unreachable == ["unreachable_value"]
-
-
-@pytest.mark.asyncio
-async def test_list_accessible_data_agents_async_from_dict():
-    await test_list_accessible_data_agents_async(request_type=dict)
 
 
 def test_list_accessible_data_agents_field_headers():
@@ -2442,8 +2460,8 @@ async def test_list_accessible_data_agents_async_pages():
 @pytest.mark.parametrize(
     "request_type",
     [
-        data_agent_service.GetDataAgentRequest,
-        dict,
+        data_agent_service.GetDataAgentRequest(),
+        {},
     ],
 )
 def test_get_data_agent(request_type, transport: str = "grpc"):
@@ -2454,7 +2472,7 @@ def test_get_data_agent(request_type, transport: str = "grpc"):
 
     # Everything is optional in proto3 as far as the runtime is concerned,
     # and we are mocking out the actual API, so just send an empty request.
-    request = request_type()
+    request = request_type
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(type(client.transport.get_data_agent), "__call__") as call:
@@ -2502,9 +2520,10 @@ def test_get_data_agent_non_empty_request_with_auto_populated_field():
         client.get_data_agent(request=request)
         call.assert_called()
         _, args, _ = call.mock_calls[0]
-        assert args[0] == data_agent_service.GetDataAgentRequest(
+        request_msg = data_agent_service.GetDataAgentRequest(
             name="name_value",
         )
+        assert args[0] == request_msg
 
 
 def test_get_data_agent_use_cached_wrapped_rpc():
@@ -2585,9 +2604,14 @@ async def test_get_data_agent_async_use_cached_wrapped_rpc(
 
 
 @pytest.mark.asyncio
-async def test_get_data_agent_async(
-    transport: str = "grpc_asyncio", request_type=data_agent_service.GetDataAgentRequest
-):
+@pytest.mark.parametrize(
+    "request_type",
+    [
+        data_agent_service.GetDataAgentRequest(),
+        {},
+    ],
+)
+async def test_get_data_agent_async(request_type, transport: str = "grpc_asyncio"):
     client = DataAgentServiceAsyncClient(
         credentials=async_anonymous_credentials(),
         transport=transport,
@@ -2595,7 +2619,7 @@ async def test_get_data_agent_async(
 
     # Everything is optional in proto3 as far as the runtime is concerned,
     # and we are mocking out the actual API, so just send an empty request.
-    request = request_type()
+    request = request_type
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(type(client.transport.get_data_agent), "__call__") as call:
@@ -2620,11 +2644,6 @@ async def test_get_data_agent_async(
     assert response.name == "name_value"
     assert response.display_name == "display_name_value"
     assert response.description == "description_value"
-
-
-@pytest.mark.asyncio
-async def test_get_data_agent_async_from_dict():
-    await test_get_data_agent_async(request_type=dict)
 
 
 def test_get_data_agent_field_headers():
@@ -2773,8 +2792,8 @@ async def test_get_data_agent_flattened_error_async():
 @pytest.mark.parametrize(
     "request_type",
     [
-        data_agent_service.CreateDataAgentRequest,
-        dict,
+        data_agent_service.CreateDataAgentRequest(),
+        {},
     ],
 )
 def test_create_data_agent(request_type, transport: str = "grpc"):
@@ -2785,7 +2804,7 @@ def test_create_data_agent(request_type, transport: str = "grpc"):
 
     # Everything is optional in proto3 as far as the runtime is concerned,
     # and we are mocking out the actual API, so just send an empty request.
-    request = request_type()
+    request = request_type
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(
@@ -2831,10 +2850,11 @@ def test_create_data_agent_non_empty_request_with_auto_populated_field():
         client.create_data_agent(request=request)
         call.assert_called()
         _, args, _ = call.mock_calls[0]
-        assert args[0] == data_agent_service.CreateDataAgentRequest(
+        request_msg = data_agent_service.CreateDataAgentRequest(
             parent="parent_value",
             data_agent_id="data_agent_id_value",
         )
+        assert args[0] == request_msg
 
 
 def test_create_data_agent_use_cached_wrapped_rpc():
@@ -2927,10 +2947,14 @@ async def test_create_data_agent_async_use_cached_wrapped_rpc(
 
 
 @pytest.mark.asyncio
-async def test_create_data_agent_async(
-    transport: str = "grpc_asyncio",
-    request_type=data_agent_service.CreateDataAgentRequest,
-):
+@pytest.mark.parametrize(
+    "request_type",
+    [
+        data_agent_service.CreateDataAgentRequest(),
+        {},
+    ],
+)
+async def test_create_data_agent_async(request_type, transport: str = "grpc_asyncio"):
     client = DataAgentServiceAsyncClient(
         credentials=async_anonymous_credentials(),
         transport=transport,
@@ -2938,7 +2962,7 @@ async def test_create_data_agent_async(
 
     # Everything is optional in proto3 as far as the runtime is concerned,
     # and we are mocking out the actual API, so just send an empty request.
-    request = request_type()
+    request = request_type
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(
@@ -2958,11 +2982,6 @@ async def test_create_data_agent_async(
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, future.Future)
-
-
-@pytest.mark.asyncio
-async def test_create_data_agent_async_from_dict():
-    await test_create_data_agent_async(request_type=dict)
 
 
 def test_create_data_agent_field_headers():
@@ -3175,8 +3194,8 @@ async def test_create_data_agent_flattened_error_async():
 @pytest.mark.parametrize(
     "request_type",
     [
-        data_agent_service.CreateDataAgentRequest,
-        dict,
+        data_agent_service.CreateDataAgentRequest(),
+        {},
     ],
 )
 def test_create_data_agent_sync(request_type, transport: str = "grpc"):
@@ -3187,7 +3206,7 @@ def test_create_data_agent_sync(request_type, transport: str = "grpc"):
 
     # Everything is optional in proto3 as far as the runtime is concerned,
     # and we are mocking out the actual API, so just send an empty request.
-    request = request_type()
+    request = request_type
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(
@@ -3240,10 +3259,11 @@ def test_create_data_agent_sync_non_empty_request_with_auto_populated_field():
         client.create_data_agent_sync(request=request)
         call.assert_called()
         _, args, _ = call.mock_calls[0]
-        assert args[0] == data_agent_service.CreateDataAgentRequest(
+        request_msg = data_agent_service.CreateDataAgentRequest(
             parent="parent_value",
             data_agent_id="data_agent_id_value",
         )
+        assert args[0] == request_msg
 
 
 def test_create_data_agent_sync_use_cached_wrapped_rpc():
@@ -3329,9 +3349,15 @@ async def test_create_data_agent_sync_async_use_cached_wrapped_rpc(
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "request_type",
+    [
+        data_agent_service.CreateDataAgentRequest(),
+        {},
+    ],
+)
 async def test_create_data_agent_sync_async(
-    transport: str = "grpc_asyncio",
-    request_type=data_agent_service.CreateDataAgentRequest,
+    request_type, transport: str = "grpc_asyncio"
 ):
     client = DataAgentServiceAsyncClient(
         credentials=async_anonymous_credentials(),
@@ -3340,7 +3366,7 @@ async def test_create_data_agent_sync_async(
 
     # Everything is optional in proto3 as far as the runtime is concerned,
     # and we are mocking out the actual API, so just send an empty request.
-    request = request_type()
+    request = request_type
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(
@@ -3367,11 +3393,6 @@ async def test_create_data_agent_sync_async(
     assert response.name == "name_value"
     assert response.display_name == "display_name_value"
     assert response.description == "description_value"
-
-
-@pytest.mark.asyncio
-async def test_create_data_agent_sync_async_from_dict():
-    await test_create_data_agent_sync_async(request_type=dict)
 
 
 def test_create_data_agent_sync_field_headers():
@@ -3584,8 +3605,8 @@ async def test_create_data_agent_sync_flattened_error_async():
 @pytest.mark.parametrize(
     "request_type",
     [
-        data_agent_service.UpdateDataAgentRequest,
-        dict,
+        data_agent_service.UpdateDataAgentRequest(),
+        {},
     ],
 )
 def test_update_data_agent(request_type, transport: str = "grpc"):
@@ -3596,7 +3617,7 @@ def test_update_data_agent(request_type, transport: str = "grpc"):
 
     # Everything is optional in proto3 as far as the runtime is concerned,
     # and we are mocking out the actual API, so just send an empty request.
-    request = request_type()
+    request = request_type
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(
@@ -3639,7 +3660,8 @@ def test_update_data_agent_non_empty_request_with_auto_populated_field():
         client.update_data_agent(request=request)
         call.assert_called()
         _, args, _ = call.mock_calls[0]
-        assert args[0] == data_agent_service.UpdateDataAgentRequest()
+        request_msg = data_agent_service.UpdateDataAgentRequest()
+        assert args[0] == request_msg
 
 
 def test_update_data_agent_use_cached_wrapped_rpc():
@@ -3732,10 +3754,14 @@ async def test_update_data_agent_async_use_cached_wrapped_rpc(
 
 
 @pytest.mark.asyncio
-async def test_update_data_agent_async(
-    transport: str = "grpc_asyncio",
-    request_type=data_agent_service.UpdateDataAgentRequest,
-):
+@pytest.mark.parametrize(
+    "request_type",
+    [
+        data_agent_service.UpdateDataAgentRequest(),
+        {},
+    ],
+)
+async def test_update_data_agent_async(request_type, transport: str = "grpc_asyncio"):
     client = DataAgentServiceAsyncClient(
         credentials=async_anonymous_credentials(),
         transport=transport,
@@ -3743,7 +3769,7 @@ async def test_update_data_agent_async(
 
     # Everything is optional in proto3 as far as the runtime is concerned,
     # and we are mocking out the actual API, so just send an empty request.
-    request = request_type()
+    request = request_type
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(
@@ -3763,11 +3789,6 @@ async def test_update_data_agent_async(
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, future.Future)
-
-
-@pytest.mark.asyncio
-async def test_update_data_agent_async_from_dict():
-    await test_update_data_agent_async(request_type=dict)
 
 
 def test_update_data_agent_field_headers():
@@ -3970,8 +3991,8 @@ async def test_update_data_agent_flattened_error_async():
 @pytest.mark.parametrize(
     "request_type",
     [
-        data_agent_service.UpdateDataAgentRequest,
-        dict,
+        data_agent_service.UpdateDataAgentRequest(),
+        {},
     ],
 )
 def test_update_data_agent_sync(request_type, transport: str = "grpc"):
@@ -3982,7 +4003,7 @@ def test_update_data_agent_sync(request_type, transport: str = "grpc"):
 
     # Everything is optional in proto3 as far as the runtime is concerned,
     # and we are mocking out the actual API, so just send an empty request.
-    request = request_type()
+    request = request_type
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(
@@ -4032,7 +4053,8 @@ def test_update_data_agent_sync_non_empty_request_with_auto_populated_field():
         client.update_data_agent_sync(request=request)
         call.assert_called()
         _, args, _ = call.mock_calls[0]
-        assert args[0] == data_agent_service.UpdateDataAgentRequest()
+        request_msg = data_agent_service.UpdateDataAgentRequest()
+        assert args[0] == request_msg
 
 
 def test_update_data_agent_sync_use_cached_wrapped_rpc():
@@ -4118,9 +4140,15 @@ async def test_update_data_agent_sync_async_use_cached_wrapped_rpc(
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "request_type",
+    [
+        data_agent_service.UpdateDataAgentRequest(),
+        {},
+    ],
+)
 async def test_update_data_agent_sync_async(
-    transport: str = "grpc_asyncio",
-    request_type=data_agent_service.UpdateDataAgentRequest,
+    request_type, transport: str = "grpc_asyncio"
 ):
     client = DataAgentServiceAsyncClient(
         credentials=async_anonymous_credentials(),
@@ -4129,7 +4157,7 @@ async def test_update_data_agent_sync_async(
 
     # Everything is optional in proto3 as far as the runtime is concerned,
     # and we are mocking out the actual API, so just send an empty request.
-    request = request_type()
+    request = request_type
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(
@@ -4156,11 +4184,6 @@ async def test_update_data_agent_sync_async(
     assert response.name == "name_value"
     assert response.display_name == "display_name_value"
     assert response.description == "description_value"
-
-
-@pytest.mark.asyncio
-async def test_update_data_agent_sync_async_from_dict():
-    await test_update_data_agent_sync_async(request_type=dict)
 
 
 def test_update_data_agent_sync_field_headers():
@@ -4363,8 +4386,8 @@ async def test_update_data_agent_sync_flattened_error_async():
 @pytest.mark.parametrize(
     "request_type",
     [
-        data_agent_service.DeleteDataAgentRequest,
-        dict,
+        data_agent_service.DeleteDataAgentRequest(),
+        {},
     ],
 )
 def test_delete_data_agent(request_type, transport: str = "grpc"):
@@ -4375,7 +4398,7 @@ def test_delete_data_agent(request_type, transport: str = "grpc"):
 
     # Everything is optional in proto3 as far as the runtime is concerned,
     # and we are mocking out the actual API, so just send an empty request.
-    request = request_type()
+    request = request_type
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(
@@ -4420,9 +4443,10 @@ def test_delete_data_agent_non_empty_request_with_auto_populated_field():
         client.delete_data_agent(request=request)
         call.assert_called()
         _, args, _ = call.mock_calls[0]
-        assert args[0] == data_agent_service.DeleteDataAgentRequest(
+        request_msg = data_agent_service.DeleteDataAgentRequest(
             name="name_value",
         )
+        assert args[0] == request_msg
 
 
 def test_delete_data_agent_use_cached_wrapped_rpc():
@@ -4515,10 +4539,14 @@ async def test_delete_data_agent_async_use_cached_wrapped_rpc(
 
 
 @pytest.mark.asyncio
-async def test_delete_data_agent_async(
-    transport: str = "grpc_asyncio",
-    request_type=data_agent_service.DeleteDataAgentRequest,
-):
+@pytest.mark.parametrize(
+    "request_type",
+    [
+        data_agent_service.DeleteDataAgentRequest(),
+        {},
+    ],
+)
+async def test_delete_data_agent_async(request_type, transport: str = "grpc_asyncio"):
     client = DataAgentServiceAsyncClient(
         credentials=async_anonymous_credentials(),
         transport=transport,
@@ -4526,7 +4554,7 @@ async def test_delete_data_agent_async(
 
     # Everything is optional in proto3 as far as the runtime is concerned,
     # and we are mocking out the actual API, so just send an empty request.
-    request = request_type()
+    request = request_type
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(
@@ -4546,11 +4574,6 @@ async def test_delete_data_agent_async(
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, future.Future)
-
-
-@pytest.mark.asyncio
-async def test_delete_data_agent_async_from_dict():
-    await test_delete_data_agent_async(request_type=dict)
 
 
 def test_delete_data_agent_field_headers():
@@ -4707,8 +4730,8 @@ async def test_delete_data_agent_flattened_error_async():
 @pytest.mark.parametrize(
     "request_type",
     [
-        data_agent_service.DeleteDataAgentRequest,
-        dict,
+        data_agent_service.DeleteDataAgentRequest(),
+        {},
     ],
 )
 def test_delete_data_agent_sync(request_type, transport: str = "grpc"):
@@ -4719,7 +4742,7 @@ def test_delete_data_agent_sync(request_type, transport: str = "grpc"):
 
     # Everything is optional in proto3 as far as the runtime is concerned,
     # and we are mocking out the actual API, so just send an empty request.
-    request = request_type()
+    request = request_type
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(
@@ -4764,9 +4787,10 @@ def test_delete_data_agent_sync_non_empty_request_with_auto_populated_field():
         client.delete_data_agent_sync(request=request)
         call.assert_called()
         _, args, _ = call.mock_calls[0]
-        assert args[0] == data_agent_service.DeleteDataAgentRequest(
+        request_msg = data_agent_service.DeleteDataAgentRequest(
             name="name_value",
         )
+        assert args[0] == request_msg
 
 
 def test_delete_data_agent_sync_use_cached_wrapped_rpc():
@@ -4852,9 +4876,15 @@ async def test_delete_data_agent_sync_async_use_cached_wrapped_rpc(
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "request_type",
+    [
+        data_agent_service.DeleteDataAgentRequest(),
+        {},
+    ],
+)
 async def test_delete_data_agent_sync_async(
-    transport: str = "grpc_asyncio",
-    request_type=data_agent_service.DeleteDataAgentRequest,
+    request_type, transport: str = "grpc_asyncio"
 ):
     client = DataAgentServiceAsyncClient(
         credentials=async_anonymous_credentials(),
@@ -4863,7 +4893,7 @@ async def test_delete_data_agent_sync_async(
 
     # Everything is optional in proto3 as far as the runtime is concerned,
     # and we are mocking out the actual API, so just send an empty request.
-    request = request_type()
+    request = request_type
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(
@@ -4881,11 +4911,6 @@ async def test_delete_data_agent_sync_async(
 
     # Establish that the response is the type that we expect.
     assert response is None
-
-
-@pytest.mark.asyncio
-async def test_delete_data_agent_sync_async_from_dict():
-    await test_delete_data_agent_sync_async(request_type=dict)
 
 
 def test_delete_data_agent_sync_field_headers():
@@ -5038,8 +5063,8 @@ async def test_delete_data_agent_sync_flattened_error_async():
 @pytest.mark.parametrize(
     "request_type",
     [
-        iam_policy_pb2.GetIamPolicyRequest,
-        dict,
+        iam_policy_pb2.GetIamPolicyRequest(),
+        {},
     ],
 )
 def test_get_iam_policy(request_type, transport: str = "grpc"):
@@ -5050,7 +5075,7 @@ def test_get_iam_policy(request_type, transport: str = "grpc"):
 
     # Everything is optional in proto3 as far as the runtime is concerned,
     # and we are mocking out the actual API, so just send an empty request.
-    request = request_type()
+    request = request_type
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(type(client.transport.get_iam_policy), "__call__") as call:
@@ -5096,9 +5121,10 @@ def test_get_iam_policy_non_empty_request_with_auto_populated_field():
         client.get_iam_policy(request=request)
         call.assert_called()
         _, args, _ = call.mock_calls[0]
-        assert args[0] == iam_policy_pb2.GetIamPolicyRequest(
+        request_msg = iam_policy_pb2.GetIamPolicyRequest(
             resource="resource_value",
         )
+        assert args[0] == request_msg
 
 
 def test_get_iam_policy_use_cached_wrapped_rpc():
@@ -5179,9 +5205,14 @@ async def test_get_iam_policy_async_use_cached_wrapped_rpc(
 
 
 @pytest.mark.asyncio
-async def test_get_iam_policy_async(
-    transport: str = "grpc_asyncio", request_type=iam_policy_pb2.GetIamPolicyRequest
-):
+@pytest.mark.parametrize(
+    "request_type",
+    [
+        iam_policy_pb2.GetIamPolicyRequest(),
+        {},
+    ],
+)
+async def test_get_iam_policy_async(request_type, transport: str = "grpc_asyncio"):
     client = DataAgentServiceAsyncClient(
         credentials=async_anonymous_credentials(),
         transport=transport,
@@ -5189,7 +5220,7 @@ async def test_get_iam_policy_async(
 
     # Everything is optional in proto3 as far as the runtime is concerned,
     # and we are mocking out the actual API, so just send an empty request.
-    request = request_type()
+    request = request_type
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(type(client.transport.get_iam_policy), "__call__") as call:
@@ -5212,11 +5243,6 @@ async def test_get_iam_policy_async(
     assert isinstance(response, policy_pb2.Policy)
     assert response.version == 774
     assert response.etag == b"etag_blob"
-
-
-@pytest.mark.asyncio
-async def test_get_iam_policy_async_from_dict():
-    await test_get_iam_policy_async(request_type=dict)
 
 
 def test_get_iam_policy_field_headers():
@@ -5378,8 +5404,8 @@ async def test_get_iam_policy_flattened_error_async():
 @pytest.mark.parametrize(
     "request_type",
     [
-        iam_policy_pb2.SetIamPolicyRequest,
-        dict,
+        iam_policy_pb2.SetIamPolicyRequest(),
+        {},
     ],
 )
 def test_set_iam_policy(request_type, transport: str = "grpc"):
@@ -5390,7 +5416,7 @@ def test_set_iam_policy(request_type, transport: str = "grpc"):
 
     # Everything is optional in proto3 as far as the runtime is concerned,
     # and we are mocking out the actual API, so just send an empty request.
-    request = request_type()
+    request = request_type
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(type(client.transport.set_iam_policy), "__call__") as call:
@@ -5436,9 +5462,10 @@ def test_set_iam_policy_non_empty_request_with_auto_populated_field():
         client.set_iam_policy(request=request)
         call.assert_called()
         _, args, _ = call.mock_calls[0]
-        assert args[0] == iam_policy_pb2.SetIamPolicyRequest(
+        request_msg = iam_policy_pb2.SetIamPolicyRequest(
             resource="resource_value",
         )
+        assert args[0] == request_msg
 
 
 def test_set_iam_policy_use_cached_wrapped_rpc():
@@ -5519,9 +5546,14 @@ async def test_set_iam_policy_async_use_cached_wrapped_rpc(
 
 
 @pytest.mark.asyncio
-async def test_set_iam_policy_async(
-    transport: str = "grpc_asyncio", request_type=iam_policy_pb2.SetIamPolicyRequest
-):
+@pytest.mark.parametrize(
+    "request_type",
+    [
+        iam_policy_pb2.SetIamPolicyRequest(),
+        {},
+    ],
+)
+async def test_set_iam_policy_async(request_type, transport: str = "grpc_asyncio"):
     client = DataAgentServiceAsyncClient(
         credentials=async_anonymous_credentials(),
         transport=transport,
@@ -5529,7 +5561,7 @@ async def test_set_iam_policy_async(
 
     # Everything is optional in proto3 as far as the runtime is concerned,
     # and we are mocking out the actual API, so just send an empty request.
-    request = request_type()
+    request = request_type
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(type(client.transport.set_iam_policy), "__call__") as call:
@@ -5552,11 +5584,6 @@ async def test_set_iam_policy_async(
     assert isinstance(response, policy_pb2.Policy)
     assert response.version == 774
     assert response.etag == b"etag_blob"
-
-
-@pytest.mark.asyncio
-async def test_set_iam_policy_async_from_dict():
-    await test_set_iam_policy_async(request_type=dict)
 
 
 def test_set_iam_policy_field_headers():
@@ -8140,7 +8167,6 @@ def test_list_data_agents_empty_call_grpc():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = data_agent_service.ListDataAgentsRequest()
-
         assert args[0] == request_msg
 
 
@@ -8163,7 +8189,6 @@ def test_list_accessible_data_agents_empty_call_grpc():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = data_agent_service.ListAccessibleDataAgentsRequest()
-
         assert args[0] == request_msg
 
 
@@ -8184,7 +8209,6 @@ def test_get_data_agent_empty_call_grpc():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = data_agent_service.GetDataAgentRequest()
-
         assert args[0] == request_msg
 
 
@@ -8207,7 +8231,6 @@ def test_create_data_agent_empty_call_grpc():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = data_agent_service.CreateDataAgentRequest()
-
         assert args[0] == request_msg
 
 
@@ -8230,7 +8253,6 @@ def test_create_data_agent_sync_empty_call_grpc():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = data_agent_service.CreateDataAgentRequest()
-
         assert args[0] == request_msg
 
 
@@ -8253,7 +8275,6 @@ def test_update_data_agent_empty_call_grpc():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = data_agent_service.UpdateDataAgentRequest()
-
         assert args[0] == request_msg
 
 
@@ -8276,7 +8297,6 @@ def test_update_data_agent_sync_empty_call_grpc():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = data_agent_service.UpdateDataAgentRequest()
-
         assert args[0] == request_msg
 
 
@@ -8299,7 +8319,6 @@ def test_delete_data_agent_empty_call_grpc():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = data_agent_service.DeleteDataAgentRequest()
-
         assert args[0] == request_msg
 
 
@@ -8322,7 +8341,6 @@ def test_delete_data_agent_sync_empty_call_grpc():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = data_agent_service.DeleteDataAgentRequest()
-
         assert args[0] == request_msg
 
 
@@ -8343,7 +8361,6 @@ def test_get_iam_policy_empty_call_grpc():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = iam_policy_pb2.GetIamPolicyRequest()
-
         assert args[0] == request_msg
 
 
@@ -8364,7 +8381,6 @@ def test_set_iam_policy_empty_call_grpc():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = iam_policy_pb2.SetIamPolicyRequest()
-
         assert args[0] == request_msg
 
 
@@ -8406,7 +8422,6 @@ async def test_list_data_agents_empty_call_grpc_asyncio():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = data_agent_service.ListDataAgentsRequest()
-
         assert args[0] == request_msg
 
 
@@ -8436,7 +8451,6 @@ async def test_list_accessible_data_agents_empty_call_grpc_asyncio():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = data_agent_service.ListAccessibleDataAgentsRequest()
-
         assert args[0] == request_msg
 
 
@@ -8465,7 +8479,6 @@ async def test_get_data_agent_empty_call_grpc_asyncio():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = data_agent_service.GetDataAgentRequest()
-
         assert args[0] == request_msg
 
 
@@ -8492,7 +8505,6 @@ async def test_create_data_agent_empty_call_grpc_asyncio():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = data_agent_service.CreateDataAgentRequest()
-
         assert args[0] == request_msg
 
 
@@ -8523,7 +8535,6 @@ async def test_create_data_agent_sync_empty_call_grpc_asyncio():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = data_agent_service.CreateDataAgentRequest()
-
         assert args[0] == request_msg
 
 
@@ -8550,7 +8561,6 @@ async def test_update_data_agent_empty_call_grpc_asyncio():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = data_agent_service.UpdateDataAgentRequest()
-
         assert args[0] == request_msg
 
 
@@ -8581,7 +8591,6 @@ async def test_update_data_agent_sync_empty_call_grpc_asyncio():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = data_agent_service.UpdateDataAgentRequest()
-
         assert args[0] == request_msg
 
 
@@ -8608,7 +8617,6 @@ async def test_delete_data_agent_empty_call_grpc_asyncio():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = data_agent_service.DeleteDataAgentRequest()
-
         assert args[0] == request_msg
 
 
@@ -8633,7 +8641,6 @@ async def test_delete_data_agent_sync_empty_call_grpc_asyncio():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = data_agent_service.DeleteDataAgentRequest()
-
         assert args[0] == request_msg
 
 
@@ -8661,7 +8668,6 @@ async def test_get_iam_policy_empty_call_grpc_asyncio():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = iam_policy_pb2.GetIamPolicyRequest()
-
         assert args[0] == request_msg
 
 
@@ -8689,7 +8695,6 @@ async def test_set_iam_policy_empty_call_grpc_asyncio():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = iam_policy_pb2.SetIamPolicyRequest()
-
         assert args[0] == request_msg
 
 
@@ -11466,7 +11471,6 @@ def test_list_data_agents_empty_call_rest():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = data_agent_service.ListDataAgentsRequest()
-
         assert args[0] == request_msg
 
 
@@ -11488,7 +11492,6 @@ def test_list_accessible_data_agents_empty_call_rest():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = data_agent_service.ListAccessibleDataAgentsRequest()
-
         assert args[0] == request_msg
 
 
@@ -11508,7 +11511,6 @@ def test_get_data_agent_empty_call_rest():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = data_agent_service.GetDataAgentRequest()
-
         assert args[0] == request_msg
 
 
@@ -11530,7 +11532,6 @@ def test_create_data_agent_empty_call_rest():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = data_agent_service.CreateDataAgentRequest()
-
         assert args[0] == request_msg
 
 
@@ -11552,7 +11553,6 @@ def test_create_data_agent_sync_empty_call_rest():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = data_agent_service.CreateDataAgentRequest()
-
         assert args[0] == request_msg
 
 
@@ -11574,7 +11574,6 @@ def test_update_data_agent_empty_call_rest():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = data_agent_service.UpdateDataAgentRequest()
-
         assert args[0] == request_msg
 
 
@@ -11596,7 +11595,6 @@ def test_update_data_agent_sync_empty_call_rest():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = data_agent_service.UpdateDataAgentRequest()
-
         assert args[0] == request_msg
 
 
@@ -11618,7 +11616,6 @@ def test_delete_data_agent_empty_call_rest():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = data_agent_service.DeleteDataAgentRequest()
-
         assert args[0] == request_msg
 
 
@@ -11640,7 +11637,6 @@ def test_delete_data_agent_sync_empty_call_rest():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = data_agent_service.DeleteDataAgentRequest()
-
         assert args[0] == request_msg
 
 
@@ -11660,7 +11656,6 @@ def test_get_iam_policy_empty_call_rest():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = iam_policy_pb2.GetIamPolicyRequest()
-
         assert args[0] == request_msg
 
 
@@ -11680,7 +11675,6 @@ def test_set_iam_policy_empty_call_rest():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = iam_policy_pb2.SetIamPolicyRequest()
-
         assert args[0] == request_msg
 
 

--- a/packages/google-cloud-geminidataanalytics/tests/unit/gapic/geminidataanalytics_v1alpha/test_data_chat_service.py
+++ b/packages/google-cloud-geminidataanalytics/tests/unit/gapic/geminidataanalytics_v1alpha/test_data_chat_service.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+import asyncio
 import json
 import math
 import os
@@ -120,6 +121,21 @@ def modify_default_endpoint_template(client):
         if ("localhost" in client._DEFAULT_ENDPOINT_TEMPLATE)
         else client._DEFAULT_ENDPOINT_TEMPLATE
     )
+
+
+@pytest.fixture(autouse=True)
+def set_event_loop():
+    try:
+        asyncio.get_running_loop()
+        yield
+    except RuntimeError:
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+        try:
+            yield
+        finally:
+            loop.close()
+            asyncio.set_event_loop(None)
 
 
 def test__get_default_mtls_endpoint():
@@ -1349,8 +1365,8 @@ def test_data_chat_service_client_create_channel_credentials_file(
 @pytest.mark.parametrize(
     "request_type",
     [
-        data_chat_service.ChatRequest,
-        dict,
+        data_chat_service.ChatRequest(),
+        {},
     ],
 )
 def test_chat(request_type, transport: str = "grpc"):
@@ -1361,7 +1377,7 @@ def test_chat(request_type, transport: str = "grpc"):
 
     # Everything is optional in proto3 as far as the runtime is concerned,
     # and we are mocking out the actual API, so just send an empty request.
-    request = request_type()
+    request = request_type
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(type(client.transport.chat), "__call__") as call:
@@ -1404,10 +1420,11 @@ def test_chat_non_empty_request_with_auto_populated_field():
         client.chat(request=request)
         call.assert_called()
         _, args, _ = call.mock_calls[0]
-        assert args[0] == data_chat_service.ChatRequest(
+        request_msg = data_chat_service.ChatRequest(
             project="project_value",
             parent="parent_value",
         )
+        assert args[0] == request_msg
 
 
 def test_chat_use_cached_wrapped_rpc():
@@ -1485,9 +1502,14 @@ async def test_chat_async_use_cached_wrapped_rpc(transport: str = "grpc_asyncio"
 
 
 @pytest.mark.asyncio
-async def test_chat_async(
-    transport: str = "grpc_asyncio", request_type=data_chat_service.ChatRequest
-):
+@pytest.mark.parametrize(
+    "request_type",
+    [
+        data_chat_service.ChatRequest(),
+        {},
+    ],
+)
+async def test_chat_async(request_type, transport: str = "grpc_asyncio"):
     client = DataChatServiceAsyncClient(
         credentials=async_anonymous_credentials(),
         transport=transport,
@@ -1495,7 +1517,7 @@ async def test_chat_async(
 
     # Everything is optional in proto3 as far as the runtime is concerned,
     # and we are mocking out the actual API, so just send an empty request.
-    request = request_type()
+    request = request_type
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(type(client.transport.chat), "__call__") as call:
@@ -1515,11 +1537,6 @@ async def test_chat_async(
     # Establish that the response is the type that we expect.
     message = await response.read()
     assert isinstance(message, data_chat_service.Message)
-
-
-@pytest.mark.asyncio
-async def test_chat_async_from_dict():
-    await test_chat_async(request_type=dict)
 
 
 def test_chat_field_headers():
@@ -1587,8 +1604,8 @@ async def test_chat_field_headers_async():
 @pytest.mark.parametrize(
     "request_type",
     [
-        gcg_conversation.CreateConversationRequest,
-        dict,
+        gcg_conversation.CreateConversationRequest(),
+        {},
     ],
 )
 def test_create_conversation(request_type, transport: str = "grpc"):
@@ -1599,7 +1616,7 @@ def test_create_conversation(request_type, transport: str = "grpc"):
 
     # Everything is optional in proto3 as far as the runtime is concerned,
     # and we are mocking out the actual API, so just send an empty request.
-    request = request_type()
+    request = request_type
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(
@@ -1650,10 +1667,11 @@ def test_create_conversation_non_empty_request_with_auto_populated_field():
         client.create_conversation(request=request)
         call.assert_called()
         _, args, _ = call.mock_calls[0]
-        assert args[0] == gcg_conversation.CreateConversationRequest(
+        request_msg = gcg_conversation.CreateConversationRequest(
             parent="parent_value",
             conversation_id="conversation_id_value",
         )
+        assert args[0] == request_msg
 
 
 def test_create_conversation_use_cached_wrapped_rpc():
@@ -1738,10 +1756,14 @@ async def test_create_conversation_async_use_cached_wrapped_rpc(
 
 
 @pytest.mark.asyncio
-async def test_create_conversation_async(
-    transport: str = "grpc_asyncio",
-    request_type=gcg_conversation.CreateConversationRequest,
-):
+@pytest.mark.parametrize(
+    "request_type",
+    [
+        gcg_conversation.CreateConversationRequest(),
+        {},
+    ],
+)
+async def test_create_conversation_async(request_type, transport: str = "grpc_asyncio"):
     client = DataChatServiceAsyncClient(
         credentials=async_anonymous_credentials(),
         transport=transport,
@@ -1749,7 +1771,7 @@ async def test_create_conversation_async(
 
     # Everything is optional in proto3 as far as the runtime is concerned,
     # and we are mocking out the actual API, so just send an empty request.
-    request = request_type()
+    request = request_type
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(
@@ -1774,11 +1796,6 @@ async def test_create_conversation_async(
     assert isinstance(response, gcg_conversation.Conversation)
     assert response.name == "name_value"
     assert response.agents == ["agents_value"]
-
-
-@pytest.mark.asyncio
-async def test_create_conversation_async_from_dict():
-    await test_create_conversation_async(request_type=dict)
 
 
 def test_create_conversation_field_headers():
@@ -1955,8 +1972,8 @@ async def test_create_conversation_flattened_error_async():
 @pytest.mark.parametrize(
     "request_type",
     [
-        conversation.DeleteConversationRequest,
-        dict,
+        conversation.DeleteConversationRequest(),
+        {},
     ],
 )
 def test_delete_conversation(request_type, transport: str = "grpc"):
@@ -1967,7 +1984,7 @@ def test_delete_conversation(request_type, transport: str = "grpc"):
 
     # Everything is optional in proto3 as far as the runtime is concerned,
     # and we are mocking out the actual API, so just send an empty request.
-    request = request_type()
+    request = request_type
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(
@@ -2012,9 +2029,10 @@ def test_delete_conversation_non_empty_request_with_auto_populated_field():
         client.delete_conversation(request=request)
         call.assert_called()
         _, args, _ = call.mock_calls[0]
-        assert args[0] == conversation.DeleteConversationRequest(
+        request_msg = conversation.DeleteConversationRequest(
             name="name_value",
         )
+        assert args[0] == request_msg
 
 
 def test_delete_conversation_use_cached_wrapped_rpc():
@@ -2099,9 +2117,14 @@ async def test_delete_conversation_async_use_cached_wrapped_rpc(
 
 
 @pytest.mark.asyncio
-async def test_delete_conversation_async(
-    transport: str = "grpc_asyncio", request_type=conversation.DeleteConversationRequest
-):
+@pytest.mark.parametrize(
+    "request_type",
+    [
+        conversation.DeleteConversationRequest(),
+        {},
+    ],
+)
+async def test_delete_conversation_async(request_type, transport: str = "grpc_asyncio"):
     client = DataChatServiceAsyncClient(
         credentials=async_anonymous_credentials(),
         transport=transport,
@@ -2109,7 +2132,7 @@ async def test_delete_conversation_async(
 
     # Everything is optional in proto3 as far as the runtime is concerned,
     # and we are mocking out the actual API, so just send an empty request.
-    request = request_type()
+    request = request_type
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(
@@ -2127,11 +2150,6 @@ async def test_delete_conversation_async(
 
     # Establish that the response is the type that we expect.
     assert response is None
-
-
-@pytest.mark.asyncio
-async def test_delete_conversation_async_from_dict():
-    await test_delete_conversation_async(request_type=dict)
 
 
 def test_delete_conversation_field_headers():
@@ -2284,8 +2302,8 @@ async def test_delete_conversation_flattened_error_async():
 @pytest.mark.parametrize(
     "request_type",
     [
-        conversation.GetConversationRequest,
-        dict,
+        conversation.GetConversationRequest(),
+        {},
     ],
 )
 def test_get_conversation(request_type, transport: str = "grpc"):
@@ -2296,7 +2314,7 @@ def test_get_conversation(request_type, transport: str = "grpc"):
 
     # Everything is optional in proto3 as far as the runtime is concerned,
     # and we are mocking out the actual API, so just send an empty request.
-    request = request_type()
+    request = request_type
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(type(client.transport.get_conversation), "__call__") as call:
@@ -2342,9 +2360,10 @@ def test_get_conversation_non_empty_request_with_auto_populated_field():
         client.get_conversation(request=request)
         call.assert_called()
         _, args, _ = call.mock_calls[0]
-        assert args[0] == conversation.GetConversationRequest(
+        request_msg = conversation.GetConversationRequest(
             name="name_value",
         )
+        assert args[0] == request_msg
 
 
 def test_get_conversation_use_cached_wrapped_rpc():
@@ -2427,9 +2446,14 @@ async def test_get_conversation_async_use_cached_wrapped_rpc(
 
 
 @pytest.mark.asyncio
-async def test_get_conversation_async(
-    transport: str = "grpc_asyncio", request_type=conversation.GetConversationRequest
-):
+@pytest.mark.parametrize(
+    "request_type",
+    [
+        conversation.GetConversationRequest(),
+        {},
+    ],
+)
+async def test_get_conversation_async(request_type, transport: str = "grpc_asyncio"):
     client = DataChatServiceAsyncClient(
         credentials=async_anonymous_credentials(),
         transport=transport,
@@ -2437,7 +2461,7 @@ async def test_get_conversation_async(
 
     # Everything is optional in proto3 as far as the runtime is concerned,
     # and we are mocking out the actual API, so just send an empty request.
-    request = request_type()
+    request = request_type
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(type(client.transport.get_conversation), "__call__") as call:
@@ -2460,11 +2484,6 @@ async def test_get_conversation_async(
     assert isinstance(response, conversation.Conversation)
     assert response.name == "name_value"
     assert response.agents == ["agents_value"]
-
-
-@pytest.mark.asyncio
-async def test_get_conversation_async_from_dict():
-    await test_get_conversation_async(request_type=dict)
 
 
 def test_get_conversation_field_headers():
@@ -2613,8 +2632,8 @@ async def test_get_conversation_flattened_error_async():
 @pytest.mark.parametrize(
     "request_type",
     [
-        conversation.ListConversationsRequest,
-        dict,
+        conversation.ListConversationsRequest(),
+        {},
     ],
 )
 def test_list_conversations(request_type, transport: str = "grpc"):
@@ -2625,7 +2644,7 @@ def test_list_conversations(request_type, transport: str = "grpc"):
 
     # Everything is optional in proto3 as far as the runtime is concerned,
     # and we are mocking out the actual API, so just send an empty request.
-    request = request_type()
+    request = request_type
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(
@@ -2675,11 +2694,12 @@ def test_list_conversations_non_empty_request_with_auto_populated_field():
         client.list_conversations(request=request)
         call.assert_called()
         _, args, _ = call.mock_calls[0]
-        assert args[0] == conversation.ListConversationsRequest(
+        request_msg = conversation.ListConversationsRequest(
             parent="parent_value",
             page_token="page_token_value",
             filter="filter_value",
         )
+        assert args[0] == request_msg
 
 
 def test_list_conversations_use_cached_wrapped_rpc():
@@ -2764,9 +2784,14 @@ async def test_list_conversations_async_use_cached_wrapped_rpc(
 
 
 @pytest.mark.asyncio
-async def test_list_conversations_async(
-    transport: str = "grpc_asyncio", request_type=conversation.ListConversationsRequest
-):
+@pytest.mark.parametrize(
+    "request_type",
+    [
+        conversation.ListConversationsRequest(),
+        {},
+    ],
+)
+async def test_list_conversations_async(request_type, transport: str = "grpc_asyncio"):
     client = DataChatServiceAsyncClient(
         credentials=async_anonymous_credentials(),
         transport=transport,
@@ -2774,7 +2799,7 @@ async def test_list_conversations_async(
 
     # Everything is optional in proto3 as far as the runtime is concerned,
     # and we are mocking out the actual API, so just send an empty request.
-    request = request_type()
+    request = request_type
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(
@@ -2797,11 +2822,6 @@ async def test_list_conversations_async(
     # Establish that the response is the type that we expect.
     assert isinstance(response, pagers.ListConversationsAsyncPager)
     assert response.next_page_token == "next_page_token_value"
-
-
-@pytest.mark.asyncio
-async def test_list_conversations_async_from_dict():
-    await test_list_conversations_async(request_type=dict)
 
 
 def test_list_conversations_field_headers():
@@ -3156,8 +3176,8 @@ async def test_list_conversations_async_pages():
 @pytest.mark.parametrize(
     "request_type",
     [
-        data_chat_service.ListMessagesRequest,
-        dict,
+        data_chat_service.ListMessagesRequest(),
+        {},
     ],
 )
 def test_list_messages(request_type, transport: str = "grpc"):
@@ -3168,7 +3188,7 @@ def test_list_messages(request_type, transport: str = "grpc"):
 
     # Everything is optional in proto3 as far as the runtime is concerned,
     # and we are mocking out the actual API, so just send an empty request.
-    request = request_type()
+    request = request_type
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(type(client.transport.list_messages), "__call__") as call:
@@ -3214,11 +3234,12 @@ def test_list_messages_non_empty_request_with_auto_populated_field():
         client.list_messages(request=request)
         call.assert_called()
         _, args, _ = call.mock_calls[0]
-        assert args[0] == data_chat_service.ListMessagesRequest(
+        request_msg = data_chat_service.ListMessagesRequest(
             parent="parent_value",
             page_token="page_token_value",
             filter="filter_value",
         )
+        assert args[0] == request_msg
 
 
 def test_list_messages_use_cached_wrapped_rpc():
@@ -3299,9 +3320,14 @@ async def test_list_messages_async_use_cached_wrapped_rpc(
 
 
 @pytest.mark.asyncio
-async def test_list_messages_async(
-    transport: str = "grpc_asyncio", request_type=data_chat_service.ListMessagesRequest
-):
+@pytest.mark.parametrize(
+    "request_type",
+    [
+        data_chat_service.ListMessagesRequest(),
+        {},
+    ],
+)
+async def test_list_messages_async(request_type, transport: str = "grpc_asyncio"):
     client = DataChatServiceAsyncClient(
         credentials=async_anonymous_credentials(),
         transport=transport,
@@ -3309,7 +3335,7 @@ async def test_list_messages_async(
 
     # Everything is optional in proto3 as far as the runtime is concerned,
     # and we are mocking out the actual API, so just send an empty request.
-    request = request_type()
+    request = request_type
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(type(client.transport.list_messages), "__call__") as call:
@@ -3330,11 +3356,6 @@ async def test_list_messages_async(
     # Establish that the response is the type that we expect.
     assert isinstance(response, pagers.ListMessagesAsyncPager)
     assert response.next_page_token == "next_page_token_value"
-
-
-@pytest.mark.asyncio
-async def test_list_messages_async_from_dict():
-    await test_list_messages_async(request_type=dict)
 
 
 def test_list_messages_field_headers():
@@ -3673,8 +3694,8 @@ async def test_list_messages_async_pages():
 @pytest.mark.parametrize(
     "request_type",
     [
-        data_chat_service.QueryDataRequest,
-        dict,
+        data_chat_service.QueryDataRequest(),
+        {},
     ],
 )
 def test_query_data(request_type, transport: str = "grpc"):
@@ -3685,7 +3706,7 @@ def test_query_data(request_type, transport: str = "grpc"):
 
     # Everything is optional in proto3 as far as the runtime is concerned,
     # and we are mocking out the actual API, so just send an empty request.
-    request = request_type()
+    request = request_type
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(type(client.transport.query_data), "__call__") as call:
@@ -3736,10 +3757,11 @@ def test_query_data_non_empty_request_with_auto_populated_field():
         client.query_data(request=request)
         call.assert_called()
         _, args, _ = call.mock_calls[0]
-        assert args[0] == data_chat_service.QueryDataRequest(
+        request_msg = data_chat_service.QueryDataRequest(
             parent="parent_value",
             prompt="prompt_value",
         )
+        assert args[0] == request_msg
 
 
 def test_query_data_use_cached_wrapped_rpc():
@@ -3818,9 +3840,14 @@ async def test_query_data_async_use_cached_wrapped_rpc(transport: str = "grpc_as
 
 
 @pytest.mark.asyncio
-async def test_query_data_async(
-    transport: str = "grpc_asyncio", request_type=data_chat_service.QueryDataRequest
-):
+@pytest.mark.parametrize(
+    "request_type",
+    [
+        data_chat_service.QueryDataRequest(),
+        {},
+    ],
+)
+async def test_query_data_async(request_type, transport: str = "grpc_asyncio"):
     client = DataChatServiceAsyncClient(
         credentials=async_anonymous_credentials(),
         transport=transport,
@@ -3828,7 +3855,7 @@ async def test_query_data_async(
 
     # Everything is optional in proto3 as far as the runtime is concerned,
     # and we are mocking out the actual API, so just send an empty request.
-    request = request_type()
+    request = request_type
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(type(client.transport.query_data), "__call__") as call:
@@ -3855,11 +3882,6 @@ async def test_query_data_async(
     assert response.intent_explanation == "intent_explanation_value"
     assert response.natural_language_answer == "natural_language_answer_value"
     assert response.disambiguation_question == ["disambiguation_question_value"]
-
-
-@pytest.mark.asyncio
-async def test_query_data_async_from_dict():
-    await test_query_data_async(request_type=dict)
 
 
 def test_query_data_field_headers():
@@ -5402,7 +5424,6 @@ def test_chat_empty_call_grpc():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = data_chat_service.ChatRequest()
-
         assert args[0] == request_msg
 
 
@@ -5425,7 +5446,6 @@ def test_create_conversation_empty_call_grpc():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = gcg_conversation.CreateConversationRequest()
-
         assert args[0] == request_msg
 
 
@@ -5448,7 +5468,6 @@ def test_delete_conversation_empty_call_grpc():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = conversation.DeleteConversationRequest()
-
         assert args[0] == request_msg
 
 
@@ -5469,7 +5488,6 @@ def test_get_conversation_empty_call_grpc():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = conversation.GetConversationRequest()
-
         assert args[0] == request_msg
 
 
@@ -5492,7 +5510,6 @@ def test_list_conversations_empty_call_grpc():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = conversation.ListConversationsRequest()
-
         assert args[0] == request_msg
 
 
@@ -5513,7 +5530,6 @@ def test_list_messages_empty_call_grpc():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = data_chat_service.ListMessagesRequest()
-
         assert args[0] == request_msg
 
 
@@ -5534,7 +5550,6 @@ def test_query_data_empty_call_grpc():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = data_chat_service.QueryDataRequest()
-
         assert args[0] == request_msg
 
 
@@ -5574,7 +5589,6 @@ async def test_chat_empty_call_grpc_asyncio():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = data_chat_service.ChatRequest()
-
         assert args[0] == request_msg
 
 
@@ -5604,7 +5618,6 @@ async def test_create_conversation_empty_call_grpc_asyncio():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = gcg_conversation.CreateConversationRequest()
-
         assert args[0] == request_msg
 
 
@@ -5629,7 +5642,6 @@ async def test_delete_conversation_empty_call_grpc_asyncio():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = conversation.DeleteConversationRequest()
-
         assert args[0] == request_msg
 
 
@@ -5657,7 +5669,6 @@ async def test_get_conversation_empty_call_grpc_asyncio():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = conversation.GetConversationRequest()
-
         assert args[0] == request_msg
 
 
@@ -5686,7 +5697,6 @@ async def test_list_conversations_empty_call_grpc_asyncio():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = conversation.ListConversationsRequest()
-
         assert args[0] == request_msg
 
 
@@ -5713,7 +5723,6 @@ async def test_list_messages_empty_call_grpc_asyncio():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = data_chat_service.ListMessagesRequest()
-
         assert args[0] == request_msg
 
 
@@ -5743,7 +5752,6 @@ async def test_query_data_empty_call_grpc_asyncio():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = data_chat_service.QueryDataRequest()
-
         assert args[0] == request_msg
 
 
@@ -7146,7 +7154,6 @@ def test_chat_empty_call_rest():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = data_chat_service.ChatRequest()
-
         assert args[0] == request_msg
 
 
@@ -7168,7 +7175,6 @@ def test_create_conversation_empty_call_rest():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = gcg_conversation.CreateConversationRequest()
-
         assert args[0] == request_msg
 
 
@@ -7190,7 +7196,6 @@ def test_delete_conversation_empty_call_rest():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = conversation.DeleteConversationRequest()
-
         assert args[0] == request_msg
 
 
@@ -7210,7 +7215,6 @@ def test_get_conversation_empty_call_rest():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = conversation.GetConversationRequest()
-
         assert args[0] == request_msg
 
 
@@ -7232,7 +7236,6 @@ def test_list_conversations_empty_call_rest():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = conversation.ListConversationsRequest()
-
         assert args[0] == request_msg
 
 
@@ -7252,7 +7255,6 @@ def test_list_messages_empty_call_rest():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = data_chat_service.ListMessagesRequest()
-
         assert args[0] == request_msg
 
 
@@ -7272,7 +7274,6 @@ def test_query_data_empty_call_rest():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = data_chat_service.QueryDataRequest()
-
         assert args[0] == request_msg
 
 

--- a/packages/google-cloud-geminidataanalytics/tests/unit/gapic/geminidataanalytics_v1beta/test_data_agent_service.py
+++ b/packages/google-cloud-geminidataanalytics/tests/unit/gapic/geminidataanalytics_v1beta/test_data_agent_service.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+import asyncio
 import json
 import math
 import os
@@ -128,6 +129,21 @@ def modify_default_endpoint_template(client):
         if ("localhost" in client._DEFAULT_ENDPOINT_TEMPLATE)
         else client._DEFAULT_ENDPOINT_TEMPLATE
     )
+
+
+@pytest.fixture(autouse=True)
+def set_event_loop():
+    try:
+        asyncio.get_running_loop()
+        yield
+    except RuntimeError:
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+        try:
+            yield
+        finally:
+            loop.close()
+            asyncio.set_event_loop(None)
 
 
 def test__get_default_mtls_endpoint():
@@ -1363,8 +1379,8 @@ def test_data_agent_service_client_create_channel_credentials_file(
 @pytest.mark.parametrize(
     "request_type",
     [
-        data_agent_service.ListDataAgentsRequest,
-        dict,
+        data_agent_service.ListDataAgentsRequest(),
+        {},
     ],
 )
 def test_list_data_agents(request_type, transport: str = "grpc"):
@@ -1375,7 +1391,7 @@ def test_list_data_agents(request_type, transport: str = "grpc"):
 
     # Everything is optional in proto3 as far as the runtime is concerned,
     # and we are mocking out the actual API, so just send an empty request.
-    request = request_type()
+    request = request_type
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(type(client.transport.list_data_agents), "__call__") as call:
@@ -1424,12 +1440,13 @@ def test_list_data_agents_non_empty_request_with_auto_populated_field():
         client.list_data_agents(request=request)
         call.assert_called()
         _, args, _ = call.mock_calls[0]
-        assert args[0] == data_agent_service.ListDataAgentsRequest(
+        request_msg = data_agent_service.ListDataAgentsRequest(
             parent="parent_value",
             page_token="page_token_value",
             filter="filter_value",
             order_by="order_by_value",
         )
+        assert args[0] == request_msg
 
 
 def test_list_data_agents_use_cached_wrapped_rpc():
@@ -1512,10 +1529,14 @@ async def test_list_data_agents_async_use_cached_wrapped_rpc(
 
 
 @pytest.mark.asyncio
-async def test_list_data_agents_async(
-    transport: str = "grpc_asyncio",
-    request_type=data_agent_service.ListDataAgentsRequest,
-):
+@pytest.mark.parametrize(
+    "request_type",
+    [
+        data_agent_service.ListDataAgentsRequest(),
+        {},
+    ],
+)
+async def test_list_data_agents_async(request_type, transport: str = "grpc_asyncio"):
     client = DataAgentServiceAsyncClient(
         credentials=async_anonymous_credentials(),
         transport=transport,
@@ -1523,7 +1544,7 @@ async def test_list_data_agents_async(
 
     # Everything is optional in proto3 as far as the runtime is concerned,
     # and we are mocking out the actual API, so just send an empty request.
-    request = request_type()
+    request = request_type
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(type(client.transport.list_data_agents), "__call__") as call:
@@ -1546,11 +1567,6 @@ async def test_list_data_agents_async(
     assert isinstance(response, pagers.ListDataAgentsAsyncPager)
     assert response.next_page_token == "next_page_token_value"
     assert response.unreachable == ["unreachable_value"]
-
-
-@pytest.mark.asyncio
-async def test_list_data_agents_async_from_dict():
-    await test_list_data_agents_async(request_type=dict)
 
 
 def test_list_data_agents_field_headers():
@@ -1889,8 +1905,8 @@ async def test_list_data_agents_async_pages():
 @pytest.mark.parametrize(
     "request_type",
     [
-        data_agent_service.ListAccessibleDataAgentsRequest,
-        dict,
+        data_agent_service.ListAccessibleDataAgentsRequest(),
+        {},
     ],
 )
 def test_list_accessible_data_agents(request_type, transport: str = "grpc"):
@@ -1901,7 +1917,7 @@ def test_list_accessible_data_agents(request_type, transport: str = "grpc"):
 
     # Everything is optional in proto3 as far as the runtime is concerned,
     # and we are mocking out the actual API, so just send an empty request.
-    request = request_type()
+    request = request_type
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(
@@ -1954,12 +1970,13 @@ def test_list_accessible_data_agents_non_empty_request_with_auto_populated_field
         client.list_accessible_data_agents(request=request)
         call.assert_called()
         _, args, _ = call.mock_calls[0]
-        assert args[0] == data_agent_service.ListAccessibleDataAgentsRequest(
+        request_msg = data_agent_service.ListAccessibleDataAgentsRequest(
             parent="parent_value",
             page_token="page_token_value",
             filter="filter_value",
             order_by="order_by_value",
         )
+        assert args[0] == request_msg
 
 
 def test_list_accessible_data_agents_use_cached_wrapped_rpc():
@@ -2045,9 +2062,15 @@ async def test_list_accessible_data_agents_async_use_cached_wrapped_rpc(
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "request_type",
+    [
+        data_agent_service.ListAccessibleDataAgentsRequest(),
+        {},
+    ],
+)
 async def test_list_accessible_data_agents_async(
-    transport: str = "grpc_asyncio",
-    request_type=data_agent_service.ListAccessibleDataAgentsRequest,
+    request_type, transport: str = "grpc_asyncio"
 ):
     client = DataAgentServiceAsyncClient(
         credentials=async_anonymous_credentials(),
@@ -2056,7 +2079,7 @@ async def test_list_accessible_data_agents_async(
 
     # Everything is optional in proto3 as far as the runtime is concerned,
     # and we are mocking out the actual API, so just send an empty request.
-    request = request_type()
+    request = request_type
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(
@@ -2081,11 +2104,6 @@ async def test_list_accessible_data_agents_async(
     assert isinstance(response, pagers.ListAccessibleDataAgentsAsyncPager)
     assert response.next_page_token == "next_page_token_value"
     assert response.unreachable == ["unreachable_value"]
-
-
-@pytest.mark.asyncio
-async def test_list_accessible_data_agents_async_from_dict():
-    await test_list_accessible_data_agents_async(request_type=dict)
 
 
 def test_list_accessible_data_agents_field_headers():
@@ -2442,8 +2460,8 @@ async def test_list_accessible_data_agents_async_pages():
 @pytest.mark.parametrize(
     "request_type",
     [
-        data_agent_service.GetDataAgentRequest,
-        dict,
+        data_agent_service.GetDataAgentRequest(),
+        {},
     ],
 )
 def test_get_data_agent(request_type, transport: str = "grpc"):
@@ -2454,7 +2472,7 @@ def test_get_data_agent(request_type, transport: str = "grpc"):
 
     # Everything is optional in proto3 as far as the runtime is concerned,
     # and we are mocking out the actual API, so just send an empty request.
-    request = request_type()
+    request = request_type
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(type(client.transport.get_data_agent), "__call__") as call:
@@ -2502,9 +2520,10 @@ def test_get_data_agent_non_empty_request_with_auto_populated_field():
         client.get_data_agent(request=request)
         call.assert_called()
         _, args, _ = call.mock_calls[0]
-        assert args[0] == data_agent_service.GetDataAgentRequest(
+        request_msg = data_agent_service.GetDataAgentRequest(
             name="name_value",
         )
+        assert args[0] == request_msg
 
 
 def test_get_data_agent_use_cached_wrapped_rpc():
@@ -2585,9 +2604,14 @@ async def test_get_data_agent_async_use_cached_wrapped_rpc(
 
 
 @pytest.mark.asyncio
-async def test_get_data_agent_async(
-    transport: str = "grpc_asyncio", request_type=data_agent_service.GetDataAgentRequest
-):
+@pytest.mark.parametrize(
+    "request_type",
+    [
+        data_agent_service.GetDataAgentRequest(),
+        {},
+    ],
+)
+async def test_get_data_agent_async(request_type, transport: str = "grpc_asyncio"):
     client = DataAgentServiceAsyncClient(
         credentials=async_anonymous_credentials(),
         transport=transport,
@@ -2595,7 +2619,7 @@ async def test_get_data_agent_async(
 
     # Everything is optional in proto3 as far as the runtime is concerned,
     # and we are mocking out the actual API, so just send an empty request.
-    request = request_type()
+    request = request_type
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(type(client.transport.get_data_agent), "__call__") as call:
@@ -2620,11 +2644,6 @@ async def test_get_data_agent_async(
     assert response.name == "name_value"
     assert response.display_name == "display_name_value"
     assert response.description == "description_value"
-
-
-@pytest.mark.asyncio
-async def test_get_data_agent_async_from_dict():
-    await test_get_data_agent_async(request_type=dict)
 
 
 def test_get_data_agent_field_headers():
@@ -2773,8 +2792,8 @@ async def test_get_data_agent_flattened_error_async():
 @pytest.mark.parametrize(
     "request_type",
     [
-        data_agent_service.CreateDataAgentRequest,
-        dict,
+        data_agent_service.CreateDataAgentRequest(),
+        {},
     ],
 )
 def test_create_data_agent(request_type, transport: str = "grpc"):
@@ -2785,7 +2804,7 @@ def test_create_data_agent(request_type, transport: str = "grpc"):
 
     # Everything is optional in proto3 as far as the runtime is concerned,
     # and we are mocking out the actual API, so just send an empty request.
-    request = request_type()
+    request = request_type
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(
@@ -2831,10 +2850,11 @@ def test_create_data_agent_non_empty_request_with_auto_populated_field():
         client.create_data_agent(request=request)
         call.assert_called()
         _, args, _ = call.mock_calls[0]
-        assert args[0] == data_agent_service.CreateDataAgentRequest(
+        request_msg = data_agent_service.CreateDataAgentRequest(
             parent="parent_value",
             data_agent_id="data_agent_id_value",
         )
+        assert args[0] == request_msg
 
 
 def test_create_data_agent_use_cached_wrapped_rpc():
@@ -2927,10 +2947,14 @@ async def test_create_data_agent_async_use_cached_wrapped_rpc(
 
 
 @pytest.mark.asyncio
-async def test_create_data_agent_async(
-    transport: str = "grpc_asyncio",
-    request_type=data_agent_service.CreateDataAgentRequest,
-):
+@pytest.mark.parametrize(
+    "request_type",
+    [
+        data_agent_service.CreateDataAgentRequest(),
+        {},
+    ],
+)
+async def test_create_data_agent_async(request_type, transport: str = "grpc_asyncio"):
     client = DataAgentServiceAsyncClient(
         credentials=async_anonymous_credentials(),
         transport=transport,
@@ -2938,7 +2962,7 @@ async def test_create_data_agent_async(
 
     # Everything is optional in proto3 as far as the runtime is concerned,
     # and we are mocking out the actual API, so just send an empty request.
-    request = request_type()
+    request = request_type
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(
@@ -2958,11 +2982,6 @@ async def test_create_data_agent_async(
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, future.Future)
-
-
-@pytest.mark.asyncio
-async def test_create_data_agent_async_from_dict():
-    await test_create_data_agent_async(request_type=dict)
 
 
 def test_create_data_agent_field_headers():
@@ -3175,8 +3194,8 @@ async def test_create_data_agent_flattened_error_async():
 @pytest.mark.parametrize(
     "request_type",
     [
-        data_agent_service.CreateDataAgentRequest,
-        dict,
+        data_agent_service.CreateDataAgentRequest(),
+        {},
     ],
 )
 def test_create_data_agent_sync(request_type, transport: str = "grpc"):
@@ -3187,7 +3206,7 @@ def test_create_data_agent_sync(request_type, transport: str = "grpc"):
 
     # Everything is optional in proto3 as far as the runtime is concerned,
     # and we are mocking out the actual API, so just send an empty request.
-    request = request_type()
+    request = request_type
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(
@@ -3240,10 +3259,11 @@ def test_create_data_agent_sync_non_empty_request_with_auto_populated_field():
         client.create_data_agent_sync(request=request)
         call.assert_called()
         _, args, _ = call.mock_calls[0]
-        assert args[0] == data_agent_service.CreateDataAgentRequest(
+        request_msg = data_agent_service.CreateDataAgentRequest(
             parent="parent_value",
             data_agent_id="data_agent_id_value",
         )
+        assert args[0] == request_msg
 
 
 def test_create_data_agent_sync_use_cached_wrapped_rpc():
@@ -3329,9 +3349,15 @@ async def test_create_data_agent_sync_async_use_cached_wrapped_rpc(
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "request_type",
+    [
+        data_agent_service.CreateDataAgentRequest(),
+        {},
+    ],
+)
 async def test_create_data_agent_sync_async(
-    transport: str = "grpc_asyncio",
-    request_type=data_agent_service.CreateDataAgentRequest,
+    request_type, transport: str = "grpc_asyncio"
 ):
     client = DataAgentServiceAsyncClient(
         credentials=async_anonymous_credentials(),
@@ -3340,7 +3366,7 @@ async def test_create_data_agent_sync_async(
 
     # Everything is optional in proto3 as far as the runtime is concerned,
     # and we are mocking out the actual API, so just send an empty request.
-    request = request_type()
+    request = request_type
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(
@@ -3367,11 +3393,6 @@ async def test_create_data_agent_sync_async(
     assert response.name == "name_value"
     assert response.display_name == "display_name_value"
     assert response.description == "description_value"
-
-
-@pytest.mark.asyncio
-async def test_create_data_agent_sync_async_from_dict():
-    await test_create_data_agent_sync_async(request_type=dict)
 
 
 def test_create_data_agent_sync_field_headers():
@@ -3584,8 +3605,8 @@ async def test_create_data_agent_sync_flattened_error_async():
 @pytest.mark.parametrize(
     "request_type",
     [
-        data_agent_service.UpdateDataAgentRequest,
-        dict,
+        data_agent_service.UpdateDataAgentRequest(),
+        {},
     ],
 )
 def test_update_data_agent(request_type, transport: str = "grpc"):
@@ -3596,7 +3617,7 @@ def test_update_data_agent(request_type, transport: str = "grpc"):
 
     # Everything is optional in proto3 as far as the runtime is concerned,
     # and we are mocking out the actual API, so just send an empty request.
-    request = request_type()
+    request = request_type
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(
@@ -3639,7 +3660,8 @@ def test_update_data_agent_non_empty_request_with_auto_populated_field():
         client.update_data_agent(request=request)
         call.assert_called()
         _, args, _ = call.mock_calls[0]
-        assert args[0] == data_agent_service.UpdateDataAgentRequest()
+        request_msg = data_agent_service.UpdateDataAgentRequest()
+        assert args[0] == request_msg
 
 
 def test_update_data_agent_use_cached_wrapped_rpc():
@@ -3732,10 +3754,14 @@ async def test_update_data_agent_async_use_cached_wrapped_rpc(
 
 
 @pytest.mark.asyncio
-async def test_update_data_agent_async(
-    transport: str = "grpc_asyncio",
-    request_type=data_agent_service.UpdateDataAgentRequest,
-):
+@pytest.mark.parametrize(
+    "request_type",
+    [
+        data_agent_service.UpdateDataAgentRequest(),
+        {},
+    ],
+)
+async def test_update_data_agent_async(request_type, transport: str = "grpc_asyncio"):
     client = DataAgentServiceAsyncClient(
         credentials=async_anonymous_credentials(),
         transport=transport,
@@ -3743,7 +3769,7 @@ async def test_update_data_agent_async(
 
     # Everything is optional in proto3 as far as the runtime is concerned,
     # and we are mocking out the actual API, so just send an empty request.
-    request = request_type()
+    request = request_type
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(
@@ -3763,11 +3789,6 @@ async def test_update_data_agent_async(
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, future.Future)
-
-
-@pytest.mark.asyncio
-async def test_update_data_agent_async_from_dict():
-    await test_update_data_agent_async(request_type=dict)
 
 
 def test_update_data_agent_field_headers():
@@ -3970,8 +3991,8 @@ async def test_update_data_agent_flattened_error_async():
 @pytest.mark.parametrize(
     "request_type",
     [
-        data_agent_service.UpdateDataAgentRequest,
-        dict,
+        data_agent_service.UpdateDataAgentRequest(),
+        {},
     ],
 )
 def test_update_data_agent_sync(request_type, transport: str = "grpc"):
@@ -3982,7 +4003,7 @@ def test_update_data_agent_sync(request_type, transport: str = "grpc"):
 
     # Everything is optional in proto3 as far as the runtime is concerned,
     # and we are mocking out the actual API, so just send an empty request.
-    request = request_type()
+    request = request_type
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(
@@ -4032,7 +4053,8 @@ def test_update_data_agent_sync_non_empty_request_with_auto_populated_field():
         client.update_data_agent_sync(request=request)
         call.assert_called()
         _, args, _ = call.mock_calls[0]
-        assert args[0] == data_agent_service.UpdateDataAgentRequest()
+        request_msg = data_agent_service.UpdateDataAgentRequest()
+        assert args[0] == request_msg
 
 
 def test_update_data_agent_sync_use_cached_wrapped_rpc():
@@ -4118,9 +4140,15 @@ async def test_update_data_agent_sync_async_use_cached_wrapped_rpc(
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "request_type",
+    [
+        data_agent_service.UpdateDataAgentRequest(),
+        {},
+    ],
+)
 async def test_update_data_agent_sync_async(
-    transport: str = "grpc_asyncio",
-    request_type=data_agent_service.UpdateDataAgentRequest,
+    request_type, transport: str = "grpc_asyncio"
 ):
     client = DataAgentServiceAsyncClient(
         credentials=async_anonymous_credentials(),
@@ -4129,7 +4157,7 @@ async def test_update_data_agent_sync_async(
 
     # Everything is optional in proto3 as far as the runtime is concerned,
     # and we are mocking out the actual API, so just send an empty request.
-    request = request_type()
+    request = request_type
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(
@@ -4156,11 +4184,6 @@ async def test_update_data_agent_sync_async(
     assert response.name == "name_value"
     assert response.display_name == "display_name_value"
     assert response.description == "description_value"
-
-
-@pytest.mark.asyncio
-async def test_update_data_agent_sync_async_from_dict():
-    await test_update_data_agent_sync_async(request_type=dict)
 
 
 def test_update_data_agent_sync_field_headers():
@@ -4363,8 +4386,8 @@ async def test_update_data_agent_sync_flattened_error_async():
 @pytest.mark.parametrize(
     "request_type",
     [
-        data_agent_service.DeleteDataAgentRequest,
-        dict,
+        data_agent_service.DeleteDataAgentRequest(),
+        {},
     ],
 )
 def test_delete_data_agent(request_type, transport: str = "grpc"):
@@ -4375,7 +4398,7 @@ def test_delete_data_agent(request_type, transport: str = "grpc"):
 
     # Everything is optional in proto3 as far as the runtime is concerned,
     # and we are mocking out the actual API, so just send an empty request.
-    request = request_type()
+    request = request_type
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(
@@ -4420,9 +4443,10 @@ def test_delete_data_agent_non_empty_request_with_auto_populated_field():
         client.delete_data_agent(request=request)
         call.assert_called()
         _, args, _ = call.mock_calls[0]
-        assert args[0] == data_agent_service.DeleteDataAgentRequest(
+        request_msg = data_agent_service.DeleteDataAgentRequest(
             name="name_value",
         )
+        assert args[0] == request_msg
 
 
 def test_delete_data_agent_use_cached_wrapped_rpc():
@@ -4515,10 +4539,14 @@ async def test_delete_data_agent_async_use_cached_wrapped_rpc(
 
 
 @pytest.mark.asyncio
-async def test_delete_data_agent_async(
-    transport: str = "grpc_asyncio",
-    request_type=data_agent_service.DeleteDataAgentRequest,
-):
+@pytest.mark.parametrize(
+    "request_type",
+    [
+        data_agent_service.DeleteDataAgentRequest(),
+        {},
+    ],
+)
+async def test_delete_data_agent_async(request_type, transport: str = "grpc_asyncio"):
     client = DataAgentServiceAsyncClient(
         credentials=async_anonymous_credentials(),
         transport=transport,
@@ -4526,7 +4554,7 @@ async def test_delete_data_agent_async(
 
     # Everything is optional in proto3 as far as the runtime is concerned,
     # and we are mocking out the actual API, so just send an empty request.
-    request = request_type()
+    request = request_type
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(
@@ -4546,11 +4574,6 @@ async def test_delete_data_agent_async(
 
     # Establish that the response is the type that we expect.
     assert isinstance(response, future.Future)
-
-
-@pytest.mark.asyncio
-async def test_delete_data_agent_async_from_dict():
-    await test_delete_data_agent_async(request_type=dict)
 
 
 def test_delete_data_agent_field_headers():
@@ -4707,8 +4730,8 @@ async def test_delete_data_agent_flattened_error_async():
 @pytest.mark.parametrize(
     "request_type",
     [
-        data_agent_service.DeleteDataAgentRequest,
-        dict,
+        data_agent_service.DeleteDataAgentRequest(),
+        {},
     ],
 )
 def test_delete_data_agent_sync(request_type, transport: str = "grpc"):
@@ -4719,7 +4742,7 @@ def test_delete_data_agent_sync(request_type, transport: str = "grpc"):
 
     # Everything is optional in proto3 as far as the runtime is concerned,
     # and we are mocking out the actual API, so just send an empty request.
-    request = request_type()
+    request = request_type
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(
@@ -4764,9 +4787,10 @@ def test_delete_data_agent_sync_non_empty_request_with_auto_populated_field():
         client.delete_data_agent_sync(request=request)
         call.assert_called()
         _, args, _ = call.mock_calls[0]
-        assert args[0] == data_agent_service.DeleteDataAgentRequest(
+        request_msg = data_agent_service.DeleteDataAgentRequest(
             name="name_value",
         )
+        assert args[0] == request_msg
 
 
 def test_delete_data_agent_sync_use_cached_wrapped_rpc():
@@ -4852,9 +4876,15 @@ async def test_delete_data_agent_sync_async_use_cached_wrapped_rpc(
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "request_type",
+    [
+        data_agent_service.DeleteDataAgentRequest(),
+        {},
+    ],
+)
 async def test_delete_data_agent_sync_async(
-    transport: str = "grpc_asyncio",
-    request_type=data_agent_service.DeleteDataAgentRequest,
+    request_type, transport: str = "grpc_asyncio"
 ):
     client = DataAgentServiceAsyncClient(
         credentials=async_anonymous_credentials(),
@@ -4863,7 +4893,7 @@ async def test_delete_data_agent_sync_async(
 
     # Everything is optional in proto3 as far as the runtime is concerned,
     # and we are mocking out the actual API, so just send an empty request.
-    request = request_type()
+    request = request_type
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(
@@ -4881,11 +4911,6 @@ async def test_delete_data_agent_sync_async(
 
     # Establish that the response is the type that we expect.
     assert response is None
-
-
-@pytest.mark.asyncio
-async def test_delete_data_agent_sync_async_from_dict():
-    await test_delete_data_agent_sync_async(request_type=dict)
 
 
 def test_delete_data_agent_sync_field_headers():
@@ -5038,8 +5063,8 @@ async def test_delete_data_agent_sync_flattened_error_async():
 @pytest.mark.parametrize(
     "request_type",
     [
-        iam_policy_pb2.GetIamPolicyRequest,
-        dict,
+        iam_policy_pb2.GetIamPolicyRequest(),
+        {},
     ],
 )
 def test_get_iam_policy(request_type, transport: str = "grpc"):
@@ -5050,7 +5075,7 @@ def test_get_iam_policy(request_type, transport: str = "grpc"):
 
     # Everything is optional in proto3 as far as the runtime is concerned,
     # and we are mocking out the actual API, so just send an empty request.
-    request = request_type()
+    request = request_type
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(type(client.transport.get_iam_policy), "__call__") as call:
@@ -5096,9 +5121,10 @@ def test_get_iam_policy_non_empty_request_with_auto_populated_field():
         client.get_iam_policy(request=request)
         call.assert_called()
         _, args, _ = call.mock_calls[0]
-        assert args[0] == iam_policy_pb2.GetIamPolicyRequest(
+        request_msg = iam_policy_pb2.GetIamPolicyRequest(
             resource="resource_value",
         )
+        assert args[0] == request_msg
 
 
 def test_get_iam_policy_use_cached_wrapped_rpc():
@@ -5179,9 +5205,14 @@ async def test_get_iam_policy_async_use_cached_wrapped_rpc(
 
 
 @pytest.mark.asyncio
-async def test_get_iam_policy_async(
-    transport: str = "grpc_asyncio", request_type=iam_policy_pb2.GetIamPolicyRequest
-):
+@pytest.mark.parametrize(
+    "request_type",
+    [
+        iam_policy_pb2.GetIamPolicyRequest(),
+        {},
+    ],
+)
+async def test_get_iam_policy_async(request_type, transport: str = "grpc_asyncio"):
     client = DataAgentServiceAsyncClient(
         credentials=async_anonymous_credentials(),
         transport=transport,
@@ -5189,7 +5220,7 @@ async def test_get_iam_policy_async(
 
     # Everything is optional in proto3 as far as the runtime is concerned,
     # and we are mocking out the actual API, so just send an empty request.
-    request = request_type()
+    request = request_type
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(type(client.transport.get_iam_policy), "__call__") as call:
@@ -5212,11 +5243,6 @@ async def test_get_iam_policy_async(
     assert isinstance(response, policy_pb2.Policy)
     assert response.version == 774
     assert response.etag == b"etag_blob"
-
-
-@pytest.mark.asyncio
-async def test_get_iam_policy_async_from_dict():
-    await test_get_iam_policy_async(request_type=dict)
 
 
 def test_get_iam_policy_field_headers():
@@ -5378,8 +5404,8 @@ async def test_get_iam_policy_flattened_error_async():
 @pytest.mark.parametrize(
     "request_type",
     [
-        iam_policy_pb2.SetIamPolicyRequest,
-        dict,
+        iam_policy_pb2.SetIamPolicyRequest(),
+        {},
     ],
 )
 def test_set_iam_policy(request_type, transport: str = "grpc"):
@@ -5390,7 +5416,7 @@ def test_set_iam_policy(request_type, transport: str = "grpc"):
 
     # Everything is optional in proto3 as far as the runtime is concerned,
     # and we are mocking out the actual API, so just send an empty request.
-    request = request_type()
+    request = request_type
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(type(client.transport.set_iam_policy), "__call__") as call:
@@ -5436,9 +5462,10 @@ def test_set_iam_policy_non_empty_request_with_auto_populated_field():
         client.set_iam_policy(request=request)
         call.assert_called()
         _, args, _ = call.mock_calls[0]
-        assert args[0] == iam_policy_pb2.SetIamPolicyRequest(
+        request_msg = iam_policy_pb2.SetIamPolicyRequest(
             resource="resource_value",
         )
+        assert args[0] == request_msg
 
 
 def test_set_iam_policy_use_cached_wrapped_rpc():
@@ -5519,9 +5546,14 @@ async def test_set_iam_policy_async_use_cached_wrapped_rpc(
 
 
 @pytest.mark.asyncio
-async def test_set_iam_policy_async(
-    transport: str = "grpc_asyncio", request_type=iam_policy_pb2.SetIamPolicyRequest
-):
+@pytest.mark.parametrize(
+    "request_type",
+    [
+        iam_policy_pb2.SetIamPolicyRequest(),
+        {},
+    ],
+)
+async def test_set_iam_policy_async(request_type, transport: str = "grpc_asyncio"):
     client = DataAgentServiceAsyncClient(
         credentials=async_anonymous_credentials(),
         transport=transport,
@@ -5529,7 +5561,7 @@ async def test_set_iam_policy_async(
 
     # Everything is optional in proto3 as far as the runtime is concerned,
     # and we are mocking out the actual API, so just send an empty request.
-    request = request_type()
+    request = request_type
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(type(client.transport.set_iam_policy), "__call__") as call:
@@ -5552,11 +5584,6 @@ async def test_set_iam_policy_async(
     assert isinstance(response, policy_pb2.Policy)
     assert response.version == 774
     assert response.etag == b"etag_blob"
-
-
-@pytest.mark.asyncio
-async def test_set_iam_policy_async_from_dict():
-    await test_set_iam_policy_async(request_type=dict)
 
 
 def test_set_iam_policy_field_headers():
@@ -8140,7 +8167,6 @@ def test_list_data_agents_empty_call_grpc():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = data_agent_service.ListDataAgentsRequest()
-
         assert args[0] == request_msg
 
 
@@ -8163,7 +8189,6 @@ def test_list_accessible_data_agents_empty_call_grpc():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = data_agent_service.ListAccessibleDataAgentsRequest()
-
         assert args[0] == request_msg
 
 
@@ -8184,7 +8209,6 @@ def test_get_data_agent_empty_call_grpc():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = data_agent_service.GetDataAgentRequest()
-
         assert args[0] == request_msg
 
 
@@ -8207,7 +8231,6 @@ def test_create_data_agent_empty_call_grpc():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = data_agent_service.CreateDataAgentRequest()
-
         assert args[0] == request_msg
 
 
@@ -8230,7 +8253,6 @@ def test_create_data_agent_sync_empty_call_grpc():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = data_agent_service.CreateDataAgentRequest()
-
         assert args[0] == request_msg
 
 
@@ -8253,7 +8275,6 @@ def test_update_data_agent_empty_call_grpc():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = data_agent_service.UpdateDataAgentRequest()
-
         assert args[0] == request_msg
 
 
@@ -8276,7 +8297,6 @@ def test_update_data_agent_sync_empty_call_grpc():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = data_agent_service.UpdateDataAgentRequest()
-
         assert args[0] == request_msg
 
 
@@ -8299,7 +8319,6 @@ def test_delete_data_agent_empty_call_grpc():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = data_agent_service.DeleteDataAgentRequest()
-
         assert args[0] == request_msg
 
 
@@ -8322,7 +8341,6 @@ def test_delete_data_agent_sync_empty_call_grpc():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = data_agent_service.DeleteDataAgentRequest()
-
         assert args[0] == request_msg
 
 
@@ -8343,7 +8361,6 @@ def test_get_iam_policy_empty_call_grpc():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = iam_policy_pb2.GetIamPolicyRequest()
-
         assert args[0] == request_msg
 
 
@@ -8364,7 +8381,6 @@ def test_set_iam_policy_empty_call_grpc():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = iam_policy_pb2.SetIamPolicyRequest()
-
         assert args[0] == request_msg
 
 
@@ -8406,7 +8422,6 @@ async def test_list_data_agents_empty_call_grpc_asyncio():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = data_agent_service.ListDataAgentsRequest()
-
         assert args[0] == request_msg
 
 
@@ -8436,7 +8451,6 @@ async def test_list_accessible_data_agents_empty_call_grpc_asyncio():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = data_agent_service.ListAccessibleDataAgentsRequest()
-
         assert args[0] == request_msg
 
 
@@ -8465,7 +8479,6 @@ async def test_get_data_agent_empty_call_grpc_asyncio():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = data_agent_service.GetDataAgentRequest()
-
         assert args[0] == request_msg
 
 
@@ -8492,7 +8505,6 @@ async def test_create_data_agent_empty_call_grpc_asyncio():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = data_agent_service.CreateDataAgentRequest()
-
         assert args[0] == request_msg
 
 
@@ -8523,7 +8535,6 @@ async def test_create_data_agent_sync_empty_call_grpc_asyncio():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = data_agent_service.CreateDataAgentRequest()
-
         assert args[0] == request_msg
 
 
@@ -8550,7 +8561,6 @@ async def test_update_data_agent_empty_call_grpc_asyncio():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = data_agent_service.UpdateDataAgentRequest()
-
         assert args[0] == request_msg
 
 
@@ -8581,7 +8591,6 @@ async def test_update_data_agent_sync_empty_call_grpc_asyncio():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = data_agent_service.UpdateDataAgentRequest()
-
         assert args[0] == request_msg
 
 
@@ -8608,7 +8617,6 @@ async def test_delete_data_agent_empty_call_grpc_asyncio():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = data_agent_service.DeleteDataAgentRequest()
-
         assert args[0] == request_msg
 
 
@@ -8633,7 +8641,6 @@ async def test_delete_data_agent_sync_empty_call_grpc_asyncio():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = data_agent_service.DeleteDataAgentRequest()
-
         assert args[0] == request_msg
 
 
@@ -8661,7 +8668,6 @@ async def test_get_iam_policy_empty_call_grpc_asyncio():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = iam_policy_pb2.GetIamPolicyRequest()
-
         assert args[0] == request_msg
 
 
@@ -8689,7 +8695,6 @@ async def test_set_iam_policy_empty_call_grpc_asyncio():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = iam_policy_pb2.SetIamPolicyRequest()
-
         assert args[0] == request_msg
 
 
@@ -11466,7 +11471,6 @@ def test_list_data_agents_empty_call_rest():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = data_agent_service.ListDataAgentsRequest()
-
         assert args[0] == request_msg
 
 
@@ -11488,7 +11492,6 @@ def test_list_accessible_data_agents_empty_call_rest():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = data_agent_service.ListAccessibleDataAgentsRequest()
-
         assert args[0] == request_msg
 
 
@@ -11508,7 +11511,6 @@ def test_get_data_agent_empty_call_rest():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = data_agent_service.GetDataAgentRequest()
-
         assert args[0] == request_msg
 
 
@@ -11530,7 +11532,6 @@ def test_create_data_agent_empty_call_rest():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = data_agent_service.CreateDataAgentRequest()
-
         assert args[0] == request_msg
 
 
@@ -11552,7 +11553,6 @@ def test_create_data_agent_sync_empty_call_rest():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = data_agent_service.CreateDataAgentRequest()
-
         assert args[0] == request_msg
 
 
@@ -11574,7 +11574,6 @@ def test_update_data_agent_empty_call_rest():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = data_agent_service.UpdateDataAgentRequest()
-
         assert args[0] == request_msg
 
 
@@ -11596,7 +11595,6 @@ def test_update_data_agent_sync_empty_call_rest():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = data_agent_service.UpdateDataAgentRequest()
-
         assert args[0] == request_msg
 
 
@@ -11618,7 +11616,6 @@ def test_delete_data_agent_empty_call_rest():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = data_agent_service.DeleteDataAgentRequest()
-
         assert args[0] == request_msg
 
 
@@ -11640,7 +11637,6 @@ def test_delete_data_agent_sync_empty_call_rest():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = data_agent_service.DeleteDataAgentRequest()
-
         assert args[0] == request_msg
 
 
@@ -11660,7 +11656,6 @@ def test_get_iam_policy_empty_call_rest():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = iam_policy_pb2.GetIamPolicyRequest()
-
         assert args[0] == request_msg
 
 
@@ -11680,7 +11675,6 @@ def test_set_iam_policy_empty_call_rest():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = iam_policy_pb2.SetIamPolicyRequest()
-
         assert args[0] == request_msg
 
 

--- a/packages/google-cloud-geminidataanalytics/tests/unit/gapic/geminidataanalytics_v1beta/test_data_chat_service.py
+++ b/packages/google-cloud-geminidataanalytics/tests/unit/gapic/geminidataanalytics_v1beta/test_data_chat_service.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+import asyncio
 import json
 import math
 import os
@@ -120,6 +121,21 @@ def modify_default_endpoint_template(client):
         if ("localhost" in client._DEFAULT_ENDPOINT_TEMPLATE)
         else client._DEFAULT_ENDPOINT_TEMPLATE
     )
+
+
+@pytest.fixture(autouse=True)
+def set_event_loop():
+    try:
+        asyncio.get_running_loop()
+        yield
+    except RuntimeError:
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+        try:
+            yield
+        finally:
+            loop.close()
+            asyncio.set_event_loop(None)
 
 
 def test__get_default_mtls_endpoint():
@@ -1349,8 +1365,8 @@ def test_data_chat_service_client_create_channel_credentials_file(
 @pytest.mark.parametrize(
     "request_type",
     [
-        data_chat_service.ChatRequest,
-        dict,
+        data_chat_service.ChatRequest(),
+        {},
     ],
 )
 def test_chat(request_type, transport: str = "grpc"):
@@ -1361,7 +1377,7 @@ def test_chat(request_type, transport: str = "grpc"):
 
     # Everything is optional in proto3 as far as the runtime is concerned,
     # and we are mocking out the actual API, so just send an empty request.
-    request = request_type()
+    request = request_type
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(type(client.transport.chat), "__call__") as call:
@@ -1404,10 +1420,11 @@ def test_chat_non_empty_request_with_auto_populated_field():
         client.chat(request=request)
         call.assert_called()
         _, args, _ = call.mock_calls[0]
-        assert args[0] == data_chat_service.ChatRequest(
+        request_msg = data_chat_service.ChatRequest(
             project="project_value",
             parent="parent_value",
         )
+        assert args[0] == request_msg
 
 
 def test_chat_use_cached_wrapped_rpc():
@@ -1485,9 +1502,14 @@ async def test_chat_async_use_cached_wrapped_rpc(transport: str = "grpc_asyncio"
 
 
 @pytest.mark.asyncio
-async def test_chat_async(
-    transport: str = "grpc_asyncio", request_type=data_chat_service.ChatRequest
-):
+@pytest.mark.parametrize(
+    "request_type",
+    [
+        data_chat_service.ChatRequest(),
+        {},
+    ],
+)
+async def test_chat_async(request_type, transport: str = "grpc_asyncio"):
     client = DataChatServiceAsyncClient(
         credentials=async_anonymous_credentials(),
         transport=transport,
@@ -1495,7 +1517,7 @@ async def test_chat_async(
 
     # Everything is optional in proto3 as far as the runtime is concerned,
     # and we are mocking out the actual API, so just send an empty request.
-    request = request_type()
+    request = request_type
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(type(client.transport.chat), "__call__") as call:
@@ -1515,11 +1537,6 @@ async def test_chat_async(
     # Establish that the response is the type that we expect.
     message = await response.read()
     assert isinstance(message, data_chat_service.Message)
-
-
-@pytest.mark.asyncio
-async def test_chat_async_from_dict():
-    await test_chat_async(request_type=dict)
 
 
 def test_chat_field_headers():
@@ -1587,8 +1604,8 @@ async def test_chat_field_headers_async():
 @pytest.mark.parametrize(
     "request_type",
     [
-        gcg_conversation.CreateConversationRequest,
-        dict,
+        gcg_conversation.CreateConversationRequest(),
+        {},
     ],
 )
 def test_create_conversation(request_type, transport: str = "grpc"):
@@ -1599,7 +1616,7 @@ def test_create_conversation(request_type, transport: str = "grpc"):
 
     # Everything is optional in proto3 as far as the runtime is concerned,
     # and we are mocking out the actual API, so just send an empty request.
-    request = request_type()
+    request = request_type
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(
@@ -1650,10 +1667,11 @@ def test_create_conversation_non_empty_request_with_auto_populated_field():
         client.create_conversation(request=request)
         call.assert_called()
         _, args, _ = call.mock_calls[0]
-        assert args[0] == gcg_conversation.CreateConversationRequest(
+        request_msg = gcg_conversation.CreateConversationRequest(
             parent="parent_value",
             conversation_id="conversation_id_value",
         )
+        assert args[0] == request_msg
 
 
 def test_create_conversation_use_cached_wrapped_rpc():
@@ -1738,10 +1756,14 @@ async def test_create_conversation_async_use_cached_wrapped_rpc(
 
 
 @pytest.mark.asyncio
-async def test_create_conversation_async(
-    transport: str = "grpc_asyncio",
-    request_type=gcg_conversation.CreateConversationRequest,
-):
+@pytest.mark.parametrize(
+    "request_type",
+    [
+        gcg_conversation.CreateConversationRequest(),
+        {},
+    ],
+)
+async def test_create_conversation_async(request_type, transport: str = "grpc_asyncio"):
     client = DataChatServiceAsyncClient(
         credentials=async_anonymous_credentials(),
         transport=transport,
@@ -1749,7 +1771,7 @@ async def test_create_conversation_async(
 
     # Everything is optional in proto3 as far as the runtime is concerned,
     # and we are mocking out the actual API, so just send an empty request.
-    request = request_type()
+    request = request_type
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(
@@ -1774,11 +1796,6 @@ async def test_create_conversation_async(
     assert isinstance(response, gcg_conversation.Conversation)
     assert response.name == "name_value"
     assert response.agents == ["agents_value"]
-
-
-@pytest.mark.asyncio
-async def test_create_conversation_async_from_dict():
-    await test_create_conversation_async(request_type=dict)
 
 
 def test_create_conversation_field_headers():
@@ -1955,8 +1972,8 @@ async def test_create_conversation_flattened_error_async():
 @pytest.mark.parametrize(
     "request_type",
     [
-        conversation.DeleteConversationRequest,
-        dict,
+        conversation.DeleteConversationRequest(),
+        {},
     ],
 )
 def test_delete_conversation(request_type, transport: str = "grpc"):
@@ -1967,7 +1984,7 @@ def test_delete_conversation(request_type, transport: str = "grpc"):
 
     # Everything is optional in proto3 as far as the runtime is concerned,
     # and we are mocking out the actual API, so just send an empty request.
-    request = request_type()
+    request = request_type
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(
@@ -2012,9 +2029,10 @@ def test_delete_conversation_non_empty_request_with_auto_populated_field():
         client.delete_conversation(request=request)
         call.assert_called()
         _, args, _ = call.mock_calls[0]
-        assert args[0] == conversation.DeleteConversationRequest(
+        request_msg = conversation.DeleteConversationRequest(
             name="name_value",
         )
+        assert args[0] == request_msg
 
 
 def test_delete_conversation_use_cached_wrapped_rpc():
@@ -2099,9 +2117,14 @@ async def test_delete_conversation_async_use_cached_wrapped_rpc(
 
 
 @pytest.mark.asyncio
-async def test_delete_conversation_async(
-    transport: str = "grpc_asyncio", request_type=conversation.DeleteConversationRequest
-):
+@pytest.mark.parametrize(
+    "request_type",
+    [
+        conversation.DeleteConversationRequest(),
+        {},
+    ],
+)
+async def test_delete_conversation_async(request_type, transport: str = "grpc_asyncio"):
     client = DataChatServiceAsyncClient(
         credentials=async_anonymous_credentials(),
         transport=transport,
@@ -2109,7 +2132,7 @@ async def test_delete_conversation_async(
 
     # Everything is optional in proto3 as far as the runtime is concerned,
     # and we are mocking out the actual API, so just send an empty request.
-    request = request_type()
+    request = request_type
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(
@@ -2127,11 +2150,6 @@ async def test_delete_conversation_async(
 
     # Establish that the response is the type that we expect.
     assert response is None
-
-
-@pytest.mark.asyncio
-async def test_delete_conversation_async_from_dict():
-    await test_delete_conversation_async(request_type=dict)
 
 
 def test_delete_conversation_field_headers():
@@ -2284,8 +2302,8 @@ async def test_delete_conversation_flattened_error_async():
 @pytest.mark.parametrize(
     "request_type",
     [
-        conversation.GetConversationRequest,
-        dict,
+        conversation.GetConversationRequest(),
+        {},
     ],
 )
 def test_get_conversation(request_type, transport: str = "grpc"):
@@ -2296,7 +2314,7 @@ def test_get_conversation(request_type, transport: str = "grpc"):
 
     # Everything is optional in proto3 as far as the runtime is concerned,
     # and we are mocking out the actual API, so just send an empty request.
-    request = request_type()
+    request = request_type
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(type(client.transport.get_conversation), "__call__") as call:
@@ -2342,9 +2360,10 @@ def test_get_conversation_non_empty_request_with_auto_populated_field():
         client.get_conversation(request=request)
         call.assert_called()
         _, args, _ = call.mock_calls[0]
-        assert args[0] == conversation.GetConversationRequest(
+        request_msg = conversation.GetConversationRequest(
             name="name_value",
         )
+        assert args[0] == request_msg
 
 
 def test_get_conversation_use_cached_wrapped_rpc():
@@ -2427,9 +2446,14 @@ async def test_get_conversation_async_use_cached_wrapped_rpc(
 
 
 @pytest.mark.asyncio
-async def test_get_conversation_async(
-    transport: str = "grpc_asyncio", request_type=conversation.GetConversationRequest
-):
+@pytest.mark.parametrize(
+    "request_type",
+    [
+        conversation.GetConversationRequest(),
+        {},
+    ],
+)
+async def test_get_conversation_async(request_type, transport: str = "grpc_asyncio"):
     client = DataChatServiceAsyncClient(
         credentials=async_anonymous_credentials(),
         transport=transport,
@@ -2437,7 +2461,7 @@ async def test_get_conversation_async(
 
     # Everything is optional in proto3 as far as the runtime is concerned,
     # and we are mocking out the actual API, so just send an empty request.
-    request = request_type()
+    request = request_type
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(type(client.transport.get_conversation), "__call__") as call:
@@ -2460,11 +2484,6 @@ async def test_get_conversation_async(
     assert isinstance(response, conversation.Conversation)
     assert response.name == "name_value"
     assert response.agents == ["agents_value"]
-
-
-@pytest.mark.asyncio
-async def test_get_conversation_async_from_dict():
-    await test_get_conversation_async(request_type=dict)
 
 
 def test_get_conversation_field_headers():
@@ -2613,8 +2632,8 @@ async def test_get_conversation_flattened_error_async():
 @pytest.mark.parametrize(
     "request_type",
     [
-        conversation.ListConversationsRequest,
-        dict,
+        conversation.ListConversationsRequest(),
+        {},
     ],
 )
 def test_list_conversations(request_type, transport: str = "grpc"):
@@ -2625,7 +2644,7 @@ def test_list_conversations(request_type, transport: str = "grpc"):
 
     # Everything is optional in proto3 as far as the runtime is concerned,
     # and we are mocking out the actual API, so just send an empty request.
-    request = request_type()
+    request = request_type
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(
@@ -2675,11 +2694,12 @@ def test_list_conversations_non_empty_request_with_auto_populated_field():
         client.list_conversations(request=request)
         call.assert_called()
         _, args, _ = call.mock_calls[0]
-        assert args[0] == conversation.ListConversationsRequest(
+        request_msg = conversation.ListConversationsRequest(
             parent="parent_value",
             page_token="page_token_value",
             filter="filter_value",
         )
+        assert args[0] == request_msg
 
 
 def test_list_conversations_use_cached_wrapped_rpc():
@@ -2764,9 +2784,14 @@ async def test_list_conversations_async_use_cached_wrapped_rpc(
 
 
 @pytest.mark.asyncio
-async def test_list_conversations_async(
-    transport: str = "grpc_asyncio", request_type=conversation.ListConversationsRequest
-):
+@pytest.mark.parametrize(
+    "request_type",
+    [
+        conversation.ListConversationsRequest(),
+        {},
+    ],
+)
+async def test_list_conversations_async(request_type, transport: str = "grpc_asyncio"):
     client = DataChatServiceAsyncClient(
         credentials=async_anonymous_credentials(),
         transport=transport,
@@ -2774,7 +2799,7 @@ async def test_list_conversations_async(
 
     # Everything is optional in proto3 as far as the runtime is concerned,
     # and we are mocking out the actual API, so just send an empty request.
-    request = request_type()
+    request = request_type
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(
@@ -2797,11 +2822,6 @@ async def test_list_conversations_async(
     # Establish that the response is the type that we expect.
     assert isinstance(response, pagers.ListConversationsAsyncPager)
     assert response.next_page_token == "next_page_token_value"
-
-
-@pytest.mark.asyncio
-async def test_list_conversations_async_from_dict():
-    await test_list_conversations_async(request_type=dict)
 
 
 def test_list_conversations_field_headers():
@@ -3156,8 +3176,8 @@ async def test_list_conversations_async_pages():
 @pytest.mark.parametrize(
     "request_type",
     [
-        data_chat_service.ListMessagesRequest,
-        dict,
+        data_chat_service.ListMessagesRequest(),
+        {},
     ],
 )
 def test_list_messages(request_type, transport: str = "grpc"):
@@ -3168,7 +3188,7 @@ def test_list_messages(request_type, transport: str = "grpc"):
 
     # Everything is optional in proto3 as far as the runtime is concerned,
     # and we are mocking out the actual API, so just send an empty request.
-    request = request_type()
+    request = request_type
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(type(client.transport.list_messages), "__call__") as call:
@@ -3214,11 +3234,12 @@ def test_list_messages_non_empty_request_with_auto_populated_field():
         client.list_messages(request=request)
         call.assert_called()
         _, args, _ = call.mock_calls[0]
-        assert args[0] == data_chat_service.ListMessagesRequest(
+        request_msg = data_chat_service.ListMessagesRequest(
             parent="parent_value",
             page_token="page_token_value",
             filter="filter_value",
         )
+        assert args[0] == request_msg
 
 
 def test_list_messages_use_cached_wrapped_rpc():
@@ -3299,9 +3320,14 @@ async def test_list_messages_async_use_cached_wrapped_rpc(
 
 
 @pytest.mark.asyncio
-async def test_list_messages_async(
-    transport: str = "grpc_asyncio", request_type=data_chat_service.ListMessagesRequest
-):
+@pytest.mark.parametrize(
+    "request_type",
+    [
+        data_chat_service.ListMessagesRequest(),
+        {},
+    ],
+)
+async def test_list_messages_async(request_type, transport: str = "grpc_asyncio"):
     client = DataChatServiceAsyncClient(
         credentials=async_anonymous_credentials(),
         transport=transport,
@@ -3309,7 +3335,7 @@ async def test_list_messages_async(
 
     # Everything is optional in proto3 as far as the runtime is concerned,
     # and we are mocking out the actual API, so just send an empty request.
-    request = request_type()
+    request = request_type
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(type(client.transport.list_messages), "__call__") as call:
@@ -3330,11 +3356,6 @@ async def test_list_messages_async(
     # Establish that the response is the type that we expect.
     assert isinstance(response, pagers.ListMessagesAsyncPager)
     assert response.next_page_token == "next_page_token_value"
-
-
-@pytest.mark.asyncio
-async def test_list_messages_async_from_dict():
-    await test_list_messages_async(request_type=dict)
 
 
 def test_list_messages_field_headers():
@@ -3673,8 +3694,8 @@ async def test_list_messages_async_pages():
 @pytest.mark.parametrize(
     "request_type",
     [
-        data_chat_service.QueryDataRequest,
-        dict,
+        data_chat_service.QueryDataRequest(),
+        {},
     ],
 )
 def test_query_data(request_type, transport: str = "grpc"):
@@ -3685,7 +3706,7 @@ def test_query_data(request_type, transport: str = "grpc"):
 
     # Everything is optional in proto3 as far as the runtime is concerned,
     # and we are mocking out the actual API, so just send an empty request.
-    request = request_type()
+    request = request_type
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(type(client.transport.query_data), "__call__") as call:
@@ -3736,10 +3757,11 @@ def test_query_data_non_empty_request_with_auto_populated_field():
         client.query_data(request=request)
         call.assert_called()
         _, args, _ = call.mock_calls[0]
-        assert args[0] == data_chat_service.QueryDataRequest(
+        request_msg = data_chat_service.QueryDataRequest(
             parent="parent_value",
             prompt="prompt_value",
         )
+        assert args[0] == request_msg
 
 
 def test_query_data_use_cached_wrapped_rpc():
@@ -3818,9 +3840,14 @@ async def test_query_data_async_use_cached_wrapped_rpc(transport: str = "grpc_as
 
 
 @pytest.mark.asyncio
-async def test_query_data_async(
-    transport: str = "grpc_asyncio", request_type=data_chat_service.QueryDataRequest
-):
+@pytest.mark.parametrize(
+    "request_type",
+    [
+        data_chat_service.QueryDataRequest(),
+        {},
+    ],
+)
+async def test_query_data_async(request_type, transport: str = "grpc_asyncio"):
     client = DataChatServiceAsyncClient(
         credentials=async_anonymous_credentials(),
         transport=transport,
@@ -3828,7 +3855,7 @@ async def test_query_data_async(
 
     # Everything is optional in proto3 as far as the runtime is concerned,
     # and we are mocking out the actual API, so just send an empty request.
-    request = request_type()
+    request = request_type
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(type(client.transport.query_data), "__call__") as call:
@@ -3855,11 +3882,6 @@ async def test_query_data_async(
     assert response.intent_explanation == "intent_explanation_value"
     assert response.natural_language_answer == "natural_language_answer_value"
     assert response.disambiguation_question == ["disambiguation_question_value"]
-
-
-@pytest.mark.asyncio
-async def test_query_data_async_from_dict():
-    await test_query_data_async(request_type=dict)
 
 
 def test_query_data_field_headers():
@@ -5402,7 +5424,6 @@ def test_chat_empty_call_grpc():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = data_chat_service.ChatRequest()
-
         assert args[0] == request_msg
 
 
@@ -5425,7 +5446,6 @@ def test_create_conversation_empty_call_grpc():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = gcg_conversation.CreateConversationRequest()
-
         assert args[0] == request_msg
 
 
@@ -5448,7 +5468,6 @@ def test_delete_conversation_empty_call_grpc():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = conversation.DeleteConversationRequest()
-
         assert args[0] == request_msg
 
 
@@ -5469,7 +5488,6 @@ def test_get_conversation_empty_call_grpc():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = conversation.GetConversationRequest()
-
         assert args[0] == request_msg
 
 
@@ -5492,7 +5510,6 @@ def test_list_conversations_empty_call_grpc():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = conversation.ListConversationsRequest()
-
         assert args[0] == request_msg
 
 
@@ -5513,7 +5530,6 @@ def test_list_messages_empty_call_grpc():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = data_chat_service.ListMessagesRequest()
-
         assert args[0] == request_msg
 
 
@@ -5534,7 +5550,6 @@ def test_query_data_empty_call_grpc():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = data_chat_service.QueryDataRequest()
-
         assert args[0] == request_msg
 
 
@@ -5574,7 +5589,6 @@ async def test_chat_empty_call_grpc_asyncio():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = data_chat_service.ChatRequest()
-
         assert args[0] == request_msg
 
 
@@ -5604,7 +5618,6 @@ async def test_create_conversation_empty_call_grpc_asyncio():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = gcg_conversation.CreateConversationRequest()
-
         assert args[0] == request_msg
 
 
@@ -5629,7 +5642,6 @@ async def test_delete_conversation_empty_call_grpc_asyncio():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = conversation.DeleteConversationRequest()
-
         assert args[0] == request_msg
 
 
@@ -5657,7 +5669,6 @@ async def test_get_conversation_empty_call_grpc_asyncio():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = conversation.GetConversationRequest()
-
         assert args[0] == request_msg
 
 
@@ -5686,7 +5697,6 @@ async def test_list_conversations_empty_call_grpc_asyncio():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = conversation.ListConversationsRequest()
-
         assert args[0] == request_msg
 
 
@@ -5713,7 +5723,6 @@ async def test_list_messages_empty_call_grpc_asyncio():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = data_chat_service.ListMessagesRequest()
-
         assert args[0] == request_msg
 
 
@@ -5743,7 +5752,6 @@ async def test_query_data_empty_call_grpc_asyncio():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = data_chat_service.QueryDataRequest()
-
         assert args[0] == request_msg
 
 
@@ -7146,7 +7154,6 @@ def test_chat_empty_call_rest():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = data_chat_service.ChatRequest()
-
         assert args[0] == request_msg
 
 
@@ -7168,7 +7175,6 @@ def test_create_conversation_empty_call_rest():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = gcg_conversation.CreateConversationRequest()
-
         assert args[0] == request_msg
 
 
@@ -7190,7 +7196,6 @@ def test_delete_conversation_empty_call_rest():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = conversation.DeleteConversationRequest()
-
         assert args[0] == request_msg
 
 
@@ -7210,7 +7215,6 @@ def test_get_conversation_empty_call_rest():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = conversation.GetConversationRequest()
-
         assert args[0] == request_msg
 
 
@@ -7232,7 +7236,6 @@ def test_list_conversations_empty_call_rest():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = conversation.ListConversationsRequest()
-
         assert args[0] == request_msg
 
 
@@ -7252,7 +7255,6 @@ def test_list_messages_empty_call_rest():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = data_chat_service.ListMessagesRequest()
-
         assert args[0] == request_msg
 
 
@@ -7272,7 +7274,6 @@ def test_query_data_empty_call_rest():
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = data_chat_service.QueryDataRequest()
-
         assert args[0] == request_msg
 
 


### PR DESCRIPTION
This is regeneration of google-cloud-geminidataanalytics and its release.

`$ docker run -u $(id -u):$(id -g) -v .:/repo -v ~/.cache:/.cache -w /repo   docker.io/library/librarian-python:${V}  generate -v google-cloud-geminidataanalytics`
` go run github.com/googleapis/librarian/cmd/legacylibrarian@v0.15.1-0.20260528141105-567c9bf1faa7 release stage -library google-cloud-geminidataanalytics -repo .  -push`



<details><summary>google-cloud-geminidataanalytics: v0.13.0</summary>

## [v0.13.0](https://github.com/googleapis/google-cloud-python/compare/google-cloud-geminidataanalytics-v0.12.0...google-cloud-geminidataanalytics-v0.13.0) (2026-05-28)

### Bug Fixes

* generate and default to v1 (#17007) ([3820d9d3](https://github.com/googleapis/google-cloud-python/commit/3820d9d3))

</details>

b/510217868
