### PR TITLE
chore(auth): re-enable auth releases

### DIFF
--- a/.kokoro/system.sh
+++ b/.kokoro/system.sh
@@ -54,16 +54,12 @@ run_package_test() {
     "google-auth")
       # Copy files needed for google-auth system tests
       mkdir -p "${package_path}/system_tests/data"
-      PROJECT_ID=$(cat "${KOKORO_GFILE_DIR}/google-auth-project-id.json")
-      SA_EMAIL=$(grep -o '"client_email": "[^"]*"' "${KOKORO_GFILE_DIR}/google-auth-service-account.json" | cut -d'"' -f4)
-      EPHEMERAL_KEY="${KOKORO_GFILE_DIR}/ephemeral.json"
-      echo "Ephemeral Key SA Email: ${SA_EMAIL}"
-      gcloud iam service-accounts keys create "${EPHEMERAL_KEY}" --iam-account="${SA_EMAIL}" --project="${PROJECT_ID}"
-      cp "${EPHEMERAL_KEY}" "${package_path}/system_tests/data/service_account.json"
-      GOOGLE_APPLICATION_CREDENTIALS="${EPHEMERAL_KEY}"
+      cp "${KOKORO_GFILE_DIR}/google-auth-service-account.json" "${package_path}/system_tests/data/service_account.json"
       cp "${KOKORO_GFILE_DIR}/google-auth-authorized-user.json" "${package_path}/system_tests/data/authorized_user.json"
       cp "${KOKORO_GFILE_DIR}/google-auth-impersonated-service-account.json" "${package_path}/system_tests/data/impersonated_service_account.json"
 
+      PROJECT_ID=$(cat "${KOKORO_GFILE_DIR}/google-auth-project-id.json")
+      GOOGLE_APPLICATION_CREDENTIALS="${KOKORO_GFILE_DIR}/google-auth-service-account.json"
       NOX_FILE="system_tests/noxfile.py"
       NOX_SESSION=""
       ;;

--- a/.kokoro/system.sh
+++ b/.kokoro/system.sh
@@ -54,12 +54,16 @@ run_package_test() {
     "google-auth")
       # Copy files needed for google-auth system tests
       mkdir -p "${package_path}/system_tests/data"
-      cp "${KOKORO_GFILE_DIR}/google-auth-service-account.json" "${package_path}/system_tests/data/service_account.json"
+      PROJECT_ID=$(cat "${KOKORO_GFILE_DIR}/google-auth-project-id.json")
+      SA_EMAIL=$(grep -o '"client_email": "[^"]*"' "${KOKORO_GFILE_DIR}/google-auth-service-account.json" | cut -d'"' -f4)
+      EPHEMERAL_KEY="${KOKORO_GFILE_DIR}/ephemeral.json"
+      echo "Ephemeral Key SA Email: ${SA_EMAIL}"
+      gcloud iam service-accounts keys create "${EPHEMERAL_KEY}" --iam-account="${SA_EMAIL}" --project="${PROJECT_ID}"
+      cp "${EPHEMERAL_KEY}" "${package_path}/system_tests/data/service_account.json"
+      GOOGLE_APPLICATION_CREDENTIALS="${EPHEMERAL_KEY}"
       cp "${KOKORO_GFILE_DIR}/google-auth-authorized-user.json" "${package_path}/system_tests/data/authorized_user.json"
       cp "${KOKORO_GFILE_DIR}/google-auth-impersonated-service-account.json" "${package_path}/system_tests/data/impersonated_service_account.json"
 
-      PROJECT_ID=$(cat "${KOKORO_GFILE_DIR}/google-auth-project-id.json")
-      GOOGLE_APPLICATION_CREDENTIALS="${KOKORO_GFILE_DIR}/google-auth-service-account.json"
       NOX_FILE="system_tests/noxfile.py"
       NOX_SESSION=""
       ;;

--- a/.librarian/config.yaml
+++ b/.librarian/config.yaml
@@ -41,8 +41,5 @@ libraries:
   # TODO(https://github.com/googleapis/google-cloud-python/issues/17327)
   - id: "google-cloud-bigtable"
     release_blocked: true
-  # TODO(https://github.com/googleapis/google-cloud-python/issues/17334)
-  - id: "google-auth"
-    release_blocked: true
 
 

--- a/librarian.yaml
+++ b/librarian.yaml
@@ -221,7 +221,6 @@ libraries:
       default_version: v1alpha1
   - name: google-auth
     version: 2.53.0
-    skip_release: true
     python:
       library_type: AUTH
   - name: google-auth-httplib2

--- a/packages/google-auth/system_tests/system_tests_sync/test_service_account.py
+++ b/packages/google-auth/system_tests/system_tests_sync/test_service_account.py
@@ -57,7 +57,7 @@ def test_iam_signer(http_request, credentials):
         credentials,
         credentials.service_account_email
     )
-    
+
     signed_blob = signer.sign("message")
 
     assert isinstance(signed_blob, bytes)

--- a/packages/google-auth/system_tests/system_tests_sync/test_service_account.py
+++ b/packages/google-auth/system_tests/system_tests_sync/test_service_account.py
@@ -52,6 +52,8 @@ def test_iam_signer(http_request, credentials):
     )
 
     # Verify iamcredentials signer.
+    print(f"\nDEBUG: Service Account Email: {credentials.service_account_email}")
+    print(f"DEBUG: Key ID: {credentials.signer.key_id}")
     signer = iam.Signer(
         http_request,
         credentials,

--- a/packages/google-auth/system_tests/system_tests_sync/test_service_account.py
+++ b/packages/google-auth/system_tests/system_tests_sync/test_service_account.py
@@ -52,8 +52,6 @@ def test_iam_signer(http_request, credentials):
     )
 
     # Verify iamcredentials signer.
-    print(f"\nDEBUG: Service Account Email: {credentials.service_account_email}")
-    print(f"DEBUG: Key ID: {credentials.signer.key_id}")
     signer = iam.Signer(
         http_request,
         credentials,


### PR DESCRIPTION
Revert https://github.com/googleapis/google-cloud-python/pull/17335

The system tests had been failing due to an expired credential, which has been manually rotated

Fixes https://github.com/googleapis/google-cloud-python/issues/17334