### PR TITLE
chore: librarian release pull request: 20260529T145921Z

### DIFF
--- a/.librarian/state.yaml
+++ b/.librarian/state.yaml
@@ -5512,7 +5512,7 @@ libraries:
       - packages/google-maps-geocode/docs/
     tag_format: '{id}-v{version}'
   - id: google-maps-mapmanagement
-    version: 0.0.0
+    version: 0.1.0
     last_generated_commit: ""
     apis:
       - path: google/maps/mapmanagement/v2beta

--- a/librarian.yaml
+++ b/librarian.yaml
@@ -2251,7 +2251,7 @@ libraries:
           - proto-plus-deps=google.geo.type
       default_version: v4
   - name: google-maps-mapmanagement
-    version: 0.0.0
+    version: 0.1.0
     apis:
       - path: google/maps/mapmanagement/v2beta
     copyright_year: "2026"

--- a/packages/google-maps-mapmanagement/CHANGELOG.md
+++ b/packages/google-maps-mapmanagement/CHANGELOG.md
@@ -3,3 +3,11 @@
 [PyPI History][1]
 
 [1]: https://pypi.org/project/google-maps-mapmanagement/#history
+
+## [0.1.0](https://github.com/googleapis/google-cloud-python/compare/google-maps-mapmanagement-v0.0.0...google-maps-mapmanagement-v0.1.0) (2026-05-29)
+
+
+### Features
+
+* regenerate google-maps packages (#17073) ([bd31a8c7fd338723ac201ad1b5d0f2a1861f8925](https://github.com/googleapis/google-cloud-python/commit/bd31a8c7fd338723ac201ad1b5d0f2a1861f8925))
+* add google-maps-mapmanagement (#16930) ([19331c96e486286ae0d23976559ff62bd1458ed3](https://github.com/googleapis/google-cloud-python/commit/19331c96e486286ae0d23976559ff62bd1458ed3))

--- a/packages/google-maps-mapmanagement/google/maps/mapmanagement/gapic_version.py
+++ b/packages/google-maps-mapmanagement/google/maps/mapmanagement/gapic_version.py
@@ -13,4 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-__version__ = "0.0.0"  # {x-release-please-version}
+__version__ = "0.1.0"  # {x-release-please-version}

--- a/packages/google-maps-mapmanagement/google/maps/mapmanagement_v2beta/gapic_version.py
+++ b/packages/google-maps-mapmanagement/google/maps/mapmanagement_v2beta/gapic_version.py
@@ -13,4 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-__version__ = "0.0.0"  # {x-release-please-version}
+__version__ = "0.1.0"  # {x-release-please-version}

--- a/packages/google-maps-mapmanagement/samples/generated_samples/snippet_metadata_google.maps.mapmanagement.v2beta.json
+++ b/packages/google-maps-mapmanagement/samples/generated_samples/snippet_metadata_google.maps.mapmanagement.v2beta.json
@@ -8,7 +8,7 @@
     ],
     "language": "PYTHON",
     "name": "google-maps-mapmanagement",
-    "version": "0.0.0"
+    "version": "0.1.0"
   },
   "snippets": [
     {


### PR DESCRIPTION
PR created by the Librarian CLI to initialize a release. Merging this PR will auto trigger a release.

Librarian Version: v0.15.1-0.20260528141105-567c9bf1faa7
Language Image: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/python-librarian-generator@sha256:234b9d1f2ddb057ed7ac6a38db0bf8163d839c65c6cf88ade52530cddebce59e
<details><summary>google-maps-mapmanagement: v0.1.0</summary>

## [v0.1.0](https://github.com/googleapis/google-cloud-python/compare/google-maps-mapmanagement-v0.0.0...google-maps-mapmanagement-v0.1.0) (2026-05-29)

### Features

* add google-maps-mapmanagement (#16930) ([19331c96](https://github.com/googleapis/google-cloud-python/commit/19331c96))

* regenerate google-maps packages (#17073) ([bd31a8c7](https://github.com/googleapis/google-cloud-python/commit/bd31a8c7))

</details>