### PR TITLE
feat(gapic-generator-python): setup.py matches prereleases

### DIFF
--- a/packages/gapic-generator/gapic/templates/setup.py.j2
+++ b/packages/gapic-generator/gapic/templates/setup.py.j2
@@ -24,7 +24,7 @@ version = None
 
 with open(os.path.join(package_root, '{{ package_path }}/gapic_version.py')) as fp:
     version_candidates = re.findall(
-        r"(?<=\")\d+\.\d+\.\d+(?:-[a-zA-Z0-9]+(?:\.[a-zA-Z0-9]+)*)?(?=\")",
+        r"(?<=\")\d+\.\d+\.\d+[^\"\s]*(?=\")",
         fp.read(),
     )
     assert (len(version_candidates) == 1)

--- a/packages/gapic-generator/gapic/templates/setup.py.j2
+++ b/packages/gapic-generator/gapic/templates/setup.py.j2
@@ -23,7 +23,10 @@ description = "{{ warehouse_description }} API client library"
 version = None
 
 with open(os.path.join(package_root, '{{ package_path }}/gapic_version.py')) as fp:
-    version_candidates = re.findall(r"(?<=\")\d+.\d+.\d+(?=\")", fp.read())
+    version_candidates = re.findall(
+        r"(?<=\")\d+\.\d+\.\d+(?:-[a-zA-Z0-9]+(?:\.[a-zA-Z0-9]+)*)?(?=\")",
+        fp.read(),
+    )
     assert (len(version_candidates) == 1)
     version = version_candidates[0]
 

--- a/packages/gapic-generator/tests/integration/goldens/asset/setup.py
+++ b/packages/gapic-generator/tests/integration/goldens/asset/setup.py
@@ -29,7 +29,10 @@ description = "Google Cloud Asset API client library"
 version = None
 
 with open(os.path.join(package_root, 'google/cloud/asset/gapic_version.py')) as fp:
-    version_candidates = re.findall(r"(?<=\")\d+.\d+.\d+(?=\")", fp.read())
+    version_candidates = re.findall(
+        r"(?<=\")\d+\.\d+\.\d+(?:-[a-zA-Z0-9]+(?:\.[a-zA-Z0-9]+)*)?(?=\")",
+        fp.read(),
+    )
     assert (len(version_candidates) == 1)
     version = version_candidates[0]
 

--- a/packages/gapic-generator/tests/integration/goldens/asset/setup.py
+++ b/packages/gapic-generator/tests/integration/goldens/asset/setup.py
@@ -30,7 +30,7 @@ version = None
 
 with open(os.path.join(package_root, 'google/cloud/asset/gapic_version.py')) as fp:
     version_candidates = re.findall(
-        r"(?<=\")\d+\.\d+\.\d+(?:-[a-zA-Z0-9]+(?:\.[a-zA-Z0-9]+)*)?(?=\")",
+        r"(?<=\")\d+\.\d+\.\d+[^\"\s]*(?=\")",
         fp.read(),
     )
     assert (len(version_candidates) == 1)

--- a/packages/gapic-generator/tests/integration/goldens/credentials/setup.py
+++ b/packages/gapic-generator/tests/integration/goldens/credentials/setup.py
@@ -29,7 +29,10 @@ description = "Google Iam Credentials API client library"
 version = None
 
 with open(os.path.join(package_root, 'google/iam/credentials/gapic_version.py')) as fp:
-    version_candidates = re.findall(r"(?<=\")\d+.\d+.\d+(?=\")", fp.read())
+    version_candidates = re.findall(
+        r"(?<=\")\d+\.\d+\.\d+(?:-[a-zA-Z0-9]+(?:\.[a-zA-Z0-9]+)*)?(?=\")",
+        fp.read(),
+    )
     assert (len(version_candidates) == 1)
     version = version_candidates[0]
 

--- a/packages/gapic-generator/tests/integration/goldens/credentials/setup.py
+++ b/packages/gapic-generator/tests/integration/goldens/credentials/setup.py
@@ -30,7 +30,7 @@ version = None
 
 with open(os.path.join(package_root, 'google/iam/credentials/gapic_version.py')) as fp:
     version_candidates = re.findall(
-        r"(?<=\")\d+\.\d+\.\d+(?:-[a-zA-Z0-9]+(?:\.[a-zA-Z0-9]+)*)?(?=\")",
+        r"(?<=\")\d+\.\d+\.\d+[^\"\s]*(?=\")",
         fp.read(),
     )
     assert (len(version_candidates) == 1)

