### PR TITLE
chore(firestore): remove named database duplication in system tests

### DIFF
--- a/packages/google-cloud-firestore/tests/system/test__helpers.py
+++ b/packages/google-cloud-firestore/tests/system/test__helpers.py
@@ -22,8 +22,8 @@ FIRESTORE_EMULATOR = os.environ.get(_FIRESTORE_EMULATOR_HOST) is not None
 FIRESTORE_OTHER_DB = os.environ.get("SYSTEM_TESTS_DATABASE", "system-tests-named-db")
 FIRESTORE_ENTERPRISE_DB = os.environ.get("ENTERPRISE_DATABASE", "enterprise-db-native")
 
-# To eliminate test duplication, we use the default database for the 
-# core test suites. The named database is ONLY tested explicitly in dedicated 
+# To eliminate test duplication, we use the default database for the
+# core test suites. The named database is ONLY tested explicitly in dedicated
 # routing tests to prove path construction works.
 TEST_DATABASES = [None]
 TEST_DATABASES_W_ENTERPRISE = TEST_DATABASES + [FIRESTORE_ENTERPRISE_DB]

--- a/packages/google-cloud-firestore/tests/system/test__helpers.py
+++ b/packages/google-cloud-firestore/tests/system/test__helpers.py
@@ -22,8 +22,10 @@ FIRESTORE_EMULATOR = os.environ.get(_FIRESTORE_EMULATOR_HOST) is not None
 FIRESTORE_OTHER_DB = os.environ.get("SYSTEM_TESTS_DATABASE", "system-tests-named-db")
 FIRESTORE_ENTERPRISE_DB = os.environ.get("ENTERPRISE_DATABASE", "enterprise-db-native")
 
-# run all tests against default database, and a named database
-TEST_DATABASES = [None, FIRESTORE_OTHER_DB]
+# To eliminate test duplication, we use the default database for the 
+# core test suites. The named database is ONLY tested explicitly in dedicated 
+# routing tests to prove path construction works.
+TEST_DATABASES = [None]
 TEST_DATABASES_W_ENTERPRISE = TEST_DATABASES + [FIRESTORE_ENTERPRISE_DB]
 
 

--- a/packages/google-cloud-firestore/tests/system/test_system.py
+++ b/packages/google-cloud-firestore/tests/system/test_system.py
@@ -36,6 +36,7 @@ from test__helpers import (
     FIRESTORE_CREDS,
     FIRESTORE_EMULATOR,
     FIRESTORE_ENTERPRISE_DB,
+    FIRESTORE_OTHER_DB,
     FIRESTORE_PROJECT,
     MISSING_DOCUMENT,
     RANDOM_ID_REGEX,
@@ -1064,7 +1065,9 @@ def check_snapshot(snapshot, document, data, write_result):
     assert snapshot.update_time == write_result.update_time
 
 
-@pytest.mark.parametrize("database", TEST_DATABASES, indirect=True)
+# We explicitly parameterize test_document_get with FIRESTORE_OTHER_DB to test 
+# named database path routing natively, without inflating the rest of the test suite.
+@pytest.mark.parametrize("database", [None, FIRESTORE_OTHER_DB], indirect=True)
 def test_document_get(client, cleanup, database):
     now = datetime.datetime.now(tz=datetime.timezone.utc)
     document_id = "for-get" + UNIQUE_RESOURCE_ID

--- a/packages/google-cloud-firestore/tests/system/test_system.py
+++ b/packages/google-cloud-firestore/tests/system/test_system.py
@@ -1065,7 +1065,7 @@ def check_snapshot(snapshot, document, data, write_result):
     assert snapshot.update_time == write_result.update_time
 
 
-# We explicitly parameterize test_document_get with FIRESTORE_OTHER_DB to test 
+# We explicitly parameterize test_document_get with FIRESTORE_OTHER_DB to test
 # named database path routing natively, without inflating the rest of the test suite.
 @pytest.mark.parametrize("database", [None, FIRESTORE_OTHER_DB], indirect=True)
 def test_document_get(client, cleanup, database):

--- a/packages/google-cloud-firestore/tests/system/test_system_async.py
+++ b/packages/google-cloud-firestore/tests/system/test_system_async.py
@@ -39,6 +39,7 @@ from test__helpers import (
     FIRESTORE_CREDS,
     FIRESTORE_EMULATOR,
     FIRESTORE_ENTERPRISE_DB,
+    FIRESTORE_OTHER_DB,
     FIRESTORE_PROJECT,
     MISSING_DOCUMENT,
     RANDOM_ID_REGEX,
@@ -1046,7 +1047,9 @@ def check_snapshot(snapshot, document, data, write_result):
     assert snapshot.update_time == write_result.update_time
 
 
-@pytest.mark.parametrize("database", TEST_DATABASES, indirect=True)
+# We explicitly parameterize test_document_get with FIRESTORE_OTHER_DB to test 
+# named database path routing natively, without inflating the rest of the test suite.
+@pytest.mark.parametrize("database", [None, FIRESTORE_OTHER_DB], indirect=True)
 async def test_document_get(client, cleanup, database):
     now = datetime.datetime.now(tz=datetime.timezone.utc)
     document_id = "for-get" + UNIQUE_RESOURCE_ID

--- a/packages/google-cloud-firestore/tests/system/test_system_async.py
+++ b/packages/google-cloud-firestore/tests/system/test_system_async.py
@@ -1047,7 +1047,7 @@ def check_snapshot(snapshot, document, data, write_result):
     assert snapshot.update_time == write_result.update_time
 
 
-# We explicitly parameterize test_document_get with FIRESTORE_OTHER_DB to test 
+# We explicitly parameterize test_document_get with FIRESTORE_OTHER_DB to test
 # named database path routing natively, without inflating the rest of the test suite.
 @pytest.mark.parametrize("database", [None, FIRESTORE_OTHER_DB], indirect=True)
 async def test_document_get(client, cleanup, database):


### PR DESCRIPTION
This PR reduces system test execution time by removing redundant test sweeps across identical standard databases.