### PR TITLE
chore: librarian release pull request: 20260608T235726Z

### DIFF
--- a/.librarian/state.yaml
+++ b/.librarian/state.yaml
@@ -14,7 +14,7 @@
 image: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/python-librarian-generator@sha256:234b9d1f2ddb057ed7ac6a38db0bf8163d839c65c6cf88ade52530cddebce59e
 libraries:
   - id: bigframes
-    version: 2.41.0
+    version: 2.42.0
     last_generated_commit: ""
     apis: []
     source_roots:

--- a/librarian.yaml
+++ b/librarian.yaml
@@ -58,7 +58,7 @@ default:
     library_type: GAPIC_AUTO
 libraries:
   - name: bigframes
-    version: 2.41.0
+    version: 2.42.0
     skip_release: true
     python:
       library_type: INTEGRATION

--- a/packages/bigframes/CHANGELOG.md
+++ b/packages/bigframes/CHANGELOG.md
@@ -4,6 +4,22 @@
 
 [1]: https://pypi.org/project/bigframes/#history
 
+## [2.42.0](https://github.com/googleapis/google-cloud-python/compare/bigframes-v2.41.0...bigframes-v2.42.0) (2026-06-08)
+
+
+### Features
+
+* create `Series.bigquery.function_name` accessors for array and AEAD functions (#17279) ([d01a4ba30040cfcb6498d0e9ef3ed3a54d56239d](https://github.com/googleapis/google-cloud-python/commit/d01a4ba30040cfcb6498d0e9ef3ed3a54d56239d))
+* support automatic per-cell execution history filtering and isolated callbacks (#17144) ([7d440111d836b94f0ce22f6b08c7ce0e7bf4a38a](https://github.com/googleapis/google-cloud-python/commit/7d440111d836b94f0ce22f6b08c7ce0e7bf4a38a))
+* Add ai_generate functions to the dataframe bq accessor (#17302) ([6b62cb6fb3de94326b8944ae08a400c12529cad2](https://github.com/googleapis/google-cloud-python/commit/6b62cb6fb3de94326b8944ae08a400c12529cad2))
+
+
+### Bug Fixes
+
+* nameless column to_frame bug for pandas 3.0 (#17371) ([b23bfa4ceb819bca8201a7fe8b64a9bed56733f0](https://github.com/googleapis/google-cloud-python/commit/b23bfa4ceb819bca8201a7fe8b64a9bed56733f0))
+* include pyopenssl as a dependency (#17362) ([1f6205ee5a370249ece2c2cc7131a47830ef00ea](https://github.com/googleapis/google-cloud-python/commit/1f6205ee5a370249ece2c2cc7131a47830ef00ea))
+* Fix IsInOp literal bug with sqlglot (#17356) ([a3d93afe74dd2b5ec8a2ae92f91c95962764debe](https://github.com/googleapis/google-cloud-python/commit/a3d93afe74dd2b5ec8a2ae92f91c95962764debe))
+
 ## [2.41.0](https://github.com/googleapis/google-cloud-python/compare/bigframes-v2.40.0...bigframes-v2.41.0) (2026-05-28)
 
 

--- a/packages/bigframes/bigframes/version.py
+++ b/packages/bigframes/bigframes/version.py
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "2.41.0"
+__version__ = "2.42.0"
 
 # {x-release-please-start-date}
-__release_date__ = "2026-05-28"
+__release_date__ = "2026-06-08"
 # {x-release-please-end}

--- a/packages/bigframes/third_party/bigframes_vendored/version.py
+++ b/packages/bigframes/third_party/bigframes_vendored/version.py
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "2.41.0"
+__version__ = "2.42.0"
 
 # {x-release-please-start-date}
-__release_date__ = "2026-05-28"
+__release_date__ = "2026-06-08"
 # {x-release-please-end}


### PR DESCRIPTION
PR created by the Librarian CLI to initialize a release. Merging this PR will auto trigger a release.

Librarian Version: v0.16.0
Language Image: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/python-librarian-generator@sha256:234b9d1f2ddb057ed7ac6a38db0bf8163d839c65c6cf88ade52530cddebce59e
<details><summary>bigframes: v2.42.0</summary>

## [v2.42.0](https://github.com/googleapis/google-cloud-python/compare/bigframes-v2.41.0...bigframes-v2.42.0) (2026-06-08)

### Features

* Add ai_generate functions to the dataframe bq accessor (#17302) ([6b62cb6f](https://github.com/googleapis/google-cloud-python/commit/6b62cb6f))

* support automatic per-cell execution history filtering and isolated callbacks (#17144) ([7d440111](https://github.com/googleapis/google-cloud-python/commit/7d440111))

* create `Series.bigquery.function_name` accessors for array and AEAD functions (#17279) ([d01a4ba3](https://github.com/googleapis/google-cloud-python/commit/d01a4ba3))

### Bug Fixes

* include pyopenssl as a dependency (#17362) ([1f6205ee](https://github.com/googleapis/google-cloud-python/commit/1f6205ee))

* Fix IsInOp literal bug with sqlglot (#17356) ([a3d93afe](https://github.com/googleapis/google-cloud-python/commit/a3d93afe))

* nameless column to_frame bug for pandas 3.0 (#17371) ([b23bfa4c](https://github.com/googleapis/google-cloud-python/commit/b23bfa4c))

</details>