### PR TITLE
chore: librarian release pull request: 20260528T220958Z

### DIFF
--- a/.librarian/state.yaml
+++ b/.librarian/state.yaml
@@ -2805,7 +2805,7 @@ libraries:
       - packages/google-cloud-gdchardwaremanagement/docs/
     tag_format: '{id}-v{version}'
   - id: google-cloud-geminidataanalytics
-    version: 0.12.0
+    version: 0.13.0
     last_generated_commit: 6df3ecf4fd43b64826de6a477d1a535ec18b0d7c
     apis:
       - path: google/cloud/geminidataanalytics/v1beta

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,7 +98,7 @@ Changelogs
 - [google-cloud-financialservices==0.4.0](https://github.com/googleapis/google-cloud-python/tree/main/packages/google-cloud-financialservices/CHANGELOG.md)
 - [google-cloud-functions==1.23.0](https://github.com/googleapis/google-cloud-python/tree/main/packages/google-cloud-functions/CHANGELOG.md)
 - [google-cloud-gdchardwaremanagement==0.5.0](https://github.com/googleapis/google-cloud-python/tree/main/packages/google-cloud-gdchardwaremanagement/CHANGELOG.md)
-- [google-cloud-geminidataanalytics==0.12.0](https://github.com/googleapis/google-cloud-python/tree/main/packages/google-cloud-geminidataanalytics/CHANGELOG.md)
+- [google-cloud-geminidataanalytics==0.13.0](https://github.com/googleapis/google-cloud-python/tree/main/packages/google-cloud-geminidataanalytics/CHANGELOG.md)
 - [google-cloud-gke-backup==0.8.0](https://github.com/googleapis/google-cloud-python/tree/main/packages/google-cloud-gke-backup/CHANGELOG.md)
 - [google-cloud-gke-connect-gateway==0.13.0](https://github.com/googleapis/google-cloud-python/tree/main/packages/google-cloud-gke-connect-gateway/CHANGELOG.md)
 - [google-cloud-gke-hub==1.24.0](https://github.com/googleapis/google-cloud-python/tree/main/packages/google-cloud-gke-hub/CHANGELOG.md)

--- a/librarian.yaml
+++ b/librarian.yaml
@@ -1150,7 +1150,7 @@ libraries:
     python:
       default_version: v1alpha
   - name: google-cloud-geminidataanalytics
-    version: 0.12.0
+    version: 0.13.0
     apis:
       - path: google/cloud/geminidataanalytics/v1
       - path: google/cloud/geminidataanalytics/v1beta

--- a/packages/google-cloud-geminidataanalytics/CHANGELOG.md
+++ b/packages/google-cloud-geminidataanalytics/CHANGELOG.md
@@ -4,6 +4,13 @@
 
 [1]: https://pypi.org/project/google-cloud-geminidataanalytics/#history
 
+## [0.13.0](https://github.com/googleapis/google-cloud-python/compare/google-cloud-geminidataanalytics-v0.12.0...google-cloud-geminidataanalytics-v0.13.0) (2026-05-28)
+
+
+### Bug Fixes
+
+* generate and default to v1 (#17007) ([3820d9d3b5c201ea9ba6ce129fd7064cba02e23c](https://github.com/googleapis/google-cloud-python/commit/3820d9d3b5c201ea9ba6ce129fd7064cba02e23c))
+
 ## [0.12.0](https://github.com/googleapis/google-cloud-python/compare/google-cloud-geminidataanalytics-v0.11.0...google-cloud-geminidataanalytics-v0.12.0) (2026-03-26)
 
 

--- a/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics/gapic_version.py
+++ b/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics/gapic_version.py
@@ -13,4 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-__version__ = "0.12.0"  # {x-release-please-version}
+__version__ = "0.13.0"  # {x-release-please-version}

--- a/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1/gapic_version.py
+++ b/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1/gapic_version.py
@@ -13,4 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-__version__ = "0.12.0"  # {x-release-please-version}
+__version__ = "0.13.0"  # {x-release-please-version}

--- a/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1alpha/gapic_version.py
+++ b/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1alpha/gapic_version.py
@@ -13,4 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-__version__ = "0.12.0"  # {x-release-please-version}
+__version__ = "0.13.0"  # {x-release-please-version}

--- a/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1beta/gapic_version.py
+++ b/packages/google-cloud-geminidataanalytics/google/cloud/geminidataanalytics_v1beta/gapic_version.py
@@ -13,4 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-__version__ = "0.12.0"  # {x-release-please-version}
+__version__ = "0.13.0"  # {x-release-please-version}

--- a/packages/google-cloud-geminidataanalytics/samples/generated_samples/snippet_metadata_google.cloud.geminidataanalytics.v1.json
+++ b/packages/google-cloud-geminidataanalytics/samples/generated_samples/snippet_metadata_google.cloud.geminidataanalytics.v1.json
@@ -8,7 +8,7 @@
     ],
     "language": "PYTHON",
     "name": "google-cloud-geminidataanalytics",
-    "version": "0.12.0"
+    "version": "0.13.0"
   },
   "snippets": [
     {

--- a/packages/google-cloud-geminidataanalytics/samples/generated_samples/snippet_metadata_google.cloud.geminidataanalytics.v1alpha.json
+++ b/packages/google-cloud-geminidataanalytics/samples/generated_samples/snippet_metadata_google.cloud.geminidataanalytics.v1alpha.json
@@ -8,7 +8,7 @@
     ],
     "language": "PYTHON",
     "name": "google-cloud-geminidataanalytics",
-    "version": "0.12.0"
+    "version": "0.13.0"
   },
   "snippets": [
     {

--- a/packages/google-cloud-geminidataanalytics/samples/generated_samples/snippet_metadata_google.cloud.geminidataanalytics.v1beta.json
+++ b/packages/google-cloud-geminidataanalytics/samples/generated_samples/snippet_metadata_google.cloud.geminidataanalytics.v1beta.json
@@ -8,7 +8,7 @@
     ],
     "language": "PYTHON",
     "name": "google-cloud-geminidataanalytics",
-    "version": "0.12.0"
+    "version": "0.13.0"
   },
   "snippets": [
     {


### PR DESCRIPTION
PR created by the Librarian CLI to initialize a release. Merging this PR will auto trigger a release.

Librarian Version: v0.15.1-0.20260528141105-567c9bf1faa7
Language Image: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/python-librarian-generator@sha256:234b9d1f2ddb057ed7ac6a38db0bf8163d839c65c6cf88ade52530cddebce59e
<details><summary>google-cloud-geminidataanalytics: v0.13.0</summary>

## [v0.13.0](https://github.com/googleapis/google-cloud-python/compare/google-cloud-geminidataanalytics-v0.12.0...google-cloud-geminidataanalytics-v0.13.0) (2026-05-28)

### Bug Fixes

* generate and default to v1 (#17007) ([3820d9d3](https://github.com/googleapis/google-cloud-python/commit/3820d9d3))

</details>