### PR TITLE
chore(ndb): add missing format session and modernize lint and blacken sessions

### DIFF
--- a/packages/google-cloud-ndb/google/cloud/ndb/__init__.py
+++ b/packages/google-cloud-ndb/google/cloud/ndb/__init__.py
@@ -25,110 +25,115 @@ from google.cloud.ndb import version
 
 __version__: str = version.__version__
 
+from google.cloud.ndb._datastore_api import EVENTUAL, EVENTUAL_CONSISTENCY, STRONG
+from google.cloud.ndb._datastore_query import Cursor, QueryIterator
+from google.cloud.ndb._transaction import (
+    in_transaction,
+    non_transactional,
+    transaction,
+    transaction_async,
+    transactional,
+    transactional_async,
+    transactional_tasklet,
+)
 from google.cloud.ndb.client import Client
-from google.cloud.ndb.context import AutoBatcher
-from google.cloud.ndb.context import Context
-from google.cloud.ndb.context import ContextOptions
-from google.cloud.ndb.context import get_context
-from google.cloud.ndb.context import get_toplevel_context
-from google.cloud.ndb.context import TransactionOptions
-from google.cloud.ndb._datastore_api import EVENTUAL
-from google.cloud.ndb._datastore_api import EVENTUAL_CONSISTENCY
-from google.cloud.ndb._datastore_api import STRONG
-from google.cloud.ndb._datastore_query import Cursor
-from google.cloud.ndb._datastore_query import QueryIterator
-from google.cloud.ndb.global_cache import GlobalCache
-from google.cloud.ndb.global_cache import MemcacheCache
-from google.cloud.ndb.global_cache import RedisCache
+from google.cloud.ndb.context import (
+    AutoBatcher,
+    Context,
+    ContextOptions,
+    TransactionOptions,
+    get_context,
+    get_toplevel_context,
+)
+from google.cloud.ndb.global_cache import GlobalCache, MemcacheCache, RedisCache
 from google.cloud.ndb.key import Key
-from google.cloud.ndb.model import BlobKey
-from google.cloud.ndb.model import BlobKeyProperty
-from google.cloud.ndb.model import BlobProperty
-from google.cloud.ndb.model import BooleanProperty
-from google.cloud.ndb.model import ComputedProperty
-from google.cloud.ndb.model import ComputedPropertyError
-from google.cloud.ndb.model import DateProperty
-from google.cloud.ndb.model import DateTimeProperty
-from google.cloud.ndb.model import delete_multi
-from google.cloud.ndb.model import delete_multi_async
-from google.cloud.ndb.model import Expando
-from google.cloud.ndb.model import FloatProperty
-from google.cloud.ndb.model import GenericProperty
-from google.cloud.ndb.model import GeoPt
-from google.cloud.ndb.model import GeoPtProperty
-from google.cloud.ndb.model import get_indexes
-from google.cloud.ndb.model import get_indexes_async
-from google.cloud.ndb.model import get_multi
-from google.cloud.ndb.model import get_multi_async
-from google.cloud.ndb.model import Index
-from google.cloud.ndb.model import IndexProperty
-from google.cloud.ndb.model import IndexState
-from google.cloud.ndb.model import IntegerProperty
-from google.cloud.ndb.model import InvalidPropertyError
-from google.cloud.ndb.model import BadProjectionError
-from google.cloud.ndb.model import JsonProperty
-from google.cloud.ndb.model import KeyProperty
-from google.cloud.ndb.model import KindError
-from google.cloud.ndb.model import LocalStructuredProperty
-from google.cloud.ndb.model import make_connection
-from google.cloud.ndb.model import MetaModel
-from google.cloud.ndb.model import Model
-from google.cloud.ndb.model import ModelAdapter
-from google.cloud.ndb.model import ModelAttribute
-from google.cloud.ndb.model import ModelKey
-from google.cloud.ndb.model import PickleProperty
-from google.cloud.ndb.model import Property
-from google.cloud.ndb.model import put_multi
-from google.cloud.ndb.model import put_multi_async
-from google.cloud.ndb.model import ReadonlyPropertyError
-from google.cloud.ndb.model import Rollback
-from google.cloud.ndb.model import StringProperty
-from google.cloud.ndb.model import StructuredProperty
-from google.cloud.ndb.model import TextProperty
-from google.cloud.ndb.model import TimeProperty
-from google.cloud.ndb.model import UnprojectedPropertyError
-from google.cloud.ndb.model import User
-from google.cloud.ndb.model import UserNotFoundError
-from google.cloud.ndb.model import UserProperty
+from google.cloud.ndb.model import (
+    BadProjectionError,
+    BlobKey,
+    BlobKeyProperty,
+    BlobProperty,
+    BooleanProperty,
+    ComputedProperty,
+    ComputedPropertyError,
+    DateProperty,
+    DateTimeProperty,
+    Expando,
+    FloatProperty,
+    GenericProperty,
+    GeoPt,
+    GeoPtProperty,
+    Index,
+    IndexProperty,
+    IndexState,
+    IntegerProperty,
+    InvalidPropertyError,
+    JsonProperty,
+    KeyProperty,
+    KindError,
+    LocalStructuredProperty,
+    MetaModel,
+    Model,
+    ModelAdapter,
+    ModelAttribute,
+    ModelKey,
+    PickleProperty,
+    Property,
+    ReadonlyPropertyError,
+    Rollback,
+    StringProperty,
+    StructuredProperty,
+    TextProperty,
+    TimeProperty,
+    UnprojectedPropertyError,
+    User,
+    UserNotFoundError,
+    UserProperty,
+    delete_multi,
+    delete_multi_async,
+    get_indexes,
+    get_indexes_async,
+    get_multi,
+    get_multi_async,
+    make_connection,
+    put_multi,
+    put_multi_async,
+)
 from google.cloud.ndb.polymodel import PolyModel