--- a/packages/gapic-generator/tests/integration/goldens/eventarc/setup.py
+++ b/packages/gapic-generator/tests/integration/goldens/eventarc/setup.py
@@ -29,7 +29,10 @@ description = "Google Cloud Eventarc API client library"
 version = None
 
 with open(os.path.join(package_root, 'google/cloud/eventarc_v1/gapic_version.py')) as fp:
-    version_candidates = re.findall(r"(?<=\")\d+.\d+.\d+(?=\")", fp.read())
+    version_candidates = re.findall(
+        r"(?<=\")\d+\.\d+\.\d+(?:-[a-zA-Z0-9]+(?:\.[a-zA-Z0-9]+)*)?(?=\")",
+        fp.read(),
+    )
     assert (len(version_candidates) == 1)
     version = version_candidates[0]
 

--- a/packages/gapic-generator/tests/integration/goldens/eventarc/setup.py
+++ b/packages/gapic-generator/tests/integration/goldens/eventarc/setup.py
@@ -30,7 +30,7 @@ version = None
 
 with open(os.path.join(package_root, 'google/cloud/eventarc_v1/gapic_version.py')) as fp:
     version_candidates = re.findall(
-        r"(?<=\")\d+\.\d+\.\d+(?:-[a-zA-Z0-9]+(?:\.[a-zA-Z0-9]+)*)?(?=\")",
+        r"(?<=\")\d+\.\d+\.\d+[^\"\s]*(?=\")",
         fp.read(),
     )
     assert (len(version_candidates) == 1)

--- a/packages/gapic-generator/tests/integration/goldens/logging/setup.py
+++ b/packages/gapic-generator/tests/integration/goldens/logging/setup.py
@@ -29,7 +29,10 @@ description = "Google Cloud Logging API client library"
 version = None
 
 with open(os.path.join(package_root, 'google/cloud/logging/gapic_version.py')) as fp:
-    version_candidates = re.findall(r"(?<=\")\d+.\d+.\d+(?=\")", fp.read())
+    version_candidates = re.findall(
+        r"(?<=\")\d+\.\d+\.\d+(?:-[a-zA-Z0-9]+(?:\.[a-zA-Z0-9]+)*)?(?=\")",
+        fp.read(),
+    )
     assert (len(version_candidates) == 1)
     version = version_candidates[0]
 

--- a/packages/gapic-generator/tests/integration/goldens/logging/setup.py
+++ b/packages/gapic-generator/tests/integration/goldens/logging/setup.py
@@ -30,7 +30,7 @@ version = None
 
 with open(os.path.join(package_root, 'google/cloud/logging/gapic_version.py')) as fp:
     version_candidates = re.findall(
-        r"(?<=\")\d+\.\d+\.\d+(?:-[a-zA-Z0-9]+(?:\.[a-zA-Z0-9]+)*)?(?=\")",
+        r"(?<=\")\d+\.\d+\.\d+[^\"\s]*(?=\")",
         fp.read(),
     )
     assert (len(version_candidates) == 1)

--- a/packages/gapic-generator/tests/integration/goldens/logging_internal/setup.py
+++ b/packages/gapic-generator/tests/integration/goldens/logging_internal/setup.py
@@ -29,7 +29,10 @@ description = "Google Cloud Logging API client library"
 version = None
 
 with open(os.path.join(package_root, 'google/cloud/logging/gapic_version.py')) as fp:
-    version_candidates = re.findall(r"(?<=\")\d+.\d+.\d+(?=\")", fp.read())
+    version_candidates = re.findall(
+        r"(?<=\")\d+\.\d+\.\d+(?:-[a-zA-Z0-9]+(?:\.[a-zA-Z0-9]+)*)?(?=\")",
+        fp.read(),
+    )
     assert (len(version_candidates) == 1)
     version = version_candidates[0]
 

--- a/packages/gapic-generator/tests/integration/goldens/logging_internal/setup.py
+++ b/packages/gapic-generator/tests/integration/goldens/logging_internal/setup.py
@@ -30,7 +30,7 @@ version = None
 
 with open(os.path.join(package_root, 'google/cloud/logging/gapic_version.py')) as fp:
     version_candidates = re.findall(
-        r"(?<=\")\d+\.\d+\.\d+(?:-[a-zA-Z0-9]+(?:\.[a-zA-Z0-9]+)*)?(?=\")",
+        r"(?<=\")\d+\.\d+\.\d+[^\"\s]*(?=\")",
         fp.read(),
     )
     assert (len(version_candidates) == 1)

