### PR TITLE
fix(logging): preserve log messages with the literal string "None"

### DIFF
--- a/packages/google-cloud-logging/google/cloud/logging_v2/handlers/handlers.py
+++ b/packages/google-cloud-logging/google/cloud/logging_v2/handlers/handlers.py
@@ -281,14 +281,19 @@ def _format_and_parse_message(record, formatter_handler):
     except (json.decoder.JSONDecodeError, IndexError):
         # log string is not valid json
         pass
+    # A record whose ``msg`` is the Python object ``None`` is treated as
+    # having no content. ``logging.Formatter`` renders such a record as the
+    # string ``"None"``; detect that case from ``record.msg`` directly so that
+    # a legitimate user message of the literal string ``"None"`` is preserved.
+    is_empty_message = record.msg is None and message == "None"
     # if json_fields was set, create a dictionary using that
     if passed_json_fields and isinstance(passed_json_fields, collections.abc.Mapping):
         passed_json_fields = passed_json_fields.copy()
-        if message != "None":
+        if not is_empty_message:
             passed_json_fields["message"] = message
         return passed_json_fields
     # if formatted message contains no content, return None
-    return message if message != "None" else None
+    return None if is_empty_message else message
 
 
 def setup_logging(

--- a/packages/google-cloud-logging/tests/unit/handlers/test_handlers.py
+++ b/packages/google-cloud-logging/tests/unit/handlers/test_handlers.py
@@ -922,6 +922,34 @@ class TestFormatAndParseMessage(unittest.TestCase):
         result = _format_and_parse_message(record, handler)
         self.assertEqual(result, None)
 
+    def test_literal_none_string_preserved(self):
+        """
+        A literal string message of "None" should be preserved, not dropped.
+        Only a record whose msg is the Python object None is treated as empty.
+        """
+        from google.cloud.logging_v2.handlers.handlers import _format_and_parse_message
+
+        message = "None"
+        record = logging.LogRecord("logname", None, None, None, message, None, None)
+        handler = logging.StreamHandler()
+        result = _format_and_parse_message(record, handler)
+        self.assertEqual(result, "None")
+
+    def test_literal_none_string_preserved_with_json_fields(self):
+        """
+        A literal string message of "None" should populate the message field
+        even when json_fields are present.
+        """
+        from google.cloud.logging_v2.handlers.handlers import _format_and_parse_message
+
+        message = "None"
+        json_fields = {"key": "val"}
+        record = logging.LogRecord("logname", None, None, None, message, None, None)
+        setattr(record, "json_fields", json_fields)
+        handler = logging.StreamHandler()
+        result = _format_and_parse_message(record, handler)
+        self.assertEqual(result, {"message": "None", "key": "val"})
+
     def test_none_formatted(self):
         """
         None messages with formatting rules should return formatted string


### PR DESCRIPTION
Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [x] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/google-cloud-python/issues) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)

Fixes #17339 🦕

## What

`_format_and_parse_message` (in `handlers/handlers.py`) treated **any** record whose formatted output equaled the string `"None"` as empty content, returning `None` (or omitting the `message` field when `json_fields` were present).

This also dropped a legitimate user message consisting of the literal string `"None"`:

```python
logging.getLogger().info("None")   # payload silently became empty / None
```

## Why

The empty-content branch is intended to cover a record whose `msg` is the Python object `None`, which `logging.Formatter` renders as the string `"None"`. Comparing the *formatted string* against `"None"` cannot distinguish that case from a user who logged the literal text `"None"`, so real content was lost.

## How

Detect the empty case from `record.msg is None` (before formatting) **and** the formatted output being `"None"`, instead of from the formatted output alone. This preserves the existing behavior for `msg=None` (with and without a custom formatter) while keeping a genuine `"None"` string.

Behavior matrix:

| `record.msg` | formatter | before | after |
|---|---|---|---|
| `None` | none | `None` | `None` (unchanged) |
| `None` | custom (`"name: %(name)s"`) | `"name: logname"` | `"name: logname"` (unchanged) |
| `"None"` (str) | none | `None` ❌ dropped | `"None"` ✅ preserved |

## Tests

Added two unit tests (`test_literal_none_string_preserved`, `test_literal_none_string_preserved_with_json_fields`). All `tests/unit/handlers/` tests pass (177 passed) and `ruff format --check` is clean.
