### PR TITLE
chore(ci): use new librarian action

### DIFF
--- a/.github/workflows/librarian_tidy.yml
+++ b/.github/workflows/librarian_tidy.yml
@@ -2,8 +2,6 @@ name: librarian tidy
 
 on:
   pull_request:
-    paths:
-      - 'librarian.yaml'
 
 permissions:
   contents: read
@@ -14,19 +12,21 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
-
-      - name: Install Go
-        uses: actions/setup-go@v6
+      - uses: dorny/paths-filter@v4
+        id: changes
         with:
-          go-version: '1.26.x'
+          filters: |
+            librarian:
+              - 'librarian.yaml'
+
+      -  uses: googleapis/librarian@main
 
       - name: Run librarian tidy
-        run: |
-          V=$(go run github.com/googleapis/librarian/cmd/librarian@latest config get version)
-          go run github.com/googleapis/librarian/cmd/librarian@${V} tidy
-          git diff
+        if: steps.changes.outputs.librarian == 'true'
+        run: librarian tidy
 
       - name: Check for diff
+        if: steps.changes.outputs.librarian == 'true'
         run: |
           if ! git diff --exit-code; then
             V=$(go run github.com/googleapis/librarian/cmd/librarian@latest config get version)

--- a/.github/workflows/regenerate-all.yml
+++ b/.github/workflows/regenerate-all.yml
@@ -20,15 +20,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
-      - name: Install Go
-        uses: actions/setup-go@v6
+      - uses: googleapis/librarian@main
         with:
-          go-version: '1.26.x'
-
-      - name: Install protoc
-        uses: arduino/setup-protoc@v3
-        with:
-          version: "25.3"
+          protoc-version: "25.3"
+          protoc-checksum: "5ec3474ca09df0511bb2ca66b5ca091fa8943c30aa26285f225d0b1ba60b5665b3419be4cd2322decbb55464039ca0a0405a47e86bcc11491589405d615d280e"
 
       - name: Install pandoc
         run: |
@@ -38,9 +33,7 @@ jobs:
           tar -xvf /tmp/pandoc.tar.gz -C /tmp/pandoc --strip-components=1
 
       - name: Install Python packages for Librarian
-        run: |
-          version=$(sed -n 's/^version: *//p' librarian.yaml)
-          go run "github.com/googleapis/librarian/cmd/librarian@${version}" install
+        run: librarian install
 
       - name: Clone Synthtool Templates
         run: |
@@ -48,11 +41,12 @@ jobs:
 
       - name: Regenerate
         run: |
-          version=$(sed -n 's/^version: *//p' librarian.yaml)
           PATH=$PATH:/tmp/pandoc/bin
-          go run "github.com/googleapis/librarian/cmd/librarian@${version}" generate -all -v
+          librarian generate -all -v
+          git diff --exit-code
 
       - name: Create issue on diff
+        if: failure()
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |

--- a/librarian.yaml
+++ b/librarian.yaml
@@ -11,10 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-
-
-
 language: python
 version: v0.15.1-0.20260528141105-567c9bf1faa7
 repo: googleapis/google-cloud-python

--- a/librarian.yaml
+++ b/librarian.yaml
@@ -11,6 +11,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+
+
+
 language: python
 version: v0.15.1-0.20260528141105-567c9bf1faa7
 repo: googleapis/google-cloud-python


### PR DESCRIPTION
Switches librarian related CI to use the new librarian action for install/setup.

Also switches `librarian_tidy` action to use path filters rather than `pull_request` filters so that we could feasibly make it a required check on presubmit that doesn't block when its not supposed to run.