### PR TITLE
chore: librarian release pull request: 20260612T171649Z

### DIFF
--- a/.librarian/config.yaml
+++ b/.librarian/config.yaml
@@ -36,9 +36,6 @@ libraries:
   - id: "sqlalchemy-bigquery"
     release_blocked: true
   # TODO(https://github.com/googleapis/google-cloud-python/issues/17327)
-  - id: "google-cloud-bigquery"
-    release_blocked: true
-  # TODO(https://github.com/googleapis/google-cloud-python/issues/17327)
   - id: "google-cloud-bigtable"
     release_blocked: true
 

--- a/.librarian/state.yaml
+++ b/.librarian/state.yaml
@@ -1139,7 +1139,7 @@ libraries:
       - packages/google-cloud-biglake-hive/docs/
     tag_format: '{id}-v{version}'
   - id: google-cloud-bigquery
-    version: 3.41.0
+    version: 3.42.0
     last_generated_commit: ""
     apis: []
     source_roots:

--- a/librarian.yaml
+++ b/librarian.yaml
@@ -538,7 +538,7 @@ libraries:
     python:
       default_version: v1beta
   - name: google-cloud-bigquery
-    version: 3.41.0
+    version: 3.42.0
     python:
       library_type: GAPIC_COMBO
       metadata_name_override: bigquery

--- a/packages/google-cloud-bigquery/CHANGELOG.md
+++ b/packages/google-cloud-bigquery/CHANGELOG.md
@@ -4,6 +4,30 @@
 
 [1]: https://pypi.org/project/google-cloud-bigquery/#history
 
