### PR TITLE
chore(bigframes): optimize system test teardown

### DIFF
--- a/packages/bigframes/bigframes/session/anonymous_dataset.py
+++ b/packages/bigframes/bigframes/session/anonymous_dataset.py
@@ -16,6 +16,7 @@ import datetime
 import threading
 import uuid
 import warnings
+from concurrent.futures import ThreadPoolExecutor
 from typing import List, Optional, Sequence
 
 import google.cloud.bigquery as bigquery
@@ -170,19 +171,23 @@ class AnonymousDatasetManager(temporary_storage.TemporaryStorageManager):
 
     def close(self):
         """Delete tables that were created with this session's session_id."""
-        for table_ref in self._table_ids:
-            self.bqclient.delete_table(table_ref, not_found_ok=True)
+        with ThreadPoolExecutor() as executor:
+            for table_ref in self._table_ids:
+                executor.submit(self.bqclient.delete_table, table_ref, not_found_ok=True)
         self._table_ids.clear()
 
-        try:
-            # Before closing the session, attempt to clean up any uncollected,
-            # old Python UDFs residing in the anonymous dataset. These UDFs
-            # accumulate over time and can eventually exceed resource limits.
-            # See more from b/450913424.
-            self._cleanup_old_udfs()
-        except Exception as e:
-            # Log a warning on the failure, do not interrupt the workflow.
-            msg = bfe.format_message(
-                f"Failed to clean up the old Python UDFs before closing the session: {e}"
-            )
-            warnings.warn(msg, category=bfe.CleanupFailedWarning)
+        def run_cleanup():
+            try:
+                # Before closing the session, attempt to clean up any uncollected,
+                # old Python UDFs residing in the anonymous dataset. These UDFs
+                # accumulate over time and can eventually exceed resource limits.
+                # See more from b/450913424.
+                self._cleanup_old_udfs()
+            except Exception as e:
+                # Log a warning on the failure, do not interrupt the workflow.
+                msg = bfe.format_message(
+                    f"Failed to clean up the old Python UDFs before closing the session: {e}"
+                )
+                warnings.warn(msg, category=bfe.CleanupFailedWarning)
+
+        threading.Thread(target=run_cleanup, daemon=True, name="bigframes-udf-cleanup").start()

--- a/packages/bigframes/bigframes/session/anonymous_dataset.py
+++ b/packages/bigframes/bigframes/session/anonymous_dataset.py
@@ -175,7 +175,9 @@ class AnonymousDatasetManager(temporary_storage.TemporaryStorageManager):
             try:
                 with ThreadPoolExecutor() as executor:
                     futures = [
-                        executor.submit(self.bqclient.delete_table, table_ref, not_found_ok=True)
+                        executor.submit(
+                            self.bqclient.delete_table, table_ref, not_found_ok=True
+                        )
                         for table_ref in self._table_ids
                     ]
                     for future in futures:
@@ -183,20 +185,15 @@ class AnonymousDatasetManager(temporary_storage.TemporaryStorageManager):
             finally:
                 self._table_ids.clear()
 
-        def run_cleanup():
-            try:
-                # Before closing the session, attempt to clean up any uncollected,
-                # old Python UDFs residing in the anonymous dataset. These UDFs
-                # accumulate over time and can eventually exceed resource limits.
-                # See more from b/450913424.
-                self._cleanup_old_udfs()
-            except Exception as e:
-                # Log a warning on the failure, do not interrupt the workflow.
-                msg = bfe.format_message(
-                    f"Failed to clean up the old Python UDFs before closing the session: {e}"
-                )
-                warnings.warn(msg, category=bfe.CleanupFailedWarning)
-
-        threading.Thread(
-            target=run_cleanup, daemon=True, name="bigframes-udf-cleanup"
-        ).start()
+        try:
+            # Before closing the session, attempt to clean up any uncollected,
+            # old Python UDFs residing in the anonymous dataset. These UDFs
+            # accumulate over time and can eventually exceed resource limits.
+            # See more from b/450913424.
+            self._cleanup_old_udfs()
+        except Exception as e:
+            # Log a warning on the failure, do not interrupt the workflow.
+            msg = bfe.format_message(
+                f"Failed to clean up the old Python UDFs before closing the session: {e}"
+            )
+            warnings.warn(msg, category=bfe.CleanupFailedWarning)

--- a/packages/bigframes/bigframes/session/anonymous_dataset.py
+++ b/packages/bigframes/bigframes/session/anonymous_dataset.py
@@ -173,7 +173,9 @@ class AnonymousDatasetManager(temporary_storage.TemporaryStorageManager):
         """Delete tables that were created with this session's session_id."""
         with ThreadPoolExecutor() as executor:
             for table_ref in self._table_ids:
-                executor.submit(self.bqclient.delete_table, table_ref, not_found_ok=True)
+                executor.submit(
+                    self.bqclient.delete_table, table_ref, not_found_ok=True
+                )
         self._table_ids.clear()
 
         def run_cleanup():
@@ -190,4 +192,6 @@ class AnonymousDatasetManager(temporary_storage.TemporaryStorageManager):
                 )
                 warnings.warn(msg, category=bfe.CleanupFailedWarning)
 
-        threading.Thread(target=run_cleanup, daemon=True, name="bigframes-udf-cleanup").start()
+        threading.Thread(
+            target=run_cleanup, daemon=True, name="bigframes-udf-cleanup"
+        ).start()

--- a/packages/bigframes/bigframes/session/anonymous_dataset.py
+++ b/packages/bigframes/bigframes/session/anonymous_dataset.py
@@ -171,12 +171,17 @@ class AnonymousDatasetManager(temporary_storage.TemporaryStorageManager):
 
     def close(self):
         """Delete tables that were created with this session's session_id."""
-        with ThreadPoolExecutor() as executor:
-            for table_ref in self._table_ids:
-                executor.submit(
-                    self.bqclient.delete_table, table_ref, not_found_ok=True
-                )
-        self._table_ids.clear()
+        if self._table_ids:
+            try:
+                with ThreadPoolExecutor() as executor:
+                    futures = [
+                        executor.submit(self.bqclient.delete_table, table_ref, not_found_ok=True)
+                        for table_ref in self._table_ids
+                    ]
+                    for future in futures:
+                        future.result()
+            finally:
+                self._table_ids.clear()
 
         def run_cleanup():
             try:

--- a/packages/bigframes/noxfile.py
+++ b/packages/bigframes/noxfile.py
@@ -354,6 +354,7 @@ def run_system(
         "py.test",
         "-v",
         f"-n={num_workers}",
+        "--dist=worksteal",
         # Any individual test taking longer than 15 mins will be terminated.
         f"--timeout={timeout_seconds}",
         # Log 20 slowest tests


### PR DESCRIPTION
brings down bigframes system tests from 23 mins to 12 mins i.e. 2x speed up.