### PR TITLE
tests: fix compatibility with pytest 9.1.0

### DIFF
--- a/packages/google-api-core/tests/unit/test_python_version_support.py
+++ b/packages/google-api-core/tests/unit/test_python_version_support.py
@@ -12,20 +12,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import pytest
 import datetime
 import textwrap
 import warnings
 from collections import namedtuple
-
 from unittest.mock import patch
+
+import pytest
 
 # Code to be tested
 from google.api_core._python_version_support import (
+    PYTHON_VERSION_INFO,
+    PythonVersionStatus,
     _flatten_message,
     check_python_version,
-    PythonVersionStatus,
-    PYTHON_VERSION_INFO,
 )
 
 # Helper object for mocking sys.version_info
@@ -67,8 +67,10 @@ def _create_failure_message(
 
 def generate_tracked_version_test_cases():
     """
-    Yields test parameters for all tracked versions and boundary conditions.
+    Returns a list of test parameters for all tracked versions and boundary conditions.
     """
+    results = []
+
     for version_tuple, version_info in PYTHON_VERSION_INFO.items():
         py_version_str = f"{version_tuple[0]}.{version_tuple[1]}"
         gapic_dep = version_info.gapic_deprecation or (
@@ -111,15 +113,18 @@ def generate_tracked_version_test_cases():
         }
 
         for name, params in test_cases.items():
-            yield pytest.param(
-                version_tuple,
-                params["date"],
-                params["expected"],
-                gapic_dep,
-                gapic_end,
-                eol_warning_starts,
-                id=f"{py_version_str}-{name}",
+            results.append(
+                pytest.param(
+                    version_tuple,
+                    params["date"],
+                    params["expected"],
+                    gapic_dep,
+                    gapic_end,
+                    eol_warning_starts,
+                    id=f"{py_version_str}-{name}",
+                )
             )
+    return results
 
 
 @pytest.mark.parametrize(

--- a/packages/google-api-core/tests/unit/test_python_version_support.py
+++ b/packages/google-api-core/tests/unit/test_python_version_support.py
@@ -65,7 +65,7 @@ def _create_failure_message(
     )
 
 
-def generate_tracked_version_test_cases():
+def get_tracked_version_test_cases():
     """
     Returns a list of test parameters for all tracked versions and boundary conditions.
     """
@@ -129,7 +129,7 @@ def generate_tracked_version_test_cases():
 
 @pytest.mark.parametrize(
     "version_tuple, mock_date, expected_status, gapic_dep, gapic_end, eol_warning_starts",
-    generate_tracked_version_test_cases(),
+    get_tracked_version_test_cases(),
 )
 def test_all_tracked_versions_and_date_scenarios(
     version_tuple, mock_date, expected_status, gapic_dep, gapic_end, eol_warning_starts


### PR DESCRIPTION
This PR fixes a compatibility issue with `pytest==9.1.0`. See https://docs.pytest.org/en/stable/deprecations.html#non-collection-iterables-in-pytest-mark-parametrize

See the stack trace below which appears without the fix 
```
________________________________________________________________________________________________________ ERROR collecting tests/unit/test_python_version_support.py ________________________________________________________________________________________________________
.nox/97a4db2a/lib/python3.14/site-packages/pluggy/_hooks.py:512: in __call__
    return self._hookexec(self.name, self._hookimpls.copy(), kwargs, firstresult)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
.nox/97a4db2a/lib/python3.14/site-packages/pluggy/_manager.py:120: in _hookexec
    return self._inner_hookexec(hook_name, methods, kwargs, firstresult)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
.nox/97a4db2a/lib/python3.14/site-packages/pluggy/_callers.py:53: in run_old_style_hookwrapper
    return result.get_result()
           ^^^^^^^^^^^^^^^^^^^
.nox/97a4db2a/lib/python3.14/site-packages/pytest_asyncio/plugin.py:701: in pytest_pycollect_makeitem_convert_async_functions_to_subclass
    ) = hook_result.get_result()
        ^^^^^^^^^^^^^^^^^^^^^^^^
.nox/97a4db2a/lib/python3.14/site-packages/pluggy/_callers.py:38: in run_old_style_hookwrapper
    res = yield
          ^^^^^
.nox/97a4db2a/lib/python3.14/site-packages/_pytest/python.py:250: in pytest_pycollect_makeitem
    return list(collector._genfunctions(name, obj))
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
.nox/97a4db2a/lib/python3.14/site-packages/_pytest/python.py:476: in _genfunctions
    self.ihook.pytest_generate_tests.call_extra(methods, dict(metafunc=metafunc))
.nox/97a4db2a/lib/python3.14/site-packages/pluggy/_hooks.py:573: in call_extra
    return self._hookexec(self.name, hookimpls, kwargs, firstresult)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
.nox/97a4db2a/lib/python3.14/site-packages/pluggy/_manager.py:120: in _hookexec
    return self._inner_hookexec(hook_name, methods, kwargs, firstresult)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
.nox/97a4db2a/lib/python3.14/site-packages/_pytest/python.py:124: in pytest_generate_tests
    metafunc.parametrize(*marker.args, **marker.kwargs, _param_mark=marker)
.nox/97a4db2a/lib/python3.14/site-packages/_pytest/python.py:1316: in parametrize
    argnames, parametersets = ParameterSet._for_parametrize(
.nox/97a4db2a/lib/python3.14/site-packages/_pytest/mark/structures.py:203: in _for_parametrize
    warnings.warn(
E   pytest.PytestRemovedIn10Warning: Passing a non-Collection iterable to parametrize is deprecated.
E   Test: tests/unit/test_python_version_support.py::test_all_tracked_versions_and_date_scenarios, argvalues type: generator
E   Please convert to a list or tuple.
E   See https://docs.pytest.org/en/stable/deprecations.html#parametrize-iterators
```