### PR TITLE
chore: skip google-auth release

### DIFF
--- a/.librarian/config.yaml
+++ b/.librarian/config.yaml
@@ -41,5 +41,8 @@ libraries:
   # TODO(https://github.com/googleapis/google-cloud-python/issues/17327)
   - id: "google-cloud-bigtable"
     release_blocked: true
+  # TODO(https://github.com/googleapis/google-cloud-python/issues/17334)
+  - id: "google-auth"
+    release_blocked: true
 
 

--- a/librarian.yaml
+++ b/librarian.yaml
@@ -221,6 +221,7 @@ libraries:
       default_version: v1alpha1
   - name: google-auth
     version: 2.53.0
+    skip_release: true
     python:
       library_type: AUTH
   - name: google-auth-httplib2


### PR DESCRIPTION
The google-auth CI is broken: https://github.com/googleapis/google-cloud-python/pull/17328#issuecomment-4597740887. Let's exclude it from the release for now.

For https://github.com/googleapis/google-cloud-python/issues/17334.


