### PR TITLE
chore(google-cloud-bigquery): unskip release

### DIFF
--- a/librarian.yaml
+++ b/librarian.yaml
@@ -539,7 +539,6 @@ libraries:
       default_version: v1beta
   - name: google-cloud-bigquery
     version: 3.41.0
-    skip_release: true
     python:
       library_type: GAPIC_COMBO
       metadata_name_override: bigquery


### PR DESCRIPTION
Removed skip_release flag for google-cloud-bigquery.