-from google.cloud.ndb.query import ConjunctionNode
-from google.cloud.ndb.query import AND
-from google.cloud.ndb.query import DisjunctionNode
-from google.cloud.ndb.query import OR
-from google.cloud.ndb.query import FalseNode
-from google.cloud.ndb.query import FilterNode
-from google.cloud.ndb.query import gql
-from google.cloud.ndb.query import Node
-from google.cloud.ndb.query import Parameter
-from google.cloud.ndb.query import ParameterizedFunction
-from google.cloud.ndb.query import ParameterizedThing
-from google.cloud.ndb.query import ParameterNode
-from google.cloud.ndb.query import PostFilterNode
-from google.cloud.ndb.query import Query
-from google.cloud.ndb.query import QueryOptions
-from google.cloud.ndb.query import RepeatedStructuredPropertyPredicate
-from google.cloud.ndb.tasklets import add_flow_exception
-from google.cloud.ndb.tasklets import Future
-from google.cloud.ndb.tasklets import make_context
-from google.cloud.ndb.tasklets import make_default_context
-from google.cloud.ndb.tasklets import QueueFuture
-from google.cloud.ndb.tasklets import ReducingFuture
-from google.cloud.ndb.tasklets import Return
-from google.cloud.ndb.tasklets import SerialQueueFuture
-from google.cloud.ndb.tasklets import set_context
-from google.cloud.ndb.tasklets import sleep
-from google.cloud.ndb.tasklets import synctasklet
-from google.cloud.ndb.tasklets import tasklet
-from google.cloud.ndb.tasklets import toplevel
-from google.cloud.ndb.tasklets import wait_all
-from google.cloud.ndb.tasklets import wait_any
-from google.cloud.ndb._transaction import in_transaction
-from google.cloud.ndb._transaction import transaction
-from google.cloud.ndb._transaction import transaction_async
-from google.cloud.ndb._transaction import transactional
-from google.cloud.ndb._transaction import transactional_async
-from google.cloud.ndb._transaction import transactional_tasklet
-from google.cloud.ndb._transaction import non_transactional
+from google.cloud.ndb.query import (
+    AND,
+    OR,
+    ConjunctionNode,
+    DisjunctionNode,
+    FalseNode,
+    FilterNode,
+    Node,
+    Parameter,
+    ParameterizedFunction,
+    ParameterizedThing,
+    ParameterNode,
+    PostFilterNode,
+    Query,
+    QueryOptions,
+    RepeatedStructuredPropertyPredicate,
+    gql,
+)
+from google.cloud.ndb.tasklets import (
+    Future,
+    QueueFuture,
+    ReducingFuture,
+    Return,
+    SerialQueueFuture,
+    add_flow_exception,
+    make_context,
+    make_default_context,
+    set_context,
+    sleep,
+    synctasklet,
+    tasklet,
+    toplevel,
+    wait_all,
+    wait_any,
+)
 
 __all__ = [
     "__version__",

--- a/packages/google-cloud-ndb/google/cloud/ndb/_cache.py
+++ b/packages/google-cloud-ndb/google/cloud/ndb/_cache.py
@@ -20,10 +20,8 @@ import warnings
 
 from google.api_core import retry as core_retry
 
-from google.cloud.ndb import _batch
+from google.cloud.ndb import _batch, tasklets, utils
 from google.cloud.ndb import context as context_module
-from google.cloud.ndb import tasklets
-from google.cloud.ndb import utils
 
 _LOCKED_FOR_READ = b"0-"
 _LOCKED_FOR_WRITE = b"00"

--- a/packages/google-cloud-ndb/google/cloud/ndb/_datastore_api.py
+++ b/packages/google-cloud-ndb/google/cloud/ndb/_datastore_api.py
@@ -14,25 +14,27 @@
 
 """Functions that interact with Datastore backend."""
 
-import grpc
 import itertools
 import logging
 
+import grpc
 from google.api_core import exceptions as core_exceptions
 from google.api_core import gapic_v1
 from google.cloud.datastore import helpers
 from google.cloud.datastore_v1.types import datastore as datastore_pb2
 from google.cloud.datastore_v1.types import entity as entity_pb2
 
+from google.cloud.ndb import (
+    _batch,
+    _cache,
+    _eventloop,
+    _options,
+    _remote,
+    _retry,
+    tasklets,
+    utils,
+)
 from google.cloud.ndb import context as context_module
-from google.cloud.ndb import _batch
-from google.cloud.ndb import _cache
-from google.cloud.ndb import _eventloop
-from google.cloud.ndb import _options
-from google.cloud.ndb import _remote
-from google.cloud.ndb import _retry
-from google.cloud.ndb import tasklets
-from google.cloud.ndb import utils
 
 EVENTUAL = datastore_pb2.ReadOptions.ReadConsistency.EVENTUAL
 EVENTUAL_CONSISTENCY = EVENTUAL  # Legacy NDB

--- a/packages/google-cloud-ndb/google/cloud/ndb/_datastore_query.py
+++ b/packages/google-cloud-ndb/google/cloud/ndb/_datastore_query.py
@@ -20,20 +20,15 @@ import functools
 import logging
 import os
 
-from google.cloud import environment_vars
-
+from google.cloud.datastore import Key, helpers
 from google.cloud.datastore_v1.types import datastore as datastore_pb2
 from google.cloud.datastore_v1.types import entity as entity_pb2
 from google.cloud.datastore_v1.types import query as query_pb2
-from google.cloud.datastore import helpers, Key
 
+from google.cloud import environment_vars
+from google.cloud.ndb import _datastore_api, exceptions, model, tasklets, utils
 from google.cloud.ndb import context as context_module
-from google.cloud.ndb import _datastore_api
-from google.cloud.ndb import exceptions
 from google.cloud.ndb import key as key_module
-from google.cloud.ndb import model
-from google.cloud.ndb import tasklets
-from google.cloud.ndb import utils
 
 log = logging.getLogger(__name__)
 

--- a/packages/google-cloud-ndb/google/cloud/ndb/_datastore_types.py
+++ b/packages/google-cloud-ndb/google/cloud/ndb/_datastore_types.py
@@ -24,7 +24,6 @@ import functools
 
 from google.cloud.ndb import exceptions
 
-
 _MAX_STRING_LENGTH = 1500
 
 
@@ -55,12 +54,13 @@ class BlobKey(object):
         if isinstance(blob_key, bytes):
             if len(blob_key) > _MAX_STRING_LENGTH:
                 raise exceptions.BadValueError(
-                    "blob key must be under {:d} " "bytes.".format(_MAX_STRING_LENGTH)
+                    "blob key must be under {:d} bytes.".format(_MAX_STRING_LENGTH)
                 )
         elif blob_key is not None:
             raise exceptions.BadValueError(
-                "blob key should be bytes; received "
-                "{} (a {})".format(blob_key, type(blob_key).__name__)
+                "blob key should be bytes; received {} (a {})".format(
+                    blob_key, type(blob_key).__name__
+                )
             )
 
         self._blob_key = blob_key

--- a/packages/google-cloud-ndb/google/cloud/ndb/_eventloop.py
+++ b/packages/google-cloud-ndb/google/cloud/ndb/_eventloop.py
@@ -16,12 +16,12 @@
 
 This should handle both asynchronous ``ndb`` objects and arbitrary callbacks.
 """
+
 import collections
 import logging
-import uuid
-import time
-
 import queue
+import time
+import uuid
 
 from google.cloud.ndb import utils
 

--- a/packages/google-cloud-ndb/google/cloud/ndb/_gql.py
+++ b/packages/google-cloud-ndb/google/cloud/ndb/_gql.py
@@ -3,12 +3,9 @@ import re
 import time
 from typing import Any
 
+from google.cloud.ndb import _datastore_query, exceptions, key, model
 from google.cloud.ndb import context as context_module
-from google.cloud.ndb import exceptions
 from google.cloud.ndb import query as query_module
-from google.cloud.ndb import key
-from google.cloud.ndb import model
-from google.cloud.ndb import _datastore_query
 
 
 class GQL(object):

--- a/packages/google-cloud-ndb/google/cloud/ndb/_legacy_protocol_buffer.py
+++ b/packages/google-cloud-ndb/google/cloud/ndb/_legacy_protocol_buffer.py
@@ -16,7 +16,6 @@
 import array
 import struct
 
-
 # Python 3 doesn't have "long" anymore
 long = int
 

--- a/packages/google-cloud-ndb/google/cloud/ndb/_options.py
+++ b/packages/google-cloud-ndb/google/cloud/ndb/_options.py
@@ -17,9 +17,9 @@
 import functools
 import itertools
 import logging
+from typing import Any
 
 from google.cloud.ndb import exceptions
-from typing import Any
 
 log = logging.getLogger(__name__)
 
@@ -135,8 +135,7 @@ class Options(object):
             global_cache_timeout = kwargs.get("global_cache_timeout")
             if global_cache_timeout is not None:
                 raise TypeError(
-                    "Can't specify both 'memcache_timeout' and "
-                    "'global_cache_timeout'"
+                    "Can't specify both 'memcache_timeout' and 'global_cache_timeout'"
                 )
             kwargs["global_cache_timeout"] = memcache_timeout
 
@@ -223,7 +222,7 @@ class ReadOptions(Options):
             )
             if kwargs.get("read_consistency"):
                 raise TypeError(
-                    "Cannot use both 'read_policy' and 'read_consistency' " "options."
+                    "Cannot use both 'read_policy' and 'read_consistency' options."
                 )
             kwargs["read_consistency"] = read_policy
 

--- a/packages/google-cloud-ndb/google/cloud/ndb/_remote.py
+++ b/packages/google-cloud-ndb/google/cloud/ndb/_remote.py
@@ -16,8 +16,9 @@
 
 # In its own module to avoid circular import between _datastore_api and
 # tasklets modules.
-import grpc
 import time
+
+import grpc
 
 from google.cloud.ndb import exceptions
 

--- a/packages/google-cloud-ndb/google/cloud/ndb/_retry.py
+++ b/packages/google-cloud-ndb/google/cloud/ndb/_retry.py
@@ -17,10 +17,10 @@
 import functools
 import itertools
 
-from google.api_core import retry as core_retry
 from google.api_core import exceptions as core_exceptions
-from google.cloud.ndb import exceptions
-from google.cloud.ndb import tasklets
+from google.api_core import retry as core_retry
+
+from google.cloud.ndb import exceptions, tasklets
 
 _DEFAULT_INITIAL_DELAY = 1.0  # seconds
 _DEFAULT_MAXIMUM_DELAY = 60.0  # seconds

--- a/packages/google-cloud-ndb/google/cloud/ndb/_transaction.py
+++ b/packages/google-cloud-ndb/google/cloud/ndb/_transaction.py
@@ -15,10 +15,7 @@
 import functools
 import logging
 
-from google.cloud.ndb import exceptions
-from google.cloud.ndb import _retry
-from google.cloud.ndb import tasklets
-from google.cloud.ndb import utils
+from google.cloud.ndb import _retry, exceptions, tasklets, utils
 
 log = logging.getLogger(__name__)
 
@@ -50,8 +47,9 @@ class _Propagation(object):
             self.propagation = propagation
         else:
             raise ValueError(
-                "Unexpected value for propagation. Got: {}. Expected one of: "
-                "{}".format(propagation, propagation_options)
+                "Unexpected value for propagation. Got: {}. Expected one of: {}".format(
+                    propagation, propagation_options
+                )
             )
 
         propagation_names = context_module.TransactionOptions._INT_TO_NAME

--- a/packages/google-cloud-ndb/google/cloud/ndb/blobstore.py
+++ b/packages/google-cloud-ndb/google/cloud/ndb/blobstore.py
@@ -20,11 +20,7 @@ Storage.
 No longer supported.
 """
 
-
-from google.cloud.ndb import _datastore_types
-from google.cloud.ndb import model
-from google.cloud.ndb import exceptions
-
+from google.cloud.ndb import _datastore_types, exceptions, model
 
 __all__ = [
     "BLOB_INFO_KIND",

--- a/packages/google-cloud-ndb/google/cloud/ndb/client.py
+++ b/packages/google-cloud-ndb/google/cloud/ndb/client.py
@@ -15,24 +15,21 @@
 """A client for NDB which manages credentials, project, namespace, and database."""
 
 import contextlib
-import grpc
 import os
-import requests
 
 import google.api_core.client_options
-
+import grpc
+import requests
 from google.api_core.gapic_v1 import client_info
-from google.cloud import environment_vars
-from google.cloud import _helpers
-from google.cloud import client as google_client
 from google.cloud.datastore_v1.services.datastore.transports import (
     grpc as datastore_grpc,
 )
 
+from google.cloud import _helpers, environment_vars
+from google.cloud import client as google_client
 from google.cloud.ndb import __version__
 from google.cloud.ndb import context as context_module
 from google.cloud.ndb import key as key_module
-
 
 _CLIENT_INFO = client_info.ClientInfo(
     user_agent="google-cloud-ndb/{}".format(__version__)

--- a/packages/google-cloud-ndb/google/cloud/ndb/context.py
+++ b/packages/google-cloud-ndb/google/cloud/ndb/context.py
@@ -24,8 +24,7 @@ import threading
 import uuid
 from typing import Any, cast
 
-from google.cloud.ndb import _eventloop
-from google.cloud.ndb import exceptions
+from google.cloud.ndb import _eventloop, exceptions
 from google.cloud.ndb import key as key_module
 
 

--- a/packages/google-cloud-ndb/google/cloud/ndb/django_middleware.py
+++ b/packages/google-cloud-ndb/google/cloud/ndb/django_middleware.py
@@ -20,7 +20,6 @@ To use Django middleware with NDB, follow the steps in
 https://cloud.google.com/appengine/docs/standard/python3/migrating-to-cloud-ndb#using_a_runtime_context_with_django
 """
 
-
 __all__ = ["NdbDjangoMiddleware"]
 
 

--- a/packages/google-cloud-ndb/google/cloud/ndb/exceptions.py
+++ b/packages/google-cloud-ndb/google/cloud/ndb/exceptions.py
@@ -19,7 +19,6 @@ types defined in the ``google.appengine.api.datastore_errors`` module in
 legacy Google App Engine runtime.
 """
 
-
 __all__ = [
     "Error",
     "ContextError",

--- a/packages/google-cloud-ndb/google/cloud/ndb/global_cache.py
+++ b/packages/google-cloud-ndb/google/cloud/ndb/global_cache.py
@@ -18,15 +18,15 @@ import abc
 import base64
 import hashlib
 import os
-import pymemcache.exceptions
-import redis.exceptions
 import threading
 import time
 import warnings
+from typing import Any
 
 import pymemcache
+import pymemcache.exceptions
 import redis as redis_module
-from typing import Any
+import redis.exceptions
 
 # Python 2.7 doesn't have ConnectionError. In Python 3, ConnectionError is subclass of
 # OSError, which Python 2.7 does have.

--- a/packages/google-cloud-ndb/google/cloud/ndb/key.py
+++ b/packages/google-cloud-ndb/google/cloud/ndb/key.py
@@ -87,19 +87,15 @@ manager is not available so the default is to have an unset or empty
 namespace. To explicitly select the empty namespace pass ``namespace=""``.
 """
 
-
-import typing
 import base64
 import functools
+import typing
 
+import google.cloud.datastore
 from google.cloud.datastore import _app_engine_key_pb2
 from google.cloud.datastore import key as _key_module
-import google.cloud.datastore
 
-from google.cloud.ndb import exceptions
-from google.cloud.ndb import _options
-from google.cloud.ndb import tasklets
-from google.cloud.ndb import utils
+from google.cloud.ndb import _options, exceptions, tasklets, utils
 
 __all__ = ["Key", "UNDEFINED"]
 _APP_ID_ENVIRONMENT = "APPLICATION_ID"
@@ -918,9 +914,8 @@ class Key(object):
             :class:`~google.cloud.ndb.tasklets.Future`
         """
         # Avoid circular import in Python 2.7
-        from google.cloud.ndb import model
+        from google.cloud.ndb import _datastore_api, model
         from google.cloud.ndb import context as context_module
-        from google.cloud.ndb import _datastore_api
 
         cls = model.Model._kind_map.get(self.kind())
 
@@ -1054,9 +1049,8 @@ class Key(object):
             force_writes (bool): No longer supported.
         """
         # Avoid circular import in Python 2.7
-        from google.cloud.ndb import model
+        from google.cloud.ndb import _datastore_api, model
         from google.cloud.ndb import context as context_module
-        from google.cloud.ndb import _datastore_api
 
         cls = model.Model._kind_map.get(self.kind())
         if cls:
@@ -1317,7 +1311,7 @@ def _parse_from_ref(
     app=None,
     namespace=None,
     database: typing.Optional[str] = None,
-    **kwargs
+    **kwargs,
 ):
     """Construct a key from a Reference.
 
@@ -1361,7 +1355,7 @@ def _parse_from_ref(
 
     if kwargs or not _exactly_one_specified(reference, serialized, urlsafe):
         raise TypeError(
-            "Cannot construct Key reference from incompatible " "keyword arguments."
+            "Cannot construct Key reference from incompatible keyword arguments."
         )
 
     if reference:
@@ -1528,8 +1522,7 @@ def _clean_flat_path(flat):
             flat[i] = kind
         if not isinstance(kind, str):
             raise TypeError(
-                "Key kind must be a string or Model class; "
-                "received {!r}".format(kind)
+                "Key kind must be a string or Model class; received {!r}".format(kind)
             )
         # Make sure the ``id_`` is either a string or int. In the special case
         # of a partial key, ``id_`` can be ``None`` for the last pair.

--- a/packages/google-cloud-ndb/google/cloud/ndb/metadata.py
+++ b/packages/google-cloud-ndb/google/cloud/ndb/metadata.py
@@ -38,10 +38,8 @@ A simplified API is also offered:
     limit the query to a range of names, such that start <= name < end.
 """
 
-from google.cloud.ndb import exceptions
-from google.cloud.ndb import model
+from google.cloud.ndb import exceptions, model
 from google.cloud.ndb import query as query_module
-
 
 __all__ = [
     "get_entity_group_version",

--- a/packages/google-cloud-ndb/google/cloud/ndb/model.py
+++ b/packages/google-cloud-ndb/google/cloud/ndb/model.py
@@ -250,32 +250,31 @@ Documentation for writing a Property subclass is in the docs for the
 :class:`Property` class.
 """
 
-
-import typing
 import copy
 import datetime
 import functools
 import inspect
 import json
 import pickle
+import typing
 import zlib
 
 import pytz
-
 from google.cloud.datastore import entity as ds_entity_module
 from google.cloud.datastore import helpers
 from google.cloud.datastore_v1.types import entity as entity_pb2
 
-from google.cloud.ndb import _legacy_entity_pb
-from google.cloud.ndb import _datastore_types
-from google.cloud.ndb import exceptions
-from google.cloud.ndb import key as key_module
+from google.cloud.ndb import (
+    _datastore_types,
+    _legacy_entity_pb,
+    _transaction,
+    exceptions,
+    tasklets,
+    utils,
+)
 from google.cloud.ndb import _options as options_module
+from google.cloud.ndb import key as key_module
 from google.cloud.ndb import query as query_module
-from google.cloud.ndb import _transaction
-from google.cloud.ndb import tasklets
-from google.cloud.ndb import utils
-
 
 __all__ = [
     "Key",
@@ -1439,8 +1438,9 @@ class Property(ModelAttribute):
         if self._choices is not None:
             if value not in self._choices:
                 raise exceptions.BadValueError(
-                    "Value {!r} for property {} is not an allowed "
-                    "choice".format(value, self._name)
+                    "Value {!r} for property {} is not an allowed choice".format(
+                        value, self._name
+                    )
                 )
 
         return value
@@ -2295,8 +2295,9 @@ def _validate_key(value, entity=None):
     if entity and type(entity) not in (Model, Expando):
         if value.kind() != entity._get_kind():
             raise KindError(
-                "Expected Key kind to be {}; received "
-                "{}".format(entity._get_kind(), value.kind())
+                "Expected Key kind to be {}; received {}".format(
+                    entity._get_kind(), value.kind()
+                )
             )
 
     return value
@@ -2625,8 +2626,9 @@ class BlobProperty(Property):
 
         if self._indexed and len(value) > _MAX_STRING_LENGTH:
             raise exceptions.BadValueError(
-                "Indexed value {} must be at most {:d} "
-                "bytes".format(self._name, _MAX_STRING_LENGTH)
+                "Indexed value {} must be at most {:d} bytes".format(
+                    self._name, _MAX_STRING_LENGTH
+                )
             )
 
     def _to_base_type(self, value):
@@ -2993,8 +2995,9 @@ class TextProperty(Property):
 
         if self._indexed and encoded_length > _MAX_STRING_LENGTH:
             raise exceptions.BadValueError(
-                "Indexed value {} must be at most {:d} "
-                "bytes".format(self._name, _MAX_STRING_LENGTH)
+                "Indexed value {} must be at most {:d} bytes".format(
+                    self._name, _MAX_STRING_LENGTH
+                )
             )
 
     def _to_base_type(self, value):
@@ -3742,8 +3745,9 @@ class KeyProperty(Property):
         if self._kind is not None:
             if value.kind() != self._kind:
                 raise exceptions.BadValueError(
-                    "In field {}, expected Key with kind={!r}, got "
-                    "{!r}".format(self._name, self._kind, value)
+                    "In field {}, expected Key with kind={!r}, got {!r}".format(
+                        self._name, self._kind, value
+                    )
                 )
 
     def _to_base_type(self, value):
@@ -4030,8 +4034,9 @@ class DateProperty(DateTimeProperty):
         """
         if not isinstance(value, datetime.date):
             raise TypeError(
-                "Cannot convert to datetime expected date value; "
-                "received {}".format(value)
+                "Cannot convert to datetime expected date value; received {}".format(
+                    value
+                )
             )
         return datetime.datetime(value.year, value.month, value.day)
 
@@ -4090,8 +4095,9 @@ class TimeProperty(DateTimeProperty):
         """
         if not isinstance(value, datetime.time):
             raise TypeError(
-                "Cannot convert to datetime expected time value; "
-                "received {}".format(value)
+                "Cannot convert to datetime expected time value; received {}".format(
+                    value
+                )
             )
         return datetime.datetime(
             1970,
@@ -4205,8 +4211,11 @@ class StructuredProperty(Property):
                 "Cannot query for unindexed StructuredProperty %s" % self._name
             )
         # Import late to avoid circular imports.
-        from .query import ConjunctionNode, PostFilterNode
-        from .query import RepeatedStructuredPropertyPredicate
+        from .query import (
+            ConjunctionNode,
+            PostFilterNode,
+            RepeatedStructuredPropertyPredicate,
+        )
 
         if value is None:
             from .query import (
@@ -4520,8 +4529,9 @@ class LocalStructuredProperty(BlobProperty):
             raise TypeError("self._model_class cannot be None")
         if not isinstance(value, self._model_class):
             raise TypeError(
-                "Cannot convert to bytes expected {} value; "
-                "received {}".format(self._model_class.__name__, value)
+                "Cannot convert to bytes expected {} value; received {}".format(
+                    self._model_class.__name__, value
+                )
             )
         return _entity_to_protobuf(
             value, set_key=self._keep_keys
@@ -5567,8 +5577,8 @@ class Model(_NotEqualMixin, metaclass=MetaModel):
                 entity. This is always a complete key.
         """
         # Avoid Python 2.7 circular import
-        from google.cloud.ndb import context as context_module
         from google.cloud.ndb import _datastore_api
+        from google.cloud.ndb import context as context_module
 
         self._pre_put_hook()
 
@@ -6402,8 +6412,7 @@ class Expando(Model):
         base_props = super(Expando, self)._properties
         if base_props is not None and name in base_props:
             raise RuntimeError(
-                "Property %s still in the list of properties for the "
-                "base class." % name
+                "Property %s still in the list of properties for the base class." % name
             )
         del self._properties[name]
 

--- a/packages/google-cloud-ndb/google/cloud/ndb/msgprop.py
+++ b/packages/google-cloud-ndb/google/cloud/ndb/msgprop.py
@@ -17,7 +17,6 @@
 These classes are not implemented.
 """
 
-
 __all__ = ["EnumProperty", "MessageProperty"]
 
 

--- a/packages/google-cloud-ndb/google/cloud/ndb/polymodel.py
+++ b/packages/google-cloud-ndb/google/cloud/ndb/polymodel.py
@@ -31,7 +31,6 @@ of Model.
 
 from google.cloud.ndb import model
 
-
 __all__ = ["PolyModel"]
 
 _CLASS_KEY_PROPERTY = "class"

--- a/packages/google-cloud-ndb/google/cloud/ndb/query.py
+++ b/packages/google-cloud-ndb/google/cloud/ndb/query.py
@@ -137,16 +137,12 @@ tasklet, properly yielding when appropriate::
         print(emp.name, emp.age)
 """
 
-import typing
 import functools
 import logging
+import typing
 
+from google.cloud.ndb import _options, exceptions, tasklets, utils
 from google.cloud.ndb import context as context_module
-from google.cloud.ndb import exceptions
-from google.cloud.ndb import _options
-from google.cloud.ndb import tasklets
-from google.cloud.ndb import utils
-
 
 __all__ = [
     "QueryOptions",
@@ -651,8 +647,9 @@ class FilterNode(Node):
         if opsymbol == _IN_OP:
             if not isinstance(value, (list, tuple, set, frozenset)):
                 raise TypeError(
-                    "in expected a list, tuple or set of values; "
-                    "received {!r}".format(value)
+                    "in expected a list, tuple or set of values; received {!r}".format(
+                        value
+                    )
                 )
             nodes = [FilterNode(name, _EQ_OP, sub_value) for sub_value in value]
             if not nodes:
@@ -1145,8 +1142,8 @@ def _query_options(wrapped):
     @functools.wraps(wrapped)
     def wrapper(self, *args, **kwargs):
         # Avoid circular import in Python 2.7
-        from google.cloud.ndb import context as context_module
         from google.cloud.ndb import _datastore_api
+        from google.cloud.ndb import context as context_module
 
         # Maybe we already did this (in the case of X calling X_async)
         if "_options" in kwargs:
@@ -1355,8 +1352,9 @@ class Query(object):
 
             if not isinstance(default_options, QueryOptions):
                 raise TypeError(
-                    "default_options must be QueryOptions or None; "
-                    "received {}".format(default_options)
+                    "default_options must be QueryOptions or None; received {}".format(
+                        default_options
+                    )
                 )
 
             # Not sure why we're doing all this checking just for this one
@@ -1392,12 +1390,12 @@ class Query(object):
                 if isinstance(ancestor, ParameterizedFunction):
                     if ancestor.func != "key":
                         raise TypeError(
-                            "ancestor cannot be a GQL function" "other than Key"
+                            "ancestor cannot be a GQL functionother than Key"
                         )
             else:
                 if not isinstance(ancestor, model.Key):
                     raise TypeError(
-                        "ancestor must be a Key; " "received {}".format(ancestor)
+                        "ancestor must be a Key; received {}".format(ancestor)
                     )
                 if not ancestor.id():
                     raise ValueError("ancestor cannot be an incomplete key")
@@ -1424,8 +1422,7 @@ class Query(object):
         if filters is not None:
             if not isinstance(filters, Node):
                 raise TypeError(
-                    "filters must be a query Node or None; "
-                    "received {}".format(filters)
+                    "filters must be a query Node or None; received {}".format(filters)
                 )
         if order_by is not None and orders is not None:
             raise TypeError(
@@ -1437,8 +1434,9 @@ class Query(object):
         if order_by is not None:
             if not isinstance(order_by, (list, tuple)):
                 raise TypeError(
-                    "order must be a list, a tuple or None; "
-                    "received {}".format(order_by)
+                    "order must be a list, a tuple or None; received {}".format(
+                        order_by
+                    )
                 )
             order_by = self._to_property_orders(order_by)
 
@@ -1459,8 +1457,9 @@ class Query(object):
                 raise TypeError("projection argument cannot be empty")
             if not isinstance(projection, (tuple, list)):
                 raise TypeError(
-                    "projection must be a tuple, list or None; "
-                    "received {}".format(projection)
+                    "projection must be a tuple, list or None; received {}".format(
+                        projection
+                    )
                 )
             projection = _to_property_names(projection)
             _check_properties(self.kind, projection)
@@ -1480,8 +1479,9 @@ class Query(object):
                 raise TypeError("distinct_on argument cannot be empty")
             if not isinstance(distinct_on, (tuple, list)):
                 raise TypeError(
-                    "distinct_on must be a tuple, list or None; "
-                    "received {}".format(distinct_on)
+                    "distinct_on must be a tuple, list or None; received {}".format(
+                        distinct_on
+                    )
                 )
             distinct_on = _to_property_names(distinct_on)
             _check_properties(self.kind, distinct_on)
@@ -2371,7 +2371,7 @@ def _to_property_names(properties):
             fixed.append(prop._name)
         else:
             raise TypeError(
-                "Unexpected property {}; " "should be string or Property".format(prop)
+                "Unexpected property {}; should be string or Property".format(prop)
             )
     return fixed
 

--- a/packages/google-cloud-ndb/google/cloud/ndb/query.py
+++ b/packages/google-cloud-ndb/google/cloud/ndb/query.py
@@ -1390,7 +1390,7 @@ class Query(object):
                 if isinstance(ancestor, ParameterizedFunction):
                     if ancestor.func != "key":
                         raise TypeError(
-                            "ancestor cannot be a GQL functionother than Key"
+                            "ancestor cannot be a GQL function other than Key"
                         )
             else:
                 if not isinstance(ancestor, model.Key):

--- a/packages/google-cloud-ndb/google/cloud/ndb/stats.py
+++ b/packages/google-cloud-ndb/google/cloud/ndb/stats.py
@@ -20,7 +20,6 @@ application's datastore by offline processes run by the Google Cloud team.
 
 from google.cloud.ndb import model
 
-
 __all__ = [
     "BaseKindStatistic",
     "BaseStatistic",

--- a/packages/google-cloud-ndb/google/cloud/ndb/tasklets.py
+++ b/packages/google-cloud-ndb/google/cloud/ndb/tasklets.py
@@ -72,12 +72,11 @@ Calling a tasklet automatically schedules it with the event loop::
         eventloop.run()  # Run until no tasklets left to do
         f.done()  # Returns True
 """
+
 import functools
 import types
 
-from google.cloud.ndb import _eventloop
-from google.cloud.ndb import exceptions
-from google.cloud.ndb import _remote
+from google.cloud.ndb import _eventloop, _remote, exceptions
 
 __all__ = [
     "add_flow_exception",

--- a/packages/google-cloud-ndb/google/cloud/ndb/utils.py
+++ b/packages/google-cloud-ndb/google/cloud/ndb/utils.py
@@ -14,7 +14,6 @@
 
 """Low-level utilities used internally by ``ndb``"""
 
-
 import functools
 import inspect
 import os

--- a/packages/google-cloud-ndb/noxfile.py
+++ b/packages/google-cloud-ndb/noxfile.py
@@ -33,6 +33,8 @@ ALL_INTERPRETERS = ("3.10", "3.11", "3.12", "3.13", "3.14")
 CURRENT_DIRECTORY = pathlib.Path(__file__).parent.absolute()
 
 BLACK_VERSION = "black[jupyter]==23.7.0"
+RUFF_VERSION = "ruff==0.14.14"
+LINT_PATHS = ["docs", "google", "tests", "noxfile.py", "setup.py"]
 UNIT_TEST_STANDARD_DEPENDENCIES = [
     "mock",
     "asyncmock",
@@ -241,40 +243,76 @@ def _run_emulator(session, emulator_args):
     emulator.wait(timeout=2)
 
 
-def run_black(session, use_check=False):
-    args = ["black"]
-    if use_check:
-        args.append("--check")
-
-    args.extend(
-        [
-            get_path("docs"),
-            get_path("noxfile.py"),
-            get_path("google"),
-            get_path("tests"),
-        ]
-    )
-
-    session.run(*args)
-
-
 @nox.session(py=DEFAULT_INTERPRETER)
 def lint(session):
     """Run linters.
+
     Returns a failure if the linters find linting errors or sufficiently
     serious code quality issues.
     """
-    session.install("flake8", BLACK_VERSION)
-    run_black(session, use_check=True)
+    session.install("flake8", RUFF_VERSION)
+
+    # 2. Check formatting
+    session.run(
+        "ruff",
+        "format",
+        "--check",
+        f"--target-version=py{ALL_INTERPRETERS[0].replace('.', '')}",
+        "--line-length=88",
+        *LINT_PATHS,
+    )
+
     session.run("flake8", "google", "tests")
 
 
 @nox.session(py=DEFAULT_INTERPRETER)
 def blacken(session):
-    # Install all dependencies.
-    session.install(BLACK_VERSION)
-    # Run ``black``.
-    run_black(session)
+    """(Deprecated) Legacy session. Please use 'nox -s format'."""
+    session.log(
+        "WARNING: The 'blacken' session is deprecated and will be removed in a future release. Please use 'nox -s format' in the future."
+    )
+
+    # Just run the ruff formatter (keeping legacy behavior of only formatting, not sorting imports)
+    session.install(RUFF_VERSION)
+    session.run(
+        "ruff",
+        "format",
+        f"--target-version=py{ALL_INTERPRETERS[0].replace('.', '')}",
+        "--line-length=88",
+        *LINT_PATHS,
+    )
+
+
+@nox.session(python=DEFAULT_INTERPRETER)
+def format(session):
+    """
+    Run ruff to sort imports and format code.
+    """
+    # 1. Install ruff (skipped automatically if you run with --no-venv)
+    session.install(RUFF_VERSION)
+
+    # 2. Run Ruff to fix imports
+    # check --select I: Enables strict import sorting
+    # --fix: Applies the changes automatically
+    session.run(
+        "ruff",
+        "check",
+        "--select",
+        "I",
+        "--fix",
+        f"--target-version=py{ALL_INTERPRETERS[0].replace('.', '')}",
+        "--line-length=88",  # Standard Black line length
+        *LINT_PATHS,
+    )
+
+    # 3. Run Ruff to format code
+    session.run(
+        "ruff",
+        "format",
+        f"--target-version=py{ALL_INTERPRETERS[0].replace('.', '')}",
+        "--line-length=88",  # Standard Black line length
+        *LINT_PATHS,
+    )
 
 
 @nox.session(py="3.10")

--- a/packages/google-cloud-ndb/setup.py
+++ b/packages/google-cloud-ndb/setup.py
@@ -18,7 +18,6 @@ import re
 
 import setuptools
 
-
 PACKAGE_ROOT = os.path.abspath(os.path.dirname(__file__))
 
 version = None
@@ -33,6 +32,7 @@ packages = [
     for package in setuptools.find_namespace_packages()
     if package.startswith("google")
 ]
+
 
 def main():
     package_root = os.path.abspath(os.path.dirname(__file__))
@@ -50,7 +50,7 @@ def main():
 
     setuptools.setup(
         name="google-cloud-ndb",
-        version = version,
+        version=version,
         description="NDB library for Google Cloud Datastore",
         long_description=readme,
         long_description_content_type="text/markdown",
@@ -59,8 +59,8 @@ def main():
         license="Apache 2.0",
         url="https://github.com/googleapis/google-cloud-python/tree/main/packages/google-cloud-ndb",
         project_urls={
-            'Documentation': 'https://googleapis.dev/python/python-ndb/latest',
-            'Issue Tracker': 'https://github.com/googleapis/google-cloud-python/tree/main/packages/google-cloud-ndb/issues'
+            "Documentation": "https://googleapis.dev/python/python-ndb/latest",
+            "Issue Tracker": "https://github.com/googleapis/google-cloud-python/tree/main/packages/google-cloud-ndb/issues",
         },
         classifiers=[
             "Development Status :: 5 - Production/Stable",

--- a/packages/google-cloud-ndb/tests/conftest.py
+++ b/packages/google-cloud-ndb/tests/conftest.py
@@ -19,17 +19,14 @@ modules.
 """
 
 import os
-
-from google.cloud import environment_vars
-from google.cloud.ndb import context as context_module
-from google.cloud.ndb import _eventloop
-from google.cloud.ndb import global_cache as global_cache_module
-from google.cloud.ndb import model
-from google.cloud.ndb import utils
+from unittest import mock
 
 import pytest
 
-from unittest import mock
+from google.cloud import environment_vars
+from google.cloud.ndb import _eventloop, model, utils
+from google.cloud.ndb import context as context_module
+from google.cloud.ndb import global_cache as global_cache_module
 
 utils.DEBUG = True
 
@@ -98,7 +95,7 @@ def context_factory():
             eventloop=TestingEventLoop(),
             datastore_policy=True,
             legacy_data=False,
-            **kwargs
+            **kwargs,
         )
         return context
 

--- a/packages/google-cloud-ndb/tests/system/conftest.py
+++ b/packages/google-cloud-ndb/tests/system/conftest.py
@@ -6,9 +6,7 @@ import uuid
 import pytest
 import requests
 
-from google.cloud import datastore
-from google.cloud import ndb
-
+from google.cloud import datastore, ndb
 from google.cloud.ndb import global_cache as global_cache_module
 
 from . import KIND, OTHER_KIND, _helpers
@@ -138,7 +136,7 @@ def fix_key_db(key, database):
             *key.flat_path,
             project=key.project,
             database=database,
-            namespace=key.namespace
+            namespace=key.namespace,
         )
         # If the current parent has already been set, we re-use
         # the same instance

--- a/packages/google-cloud-ndb/tests/system/test_crud.py
+++ b/packages/google-cloud-ndb/tests/system/test_crud.py
@@ -15,25 +15,24 @@
 """
 System tests for Create, Update, Delete. (CRUD)
 """
+
 import datetime
 import os
 import pickle
-import pytz
 import random
 import threading
 import zlib
-
 from unittest import mock
 
 import pytest
-
+import pytz
 import test_utils.system
 
 from google.cloud import ndb
 from google.cloud.ndb import _cache
 from google.cloud.ndb import global_cache as global_cache_module
 
-from . import KIND, eventually, equals
+from . import KIND, equals, eventually
 
 USE_REDIS_CACHE = bool(os.environ.get("REDIS_CACHE_URL"))
 USE_MEMCACHE = bool(os.environ.get("MEMCACHED_HOSTS"))
@@ -1174,7 +1173,7 @@ def test_retrieve_entity_with_legacy_repeated_structured_property(ds_entity):
     ds_entity(
         KIND,
         entity_id,
-        **{"foo": 42, "bar.one": ["hi", "hello"], "bar.two": ["mom", "dad"]}
+        **{"foo": 42, "bar.one": ["hi", "hello"], "bar.two": ["mom", "dad"]},
     )
 
     key = ndb.Key(KIND, entity_id)

--- a/packages/google-cloud-ndb/tests/system/test_metadata.py
+++ b/packages/google-cloud-ndb/tests/system/test_metadata.py
@@ -15,14 +15,13 @@
 """
 System tests for metadata.
 """
-import pytest
 
 from importlib import reload
 
-from google.cloud import ndb
-
+import pytest
 from test_utils import retry
 
+from google.cloud import ndb
 
 _retry_assertion_errors = retry.RetryErrors(AssertionError)
 

--- a/packages/google-cloud-ndb/tests/system/test_misc.py
+++ b/packages/google-cloud-ndb/tests/system/test_misc.py
@@ -15,24 +15,22 @@
 """
 Difficult to classify regression tests.
 """
+
 import os
 import pickle
 import threading
 import time
 import traceback
-
-import redis
-
 from unittest import mock
 
 import pytest
-
+import redis
 import test_utils.system
-
 from google.api_core import exceptions as core_exceptions
+
 from google.cloud import ndb
 
-from . import eventually, length_equals, KIND
+from . import KIND, eventually, length_equals
 
 USE_REDIS_CACHE = bool(os.environ.get("REDIS_CACHE_URL"))
 

--- a/packages/google-cloud-ndb/tests/system/test_query.py
+++ b/packages/google-cloud-ndb/tests/system/test_query.py
@@ -23,14 +23,13 @@ import uuid
 
 import pytest
 import pytz
-
 import test_utils.system
-
 from google.api_core import exceptions as core_exceptions
-from google.cloud import ndb
 from google.cloud.datastore import key as ds_key_module
 
-from . import KIND, eventually, equals, length_equals
+from google.cloud import ndb
+
+from . import KIND, equals, eventually, length_equals
 
 
 @pytest.mark.usefixtures("client_context")
@@ -1097,14 +1096,14 @@ def test_query_legacy_structured_property(ds_entity):
     ds_entity(
         KIND,
         entity_id,
-        **{"foo": 1, "bar.one": "pish", "bar.two": "posh", "bar.three": "pash"}
+        **{"foo": 1, "bar.one": "pish", "bar.two": "posh", "bar.three": "pash"},
     )
 
     entity_id = test_utils.system.unique_resource_id()
     ds_entity(
         KIND,
         entity_id,
-        **{"foo": 2, "bar.one": "pish", "bar.two": "posh", "bar.three": "push"}
+        **{"foo": 2, "bar.one": "pish", "bar.two": "posh", "bar.three": "push"},
     )
 
     entity_id = test_utils.system.unique_resource_id()
@@ -1116,7 +1115,7 @@ def test_query_legacy_structured_property(ds_entity):
             "bar.one": "pish",
             "bar.two": "moppish",
             "bar.three": "pass the peas",
-        }
+        },
     )
 
     eventually(SomeKind.query().fetch, length_equals(3))
@@ -1647,7 +1646,7 @@ def test_query_legacy_repeated_structured_property(ds_entity):
             "bar.one": ["pish", "bish"],
             "bar.two": ["posh", "bosh"],
             "bar.three": ["pash", "bash"],
-        }
+        },
     )
 
     entity_id = test_utils.system.unique_resource_id()
@@ -1659,7 +1658,7 @@ def test_query_legacy_repeated_structured_property(ds_entity):
             "bar.one": ["bish", "pish"],
             "bar.two": ["bosh", "posh"],
             "bar.three": ["bass", "pass"],
-        }
+        },
     )
 
     entity_id = test_utils.system.unique_resource_id()
@@ -1671,7 +1670,7 @@ def test_query_legacy_repeated_structured_property(ds_entity):
             "bar.one": ["pish", "bish"],
             "bar.two": ["fosh", "posh"],
             "bar.three": ["fash", "bash"],
-        }
+        },
     )
 
     eventually(SomeKind.query().fetch, length_equals(3))
@@ -1710,7 +1709,7 @@ def test_query_legacy_repeated_structured_property_with_name(ds_entity):
             "b.one": ["pish", "bish"],
             "b.two": ["posh", "bosh"],
             "b.three": ["pash", "bash"],
-        }
+        },
     )
 
     eventually(SomeKind.query().fetch, length_equals(1))

--- a/packages/google-cloud-ndb/tests/unit/test__batch.py
+++ b/packages/google-cloud-ndb/tests/unit/test__batch.py
@@ -14,8 +14,7 @@
 
 import pytest
 
-from google.cloud.ndb import _batch
-from google.cloud.ndb import _eventloop
+from google.cloud.ndb import _batch, _eventloop
 
 
 @pytest.mark.usefixtures("in_context")

--- a/packages/google-cloud-ndb/tests/unit/test__cache.py
+++ b/packages/google-cloud-ndb/tests/unit/test__cache.py
@@ -13,13 +13,11 @@
 # limitations under the License.
 
 import warnings
-
 from unittest import mock
 
 import pytest
 
-from google.cloud.ndb import _cache
-from google.cloud.ndb import tasklets
+from google.cloud.ndb import _cache, tasklets
 
 
 def future_result(result):

--- a/packages/google-cloud-ndb/tests/unit/test__datastore_api.py
+++ b/packages/google-cloud-ndb/tests/unit/test__datastore_api.py
@@ -16,23 +16,17 @@ from unittest import mock
 
 import grpc
 import pytest
-
 from google.api_core import client_info
 from google.api_core import exceptions as core_exceptions
-from google.cloud.datastore import entity
-from google.cloud.datastore import helpers
+from google.cloud.datastore import entity, helpers
 from google.cloud.datastore import key as ds_key_module
 from google.cloud.datastore_v1.types import datastore as datastore_pb2
 from google.cloud.datastore_v1.types import entity as entity_pb2
-from google.cloud.ndb import _batch
-from google.cloud.ndb import _cache
-from google.cloud.ndb import context as context_module
+
+from google.cloud.ndb import __version__, _batch, _cache, _options, model, tasklets
 from google.cloud.ndb import _datastore_api as _api
+from google.cloud.ndb import context as context_module
 from google.cloud.ndb import key as key_module
-from google.cloud.ndb import model
-from google.cloud.ndb import _options
-from google.cloud.ndb import tasklets
-from google.cloud.ndb import __version__
 
 from . import utils
 

--- a/packages/google-cloud-ndb/tests/unit/test__datastore_query.py
+++ b/packages/google-cloud-ndb/tests/unit/test__datastore_query.py
@@ -13,22 +13,17 @@
 # limitations under the License.
 
 import base64
-
 from unittest import mock
 
 import pytest
-
 from google.cloud.datastore_v1.types import datastore as datastore_pb2
 from google.cloud.datastore_v1.types import entity as entity_pb2
 from google.cloud.datastore_v1.types import query as query_pb2
 
-from google.cloud.ndb import _datastore_query
+from google.cloud.ndb import _datastore_query, exceptions, model, tasklets
 from google.cloud.ndb import context as context_module
-from google.cloud.ndb import exceptions
 from google.cloud.ndb import key as key_module
-from google.cloud.ndb import model
 from google.cloud.ndb import query as query_module
-from google.cloud.ndb import tasklets
 
 from . import utils
 

--- a/packages/google-cloud-ndb/tests/unit/test__datastore_types.py
+++ b/packages/google-cloud-ndb/tests/unit/test__datastore_types.py
@@ -16,8 +16,7 @@ from unittest import mock
 
 import pytest
 
-from google.cloud.ndb import _datastore_types
-from google.cloud.ndb import exceptions
+from google.cloud.ndb import _datastore_types, exceptions
 
 
 class TestBlobKey:

--- a/packages/google-cloud-ndb/tests/unit/test__eventloop.py
+++ b/packages/google-cloud-ndb/tests/unit/test__eventloop.py
@@ -13,14 +13,12 @@
 # limitations under the License.
 
 import collections
-
 from unittest import mock
 
 import grpc
 import pytest
 
-from google.cloud.ndb import exceptions
-from google.cloud.ndb import _eventloop
+from google.cloud.ndb import _eventloop, exceptions
 
 
 def _Event(when=0, what="foo", args=(), kw={}):

--- a/packages/google-cloud-ndb/tests/unit/test__gql.py
+++ b/packages/google-cloud-ndb/tests/unit/test__gql.py
@@ -13,14 +13,12 @@
 # limitations under the License.
 
 import datetime
+
 import pytest
 
-from google.cloud.ndb import exceptions
-from google.cloud.ndb import key
-from google.cloud.ndb import model
 from google.cloud.ndb import _gql as gql_module
+from google.cloud.ndb import exceptions, key, model
 from google.cloud.ndb import query as query_module
-
 
 GQL_QUERY = """
     SELECT prop1, prop2 FROM SomeKind WHERE prop3>5 and prop2='xxx'
@@ -475,8 +473,7 @@ class TestGQL:
             prop1 = model.DateTimeProperty()
 
         gql = gql_module.GQL(
-            "SELECT prop1 FROM SomeKind WHERE prop1 = DateTime(2020, 3, 26,"
-            "12, 45, 5)"
+            "SELECT prop1 FROM SomeKind WHERE prop1 = DateTime(2020, 3, 26,12, 45, 5)"
         )
         query = gql.get_query()
         assert query.filters == query_module.FilterNode(
@@ -490,8 +487,7 @@ class TestGQL:
             prop1 = model.DateTimeProperty()
 
         gql = gql_module.GQL(
-            "SELECT prop1 FROM SomeKind WHERE prop1 = "
-            "DateTime('2020-03-26 12:45:05')"
+            "SELECT prop1 FROM SomeKind WHERE prop1 = DateTime('2020-03-26 12:45:05')"
         )
         query = gql.get_query()
         assert query.filters == query_module.FilterNode(
@@ -667,7 +663,7 @@ class TestGQL:
             prop1 = model.GeoPtProperty()
 
         gql = gql_module.GQL(
-            "SELECT prop1 FROM SomeKind WHERE prop1 = " "GeoPt(20.67,-100.32, 1.5)"
+            "SELECT prop1 FROM SomeKind WHERE prop1 = GeoPt(20.67,-100.32, 1.5)"
         )
         with pytest.raises(exceptions.BadQueryError):
             gql.get_query()
@@ -679,8 +675,7 @@ class TestGQL:
             prop1 = model.KeyProperty()
 
         gql = gql_module.GQL(
-            "SELECT prop1 FROM SomeKind WHERE prop1 = Key('parent', 'c', "
-            "'child', 42)"
+            "SELECT prop1 FROM SomeKind WHERE prop1 = Key('parent', 'c', 'child', 42)"
         )
         query = gql.get_query()
         assert query.filters == query_module.FilterNode(

--- a/packages/google-cloud-ndb/tests/unit/test__legacy_entity_pb.py
+++ b/packages/google-cloud-ndb/tests/unit/test__legacy_entity_pb.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import array
+
 import pytest
 
 from google.cloud.ndb import _legacy_entity_pb as entity_module
@@ -106,7 +107,7 @@ class TestEntityProto:
     def test_TryMerge_mutable_key_path_with_skip_data():
         entity = entity_module.EntityProto()
         d = _get_decoder(
-            b"\x6a\x0f\x72\x0d\x02\x01\x01\x0b\x12\x01\x44\x18\x01\x22\x01" b"\x45\x0c"
+            b"\x6a\x0f\x72\x0d\x02\x01\x01\x0b\x12\x01\x44\x18\x01\x22\x01\x45\x0c"
         )
         entity.TryMerge(d)
         assert entity.key().has_path()
@@ -122,7 +123,7 @@ class TestEntityProto:
     def test_TryMerge_mutable_key_path_element_with_skip_data():
         entity = entity_module.EntityProto()
         d = _get_decoder(
-            b"\x6a\x0f\x72\x0d\x0b\x02\x01\x01\x12\x01\x44\x18\x01\x22\x01" b"\x45\x0c"
+            b"\x6a\x0f\x72\x0d\x0b\x02\x01\x01\x12\x01\x44\x18\x01\x22\x01\x45\x0c"
         )
         entity.TryMerge(d)
         assert entity.key().has_path()
@@ -329,7 +330,7 @@ class TestEntityProto:
     @staticmethod
     def test_TryMerge_property_reference_name_space():
         entity = entity_module.EntityProto()
-        d = _get_decoder(b"\x72\x0b\x1a\x01\x46\x2a\x06\x63\xa2\x01\x01\x41" b"\x64")
+        d = _get_decoder(b"\x72\x0b\x1a\x01\x46\x2a\x06\x63\xa2\x01\x01\x41\x64")
         entity.TryMerge(d)
         assert entity.entity_props()["F"].has_name_space()
         assert entity.entity_props()["F"].name_space().decode() == "A"
@@ -337,7 +338,7 @@ class TestEntityProto:
     @staticmethod
     def test_TryMerge_property_reference_database_id():
         entity = entity_module.EntityProto()
-        d = _get_decoder(b"\x72\x0b\x1a\x01\x46\x2a\x06\x63\xba\x01\x01\x41" b"\x64")
+        d = _get_decoder(b"\x72\x0b\x1a\x01\x46\x2a\x06\x63\xba\x01\x01\x41\x64")
         entity.TryMerge(d)
         assert entity.entity_props()["F"].has_database_id()
         assert entity.entity_props()["F"].database_id().decode() == "A"
@@ -346,7 +347,7 @@ class TestEntityProto:
     def test_TryMerge_property_reference_skip_data():
         entity = entity_module.EntityProto()
         d = _get_decoder(
-            b"\x72\x0d\x1a\x01\x46\x2a\x08\x63\x02\x01\x01\x6a" b"\x01\x41\x64"
+            b"\x72\x0d\x1a\x01\x46\x2a\x08\x63\x02\x01\x01\x6a\x01\x41\x64"
         )
         entity.TryMerge(d)
         assert entity.entity_props()["F"].has_app()
@@ -383,7 +384,7 @@ class TestEntityProto:
     @staticmethod
     def test_TryMerge_with_skip_data():
         entity = entity_module.EntityProto()
-        d = _get_decoder(b"\x02\x01\x01\x7a\x08\x1a\x01\x46\x2a\x03\x1a\x01" b"\x47")
+        d = _get_decoder(b"\x02\x01\x01\x7a\x08\x1a\x01\x46\x2a\x03\x1a\x01\x47")
         entity.TryMerge(d)
         assert entity.entity_props()["F"].decode() == "G"
 

--- a/packages/google-cloud-ndb/tests/unit/test__options.py
+++ b/packages/google-cloud-ndb/tests/unit/test__options.py
@@ -14,9 +14,7 @@
 
 import pytest
 
-from google.cloud.ndb import _datastore_api
-from google.cloud.ndb import _options
-from google.cloud.ndb import utils
+from google.cloud.ndb import _datastore_api, _options, utils
 
 
 class MyOptions(_options.Options):

--- a/packages/google-cloud-ndb/tests/unit/test__remote.py
+++ b/packages/google-cloud-ndb/tests/unit/test__remote.py
@@ -17,9 +17,7 @@ from unittest import mock
 import grpc
 import pytest
 
-from google.cloud.ndb import exceptions
-from google.cloud.ndb import _remote
-from google.cloud.ndb import tasklets
+from google.cloud.ndb import _remote, exceptions, tasklets
 
 
 class TestRemoteCall:

--- a/packages/google-cloud-ndb/tests/unit/test__retry.py
+++ b/packages/google-cloud-ndb/tests/unit/test__retry.py
@@ -13,14 +13,12 @@
 # limitations under the License.
 
 import itertools
-
 from unittest import mock
 
 import pytest
-
 from google.api_core import exceptions as core_exceptions
-from google.cloud.ndb import _retry
-from google.cloud.ndb import tasklets
+
+from google.cloud.ndb import _retry, tasklets
 
 from . import utils
 

--- a/packages/google-cloud-ndb/tests/unit/test__transaction.py
+++ b/packages/google-cloud-ndb/tests/unit/test__transaction.py
@@ -14,16 +14,13 @@
 
 import itertools
 import logging
-
 from unittest import mock
 
 import pytest
-
 from google.api_core import exceptions as core_exceptions
+
+from google.cloud.ndb import _transaction, exceptions, tasklets
 from google.cloud.ndb import context as context_module
-from google.cloud.ndb import exceptions
-from google.cloud.ndb import tasklets
-from google.cloud.ndb import _transaction
 
 
 class Test_in_transaction:

--- a/packages/google-cloud-ndb/tests/unit/test_blobstore.py
+++ b/packages/google-cloud-ndb/tests/unit/test_blobstore.py
@@ -14,9 +14,7 @@
 
 import pytest
 
-from google.cloud.ndb import _datastore_types
-from google.cloud.ndb import blobstore
-from google.cloud.ndb import model
+from google.cloud.ndb import _datastore_types, blobstore, model
 
 from . import utils
 

--- a/packages/google-cloud-ndb/tests/unit/test_client.py
+++ b/packages/google-cloud-ndb/tests/unit/test_client.py
@@ -13,18 +13,17 @@
 # limitations under the License.
 
 import contextlib
-import pytest
-
 from unittest import mock
 
-from google.auth import credentials
+import pytest
 from google.api_core.client_options import ClientOptions
-from google.cloud import environment_vars
+from google.auth import credentials
 from google.cloud.datastore import _http
 
+from google.cloud import environment_vars
+from google.cloud.ndb import _eventloop
 from google.cloud.ndb import client as client_module
 from google.cloud.ndb import context as context_module
-from google.cloud.ndb import _eventloop
 
 
 @contextlib.contextmanager

--- a/packages/google-cloud-ndb/tests/unit/test_concurrency.py
+++ b/packages/google-cloud-ndb/tests/unit/test_concurrency.py
@@ -17,9 +17,8 @@ import os
 
 import pytest
 
-from google.cloud.ndb import _cache
+from google.cloud.ndb import _cache, tasklets
 from google.cloud.ndb import global_cache as global_cache_module
-from google.cloud.ndb import tasklets
 
 try:
     from test_utils import orchestrate

--- a/packages/google-cloud-ndb/tests/unit/test_context.py
+++ b/packages/google-cloud-ndb/tests/unit/test_context.py
@@ -12,17 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import pytest
 import threading
-
 from unittest import mock
 
+import pytest
+
+from google.cloud.ndb import _eventloop, _options, exceptions, model
 from google.cloud.ndb import context as context_module
-from google.cloud.ndb import _eventloop
-from google.cloud.ndb import exceptions
 from google.cloud.ndb import key as key_module
-from google.cloud.ndb import model
-from google.cloud.ndb import _options
 
 
 class Test_get_context:

--- a/packages/google-cloud-ndb/tests/unit/test_global_cache.py
+++ b/packages/google-cloud-ndb/tests/unit/test_global_cache.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import collections
-
 from unittest import mock
 
 import pytest

--- a/packages/google-cloud-ndb/tests/unit/test_key.py
+++ b/packages/google-cloud-ndb/tests/unit/test_key.py
@@ -14,18 +14,14 @@
 
 import base64
 import pickle
-
 from unittest import mock
 
-from google.cloud.datastore import _app_engine_key_pb2
 import google.cloud.datastore
 import pytest
+from google.cloud.datastore import _app_engine_key_pb2
 
-from google.cloud.ndb import exceptions
+from google.cloud.ndb import _options, exceptions, model, tasklets
 from google.cloud.ndb import key as key_module
-from google.cloud.ndb import model
-from google.cloud.ndb import _options
-from google.cloud.ndb import tasklets
 
 from . import utils
 
@@ -1102,8 +1098,7 @@ class Test__from_urlsafe:
     @staticmethod
     def test_basic():
         urlsafe = (
-            "agxzfnNhbXBsZS1hcHByHgsSBlBhcmVudBg7DAsSBUNoaWxkIgdGZ"
-            "WF0aGVyDKIBBXNwYWNl"
+            "agxzfnNhbXBsZS1hcHByHgsSBlBhcmVudBg7DAsSBUNoaWxkIgdGZWF0aGVyDKIBBXNwYWNl"
         )
         urlsafe_bytes = urlsafe.encode("ascii")
         for value in (urlsafe, urlsafe_bytes):

--- a/packages/google-cloud-ndb/tests/unit/test_metadata.py
+++ b/packages/google-cloud-ndb/tests/unit/test_metadata.py
@@ -16,10 +16,8 @@ from unittest import mock
 
 import pytest
 
-from google.cloud.ndb import exceptions
-from google.cloud.ndb import metadata
+from google.cloud.ndb import exceptions, metadata, tasklets
 from google.cloud.ndb import key as key_module
-from google.cloud.ndb import tasklets
 
 from . import utils
 

--- a/packages/google-cloud-ndb/tests/unit/test_model.py
+++ b/packages/google-cloud-ndb/tests/unit/test_model.py
@@ -14,30 +14,31 @@
 
 import datetime
 import pickle
-import pytz
 import types
 import zlib
-
 from unittest import mock
 
-from google.cloud import datastore
+import pytest
+import pytz
 from google.cloud.datastore import entity as entity_module
-from google.cloud.datastore import key as ds_key_module
 from google.cloud.datastore import helpers
+from google.cloud.datastore import key as ds_key_module
 from google.cloud.datastore_v1 import types as ds_types
 from google.cloud.datastore_v1.types import entity as entity_pb2
-import pytest
 
-from google.cloud.ndb import _datastore_types
-from google.cloud.ndb import exceptions
+from google.cloud import datastore
+from google.cloud.ndb import (
+    _datastore_types,
+    _legacy_entity_pb,
+    _options,
+    exceptions,
+    model,
+    polymodel,
+    tasklets,
+)
 from google.cloud.ndb import key as key_module
-from google.cloud.ndb import model
-from google.cloud.ndb import _options
-from google.cloud.ndb import polymodel
 from google.cloud.ndb import query as query_module
-from google.cloud.ndb import tasklets
 from google.cloud.ndb import utils as ndb_utils
-from google.cloud.ndb import _legacy_entity_pb
 
 from . import utils
 
@@ -2286,7 +2287,7 @@ class TestCompressedTextProperty:
     def test__to_base_type_converted():
         prop = model.CompressedTextProperty(name="text")
         value = b"\xe2\x98\x83"
-        assert prop._to_base_type("\N{snowman}") == value
+        assert prop._to_base_type("\N{SNOWMAN}") == value
 
     @staticmethod
     def test__from_base_type():
@@ -2297,7 +2298,7 @@ class TestCompressedTextProperty:
     def test__from_base_type_converted():
         prop = model.CompressedTextProperty(name="text")
         value = b"\xe2\x98\x83"
-        assert prop._from_base_type(value) == "\N{snowman}"
+        assert prop._from_base_type(value) == "\N{SNOWMAN}"
 
     @staticmethod
     def test__from_base_type_cannot_convert():
@@ -2366,7 +2367,7 @@ class TestTextProperty:
     @staticmethod
     def test__to_base_type_converted():
         prop = model.TextProperty(name="text")
-        value = "\N{snowman}"
+        value = "\N{SNOWMAN}"
         assert prop._to_base_type(b"\xe2\x98\x83") == value
 
     @staticmethod
@@ -2378,7 +2379,7 @@ class TestTextProperty:
     def test__from_base_type_converted():
         prop = model.TextProperty(name="text")
         value = b"\xe2\x98\x83"
-        assert prop._from_base_type(value) == "\N{snowman}"
+        assert prop._from_base_type(value) == "\N{SNOWMAN}"
 
     @staticmethod
     def test__from_base_type_cannot_convert():
@@ -2529,7 +2530,7 @@ class TestJsonProperty:
     @staticmethod
     def test__to_base_type():
         prop = model.JsonProperty(name="json-val")
-        value = [14, [15, 16], {"seventeen": 18}, "\N{snowman}"]
+        value = [14, [15, 16], {"seventeen": 18}, "\N{SNOWMAN}"]
         expected = b'[14,[15,16],{"seventeen":18},"\\u2603"]'
         assert prop._to_base_type(value) == expected
 
@@ -2537,14 +2538,14 @@ class TestJsonProperty:
     def test__from_base_type():
         prop = model.JsonProperty(name="json-val")
         value = b'[14,true,{"a":null,"b":"\\u2603"}]'
-        expected = [14, True, {"a": None, "b": "\N{snowman}"}]
+        expected = [14, True, {"a": None, "b": "\N{SNOWMAN}"}]
         assert prop._from_base_type(value) == expected
 
     @staticmethod
     def test__from_base_type_str():
         prop = model.JsonProperty(name="json-val")
         value = '[14,true,{"a":null,"b":"\\u2603"}]'
-        expected = [14, True, {"a": None, "b": "\N{snowman}"}]
+        expected = [14, True, {"a": None, "b": "\N{SNOWMAN}"}]
         assert prop._from_base_type(value) == expected
 
 
@@ -4330,7 +4331,7 @@ class TestMetaModel:
             second = model.StringProperty()
 
         expected = (
-            "Mine<first=IntegerProperty('first'), " "second=StringProperty('second')>"
+            "Mine<first=IntegerProperty('first'), second=StringProperty('second')>"
         )
         assert repr(Mine) == expected
 
@@ -4549,7 +4550,7 @@ class TestModel:
         ManyFields = ManyFieldsFactory()
         entity = ManyFields(self=909, id="hi", value=None, _id=78)
         expected = (
-            "ManyFields(_key=Key('ManyFields', 78), id='hi', " "self=909, value=None)"
+            "ManyFields(_key=Key('ManyFields', 78), id='hi', self=909, value=None)"
         )
         assert repr(entity) == expected
 

--- a/packages/google-cloud-ndb/tests/unit/test_polymodel.py
+++ b/packages/google-cloud-ndb/tests/unit/test_polymodel.py
@@ -15,12 +15,10 @@
 from unittest import mock
 
 import pytest
+from google.cloud.datastore import helpers
 
 from google.cloud import datastore
-from google.cloud.datastore import helpers
-from google.cloud.ndb import model
-from google.cloud.ndb import polymodel
-from google.cloud.ndb import query
+from google.cloud.ndb import model, polymodel, query
 
 from . import utils
 

--- a/packages/google-cloud-ndb/tests/unit/test_query.py
+++ b/packages/google-cloud-ndb/tests/unit/test_query.py
@@ -13,21 +13,21 @@
 # limitations under the License.
 
 import pickle
-
 from unittest import mock
 
 import pytest
-
 from google.cloud.datastore import entity as datastore_entity
 from google.cloud.datastore import helpers
 
-from google.cloud.ndb import _datastore_api
-from google.cloud.ndb import _datastore_query
-from google.cloud.ndb import exceptions
+from google.cloud.ndb import (
+    _datastore_api,
+    _datastore_query,
+    exceptions,
+    model,
+    tasklets,
+)
 from google.cloud.ndb import key as key_module
-from google.cloud.ndb import model
 from google.cloud.ndb import query as query_module
-from google.cloud.ndb import tasklets
 
 from . import utils
 

--- a/packages/google-cloud-ndb/tests/unit/test_stats.py
+++ b/packages/google-cloud-ndb/tests/unit/test_stats.py
@@ -18,7 +18,6 @@ from google.cloud.ndb import stats
 
 from . import utils
 
-
 DEFAULTS = {
     "bytes": 4,
     "count": 2,
@@ -215,7 +214,7 @@ class TestKindPropertyNamePropertyTypeStat:
             kind_name="test_stat",
             property_name="test_name",
             property_type="test_type",
-            **DEFAULTS
+            **DEFAULTS,
         )
         assert stat.bytes == 4
         assert stat.count == 2
@@ -306,7 +305,7 @@ class TestNamespaceKindPropertyNamePropertyTypeStat:
             kind_name="test_stat",
             property_name="test_name",
             property_type="test_type",
-            **DEFAULTS
+            **DEFAULTS,
         )
         assert stat.bytes == 4
         assert stat.count == 2

--- a/packages/google-cloud-ndb/tests/unit/test_tasklets.py
+++ b/packages/google-cloud-ndb/tests/unit/test_tasklets.py
@@ -16,11 +16,8 @@ from unittest import mock
 
 import pytest
 
+from google.cloud.ndb import _eventloop, _remote, exceptions, tasklets
 from google.cloud.ndb import context as context_module
-from google.cloud.ndb import _eventloop
-from google.cloud.ndb import exceptions
-from google.cloud.ndb import _remote
-from google.cloud.ndb import tasklets
 
 from . import utils
 
@@ -451,8 +448,9 @@ class Test_MultiFuture:
         this, that = (tasklets.Future("this"), tasklets.Future("that"))
         future = tasklets._MultiFuture((this, that))
         assert repr(future) == (
-            "_MultiFuture(Future('this') <{}>,"
-            " Future('that') <{}>) <{}>".format(id(this), id(that), id(future))
+            "_MultiFuture(Future('this') <{}>, Future('that') <{}>) <{}>".format(
+                id(this), id(that), id(future)
+            )
         )
 
     @staticmethod

--- a/packages/google-cloud-ndb/tests/unit/test_utils.py
+++ b/packages/google-cloud-ndb/tests/unit/test_utils.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import threading
-
 from unittest import mock
 
 import pytest


### PR DESCRIPTION
This PR adds missing `format` nox session and modernizes `lint` and `blacken` sessions to use Ruff for this package. 

### Additional changes:
* Also marks `blacken` as deprecated.
* Runs Ruff formatter and thus incorporates linting changes.

Changes to each nox session are based on the versions found in the **gapic-generator** [`noxfile.py.j2` template](https://github.com/googleapis/google-cloud-python/blob/main/packages/gapic-generator/gapic/templates/noxfile.py.j2).

Fixes #17049