### PR TITLE
chore: update librarian to v0.16.0

### DIFF
--- a/librarian.yaml
+++ b/librarian.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 language: python
-version: v0.15.1-0.20260528141105-567c9bf1faa7
+version: v0.16.0
 repo: googleapis/google-cloud-python
 sources:
   googleapis:

--- a/packages/google-cloud-spanner/samples/samples/async_snippets.py
+++ b/packages/google-cloud-spanner/samples/samples/async_snippets.py
@@ -19,8 +19,9 @@ Cloud Spanner.
 """
 
 import asyncio
-from google.cloud.spanner_v1 import AsyncClient
-from google.cloud.spanner_v1 import KeySet
+
+from google.cloud.spanner_v1 import AsyncClient, KeySet
+
 
 # [START spanner_async_create_client]
 async def async_create_client(instance_id, database_id):
@@ -31,6 +32,8 @@ async def async_create_client(instance_id, database_id):
 
     print("Async Spanner client instantiated successfully.")
     return database
+
+
 # [END spanner_async_create_client]
 
 
@@ -48,6 +51,8 @@ async def async_query_data(instance_id, database_id):
 
         async for row in results:
             print("SingerId: {}, AlbumId: {}, AlbumTitle: {}".format(*row))
+
+
 # [END spanner_async_query_data]
 
 
@@ -68,6 +73,8 @@ async def async_insert_data(instance_id, database_id):
 
     await database.run_in_transaction(insert_singers)
     print("Async DML Insert transaction complete.")
+
+
 # [END spanner_async_insert_data]
 
 
@@ -84,7 +91,9 @@ async def async_read_write_transaction(instance_id, database_id):
             "SELECT SingerId, FirstName, LastName FROM Singers WHERE SingerId = 12"
         )
         async for row in results:
-            print("Before Update - SingerId: {}, FirstName: {}, LastName: {}".format(*row))
+            print(
+                "Before Update - SingerId: {}, FirstName: {}, LastName: {}".format(*row)
+            )
 
         # Update LastName
         await transaction.execute_update(
@@ -93,6 +102,8 @@ async def async_read_write_transaction(instance_id, database_id):
 
     await database.run_in_transaction(update_singer_lastname)
     print("Async read-write transaction complete.")
+
+
 # [END spanner_async_read_write_transaction]
 
 
@@ -114,4 +125,6 @@ async def async_read_only_transaction(instance_id, database_id):
 
         async for row in results:
             print("Read Row - SingerId: {}, FirstName: {}, LastName: {}".format(*row))
+
+
 # [END spanner_async_read_only_transaction]

--- a/packages/google-cloud-spanner/samples/samples/async_snippets_test.py
+++ b/packages/google-cloud-spanner/samples/samples/async_snippets_test.py
@@ -13,7 +13,9 @@
 # limitations under the License.
 
 import pytest
+
 import async_snippets
+
 
 @pytest.fixture(scope="module")
 def database_ddl():
@@ -30,14 +32,16 @@ def database_ddl():
             AlbumId      INT64 NOT NULL,
             AlbumTitle   STRING(MAX)
         ) PRIMARY KEY (SingerId, AlbumId),
-        INTERLEAVE IN PARENT Singers ON DELETE CASCADE"""
+        INTERLEAVE IN PARENT Singers ON DELETE CASCADE""",
     ]
 
 
 @pytest.mark.asyncio
 async def test_async_snippets_flow(capsys, instance_id, sample_database):
     # 1. Test Async Spanner Client Creation
-    db = await async_snippets.async_create_client(instance_id, sample_database.database_id)
+    db = await async_snippets.async_create_client(
+        instance_id, sample_database.database_id
+    )
     assert db is not None
     out, _ = capsys.readouterr()
     assert "Async Spanner client instantiated successfully." in out
@@ -65,13 +69,17 @@ async def test_async_snippets_flow(capsys, instance_id, sample_database):
     assert "SingerId: 13, AlbumId: 2, AlbumTitle: Go, Go, Go" in out
 
     # 5. Test Async Read-Write Transaction
-    await async_snippets.async_read_write_transaction(instance_id, sample_database.database_id)
+    await async_snippets.async_read_write_transaction(
+        instance_id, sample_database.database_id
+    )
     out, _ = capsys.readouterr()
     assert "Before Update - SingerId: 12, FirstName: Melissa, LastName: Garcia" in out
     assert "Async read-write transaction complete." in out
 
     # 6. Test Async Read-Only Transaction
-    await async_snippets.async_read_only_transaction(instance_id, sample_database.database_id)
+    await async_snippets.async_read_only_transaction(
+        instance_id, sample_database.database_id
+    )
     out, _ = capsys.readouterr()
     assert "Read Row - SingerId: 12, FirstName: Melissa, LastName: Jackson" in out
     assert "Read Row - SingerId: 13, FirstName: Russell, LastName: Morales" in out


### PR DESCRIPTION
The changes are from:

```
~/librarian-2026/google-cloud-python$ go run github.com/googleapis/librarian/cmd/librarian@latest update version
~/librarian-2026/google-cloud-python$ V=$(go run github.com/googleapis/librarian/cmd/librarian@latest config get version)
~/librarian-2026/google-cloud-python$ echo $V
v0.16.0
~/librarian-2026/google-cloud-python$ go run github.com/googleapis/librarian/tool/cmd/builddockerimages@latest --language python --version=${V}
~/librarian-2026/google-cloud-python$ time docker run -u $(id -u):$(id -g) -v .:/repo -v ~/.cache:/.cache -w /repo docker.io/library/librarian-python:${V}  generate -v --all
```