### PR TITLE
fix(auth): configure mTLS for impersonated credentials

### DIFF
--- a/packages/google-auth/google/auth/impersonated_credentials.py
+++ b/packages/google-auth/google/auth/impersonated_credentials.py
@@ -388,6 +388,7 @@ class Credentials(
         headers = {"Content-Type": "application/json"}
 
         authed_session = AuthorizedSession(self._source_credentials)
+        authed_session.configure_mtls_channel()
 
         try:
             retries = _exponential_backoff.ExponentialBackoff()
@@ -627,6 +628,7 @@ class IDTokenCredentials(credentials.CredentialsWithQuotaProject):
         authed_session = AuthorizedSession(
             self._target_credentials._source_credentials, auth_request=request
         )
+        authed_session.configure_mtls_channel()
 
         try:
             response = authed_session.post(

--- a/packages/google-auth/tests/test_impersonated_credentials.py
+++ b/packages/google-auth/tests/test_impersonated_credentials.py
@@ -639,12 +639,19 @@ class TestImpersonatedCredentials(object):
 
         assert signature == b"signature"
 
-    @mock.patch("google.auth.transport.requests.AuthorizedSession.configure_mtls_channel", autospec=True)
-    def test_sign_bytes_configures_mtls(self, mock_configure_mtls, mock_donor_credentials, mock_authorizedsession_sign):
+    @mock.patch(
+        "google.auth.transport.requests.AuthorizedSession.configure_mtls_channel",
+        autospec=True,
+    )
+    def test_sign_bytes_configures_mtls(
+        self, mock_configure_mtls, mock_donor_credentials, mock_authorizedsession_sign
+    ):
         credentials = self.make_credentials(lifetime=None)
         # Refresh is needed to make credentials valid before signing
         request = self.make_request(
-            data=json.dumps({"accessToken": "token", "expireTime": "2026-06-09T00:00:00Z"}),
+            data=json.dumps(
+                {"accessToken": "token", "expireTime": "2026-06-09T00:00:00Z"}
+            ),
             status=http_client.OK,
         )
         credentials.refresh(request)
@@ -764,8 +771,13 @@ class TestImpersonatedCredentials(object):
         )
         assert credentials._target_scopes == ["fake_scope1"]
 
-    @mock.patch("google.auth.transport.requests.AuthorizedSession.configure_mtls_channel", autospec=True)
-    def test_id_token_refresh_configures_mtls(self, mock_configure_mtls, mock_donor_credentials):
+    @mock.patch(
+        "google.auth.transport.requests.AuthorizedSession.configure_mtls_channel",
+        autospec=True,
+    )
+    def test_id_token_refresh_configures_mtls(
+        self, mock_configure_mtls, mock_donor_credentials
+    ):
         credentials = self.make_credentials(lifetime=None)
         credentials.token = "token"
         id_creds = impersonated_credentials.IDTokenCredentials(
@@ -775,7 +787,9 @@ class TestImpersonatedCredentials(object):
         with mock.patch(
             "google.auth.transport.requests.AuthorizedSession.post", autospec=True
         ) as mock_post:
-            mock_post.return_value = MockResponse({"token": ID_TOKEN_DATA}, http_client.OK)
+            mock_post.return_value = MockResponse(
+                {"token": ID_TOKEN_DATA}, http_client.OK
+            )
             id_creds.refresh(None)
 
             mock_configure_mtls.assert_called_once()

--- a/packages/google-auth/tests/test_impersonated_credentials.py
+++ b/packages/google-auth/tests/test_impersonated_credentials.py
@@ -639,6 +639,19 @@ class TestImpersonatedCredentials(object):
 
         assert signature == b"signature"
 
+    @mock.patch("google.auth.transport.requests.AuthorizedSession.configure_mtls_channel", autospec=True)
+    def test_sign_bytes_configures_mtls(self, mock_configure_mtls, mock_donor_credentials, mock_authorizedsession_sign):
+        credentials = self.make_credentials(lifetime=None)
+        # Refresh is needed to make credentials valid before signing
+        request = self.make_request(
+            data=json.dumps({"accessToken": "token", "expireTime": "2026-06-09T00:00:00Z"}),
+            status=http_client.OK,
+        )
+        credentials.refresh(request)
+
+        credentials.sign_bytes(b"signed bytes")
+        mock_configure_mtls.assert_called_once()
+
     def test_sign_bytes_failure(self):
         credentials = self.make_credentials(lifetime=None)
 
@@ -750,6 +763,22 @@ class TestImpersonatedCredentials(object):
             ["fake_scope1"], default_scopes=["fake_scope2"]
         )
         assert credentials._target_scopes == ["fake_scope1"]
+
+    @mock.patch("google.auth.transport.requests.AuthorizedSession.configure_mtls_channel", autospec=True)
+    def test_id_token_refresh_configures_mtls(self, mock_configure_mtls, mock_donor_credentials):
+        credentials = self.make_credentials(lifetime=None)
+        credentials.token = "token"
+        id_creds = impersonated_credentials.IDTokenCredentials(
+            credentials, target_audience="https://foo.bar"
+        )
+
+        with mock.patch(
+            "google.auth.transport.requests.AuthorizedSession.post", autospec=True
+        ) as mock_post:
+            mock_post.return_value = MockResponse({"token": ID_TOKEN_DATA}, http_client.OK)
+            id_creds.refresh(None)
+
+            mock_configure_mtls.assert_called_once()
 
     def test_id_token_success(
         self, mock_donor_credentials, mock_authorizedsession_idtoken


### PR DESCRIPTION
### Description
This PR configures `AuthorizedSession` to support mutual TLS (mTLS) when refreshing impersonated ID tokens or signing bytes.

### Context
When using impersonated credentials (e.g., via `gcloud auth print-identity-token --impersonate-service-account=...`) in environments where mTLS is enforced by Context Aware Access (CAA) policies, the requests fail with `401 UNAUTHENTICATED` (specifically `ACCESS_TOKEN_TYPE_UNSUPPORTED`). 

Although the endpoint correctly resolves to the mTLS domain (`iamcredentials.mtls.googleapis.com`), the underlying `AuthorizedSession` created in `impersonated_credentials.py` is never configured with the client certificate, causing the TLS handshake to lack the required client cert.

### Changes
* **`google/auth/impersonated_credentials.py`**:
    * Added `authed_session.configure_mtls_channel()` in `Credentials.sign_bytes` right after the session is created.
    * Added `authed_session.configure_mtls_channel()` in `IDTokenCredentials.refresh` right after the session is created.
* **`tests/test_impersonated_credentials.py`**:
    * Added `test_sign_bytes_configures_mtls` and `test_id_token_refresh_configures_mtls` unit tests to verify `configure_mtls_channel` is invoked.