### PR TITLE
chore: bigframes release 2.41.0

### DIFF
--- a/.librarian/state.yaml
+++ b/.librarian/state.yaml
@@ -14,7 +14,7 @@
 image: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/python-librarian-generator@sha256:234b9d1f2ddb057ed7ac6a38db0bf8163d839c65c6cf88ade52530cddebce59e
 libraries:
   - id: bigframes
-    version: 2.40.0
+    version: 2.41.0
     last_generated_commit: ""
     apis: []
     source_roots:

--- a/librarian.yaml
+++ b/librarian.yaml
@@ -50,7 +50,7 @@ default:
     library_type: GAPIC_AUTO
 libraries:
   - name: bigframes
-    version: 2.40.0
+    version: 2.41.0
     skip_release: true
     python:
       library_type: INTEGRATION

--- a/packages/bigframes/CHANGELOG.md
+++ b/packages/bigframes/CHANGELOG.md
@@ -4,6 +4,38 @@
 
 [1]: https://pypi.org/project/bigframes/#history
 
+## [2.41.0](https://github.com/googleapis/google-cloud-python/compare/bigframes-v2.40.0...bigframes-v2.41.0) (2026-05-28)
+
+
+### Documentation
+
+* modernize multimodal tutorials and migrate legacy blob APIs (#16918) ([05d80c3cccc237480dc5f589b7768b57a147cb0e](https://github.com/googleapis/google-cloud-python/commit/05d80c3cccc237480dc5f589b7768b57a147cb0e))
+
+
+### Features
+
+* Defer unnamed @udf deployment until needed (#17217) ([ad3b8fa9693b7d23859c417f2f5954ea946f2bb8](https://github.com/googleapis/google-cloud-python/commit/ad3b8fa9693b7d23859c417f2f5954ea946f2bb8))
+* set up Angular infrastructure for TableWidget (#16934) ([4d20bab8ce15c31e5832789e6a5d306983b8584a](https://github.com/googleapis/google-cloud-python/commit/4d20bab8ce15c31e5832789e6a5d306983b8584a))
+* support pandas inputs in more bigframes.bigquery functions (#17224) ([d4d885547f99c08caabad5e715aecd8c6f1fb4d6](https://github.com/googleapis/google-cloud-python/commit/d4d885547f99c08caabad5e715aecd8c6f1fb4d6))
+* add more scalar array functions to `bigframes.bigquery` (#17213) ([4f8a6c81797204f4334c7251c244bc0b6bd568e2](https://github.com/googleapis/google-cloud-python/commit/4f8a6c81797204f4334c7251c244bc0b6bd568e2))
+* add `bigframes.bigquery.deterministic_decrypt*` and `bigframes.bigquery.deterministic_encrypt` functions (#17212) ([85f36725802f3e7ad16156ca9e957e61d57d3112](https://github.com/googleapis/google-cloud-python/commit/85f36725802f3e7ad16156ca9e957e61d57d3112))
+* add `bigframes.bigquery.aead.*` scalar functions (#17168) ([a7e4d048e254cdb723df0a47ccbd8d09aed00c7a](https://github.com/googleapis/google-cloud-python/commit/a7e4d048e254cdb723df0a47ccbd8d09aed00c7a))
+* complete deprecation and cleanup of multimodal blob APIs (#16618) ([3624f3bb102e7d599097975db5cdaee508c9549a](https://github.com/googleapis/google-cloud-python/commit/3624f3bb102e7d599097975db5cdaee508c9549a))
+* support output_mode for ai.classify (#17097) ([098c35c5a8383d1585848e10806f9914b2ef4f97](https://github.com/googleapis/google-cloud-python/commit/098c35c5a8383d1585848e10806f9914b2ef4f97))
+
+
+### Bug Fixes
+
+* cast JSON and nested struct columns to string for anywidget rendering (#17189) ([994a22d64856b436d196743d16c3fd1967b20784](https://github.com/googleapis/google-cloud-python/commit/994a22d64856b436d196743d16c3fd1967b20784))
+* Respect display.progress_bar=None in background threads (#16715) ([07dd3315447d2feb6de8d53e0915798da9c04151](https://github.com/googleapis/google-cloud-python/commit/07dd3315447d2feb6de8d53e0915798da9c04151))
+
+
+### Dependencies
+
+* bump mistune from 3.1.3 to 3.2.1 in /packages/bigframes (#17202) ([52f21788f76575036624c9163b63620a1bb92a83](https://github.com/googleapis/google-cloud-python/commit/52f21788f76575036624c9163b63620a1bb92a83))
+* bump langsmith from 0.4.10 to 0.8.0 in /packages/bigframes (#17210) ([9dd0c02c585f7fda34d6e2199ab2bc7c0b5a246a](https://github.com/googleapis/google-cloud-python/commit/9dd0c02c585f7fda34d6e2199ab2bc7c0b5a246a))
+* bump gdal from 3.8.4 to 3.13.0 in /packages/bigframes (#17204) ([900007bab07feb7580cb7e8a36a5d4ee4cce14ab](https://github.com/googleapis/google-cloud-python/commit/900007bab07feb7580cb7e8a36a5d4ee4cce14ab))
+
 ## [2.40.0](https://github.com/googleapis/google-cloud-python/compare/bigframes-v2.39.0...bigframes-v2.40.0) (2026-05-13)
 
 

--- a/packages/bigframes/bigframes/version.py
+++ b/packages/bigframes/bigframes/version.py
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "2.40.0"
+__version__ = "2.41.0"
 
 # {x-release-please-start-date}
-__release_date__ = "2026-05-13"
+__release_date__ = "2026-05-28"
 # {x-release-please-end}

--- a/packages/bigframes/third_party/bigframes_vendored/version.py
+++ b/packages/bigframes/third_party/bigframes_vendored/version.py
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "2.40.0"
+__version__ = "2.41.0"
 
 # {x-release-please-start-date}
-__release_date__ = "2026-05-13"
+__release_date__ = "2026-05-28"
 # {x-release-please-end}


### PR DESCRIPTION
PR created by the Librarian CLI to initialize a release. Merging this PR will auto trigger a release.

Librarian Version: v0.15.0
Language Image: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/python-librarian-generator@sha256:234b9d1f2ddb057ed7ac6a38db0bf8163d839c65c6cf88ade52530cddebce59e
<details><summary>bigframes: v2.41.0</summary>

## [v2.41.0](https://github.com/googleapis/google-cloud-python/compare/bigframes-v2.40.0...bigframes-v2.41.0) (2026-05-28)

### Features

* support output_mode for ai.classify (#17097) ([098c35c5](https://github.com/googleapis/google-cloud-python/commit/098c35c5))

* complete deprecation and cleanup of multimodal blob APIs (#16618) ([3624f3bb](https://github.com/googleapis/google-cloud-python/commit/3624f3bb))

* set up Angular infrastructure for TableWidget (#16934) ([4d20bab8](https://github.com/googleapis/google-cloud-python/commit/4d20bab8))

* add more scalar array functions to `bigframes.bigquery` (#17213) ([4f8a6c81](https://github.com/googleapis/google-cloud-python/commit/4f8a6c81))

* add `bigframes.bigquery.deterministic_decrypt*` and `bigframes.bigquery.deterministic_encrypt` functions (#17212) ([85f36725](https://github.com/googleapis/google-cloud-python/commit/85f36725))

* add `bigframes.bigquery.aead.*` scalar functions (#17168) ([a7e4d048](https://github.com/googleapis/google-cloud-python/commit/a7e4d048))

* Defer unnamed @udf deployment until needed (#17217) ([ad3b8fa9](https://github.com/googleapis/google-cloud-python/commit/ad3b8fa9))

* support pandas inputs in more bigframes.bigquery functions (#17224) ([d4d88554](https://github.com/googleapis/google-cloud-python/commit/d4d88554))

### Bug Fixes

* cast JSON and nested struct columns to string for anywidget rendering (#17189) ([994a22d6](https://github.com/googleapis/google-cloud-python/commit/994a22d6))

* Respect display.progress_bar=None in background threads (#16715) ([07dd3315](https://github.com/googleapis/google-cloud-python/commit/07dd3315))

### Dependencies

* bump mistune from 3.1.3 to 3.2.1 in /packages/bigframes (#17202) ([52f21788](https://github.com/googleapis/google-cloud-python/commit/52f21788))

* bump langsmith from 0.4.10 to 0.8.0 in /packages/bigframes (#17210) ([9dd0c02c](https://github.com/googleapis/google-cloud-python/commit/9dd0c02c))

* bump gdal from 3.8.4 to 3.13.0 in /packages/bigframes (#17204) ([900007ba](https://github.com/googleapis/google-cloud-python/commit/900007ba))

### Documentation

* modernize multimodal tutorials and migrate legacy blob APIs (#16918) ([05d80c3c](https://github.com/googleapis/google-cloud-python/commit/05d80c3c))

</details>