### PR TITLE
chore(spanner): fix event loop leak in unit tests

### DIFF
--- a/packages/google-cloud-spanner/tests/unit/gapic/conftest.py
+++ b/packages/google-cloud-spanner/tests/unit/gapic/conftest.py
@@ -11,10 +11,14 @@ def provide_loop_to_sync_grpc_tests():
     If no global loop exists, `grpc.aio` engine crashes during initialization.
     """
     try:
-        loop = asyncio.get_event_loop()
+        asyncio.get_running_loop()
     except RuntimeError:
         loop = asyncio.new_event_loop()
         asyncio.set_event_loop(loop)
-
-    yield
-    # No close here, just ensure existance
+        try:
+            yield
+        finally:
+            loop.close()
+            asyncio.set_event_loop(None)
+    else:
+        yield


### PR DESCRIPTION
This PR resolves leaky asyncio event loops inside the Spanner unit tests that were causing flaky results during local nox testing. The original version of the event loop was not closing out events and we were left with too many open files.

Fixes #17050 