--- a/packages/gapic-generator/tests/integration/goldens/redis/setup.py
+++ b/packages/gapic-generator/tests/integration/goldens/redis/setup.py
@@ -30,7 +30,7 @@ version = None
 
 with open(os.path.join(package_root, 'google/cloud/redis/gapic_version.py')) as fp:
     version_candidates = re.findall(
-        r"(?<=\")\d+\.\d+\.\d+(?:-[a-zA-Z0-9]+(?:\.[a-zA-Z0-9]+)*)?(?=\")",
+        r"(?<=\")\d+\.\d+\.\d+[^\"\s]*(?=\")",
         fp.read(),
     )
     assert (len(version_candidates) == 1)

--- a/packages/gapic-generator/tests/integration/goldens/redis/setup.py
+++ b/packages/gapic-generator/tests/integration/goldens/redis/setup.py
@@ -29,7 +29,10 @@ description = "Google Cloud Redis API client library"
 version = None
 
 with open(os.path.join(package_root, 'google/cloud/redis/gapic_version.py')) as fp:
-    version_candidates = re.findall(r"(?<=\")\d+.\d+.\d+(?=\")", fp.read())
+    version_candidates = re.findall(
+        r"(?<=\")\d+\.\d+\.\d+(?:-[a-zA-Z0-9]+(?:\.[a-zA-Z0-9]+)*)?(?=\")",
+        fp.read(),
+    )
     assert (len(version_candidates) == 1)
     version = version_candidates[0]
 

--- a/packages/gapic-generator/tests/integration/goldens/redis_selective/setup.py
+++ b/packages/gapic-generator/tests/integration/goldens/redis_selective/setup.py
@@ -30,7 +30,7 @@ version = None
 
 with open(os.path.join(package_root, 'google/cloud/redis/gapic_version.py')) as fp:
     version_candidates = re.findall(
-        r"(?<=\")\d+\.\d+\.\d+(?:-[a-zA-Z0-9]+(?:\.[a-zA-Z0-9]+)*)?(?=\")",
+        r"(?<=\")\d+\.\d+\.\d+[^\"\s]*(?=\")",
         fp.read(),
     )
     assert (len(version_candidates) == 1)

--- a/packages/gapic-generator/tests/integration/goldens/redis_selective/setup.py
+++ b/packages/gapic-generator/tests/integration/goldens/redis_selective/setup.py
@@ -29,7 +29,10 @@ description = "Google Cloud Redis API client library"
 version = None
 
 with open(os.path.join(package_root, 'google/cloud/redis/gapic_version.py')) as fp:
-    version_candidates = re.findall(r"(?<=\")\d+.\d+.\d+(?=\")", fp.read())
+    version_candidates = re.findall(
+        r"(?<=\")\d+\.\d+\.\d+(?:-[a-zA-Z0-9]+(?:\.[a-zA-Z0-9]+)*)?(?=\")",
+        fp.read(),
+    )
     assert (len(version_candidates) == 1)
     version = version_candidates[0]
 

--- a/packages/gapic-generator/tests/integration/goldens/storagebatchoperations/setup.py
+++ b/packages/gapic-generator/tests/integration/goldens/storagebatchoperations/setup.py
@@ -30,7 +30,7 @@ version = None
 
 with open(os.path.join(package_root, 'google/cloud/storagebatchoperations/gapic_version.py')) as fp:
     version_candidates = re.findall(
-        r"(?<=\")\d+\.\d+\.\d+(?:-[a-zA-Z0-9]+(?:\.[a-zA-Z0-9]+)*)?(?=\")",
+        r"(?<=\")\d+\.\d+\.\d+[^\"\s]*(?=\")",
         fp.read(),
     )
     assert (len(version_candidates) == 1)

--- a/packages/gapic-generator/tests/integration/goldens/storagebatchoperations/setup.py
+++ b/packages/gapic-generator/tests/integration/goldens/storagebatchoperations/setup.py
@@ -29,7 +29,10 @@ description = "Google Cloud Storagebatchoperations API client library"
 version = None
 
 with open(os.path.join(package_root, 'google/cloud/storagebatchoperations/gapic_version.py')) as fp:
-    version_candidates = re.findall(r"(?<=\")\d+.\d+.\d+(?=\")", fp.read())
+    version_candidates = re.findall(
+        r"(?<=\")\d+\.\d+\.\d+(?:-[a-zA-Z0-9]+(?:\.[a-zA-Z0-9]+)*)?(?=\")",
+        fp.read(),
+    )
     assert (len(version_candidates) == 1)
     version = version_candidates[0]
 


### PR DESCRIPTION
Expand the `version_candidates` matching regex in `setup.py` to support SemVer prerelease suffixes.

To support both SemVer and PEP 440 prerelease formats robustly, we can match any trailing non-quote, non-whitespace characters after the major.minor.patch version.

Regenerated one API and opened a PR to see [checks passing](https://github.com/googleapis/google-cloud-python/pull/17378/checks).

Towards https://github.com/googleapis/librarian/issues/6289