### PR TITLE
feat: new library for google/devicesandservices/health/v4

### DIFF
--- a/.librarian/state.yaml
+++ b/.librarian/state.yaml
@@ -5386,6 +5386,22 @@ libraries:
       - packages/google-crc32c/README.rst
       - packages/google-crc32c/docs/
     tag_format: '{id}-v{version}'
+  - id: google-devicesandservices-health
+    version: 0.0.0
+    last_generated_commit: ""
+    apis:
+      - path: google/devicesandservices/health/v4
+    source_roots:
+      - packages/google-devicesandservices-health
+    preserve_regex: []
+    remove_regex: []
+    release_exclude_paths:
+      - packages/google-devicesandservices-health/.repo-metadata.json
+      - packages/google-devicesandservices-health/noxfile.py
+      - packages/google-devicesandservices-health/tests/
+      - packages/google-devicesandservices-health/README.rst
+      - packages/google-devicesandservices-health/docs/
+    tag_format: '{id}-v{version}'
   - id: google-geo-type
     version: 0.7.0
     last_generated_commit: 3322511885371d2b2253f209ccc3aa60d4100cfd

--- a/librarian.yaml
+++ b/librarian.yaml
@@ -22,6 +22,13 @@ default:
   output: packages
   tag_format: '{name}-v{version}'
   python:
+    allowed_namespaces:
+      - google.ads
+      - google.apps
+      - google.cloud
+      - google.maps
+      - google.shopping
+      - google.devicesandservices
     common_gapic_paths:
       - samples/generated_samples
       - tests/unit/gapic
@@ -2197,6 +2204,13 @@ libraries:
     skip_release: true
     python:
       library_type: OTHER
+  - name: google-devicesandservices-health
+    version: 0.0.0
+    apis:
+      - path: google/devicesandservices/health/v4
+    copyright_year: "2026"
+    python:
+      default_version: v4
   - name: google-geo-type
     version: 0.7.0
     apis:


### PR DESCRIPTION
`librarian generate` did not generate code.

```
suztomo@suztomo:~/librarian-2026/google-cloud-python$ docker run -u $(id -u):$(id -g) -v .:/repo -v ~/.cache:/.cache -w /repo   docker.io/library/librarian-python:${V}  generate -v google-devicesandservices-health
/usr/local/bin/protoc google/devicesandservices/health/v4/data_coordinates.proto google/devicesandservices/health/v4/data_model.proto google/devicesandservices/health/v4/data_points.proto google/devicesandservices/health/v4/data_source.proto google/devicesandservices/health/v4/data_subscription_service.proto google/devicesandservices/health/v4/health_profile.proto google/devicesandservices/health/v4/medical_device_info.proto google/devicesandservices/health/v4/webhook_notification_cloud_log.proto --python_gapic_out=/repo/packages/google-devicesandservices-health/tmp/owl-bot-staging/google-devicesandservices-health/v4 --python_gapic_opt=metadata,rest-numeric-enums,transport=grpc+rest,python-gapic-namespace=google.devicesandservices,python-gapic-name=health,warehouse-package-name=google-devicesandservices-health,gapic-version=0.0.0,retry-config=google/devicesandservices/health/v4/health_v4_grpc_service_config.json,service-yaml=google/devicesandservices/health/v4/health_v4.yaml
/usr/bin/python3 -c 
from synthtool.languages import python_mono_repo
python_mono_repo.owlbot_main("/repo/packages/google-devicesandservices-health")

/python-packages/bin/nox -s format --no-venv --no-install
suztomo@suztomo:~/librarian-2026/google-cloud-python$ echo $?
0
suztomo@suztomo:~/librarian-2026/google-cloud-python$ git diff --name-status
suztomo@suztomo:~/librarian-2026/google-cloud-python$ 
```