### PR TITLE
chore: librarian release pull request: 20260608T175401Z

### DIFF
--- a/.librarian/state.yaml
+++ b/.librarian/state.yaml
@@ -432,7 +432,7 @@ libraries:
       - packages/google-auth-oauthlib/docs/
     tag_format: '{id}-v{version}'
   - id: google-backstory
-    version: 0.0.0
+    version: 0.1.0
     last_generated_commit: ""
     apis:
       - path: backstory

--- a/librarian.yaml
+++ b/librarian.yaml
@@ -240,7 +240,7 @@ libraries:
     python:
       library_type: AUTH
   - name: google-backstory
-    version: 0.0.0
+    version: 0.1.0
     apis:
       - path: backstory
     keep:

--- a/packages/google-backstory/CHANGELOG.md
+++ b/packages/google-backstory/CHANGELOG.md
@@ -3,3 +3,10 @@
 [PyPI History][1]
 
 [1]: https://pypi.org/project/google-backstory/#history
+
+## [0.1.0](https://github.com/googleapis/google-cloud-python/compare/google-backstory-v0.0.0...google-backstory-v0.1.0) (2026-06-08)
+
+
+### Features
+
+* new library google-backstory  (#17374) ([65f059e22ea1d710e06230cf5f6ee9eb5fe45e8e](https://github.com/googleapis/google-cloud-python/commit/65f059e22ea1d710e06230cf5f6ee9eb5fe45e8e))

--- a/packages/google-backstory/google/backstory/gapic_version.py
+++ b/packages/google-backstory/google/backstory/gapic_version.py
@@ -13,4 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-__version__ = "0.0.0"  # {x-release-please-version}
+__version__ = "0.1.0"  # {x-release-please-version}


### PR DESCRIPTION
PR created by the Librarian CLI to initialize a release. Merging this PR will auto trigger a release.

Librarian Version: v0.16.0
Language Image: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/python-librarian-generator@sha256:234b9d1f2ddb057ed7ac6a38db0bf8163d839c65c6cf88ade52530cddebce59e
<details><summary>google-backstory: v0.1.0</summary>

## [v0.1.0](https://github.com/googleapis/google-cloud-python/compare/google-backstory-v0.0.0...google-backstory-v0.1.0) (2026-06-08)

### Features

* new library google-backstory  (#17374) ([65f059e2](https://github.com/googleapis/google-cloud-python/commit/65f059e2))

</details>