### PR TITLE
chore(generator): support parallel system test execution in generated noxfiles

### DIFF
--- a/packages/gapic-generator/gapic/templates/noxfile.py.j2
+++ b/packages/gapic-generator/gapic/templates/noxfile.py.j2
@@ -67,6 +67,7 @@ SYSTEM_TEST_STANDARD_DEPENDENCIES = [
     "mock",
     "pytest",
     "google-cloud-testutils",
+    "pytest-xdist",
 ]
 SYSTEM_TEST_EXTERNAL_DEPENDENCIES: List[str] = []
 SYSTEM_TEST_LOCAL_DEPENDENCIES: List[str] = []
@@ -345,6 +346,8 @@ def system(session):
     if system_test_exists:
         session.run(
             "py.test",
+            "-n",
+            "auto",
             "--quiet",
             f"--junitxml=system_{session.python}_sponge_log.xml",
             system_test_path,
@@ -353,6 +356,8 @@ def system(session):
     if system_test_folder_exists:
         session.run(
             "py.test",
+            "-n",
+            "auto",
             "--quiet",
             f"--junitxml=system_{session.python}_sponge_log.xml",
             system_test_folder_path,

--- a/packages/gapic-generator/tests/integration/goldens/asset/noxfile.py
+++ b/packages/gapic-generator/tests/integration/goldens/asset/noxfile.py
@@ -74,6 +74,7 @@ SYSTEM_TEST_STANDARD_DEPENDENCIES = [
     "mock",
     "pytest",
     "google-cloud-testutils",
+    "pytest-xdist",
 ]
 SYSTEM_TEST_EXTERNAL_DEPENDENCIES: List[str] = []
 SYSTEM_TEST_LOCAL_DEPENDENCIES: List[str] = []
@@ -337,6 +338,8 @@ def system(session):
     if system_test_exists:
         session.run(
             "py.test",
+            "-n",
+            "auto",
             "--quiet",
             f"--junitxml=system_{session.python}_sponge_log.xml",
             system_test_path,
@@ -345,6 +348,8 @@ def system(session):
     if system_test_folder_exists:
         session.run(
             "py.test",
+            "-n",
+            "auto",
             "--quiet",
             f"--junitxml=system_{session.python}_sponge_log.xml",
             system_test_folder_path,

--- a/packages/gapic-generator/tests/integration/goldens/credentials/noxfile.py
+++ b/packages/gapic-generator/tests/integration/goldens/credentials/noxfile.py
@@ -74,6 +74,7 @@ SYSTEM_TEST_STANDARD_DEPENDENCIES = [
     "mock",
     "pytest",
     "google-cloud-testutils",
+    "pytest-xdist",
 ]
 SYSTEM_TEST_EXTERNAL_DEPENDENCIES: List[str] = []
 SYSTEM_TEST_LOCAL_DEPENDENCIES: List[str] = []
@@ -337,6 +338,8 @@ def system(session):
     if system_test_exists:
         session.run(
             "py.test",
+            "-n",
+            "auto",
             "--quiet",
             f"--junitxml=system_{session.python}_sponge_log.xml",
             system_test_path,
@@ -345,6 +348,8 @@ def system(session):
     if system_test_folder_exists:
         session.run(
             "py.test",
+            "-n",
+            "auto",
             "--quiet",
             f"--junitxml=system_{session.python}_sponge_log.xml",
             system_test_folder_path,

--- a/packages/gapic-generator/tests/integration/goldens/eventarc/noxfile.py
+++ b/packages/gapic-generator/tests/integration/goldens/eventarc/noxfile.py
@@ -74,6 +74,7 @@ SYSTEM_TEST_STANDARD_DEPENDENCIES = [
     "mock",
     "pytest",
     "google-cloud-testutils",
+    "pytest-xdist",
 ]
 SYSTEM_TEST_EXTERNAL_DEPENDENCIES: List[str] = []
 SYSTEM_TEST_LOCAL_DEPENDENCIES: List[str] = []
@@ -337,6 +338,8 @@ def system(session):
     if system_test_exists:
         session.run(
             "py.test",
+            "-n",
+            "auto",
             "--quiet",
             f"--junitxml=system_{session.python}_sponge_log.xml",
             system_test_path,
@@ -345,6 +348,8 @@ def system(session):
     if system_test_folder_exists:
         session.run(
             "py.test",
+            "-n",
+            "auto",
             "--quiet",
             f"--junitxml=system_{session.python}_sponge_log.xml",
             system_test_folder_path,

--- a/packages/gapic-generator/tests/integration/goldens/logging/noxfile.py
+++ b/packages/gapic-generator/tests/integration/goldens/logging/noxfile.py
@@ -74,6 +74,7 @@ SYSTEM_TEST_STANDARD_DEPENDENCIES = [
     "mock",
     "pytest",
     "google-cloud-testutils",
+    "pytest-xdist",
 ]
 SYSTEM_TEST_EXTERNAL_DEPENDENCIES: List[str] = []
 SYSTEM_TEST_LOCAL_DEPENDENCIES: List[str] = []
@@ -337,6 +338,8 @@ def system(session):
     if system_test_exists:
         session.run(
             "py.test",
+            "-n",
+            "auto",
             "--quiet",
             f"--junitxml=system_{session.python}_sponge_log.xml",
             system_test_path,
@@ -345,6 +348,8 @@ def system(session):
     if system_test_folder_exists:
         session.run(
             "py.test",
+            "-n",
+            "auto",
             "--quiet",
             f"--junitxml=system_{session.python}_sponge_log.xml",
             system_test_folder_path,

--- a/packages/gapic-generator/tests/integration/goldens/logging_internal/noxfile.py
+++ b/packages/gapic-generator/tests/integration/goldens/logging_internal/noxfile.py
@@ -74,6 +74,7 @@ SYSTEM_TEST_STANDARD_DEPENDENCIES = [
     "mock",
     "pytest",
     "google-cloud-testutils",
+    "pytest-xdist",
 ]
 SYSTEM_TEST_EXTERNAL_DEPENDENCIES: List[str] = []
 SYSTEM_TEST_LOCAL_DEPENDENCIES: List[str] = []
@@ -337,6 +338,8 @@ def system(session):
     if system_test_exists:
         session.run(
             "py.test",
+            "-n",
+            "auto",
             "--quiet",
             f"--junitxml=system_{session.python}_sponge_log.xml",
             system_test_path,
@@ -345,6 +348,8 @@ def system(session):
     if system_test_folder_exists:
         session.run(
             "py.test",
+            "-n",
+            "auto",
             "--quiet",
             f"--junitxml=system_{session.python}_sponge_log.xml",
             system_test_folder_path,

--- a/packages/gapic-generator/tests/integration/goldens/redis/noxfile.py
+++ b/packages/gapic-generator/tests/integration/goldens/redis/noxfile.py
@@ -74,6 +74,7 @@ SYSTEM_TEST_STANDARD_DEPENDENCIES = [
     "mock",
     "pytest",
     "google-cloud-testutils",
+    "pytest-xdist",
 ]
 SYSTEM_TEST_EXTERNAL_DEPENDENCIES: List[str] = []
 SYSTEM_TEST_LOCAL_DEPENDENCIES: List[str] = []
@@ -337,6 +338,8 @@ def system(session):
     if system_test_exists:
         session.run(
             "py.test",
+            "-n",
+            "auto",
             "--quiet",
             f"--junitxml=system_{session.python}_sponge_log.xml",
             system_test_path,
@@ -345,6 +348,8 @@ def system(session):
     if system_test_folder_exists:
         session.run(
             "py.test",
+            "-n",
+            "auto",
             "--quiet",
             f"--junitxml=system_{session.python}_sponge_log.xml",
             system_test_folder_path,

--- a/packages/gapic-generator/tests/integration/goldens/redis_selective/noxfile.py
+++ b/packages/gapic-generator/tests/integration/goldens/redis_selective/noxfile.py
@@ -74,6 +74,7 @@ SYSTEM_TEST_STANDARD_DEPENDENCIES = [
     "mock",
     "pytest",
     "google-cloud-testutils",
+    "pytest-xdist",
 ]
 SYSTEM_TEST_EXTERNAL_DEPENDENCIES: List[str] = []
 SYSTEM_TEST_LOCAL_DEPENDENCIES: List[str] = []
@@ -337,6 +338,8 @@ def system(session):
     if system_test_exists:
         session.run(
             "py.test",
+            "-n",
+            "auto",
             "--quiet",
             f"--junitxml=system_{session.python}_sponge_log.xml",
             system_test_path,
@@ -345,6 +348,8 @@ def system(session):
     if system_test_folder_exists:
         session.run(
             "py.test",
+            "-n",
+            "auto",
             "--quiet",
             f"--junitxml=system_{session.python}_sponge_log.xml",
             system_test_folder_path,

--- a/packages/gapic-generator/tests/integration/goldens/storagebatchoperations/noxfile.py
+++ b/packages/gapic-generator/tests/integration/goldens/storagebatchoperations/noxfile.py
@@ -74,6 +74,7 @@ SYSTEM_TEST_STANDARD_DEPENDENCIES = [
     "mock",
     "pytest",
     "google-cloud-testutils",
+    "pytest-xdist",
 ]
 SYSTEM_TEST_EXTERNAL_DEPENDENCIES: List[str] = []
 SYSTEM_TEST_LOCAL_DEPENDENCIES: List[str] = []
@@ -337,6 +338,8 @@ def system(session):
     if system_test_exists:
         session.run(
             "py.test",
+            "-n",
+            "auto",
             "--quiet",
             f"--junitxml=system_{session.python}_sponge_log.xml",
             system_test_path,
@@ -345,6 +348,8 @@ def system(session):
     if system_test_folder_exists:
         session.run(
             "py.test",
+            "-n",
+            "auto",
             "--quiet",
             f"--junitxml=system_{session.python}_sponge_log.xml",
             system_test_folder_path,


### PR DESCRIPTION
Updates the default `noxfile.py` template (`noxfile.py.j2`) in gapic-generator to support parallel test execution for system test suites by default using `pytest-xdist`. This allows all generated python client library packages to run their system tests in parallel.

- Template Updates:
    - Added `"pytest-xdist"` to `SYSTEM_TEST_STANDARD_DEPENDENCIES` in gapic/templates/noxfile.py.j2.
    - Updated py.test invocations in the system(session) session of `noxfile.py.j2` to run with parallel worker allocation (-n auto).

