### PR TITLE
chore: librarian release pull request: 20260608T180838Z

### DIFF
--- a/.librarian/state.yaml
+++ b/.librarian/state.yaml
@@ -5405,7 +5405,7 @@ libraries:
       - packages/google-crc32c/docs/
     tag_format: '{id}-v{version}'
   - id: google-developers-knowledge
-    version: 0.0.0
+    version: 0.1.0
     last_generated_commit: ""
     apis:
       - path: google/developers/knowledge/v1

--- a/librarian.yaml
+++ b/librarian.yaml
@@ -2220,7 +2220,7 @@ libraries:
     python:
       library_type: OTHER
   - name: google-developers-knowledge
-    version: 0.0.0
+    version: 0.1.0
     apis:
       - path: google/developers/knowledge/v1
     copyright_year: "2026"

--- a/packages/google-developers-knowledge/CHANGELOG.md
+++ b/packages/google-developers-knowledge/CHANGELOG.md
@@ -3,3 +3,10 @@
 [PyPI History][1]
 
 [1]: https://pypi.org/project/google-developers-knowledge/#history
+
+## [0.1.0](https://github.com/googleapis/google-cloud-python/compare/google-developers-knowledge-v0.0.0...google-developers-knowledge-v0.1.0) (2026-06-08)
+
+
+### Features
+
+* add google-developers-knowledge (#17393) ([7611ac79e9ee762571c6a3c44060935923d336b9](https://github.com/googleapis/google-cloud-python/commit/7611ac79e9ee762571c6a3c44060935923d336b9))

--- a/packages/google-developers-knowledge/google/developers_knowledge/gapic_version.py
+++ b/packages/google-developers-knowledge/google/developers_knowledge/gapic_version.py
@@ -13,4 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-__version__ = "0.0.0"  # {x-release-please-version}
+__version__ = "0.1.0"  # {x-release-please-version}

--- a/packages/google-developers-knowledge/google/developers_knowledge_v1/gapic_version.py
+++ b/packages/google-developers-knowledge/google/developers_knowledge_v1/gapic_version.py
@@ -13,4 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-__version__ = "0.0.0"  # {x-release-please-version}
+__version__ = "0.1.0"  # {x-release-please-version}

--- a/packages/google-developers-knowledge/samples/generated_samples/snippet_metadata_google.developers.knowledge.v1.json
+++ b/packages/google-developers-knowledge/samples/generated_samples/snippet_metadata_google.developers.knowledge.v1.json
@@ -8,7 +8,7 @@
     ],
     "language": "PYTHON",
     "name": "google-developers-knowledge",
-    "version": "0.0.0"
+    "version": "0.1.0"
   },
   "snippets": [
     {


### PR DESCRIPTION
PR created by the Librarian CLI to initialize a release. Merging this PR will auto trigger a release.

Librarian Version: v0.16.0
Language Image: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/python-librarian-generator@sha256:234b9d1f2ddb057ed7ac6a38db0bf8163d839c65c6cf88ade52530cddebce59e
<details><summary>google-developers-knowledge: v0.1.0</summary>

## [v0.1.0](https://github.com/googleapis/google-cloud-python/compare/google-developers-knowledge-v0.0.0...google-developers-knowledge-v0.1.0) (2026-06-08)

### Features

* add google-developers-knowledge (#17393) ([7611ac79](https://github.com/googleapis/google-cloud-python/commit/7611ac79))

</details>