### PR TITLE
chore: librarian release pull request: 20260608T174331Z

### DIFF
--- a/.librarian/state.yaml
+++ b/.librarian/state.yaml
@@ -5421,7 +5421,7 @@ libraries:
       - packages/google-developers-knowledge/docs/
     tag_format: '{id}-v{version}'
   - id: google-devicesandservices-health
-    version: 0.0.0
+    version: 0.1.0
     last_generated_commit: ""
     apis:
       - path: google/devicesandservices/health/v4

--- a/librarian.yaml
+++ b/librarian.yaml
@@ -2231,7 +2231,7 @@ libraries:
           - python-gapic-name=developers_knowledge
       default_version: v1
   - name: google-devicesandservices-health
-    version: 0.0.0
+    version: 0.1.0
     apis:
       - path: google/devicesandservices/health/v4
     copyright_year: "2026"

--- a/packages/google-devicesandservices-health/CHANGELOG.md
+++ b/packages/google-devicesandservices-health/CHANGELOG.md
@@ -3,3 +3,10 @@
 [PyPI History][1]
 
 [1]: https://pypi.org/project/google-devicesandservices-health/#history
+
+## [0.1.0](https://github.com/googleapis/google-cloud-python/compare/google-devicesandservices-health-v0.0.0...google-devicesandservices-health-v0.1.0) (2026-06-08)
+
+
+### Features
+
+* add google-devicesandservices-health (#17365) ([f9ff3b1baf56980210a7770e54e50711754f1d2d](https://github.com/googleapis/google-cloud-python/commit/f9ff3b1baf56980210a7770e54e50711754f1d2d))

--- a/packages/google-devicesandservices-health/google/devicesandservices/health/gapic_version.py
+++ b/packages/google-devicesandservices-health/google/devicesandservices/health/gapic_version.py
@@ -13,4 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-__version__ = "0.0.0"  # {x-release-please-version}
+__version__ = "0.1.0"  # {x-release-please-version}

--- a/packages/google-devicesandservices-health/google/devicesandservices/health_v4/gapic_version.py
+++ b/packages/google-devicesandservices-health/google/devicesandservices/health_v4/gapic_version.py
@@ -13,4 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-__version__ = "0.0.0"  # {x-release-please-version}
+__version__ = "0.1.0"  # {x-release-please-version}

--- a/packages/google-devicesandservices-health/samples/generated_samples/snippet_metadata_google.devicesandservices.health.v4.json
+++ b/packages/google-devicesandservices-health/samples/generated_samples/snippet_metadata_google.devicesandservices.health.v4.json
@@ -8,7 +8,7 @@
     ],
     "language": "PYTHON",
     "name": "google-devicesandservices-health",
-    "version": "0.0.0"
+    "version": "0.1.0"
   },
   "snippets": [
     {


### PR DESCRIPTION
PR created by the Librarian CLI to initialize a release. Merging this PR will auto trigger a release.

Librarian Version: v0.16.0
Language Image: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/python-librarian-generator@sha256:234b9d1f2ddb057ed7ac6a38db0bf8163d839c65c6cf88ade52530cddebce59e
<details><summary>google-devicesandservices-health: v0.1.0</summary>

## [v0.1.0](https://github.com/googleapis/google-cloud-python/compare/google-devicesandservices-health-v0.0.0...google-devicesandservices-health-v0.1.0) (2026-06-08)

### Features

* add google-devicesandservices-health (#17365) ([f9ff3b1b](https://github.com/googleapis/google-cloud-python/commit/f9ff3b1b))

</details>