+## [3.42.0](https://github.com/googleapis/google-cloud-python/compare/google-cloud-bigquery-v3.41.0...google-cloud-bigquery-v3.42.0) (2026-06-12)
+
+
+### Documentation
+
+* fix FAQ grammar in httplib2 example</li> <li><a href="https://github.com/psf/requests/commit/774a0b837a194ee885d4fdd9ca947900cc3daf71"><code>774a0b8</code></a> ([5283c92639438d9e4dd3519d00a64755e87ea669](https://github.com/googleapis/google-cloud-python/commit/5283c92639438d9e4dd3519d00a64755e87ea669))
+* same block as other sections</li> <li><a href="https://github.com/psf/requests/commit/9c72a41bec8597f948c9d8caa5dc3f12273b3303"><code>9c72a41</code></a> Bump github/codeql-action from 4.33.0 to 4.34.1</li> <li><a href="https://github.com/psf/requests/commit/ebf71906798ec82f34e07d3168f8b8aecaf8a3be"><code>ebf7190</code></a> Bump github/codeql-action from 4.32.0 to 4.33.0</li> <li><a href="https://github.com/psf/requests/commit/0e4ae38f0c93d4f92a96c774bd52c069d12a4798"><code>0e4ae38</code></a> ([5283c92639438d9e4dd3519d00a64755e87ea669](https://github.com/googleapis/google-cloud-python/commit/5283c92639438d9e4dd3519d00a64755e87ea669))
+* exclude Response.is_permanent_redirect from API docs (<a href="https://redirect.github.com/psf/requests/issues/7244">#7244</a>)</li> <li><a href="https://github.com/psf/requests/commit/d568f47278492e630cc990a259047c67991d007a"><code>d568f47</code></a> ([5283c92639438d9e4dd3519d00a64755e87ea669](https://github.com/googleapis/google-cloud-python/commit/5283c92639438d9e4dd3519d00a64755e87ea669))
+* clarify Quickstart POST example (<a href="https://redirect.github.com/psf/requests/issues/6960">#6960</a>)</li> <li>Additional commits viewable in <a href="https://github.com/psf/requests/compare/v2.21.0...v2.33.0">compare view</a></li> </ul> </details> <br /> ([5283c92639438d9e4dd3519d00a64755e87ea669](https://github.com/googleapis/google-cloud-python/commit/5283c92639438d9e4dd3519d00a64755e87ea669))
+
+
+### Features
+
+* drop Python 3.7-3.9 support and regenerate (#17187) ([494abcdfc2bc4f28be9477db86fde149a3af6b66](https://github.com/googleapis/google-cloud-python/commit/494abcdfc2bc4f28be9477db86fde149a3af6b66))
+
+
+### Bug Fixes
+
+* include pyopenssl as a dependency (#17345) ([12817900fd11e68067a5ce9b4254fa8703e864d8](https://github.com/googleapis/google-cloud-python/commit/12817900fd11e68067a5ce9b4254fa8703e864d8))
+* bump requests from 2.21.0 to 2.33.0 in /packages/google-cloud-bigquery (#17192) ([5283c92639438d9e4dd3519d00a64755e87ea669](https://github.com/googleapis/google-cloud-python/commit/5283c92639438d9e4dd3519d00a64755e87ea669))
+* bump tqdm from 4.23.4 to 4.66.3 in /packages/google-cloud-bigquery (#17194) ([8cda5fe1c6aec69af209851c778183e1bb673f07](https://github.com/googleapis/google-cloud-python/commit/8cda5fe1c6aec69af209851c778183e1bb673f07))
+* bump opentelemetry-instrumentation from 0.37b0 to 0.41b0 in /packages/google-cloud-bigquery (#17195) ([f530a2c64fb468c611cfe23c833efdb0b9ea45e1](https://github.com/googleapis/google-cloud-python/commit/f530a2c64fb468c611cfe23c833efdb0b9ea45e1))
+* allow multi-part dataset IDs to support BigLake tables (#17137) ([f93911c0a7f163a8d0374f96cbb73cce75e8dc42](https://github.com/googleapis/google-cloud-python/commit/f93911c0a7f163a8d0374f96cbb73cce75e8dc42))
+
 ## [3.41.0](https://github.com/googleapis/google-cloud-python/compare/google-cloud-bigquery-v3.40.1...google-cloud-bigquery-v3.41.0) (2026-03-26)
 
 

--- a/packages/google-cloud-bigquery/google/cloud/bigquery/version.py
+++ b/packages/google-cloud-bigquery/google/cloud/bigquery/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "3.41.0"
+__version__ = "3.42.0"


### PR DESCRIPTION
PR created by the Librarian CLI to initialize a release. Merging this PR will auto trigger a release.

Librarian Version: v0.19.0
Language Image: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/python-librarian-generator@sha256:234b9d1f2ddb057ed7ac6a38db0bf8163d839c65c6cf88ade52530cddebce59e
<details><summary>google-cloud-bigquery: v3.42.0</summary>

## [v3.42.0](https://github.com/googleapis/google-cloud-python/compare/google-cloud-bigquery-v3.41.0...google-cloud-bigquery-v3.42.0) (2026-06-12)

### Features

* drop Python 3.7-3.9 support and regenerate (#17187) ([494abcdf](https://github.com/googleapis/google-cloud-python/commit/494abcdf))

### Bug Fixes

* include pyopenssl as a dependency (#17345) ([12817900](https://github.com/googleapis/google-cloud-python/commit/12817900))

* bump requests from 2.21.0 to 2.33.0 in /packages/google-cloud-bigquery (#17192) ([5283c926](https://github.com/googleapis/google-cloud-python/commit/5283c926))

* bump tqdm from 4.23.4 to 4.66.3 in /packages/google-cloud-bigquery (#17194) ([8cda5fe1](https://github.com/googleapis/google-cloud-python/commit/8cda5fe1))

* bump opentelemetry-instrumentation from 0.37b0 to 0.41b0 in /packages/google-cloud-bigquery (#17195) ([f530a2c6](https://github.com/googleapis/google-cloud-python/commit/f530a2c6))

* allow multi-part dataset IDs to support BigLake tables (#17137) ([f93911c0](https://github.com/googleapis/google-cloud-python/commit/f93911c0))

### Documentation

* clarify Quickstart POST example (&lt;a href=&#34;https://redirect.github.com/psf/requests/issues/6960&#34;&gt;#6960&lt;/a&gt;)&lt;/li&gt; &lt;li&gt;Additional commits viewable in &lt;a href=&#34;https://github.com/psf/requests/compare/v2.21.0...v2.33.0&#34;&gt;compare view&lt;/a&gt;&lt;/li&gt; &lt;/ul&gt; &lt;/details&gt; &lt;br /&gt; ([5283c926](https://github.com/googleapis/google-cloud-python/commit/5283c926))

* fix FAQ grammar in httplib2 example&lt;/li&gt; &lt;li&gt;&lt;a href=&#34;https://github.com/psf/requests/commit/774a0b837a194ee885d4fdd9ca947900cc3daf71&#34;&gt;&lt;code&gt;774a0b8&lt;/code&gt;&lt;/a&gt; ([5283c926](https://github.com/googleapis/google-cloud-python/commit/5283c926))

* same block as other sections&lt;/li&gt; &lt;li&gt;&lt;a href=&#34;https://github.com/psf/requests/commit/9c72a41bec8597f948c9d8caa5dc3f12273b3303&#34;&gt;&lt;code&gt;9c72a41&lt;/code&gt;&lt;/a&gt; Bump github/codeql-action from 4.33.0 to 4.34.1&lt;/li&gt; &lt;li&gt;&lt;a href=&#34;https://github.com/psf/requests/commit/ebf71906798ec82f34e07d3168f8b8aecaf8a3be&#34;&gt;&lt;code&gt;ebf7190&lt;/code&gt;&lt;/a&gt; Bump github/codeql-action from 4.32.0 to 4.33.0&lt;/li&gt; &lt;li&gt;&lt;a href=&#34;https://github.com/psf/requests/commit/0e4ae38f0c93d4f92a96c774bd52c069d12a4798&#34;&gt;&lt;code&gt;0e4ae38&lt;/code&gt;&lt;/a&gt; ([5283c926](https://github.com/googleapis/google-cloud-python/commit/5283c926))

* exclude Response.is_permanent_redirect from API docs (&lt;a href=&#34;https://redirect.github.com/psf/requests/issues/7244&#34;&gt;#7244&lt;/a&gt;)&lt;/li&gt; &lt;li&gt;&lt;a href=&#34;https://github.com/psf/requests/commit/d568f47278492e630cc990a259047c67991d007a&#34;&gt;&lt;code&gt;d568f47&lt;/code&gt;&lt;/a&gt; ([5283c926](https://github.com/googleapis/google-cloud-python/commit/5283c926))

</details>