### PR TITLE
chore: update action versions for node24

### DIFF
--- a/.github/workflows/django-spanner-django5.2_tests.yml
+++ b/.github/workflows/django-spanner-django5.2_tests.yml
@@ -21,7 +21,7 @@ jobs:
     outputs:
       run_django_spanner: ${{ steps.filter.outputs.django_spanner }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: dorny/paths-filter@v3
         id: filter
         with:
@@ -68,9 +68,9 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.10"
       - name: Run Django tests

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -20,14 +20,14 @@ jobs:
         python: ['3.9', '3.10', "3.11", "3.12", "3.13", "3.14"]
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       # Use a fetch-depth of 2 to avoid error `fatal: origin/main...HEAD: no merge base`
       # See https://github.com/googleapis/google-cloud-python/issues/12013
       # and https://github.com/actions/checkout#checkout-head.
       with:
         fetch-depth: 2
     - name: Setup Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python }}
     - name: Install nox
@@ -75,7 +75,7 @@ jobs:
         python -m pip install coverage
     - name: Download coverage results
       if: ${{ steps.date.packages.num_files_changed > 0 }}
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v5
       with:
         path: .coverage-results/
     - name: Report coverage results

--- a/packages/google-cloud-firestore/tests/unit/v1/test_query_profile.py
+++ b/packages/google-cloud-firestore/tests/unit/v1/test_query_profile.py
@@ -96,8 +96,8 @@ def test_explain_metrics__from_pb_empty():
 
 def test_explain_metrics_execution_stats():
     """
-    Standard ExplainMetrics class should raise exception when execution_stats is accessed.
-    _ExplainAnalyzeMetrics should include the field
+    Standard ExplainMetrics class should raise exception when execution_stats
+    is accessed. _ExplainAnalyzeMetrics should include the field
     """
     from google.cloud.firestore_v1.query_profile import (
         ExplainMetrics,


### PR DESCRIPTION
Addressing warning in recent CI runs:

>Warning: Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: actions/checkout@v4, actions/download-artifact@v4, actions/setup-python@v5. Actions will be forced to run with Node.js 24 by default starting June 16th, 2026. Node.js 20 will be removed from the runner on September 16th, 2026. Please check if updated versions of these actions are available that support Node.js 24. To opt into Node.js 24 now, set the FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true environment variable on the runner or in your workflow file. Once Node.js 24 becomes the default, you can temporarily opt out by setting ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/