### PR TITLE
fix(google-cloud-bigquery): include pyopenssl as a dependency

### DIFF
--- a/packages/google-cloud-bigquery/pyproject.toml
+++ b/packages/google-cloud-bigquery/pyproject.toml
@@ -42,7 +42,7 @@ classifiers = [
 ]
 dependencies = [
   "google-api-core[grpc] >= 2.11.1, < 3.0.0",
-  "google-auth >= 2.14.1, < 3.0.0",
+  "google-auth[pyopenssl] >= 2.14.1, < 3.0.0",
   "google-cloud-core >= 2.4.1, < 3.0.0",
   "google-resumable-media >= 2.0.0, < 3.0.0",
   "packaging >= 24.2.0",

--- a/packages/google-cloud-bigquery/tests/system/test_pandas.py
+++ b/packages/google-cloud-bigquery/tests/system/test_pandas.py
@@ -17,8 +17,8 @@
 import collections
 import datetime
 import decimal
-import json
 import io
+import json
 import operator
 import warnings
 
@@ -31,11 +31,9 @@ except ImportError:
     import importlib_metadata as metadata
 
 from google.cloud import bigquery
-
 from google.cloud.bigquery import enums
 
 from . import helpers
-
 
 pandas = pytest.importorskip("pandas", minversion="0.23.0")
 pyarrow = pytest.importorskip("pyarrow")
@@ -957,8 +955,7 @@ def test_insert_rows_from_dataframe(bigquery_client, dataset_id):
 
 
 def test_nested_table_to_dataframe(bigquery_client, dataset_id):
-    from google.cloud.bigquery.job import SourceFormat
-    from google.cloud.bigquery.job import WriteDisposition
+    from google.cloud.bigquery.job import SourceFormat, WriteDisposition
 
     SF = bigquery.SchemaField
     schema = [
@@ -1085,10 +1082,13 @@ def test_list_rows_nullable_scalars_dtypes(bigquery_client, scalars_table, max_r
     ).to_dataframe()
 
     assert df.dtypes["bool_col"].name == "boolean"
-    assert df.dtypes["datetime_col"].name == "datetime64[ns]"
+    assert df.dtypes["datetime_col"].name in ("datetime64[us]", "datetime64[ns]")
     assert df.dtypes["float64_col"].name == "float64"
     assert df.dtypes["int64_col"].name == "Int64"
-    assert df.dtypes["timestamp_col"].name == "datetime64[ns, UTC]"
+    assert df.dtypes["timestamp_col"].name in (
+        "datetime64[us, UTC]",
+        "datetime64[ns, UTC]",
+    )
     assert df.dtypes["date_col"].name == "dbdate"
     assert df.dtypes["time_col"].name == "dbtime"
 
@@ -1389,8 +1389,8 @@ def test_to_geodataframe(bigquery_client, dataset_id):
 def test_load_geodataframe(bigquery_client, dataset_id):
     geopandas = pytest.importorskip("geopandas")
     import pandas
-    from shapely import wkt
     from google.cloud.bigquery.schema import SchemaField
+    from shapely import wkt
 
     df = geopandas.GeoDataFrame(
         pandas.DataFrame(
@@ -1450,8 +1450,8 @@ def test_load_dataframe_w_shapely(bigquery_client, dataset_id):
 
 def test_load_dataframe_w_wkb(bigquery_client, dataset_id):
     wkt = pytest.importorskip("shapely.wkt")
-    from shapely import wkb
     from google.cloud.bigquery.schema import SchemaField
+    from shapely import wkb
 
     df = pandas.DataFrame(
         dict(name=["foo", "bar"], geo=[None, wkb.dumps(wkt.loads("Point(1 1)"))])

--- a/packages/google-cloud-bigquery/tests/unit/test_magics.py
+++ b/packages/google-cloud-bigquery/tests/unit/test_magics.py
@@ -14,22 +14,20 @@
 
 import copy
 import re
+import warnings
 from concurrent import futures
 from unittest import mock
-import warnings
 
-from google.api_core import exceptions
 import google.auth.credentials
 import pytest
-from tests.unit.helpers import make_connection
-from test_utils.imports import maybe_fail_import
-
+from google.api_core import exceptions
 from google.cloud import bigquery
 from google.cloud.bigquery import exceptions as bq_exceptions
-from google.cloud.bigquery import job
-from google.cloud.bigquery import table
+from google.cloud.bigquery import job, table
 from google.cloud.bigquery.retry import DEFAULT_TIMEOUT
+from test_utils.imports import maybe_fail_import
 
+from tests.unit.helpers import make_connection
 
 try:
     from google.cloud.bigquery.magics import magics
@@ -2138,6 +2136,7 @@ def test_bigquery_magic_w_destination_table(monkeypatch):
     magics.context.credentials = mock.create_autospec(
         google.auth.credentials.Credentials, instance=True
     )
+    magics.context._project = "test-project"
 
     create_dataset_if_necessary_patch = mock.patch(
         "google.cloud.bigquery.magics.magics._create_dataset_if_necessary",
@@ -2171,6 +2170,7 @@ def test_bigquery_magic_create_dataset_fails(monkeypatch):
     magics.context.credentials = mock.create_autospec(
         google.auth.credentials.Credentials, instance=True
     )
+    magics.context._project = "test-project"
 
     create_dataset_if_necessary_patch = mock.patch(
         "google.cloud.bigquery.magics.magics._create_dataset_if_necessary",


### PR DESCRIPTION
This seems to be required when I do a fresh Python 3.14 install. Also,

- updates the pandas tests to relax data type assertions on timestamp/datetime.

See internal issue b/516834095#comment8
🦕