### PR TITLE
chore(bigtable): resolve pytest-asyncio test failures

### DIFF
--- a/packages/google-cloud-bigtable/noxfile.py
+++ b/packages/google-cloud-bigtable/noxfile.py
@@ -40,7 +40,7 @@ UNIT_TEST_STANDARD_DEPENDENCIES = [
     "asyncmock",
     "pytest",
     "pytest-cov",
-    "pytest-asyncio",
+    "pytest-asyncio==1.3.0",
     RUFF_VERSION,
 ]
 UNIT_TEST_EXTERNAL_DEPENDENCIES: List[str] = []

--- a/packages/google-cloud-bigtable/noxfile.py
+++ b/packages/google-cloud-bigtable/noxfile.py
@@ -40,7 +40,7 @@ UNIT_TEST_STANDARD_DEPENDENCIES = [
     "asyncmock",
     "pytest",
     "pytest-cov",
-    "pytest-asyncio==1.3.0",
+    "pytest-asyncio",
     RUFF_VERSION,
 ]
 UNIT_TEST_EXTERNAL_DEPENDENCIES: List[str] = []

--- a/packages/google-cloud-bigtable/tests/unit/conftest.py
+++ b/packages/google-cloud-bigtable/tests/unit/conftest.py
@@ -1,5 +1,18 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import asyncio
-import sys
 
 import pytest
 

--- a/packages/google-cloud-bigtable/tests/unit/conftest.py
+++ b/packages/google-cloud-bigtable/tests/unit/conftest.py
@@ -1,0 +1,24 @@
+import asyncio
+import sys
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def provide_loop_to_sync_grpc_tests():
+    """
+    GAPIC creates synchronous methods testing Asyncio transports.
+    If no global loop exists, `grpc.aio` engine crashes during initialization.
+    """
+    try:
+        asyncio.get_running_loop()
+    except RuntimeError:
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+        try:
+            yield
+        finally:
+            loop.close()
+            asyncio.set_event_loop(None)
+    else:
+        yield


### PR DESCRIPTION
Adds an event loop fixture, to support latest version of pytest-asyncio