### PR TITLE
chore: remove prerelease and unit tests for goldens

### DIFF
--- a/.github/workflows/gapic-generator-tests.yml
+++ b/.github/workflows/gapic-generator-tests.yml
@@ -113,7 +113,7 @@ jobs:
           pip install nox
           cd packages/gapic-generator
           for pkg in credentials eventarc logging redis; do
-            nox -f tests/integration/goldens/$pkg/noxfile.py -s format lint unit-${{ needs.python_config.outputs.latest_stable_python }}
+            nox -f tests/integration/goldens/$pkg/noxfile.py -s format lint
           done
       # Run pylint (errors-only) over the goldens so generator regressions
       # like undefined names or import-time breakage that ruff/flake8 do
@@ -125,25 +125,6 @@ jobs:
           cd packages/gapic-generator/tests/integration/goldens
           for pkg in credentials eventarc logging redis; do
             pylint --rcfile=.pylintrc --errors-only --recursive=y "$pkg/google"
-          done
-
-  goldens-prerelease:
-    needs: python_config
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-      - name: Set up Python
-        uses: actions/setup-python@v6
-        with:
-          python-version: ${{ needs.python_config.outputs.latest_stable_python }}
-      - name: Install System Deps
-        run: sudo apt-get update && sudo apt-get install -y pandoc
-      - name: Run Goldens (Prerelease)
-        run: |
-          pip install nox
-          cd packages/gapic-generator
-          for pkg in credentials eventarc logging redis; do
-            nox -f tests/integration/goldens/$pkg/noxfile.py -s core_deps_from_source prerelease_deps
           done
 
   fragment-snippet:


### PR DESCRIPTION
We are defining a purpose for each of our testing type. Goldens should verify that the generated code is syntactically valid Python code.

These tests are run downstream so having them here is redundant. In the long run, they will be removed from downstream as well and will be run for showcase and a list of canaries upstream only.

Changes introduced:

Deleted the goldens-prerelease job: Removed `prerelease_deps` and `core_deps_from_source` from the PR blocking path.

Stripped unit execution from the goldens job: Removed the `unit-${{ ... }}` Nox session. The goldens job now strictly runs static structural checks (format, lint, and pylint).

