### PR TITLE
chore(librarian): use librarian pseudo-version

### DIFF
--- a/librarian.yaml
+++ b/librarian.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 language: python
-version: v0.16.0
+version: v0.16.1-0.20260605194008-9ebe31201f8d
 repo: googleapis/google-cloud-python
 sources:
   googleapis:


### PR DESCRIPTION
Updates librarian version to pseudo-version of https://github.com/googleapis/librarian/commit/9ebe31201f8d56fc1d916b6783306e6920f38d85 capturing fix for onboarding bug https://github.com/googleapis/librarian/issues/6323.

To unblock b/520427993.