### PR TITLE
test(auth): assert quota project header injection in google-auth tests

### DIFF
--- a/packages/google-auth/tests/compute_engine/test_credentials.py
+++ b/packages/google-auth/tests/compute_engine/test_credentials.py
@@ -860,6 +860,11 @@ class TestIDTokenCredentials(object):
         # Check that the signer have been initialized with a Request object
         assert isinstance(self.credentials._signer._request, transport.Request)
 
+        headers = {}
+        self.credentials.token = "fake-token"
+        self.credentials.before_request(request, "GET", "https://example.com", headers)
+        assert headers.get("x-goog-user-project") == "project-foo"
+
     @mock.patch(
         "google.auth._helpers.utcnow",
         return_value=_helpers.utcfromtimestamp(0),

--- a/packages/google-auth/tests/oauth2/test_credentials.py
+++ b/packages/google-auth/tests/oauth2/test_credentials.py
@@ -844,9 +844,10 @@ class TestCredentials(object):
 
         new_creds = creds.with_quota_project("new-project-456")
         assert new_creds.quota_project_id == "new-project-456"
+        request = mock.create_autospec(transport.Request, instance=True)
         headers = {}
-        creds.apply(headers)
-        assert "x-goog-user-project" in headers
+        new_creds.before_request(request, "GET", "https://example.com", headers)
+        assert headers.get("x-goog-user-project") == "new-project-456"
 
     def test_with_universe_domain(self):
         creds = credentials.Credentials(token="token")

--- a/packages/google-auth/tests/oauth2/test_service_account.py
+++ b/packages/google-auth/tests/oauth2/test_service_account.py
@@ -224,9 +224,11 @@ class TestCredentials(object):
         credentials = self.make_credentials()
         new_credentials = credentials.with_quota_project("new-project-456")
         assert new_credentials.quota_project_id == "new-project-456"
+        request = mock.create_autospec(transport.Request, instance=True)
         hdrs = {}
-        new_credentials.apply(hdrs, token="tok")
-        assert "x-goog-user-project" in hdrs
+        new_credentials.token = "tok"
+        new_credentials.before_request(request, "GET", "https://example.com", hdrs)
+        assert hdrs.get("x-goog-user-project") == "new-project-456"
 
     def test_copy_regional_access_boundary_manager_state_and_config_with_scopes(self):
         credentials = self.make_credentials()

--- a/packages/google-auth/tests/test_external_account.py
+++ b/packages/google-auth/tests/test_external_account.py
@@ -456,6 +456,13 @@ class TestCredentials(object):
         quota_project_creds = credentials.with_quota_project("project-foo")
 
         assert quota_project_creds.quota_project_id == "project-foo"
+        request = mock.create_autospec(transport.Request, instance=True)
+        headers = {}
+        quota_project_creds.token = "fake-token"
+        quota_project_creds.before_request(
+            request, "GET", "https://example.com", headers
+        )
+        assert headers.get("x-goog-user-project") == "project-foo"
 
     def test_with_quota_project_workforce_pool(self):
         credentials = self.make_workforce_pool_credentials(

--- a/packages/google-auth/tests_async/oauth2/test_credentials_async.py
+++ b/packages/google-auth/tests_async/oauth2/test_credentials_async.py
@@ -23,6 +23,7 @@ import pytest  # type: ignore
 
 from google.auth import _helpers
 from google.auth import exceptions
+from google.auth import transport
 from google.oauth2 import _credentials_async as _credentials_async
 from google.oauth2 import credentials
 from tests.oauth2 import test_credentials
@@ -344,7 +345,8 @@ class TestCredentials:
         creds.apply(headers)
         assert "x-goog-user-project" not in headers
 
-    def test_with_quota_project(self):
+    @pytest.mark.asyncio
+    async def test_with_quota_project(self):
         creds = _credentials_async.Credentials(
             token="token",
             refresh_token=self.REFRESH_TOKEN,
@@ -356,9 +358,10 @@ class TestCredentials:
 
         new_creds = creds.with_quota_project("new-project-456")
         assert new_creds.quota_project_id == "new-project-456"
+        request = mock.create_autospec(transport.Request, instance=True)
         headers = {}
-        creds.apply(headers)
-        assert "x-goog-user-project" in headers
+        await new_creds.before_request(request, "GET", "https://example.com", headers)
+        assert headers.get("x-goog-user-project") == "new-project-456"
 
     def test_from_authorized_user_info(self):
         info = test_credentials.AUTH_USER_INFO.copy()

--- a/packages/google-auth/tests_async/oauth2/test_service_account_async.py
+++ b/packages/google-auth/tests_async/oauth2/test_service_account_async.py
@@ -139,13 +139,18 @@ class TestCredentials(object):
         new_credentials = credentials.with_claims({"meep": "moop"})
         assert new_credentials._additional_claims == {"meep": "moop"}
 
-    def test_with_quota_project(self):
+    @pytest.mark.asyncio
+    async def test_with_quota_project(self):
         credentials = self.make_credentials()
         new_credentials = credentials.with_quota_project("new-project-456")
         assert new_credentials.quota_project_id == "new-project-456"
+        request = mock.create_autospec(transport.Request, instance=True)
         hdrs = {}
-        new_credentials.apply(hdrs, token="tok")
-        assert "x-goog-user-project" in hdrs
+        new_credentials.token = "tok"
+        await new_credentials.before_request(
+            request, "GET", "https://example.com", hdrs
+        )
+        assert hdrs.get("x-goog-user-project") == "new-project-456"
 
     def test__make_authorization_grant_assertion(self):
         credentials = self.make_credentials()


### PR DESCRIPTION
Other languages like Rust, .NET, and Swift have tests verifying that the user-project configuration propagates as an HTTP request header (x-goog-user-project). The Python auth tests were only checking that the quota project property was assigned, without asserting the outbound HTTP header payload.