### PR TITLE
chore: release bigframes v2.43.0

### DIFF
--- a/.librarian/state.yaml
+++ b/.librarian/state.yaml
@@ -14,7 +14,7 @@
 image: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/python-librarian-generator@sha256:234b9d1f2ddb057ed7ac6a38db0bf8163d839c65c6cf88ade52530cddebce59e
 libraries:
   - id: bigframes
-    version: 2.42.0
+    version: 2.43.0
     last_generated_commit: ""
     apis: []
     source_roots:

--- a/librarian.yaml
+++ b/librarian.yaml
@@ -58,7 +58,7 @@ default:
     library_type: GAPIC_AUTO
 libraries:
   - name: bigframes
-    version: 2.42.0
+    version: 2.43.0
     skip_release: true
     python:
       library_type: INTEGRATION

--- a/packages/bigframes/CHANGELOG.md
+++ b/packages/bigframes/CHANGELOG.md
@@ -4,6 +4,25 @@
 
 [1]: https://pypi.org/project/bigframes/#history
 
+## [2.43.0](https://github.com/googleapis/google-cloud-python/compare/bigframes-v2.42.0...bigframes-v2.43.0) (2026-06-12)
+
+
+### Documentation
+
+* add a notebook explaining bqsql magics cell chaining (#17216) ([1a0de4a7701b7fdf4c2593b1960f1194ebc49793](https://github.com/googleapis/google-cloud-python/commit/1a0de4a7701b7fdf4c2593b1960f1194ebc49793))
+
+
+### Features
+
+* add `bigframes.bigquery.bit_count` and conversion scalar function (#17433) ([7f29823fadb3cff42dbe666f8c7aa33bab3c7021](https://github.com/googleapis/google-cloud-python/commit/7f29823fadb3cff42dbe666f8c7aa33bab3c7021))
+
+
+### Bug Fixes
+
+* preserve aliases on cast columns and fix star selection in sqlglot (#17394) (#17455) ([145034a345eb3e14ea3f23dfcafa3d2409a09067](https://github.com/googleapis/google-cloud-python/commit/145034a345eb3e14ea3f23dfcafa3d2409a09067))
+* bump pyarrow from 15.0.2 to 23.0.1 in /packages/bigframes (#17386) ([f59c2b2aa61316cf04b650933036ef50f6a1f08c](https://github.com/googleapis/google-cloud-python/commit/f59c2b2aa61316cf04b650933036ef50f6a1f08c))
+* improve error message when unescaped `{` are found in SQL cells (#17346) ([3a90cc8e867c8a2d2f8060858fde9eda94f80a54](https://github.com/googleapis/google-cloud-python/commit/3a90cc8e867c8a2d2f8060858fde9eda94f80a54))
+
 ## [2.42.0](https://github.com/googleapis/google-cloud-python/compare/bigframes-v2.41.0...bigframes-v2.42.0) (2026-06-08)
 
 

--- a/packages/bigframes/bigframes/version.py
+++ b/packages/bigframes/bigframes/version.py
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "2.42.0"
+__version__ = "2.43.0"
 
 # {x-release-please-start-date}
-__release_date__ = "2026-06-08"
+__release_date__ = "2026-06-12"
 # {x-release-please-end}

--- a/packages/bigframes/third_party/bigframes_vendored/version.py
+++ b/packages/bigframes/third_party/bigframes_vendored/version.py
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "2.42.0"
+__version__ = "2.43.0"
 
 # {x-release-please-start-date}
-__release_date__ = "2026-06-08"
+__release_date__ = "2026-06-12"
 # {x-release-please-end}


### PR DESCRIPTION
PR created by the Librarian CLI to initialize a release. Merging this PR will auto trigger a release.

Librarian Version: v0.16.0
Language Image: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/python-librarian-generator@sha256:234b9d1f2ddb057ed7ac6a38db0bf8163d839c65c6cf88ade52530cddebce59e
<details><summary>bigframes: v2.43.0</summary>

## [v2.43.0](https://github.com/googleapis/google-cloud-python/compare/bigframes-v2.42.0...bigframes-v2.43.0) (2026-06-12)

### Features

* add `bigframes.bigquery.bit_count` and conversion scalar function (#17433) ([7f29823f](https://github.com/googleapis/google-cloud-python/commit/7f29823f))

### Bug Fixes

* preserve aliases on cast columns and fix star selection in sqlglot (#17394) (#17455) ([145034a3](https://github.com/googleapis/google-cloud-python/commit/145034a3))

* improve error message when unescaped `{` are found in SQL cells (#17346) ([3a90cc8e](https://github.com/googleapis/google-cloud-python/commit/3a90cc8e))

* bump pyarrow from 15.0.2 to 23.0.1 in /packages/bigframes (#17386) ([f59c2b2a](https://github.com/googleapis/google-cloud-python/commit/f59c2b2a))

### Documentation

* add a notebook explaining bqsql magics cell chaining (#17216) ([1a0de4a7](https://github.com/googleapis/google-cloud-python/commit/1a0de4a7))

</details>
