### PR TITLE
feat: add import profiler tool with dynamic loaded lines code volume …

### DIFF
--- a/scripts/import_profiler/documentation.md
+++ b/scripts/import_profiler/documentation.md
@@ -1,0 +1,74 @@
+# Python SDK Import Profiler: Documentation & Breakdown
+
+This document provides a comprehensive guide to the `import_profiler` scripts, directory files, and how to analyze the generated import trace logs to target optimization areas, along with the details of the implemented lazy-loading refactor.
+
+---
+
+## 1. File Guide & Directory Structure
+The profiling tool is located in the [scripts/import_profiler/](file:///usr/local/google/home/hebaalazzeh/git/google-cloud-python/scripts/import_profiler/) directory:
+
+* **[profiler.py](file:///usr/local/google/home/hebaalazzeh/git/google-cloud-python/scripts/import_profiler/profiler.py)**: The core executable script. It is designed as a single-file, self-spawning harness that performs process-isolated importing benchmarks and generates trace logs.
+* **[plan.md](file:///usr/local/google/home/hebaalazzeh/git/google-cloud-python/scripts/import_profiler/plan.md)**: The current project phases and roadmap checklist.
+* **[status.md](file:///usr/local/google/home/hebaalazzeh/git/google-cloud-python/scripts/import_profiler/status.md)**: Tracks the active task state and hosts recorded baseline performance metrics.
+
+---
+
+## 2. Profiler Mechanism (`profiler.py`)
+
+**Objective**
+The Profiler functions as a process-isolated verification harness designed to capture before-and-after metrics across three distinct vectors: Initialization Latency (ms), Peak Memory Usage (MB), and **Dynamic Code Volume (Loaded Modules & Lines of Code)**.
+
+**Proposed Solution**
+The selected design for the tracking framework is Hybrid Process Orchestration, implemented via a highly isolated Master/Worker architecture within a single self-spawning script (`profiler.py`). This setup directly resolves the "Cache Problem," where Python caches completed imports inside `sys.modules` and loads them in <0.1ms on subsequent calls, making standard loop benchmarking inaccurate.
+
+*   **The Master Process:** Operates as the central harness controller, looping exactly N times. For each iteration, it calls a clean subprocess using `sys.executable` pointing back to itself with a specialized `--worker` flag. This isolates every single run from Python's runtime memory cache, guaranteeing a true, 100% "cold start" baseline.
+*   **The Worker Process:** Spawns a fresh interpreter instance, executes the dynamic target module import via `importlib.import_module()`, natively tracks system metrics, pipes the final calculation payload out as a clean JSON string to `stdout`, and exits.
+
+**Telemetry Vector Coverage:**
+*   **Load Time Latency:** Captured at high-resolution around the target execution window via `time.perf_counter()`.
+*   **Peak Memory (RAM):** Monitored safely through standard library `tracemalloc` block tracking to catch true memory consumption shifts while avoiding the "observer effect" (profiler overhead distorting data).
+*   **Dynamic Code Volume:** Measured deterministically by snapshotting the `sys.modules` cache before and after the target import. By isolating the delta of newly loaded modules and dynamically summing their physical source lines of code (LOC), the profiler granularly detects optimization savings (e.g., lazy-loading a large layer or pruning a single function block) that might be too small to reliably appear in RAM metrics.
+
+**Alternatives**
+
+*   **Pure Python-Native Profiling**
+    *   **Mechanism:** Running a continuous runtime script tracking live initialization performance sequentially via standard libraries.
+    *   **Trade-off:** Discarded because the profiler framework script remains co-located within the active module process pool. This results in heavy observer interference and completely fails to report critical OS-level interpreter boot latencies.
+*   **Pure Shell/Bash Scripting**
+    *   **Mechanism:** Utilizing OS-level shell commands to time python execution from the shell layer (e.g., `/usr/bin/time -v python -c "import package"`).
+    *   **Trade-off:** Discarded because it relies heavily on brittle string parsing of raw console streams, is highly unportable across disparate platform engines (GNU vs. BSD time formats), and cannot profile deep sub-module dependency chains.
+*   **Static Analysis (AST Parsing / Disk Footprint)**
+    *   **Mechanism:** Statically traversing target library code structures via Abstract Syntax Trees or file sizes to estimate footprint weight before package loading.
+    *   **Trade-off:** Eliminated because static checks are blind to runtime behavior like lazy-loading. A file might exist on disk but never be imported. Our chosen dynamic module-diffing approach accurately counts only what is *actually* evaluated by the interpreter during execution.
+
+---
+
+## 3. How to Interpret Python `-X importtime` Trace Logs
+When running with the `--trace` flag, the script captures the raw stderr trace produced by Python's `-X importtime` option. The trace looks like this:
+
+```
+import time: self [us] | cumulative | imported package
+import time:       536 |        536 |   _io
+import time:      1077 |       2385 | _frozen_importlib_external
+import time:    773659 |     793010 |                   google.cloud.compute_v1.types.compute
+```
+
+### Explaining the Fields:
+1. **`self [us]` (Microseconds):** The time spent importing the module itself, *excluding* any time spent importing its child dependencies.
+2. **`cumulative` (Microseconds):** The total time spent loading the module *including* all nested imports. This represents the total wait time introduced by this line.
+3. **Hierarchy Indentation:** Indented packages are sub-imports triggered by the parent module. A package with higher indentation is loaded deeper in the call stack.
+
+---
+
+## 4. Execution Reference
+Ensure you are in the correct pyenv virtual environment where packages are installed in editable mode:
+
+```bash
+# 1. Run the profiler to get baseline/optimized outcomes (e.g. 5 iterations)
+PYENV_VERSION=py312 python profiler.py --module=google.cloud.compute --iterations=5
+PYENV_VERSION=py312 python profiler.py --module=google.cloud.aiplatform --iterations=5
+
+# 2. Run the profiler to generate trace logs
+PYENV_VERSION=py312 python profiler.py --module=google.cloud.compute --trace
+PYENV_VERSION=py312 python profiler.py --module=google.cloud.aiplatform --trace
+```

--- a/scripts/import_profiler/documentation.md
+++ b/scripts/import_profiler/documentation.md
@@ -5,11 +5,11 @@ This document provides a comprehensive guide to the `import_profiler` scripts, d
 ---
 
 ## 1. File Guide & Directory Structure
-The profiling tool is located in the [scripts/import_profiler/](file:///usr/local/google/home/hebaalazzeh/git/google-cloud-python/scripts/import_profiler/) directory:
+The profiling tool is located in the [scripts/import_profiler/](./) directory:
 
-* **[profiler.py](file:///usr/local/google/home/hebaalazzeh/git/google-cloud-python/scripts/import_profiler/profiler.py)**: The core executable script. It is designed as a single-file, self-spawning harness that performs process-isolated importing benchmarks and generates trace logs.
-* **[plan.md](file:///usr/local/google/home/hebaalazzeh/git/google-cloud-python/scripts/import_profiler/plan.md)**: The current project phases and roadmap checklist.
-* **[status.md](file:///usr/local/google/home/hebaalazzeh/git/google-cloud-python/scripts/import_profiler/status.md)**: Tracks the active task state and hosts recorded baseline performance metrics.
+* **[profiler.py](./profiler.py)**: The core executable script. It is designed as a single-file, self-spawning harness that performs process-isolated importing benchmarks and generates trace logs.
+* **[plan.md](./plan.md)**: The current project phases and roadmap checklist.
+* **[status.md](./status.md)**: Tracks the active task state and hosts recorded baseline performance metrics.
 
 ---
 

--- a/scripts/import_profiler/documentation.md
+++ b/scripts/import_profiler/documentation.md
@@ -1,6 +1,6 @@
 # Python SDK Import Profiler: Documentation & Breakdown
 
-This document provides a comprehensive guide to the `import_profiler` scripts, directory files, and how to analyze the generated import trace logs to target optimization areas, along with the details of the implemented lazy-loading refactor.
+This document provides a comprehensive guide to the `import_profiler` scripts, directory files, and how to analyze the generated import trace logs to target optimization areas.
 
 ---
 
@@ -8,15 +8,13 @@ This document provides a comprehensive guide to the `import_profiler` scripts, d
 The profiling tool is located in the [scripts/import_profiler/](./) directory:
 
 * **[profiler.py](./profiler.py)**: The core executable script. It is designed as a single-file, self-spawning harness that performs process-isolated importing benchmarks and generates trace logs.
-* **[plan.md](./plan.md)**: The current project phases and roadmap checklist.
-* **[status.md](./status.md)**: Tracks the active task state and hosts recorded baseline performance metrics.
 
 ---
 
 ## 2. Profiler Mechanism (`profiler.py`)
 
 **Objective**
-The Profiler functions as a process-isolated verification harness designed to capture before-and-after metrics across three distinct vectors: Initialization Latency (ms), Peak Memory Usage (MB), and **Dynamic Code Volume (Loaded Modules & Lines of Code)**.
+The Profiler functions as a process-isolated verification harness designed to capture before-and-after metrics across three distinct vectors: Initialization Latency (ms), Peak Memory Usage (MB), and Dynamic Code Volume (Loaded Modules & Lines of Code).
 
 **Usage**
 

--- a/scripts/import_profiler/documentation.md
+++ b/scripts/import_profiler/documentation.md
@@ -18,28 +18,28 @@ The profiling tool is located in the [scripts/import_profiler/](./) directory:
 **Objective**
 The Profiler functions as a process-isolated verification harness designed to capture before-and-after metrics across three distinct vectors: Initialization Latency (ms), Peak Memory Usage (MB), and **Dynamic Code Volume (Loaded Modules & Lines of Code)**.
 
-**Proposed Solution**
-The selected design for the tracking framework is Hybrid Process Orchestration, implemented via a highly isolated Master/Worker architecture within a single self-spawning script (`profiler.py`). This setup directly resolves the "Cache Problem," where Python caches completed imports inside `sys.modules` and loads them in <0.1ms on subsequent calls, making standard loop benchmarking inaccurate.
+**Usage**
 
-*   **The Master Process:** Operates as the central harness controller, looping exactly N times. For each iteration, it calls a clean subprocess using `sys.executable` pointing back to itself with a specialized `--worker` flag. This isolates every single run from Python's runtime memory cache, guaranteeing a true, 100% "cold start" baseline.
-*   **The Worker Process:** Spawns a fresh interpreter instance, executes the dynamic target module import via `importlib.import_module()`, natively tracks system metrics, pipes the final calculation payload out as a clean JSON string to `stdout`, and exits.
+Run this command to collect the metrics:
+```bash
+python profiler.py --module <target_module> --iterations <N>
+```
 
-**Telemetry Vector Coverage:**
-*   **Load Time Latency:** Captured at high-resolution around the target execution window via `time.perf_counter()`.
-*   **Peak Memory (RAM):** Monitored safely through standard library `tracemalloc` block tracking to catch true memory consumption shifts while avoiding the "observer effect" (profiler overhead distorting data).
-*   **Dynamic Code Volume:** Measured deterministically by snapshotting the `sys.modules` cache before and after the target import. By isolating the delta of newly loaded modules and dynamically summing their physical source lines of code (LOC), the profiler granularly detects optimization savings (e.g., lazy-loading a large layer or pruning a single function block) that might be too small to reliably appear in RAM metrics.
-
-**Alternatives**
-
-*   **Pure Python-Native Profiling**
-    *   **Mechanism:** Running a continuous runtime script tracking live initialization performance sequentially via standard libraries.
-    *   **Trade-off:** Discarded because the profiler framework script remains co-located within the active module process pool. This results in heavy observer interference and completely fails to report critical OS-level interpreter boot latencies.
-*   **Pure Shell/Bash Scripting**
-    *   **Mechanism:** Utilizing OS-level shell commands to time python execution from the shell layer (e.g., `/usr/bin/time -v python -c "import package"`).
-    *   **Trade-off:** Discarded because it relies heavily on brittle string parsing of raw console streams, is highly unportable across disparate platform engines (GNU vs. BSD time formats), and cannot profile deep sub-module dependency chains.
-*   **Static Analysis (AST Parsing / Disk Footprint)**
-    *   **Mechanism:** Statically traversing target library code structures via Abstract Syntax Trees or file sizes to estimate footprint weight before package loading.
-    *   **Trade-off:** Eliminated because static checks are blind to runtime behavior like lazy-loading. A file might exist on disk but never be imported. Our chosen dynamic module-diffing approach accurately counts only what is *actually* evaluated by the interpreter during execution.
+**Expected Output**
+```text
+--- Results for <target_module> (<N> iterations) ---
+Code Volume (Deterministic):
+  Loaded Modules: <count>
+  Loaded Lines:   <count>
+Time (ms):
+  P50 (Median): <time>
+  P90:          <time>
+  P99:          <time>
+RAM (MB):
+  P50 (Median): <memory>
+  P90:          <memory>
+  P99:          <memory>
+```
 
 ---
 

--- a/scripts/import_profiler/profiler.py
+++ b/scripts/import_profiler/profiler.py
@@ -41,13 +41,13 @@ def run_worker(target_module):
     tracemalloc.start()
     importlib.invalidate_caches()
     sys.path_importer_cache.clear()
+    rss_before = get_rss_mb()
+    modules_before = set(sys.modules.keys())
+    
     # We start the high-resolution timer from *inside* the already-booted worker process.
     # This explicitly isolates the pure import latency and entirely omits the 
     # 10ms-50ms Python VM interpreter startup overhead that would skew the metrics.
     start_time = time.perf_counter()
-    rss_before = get_rss_mb()
-    
-    modules_before = set(sys.modules.keys())
     
     # --- TARGET IMPORT ---
     importlib.import_module(target_module)

--- a/scripts/import_profiler/profiler.py
+++ b/scripts/import_profiler/profiler.py
@@ -129,6 +129,26 @@ def _calculate_percentiles(data_list):
     val = data_list[0] if data_list else 0.0
     return val, val, val
 
+def _print_outputs(target_module, iterations, loaded_modules_val, loaded_lines_val,
+                   times, p50_time, p90_time, p99_time,
+                   memories, p50_mem, p90_mem, p99_mem,
+                   rss_memories, p50_rss, p90_rss, p99_rss):
+    """Helper method to format and print the final benchmark results."""
+    def _format_stats(title, data, p50, p90, p99, fmt):
+        if not data: return ""
+        std_str = f"  StdDev:       {statistics.stdev(data):{fmt}}\n" if len(data) > 1 else ""
+        return f"{title}:\n  P50 (Median): {p50:{fmt}}\n  P90:          {p90:{fmt}}\n  P99:          {p99:{fmt}}\n  Mean:         {statistics.mean(data):{fmt}}\n  Min:          {min(data):{fmt}}\n  Max:          {max(data):{fmt}}\n{std_str}"
+
+    final_output = f"""
+--- Results for {target_module} ({iterations} iterations) ---
+Code Volume (Deterministic):
+  Loaded Modules: {loaded_modules_val}
+  Loaded Lines:   {loaded_lines_val}
+{_format_stats("Time (ms)", times, p50_time, p90_time, p99_time, ".2f")}
+{_format_stats("Tracemalloc RAM (MB)", memories, p50_mem, p90_mem, p99_mem, ".4f")}
+{_format_stats("Physical RSS RAM (MB)", rss_memories, p50_rss, p90_rss, p99_rss, ".4f")}"""
+    print(final_output.strip())
+
 def run_master(iterations, target_module, cpu=0, csv_path=None, clear_cache=True):
     """Orchestrates the benchmark."""
     if iterations < 1:
@@ -162,6 +182,11 @@ def run_master(iterations, target_module, cpu=0, csv_path=None, clear_cache=True
             times.append(data["time_ms"])
             memories.append(data["peak_ram_mb"])
             rss_memories.append(data["rss_ram_mb"])
+            if i > 0 and loaded_modules_val != data["loaded_modules"]:
+                print(f"WARNING: Non-deterministic import behavior! Iteration {i+1} loaded {data['loaded_modules']} modules (expected {loaded_modules_val}).", file=sys.stderr)
+            if i > 0 and loaded_lines_val != data["loaded_lines"]:
+                print(f"WARNING: Non-deterministic import behavior! Iteration {i+1} loaded {data['loaded_lines']} lines (expected {loaded_lines_val}).", file=sys.stderr)
+            
             loaded_modules_val = data["loaded_modules"]
             loaded_lines_val = data["loaded_lines"]
         except FileNotFoundError as e:
@@ -188,39 +213,12 @@ def run_master(iterations, target_module, cpu=0, csv_path=None, clear_cache=True
     p50_mem, p90_mem, p99_mem = _calculate_percentiles(memories)
     p50_rss, p90_rss, p99_rss = _calculate_percentiles(rss_memories)
 
-    print(f"\n--- Results for {target_module} ({iterations} iterations) ---")
-    print(f"Code Volume (Deterministic):")
-    print(f"  Loaded Modules: {loaded_modules_val}")
-    print(f"  Loaded Lines:   {loaded_lines_val}")
-    print(f"Time (ms):")
-    print(f"  P50 (Median): {p50_time:.2f}")
-    print(f"  P90:          {p90_time:.2f}")
-    print(f"  P99:          {p99_time:.2f}")
-    print(f"  Mean:         {statistics.mean(times):.2f}")
-    print(f"  Min:          {min(times):.2f}")
-    print(f"  Max:          {max(times):.2f}")
-    if len(times) > 1:
-        print(f"  StdDev:       {statistics.stdev(times):.2f}")
-        
-    print(f"Tracemalloc RAM (MB):")
-    print(f"  P50 (Median): {p50_mem:.4f}")
-    print(f"  P90:          {p90_mem:.4f}")
-    print(f"  P99:          {p99_mem:.4f}")
-    print(f"  Mean:         {statistics.mean(memories):.4f}")
-    print(f"  Min:          {min(memories):.4f}")
-    print(f"  Max:          {max(memories):.4f}")
-    if len(memories) > 1:
-        print(f"  StdDev:       {statistics.stdev(memories):.4f}")
-
-    print(f"Physical RSS RAM (MB):")
-    print(f"  P50 (Median): {p50_rss:.4f}")
-    print(f"  P90:          {p90_rss:.4f}")
-    print(f"  P99:          {p99_rss:.4f}")
-    print(f"  Mean:         {statistics.mean(rss_memories):.4f}")
-    print(f"  Min:          {min(rss_memories):.4f}")
-    print(f"  Max:          {max(rss_memories):.4f}")
-    if len(rss_memories) > 1:
-        print(f"  StdDev:       {statistics.stdev(rss_memories):.4f}")
+    _print_outputs(
+        target_module, iterations, loaded_modules_val, loaded_lines_val,
+        times, p50_time, p90_time, p99_time,
+        memories, p50_mem, p90_mem, p99_mem,
+        rss_memories, p50_rss, p90_rss, p99_rss
+    )
 
 def run_trace(target_module):
     """Generates importtime trace log and writes it to a file."""

--- a/scripts/import_profiler/profiler.py
+++ b/scripts/import_profiler/profiler.py
@@ -63,9 +63,11 @@ def run_worker(target_module):
     
     loaded_lines = 0
     for m in new_modules:
-        mod = sys.modules.get(m)
-        if mod and getattr(mod, '__file__', None):
-            file_path = mod.__file__
+        try:
+            file_path = sys.modules[m].__file__
+            if not file_path:
+                continue
+
             if file_path.endswith('.pyc'):
                 try:
                     file_path = importlib.util.source_from_cache(file_path)
@@ -81,6 +83,10 @@ def run_worker(target_module):
                         loaded_lines += sum(1 for _ in f)
                 except OSError as e:
                     logging.warning(f"Failed to read lines from {file_path}: {e}")
+        except KeyError:
+            logging.debug(f"Module {m} disappeared from sys.modules during execution.")
+        except AttributeError:
+            logging.debug(f"Module {m} has no __file__ attribute (likely a C-extension or built-in). Skipping.")
     
     # Output to stdout for the Master to capture
     metrics = {

--- a/scripts/import_profiler/profiler.py
+++ b/scripts/import_profiler/profiler.py
@@ -9,7 +9,6 @@ import importlib.util
 import csv
 import os
 import shutil
-import pathlib
 import multiprocessing
 
 NO_CPU_PINNING = -1

--- a/scripts/import_profiler/profiler.py
+++ b/scripts/import_profiler/profiler.py
@@ -1,0 +1,220 @@
+import sys
+import json
+import time
+import subprocess
+import statistics
+import tracemalloc
+import importlib
+import csv
+import os
+
+def run_worker(target_module):
+    """Performs ONE import and returns metrics."""
+    tracemalloc.start()
+    start_time = time.perf_counter()
+    
+    modules_before = set(sys.modules.keys())
+    
+    # --- TARGET IMPORT ---
+    importlib.import_module(target_module)
+    # ---------------------
+    
+    end_time = time.perf_counter()
+    _, peak = tracemalloc.get_traced_memory()
+    tracemalloc.stop()
+    
+    modules_after = set(sys.modules.keys())
+    new_modules = modules_after - modules_before
+    
+    loaded_lines = 0
+    for m in new_modules:
+        mod = sys.modules.get(m)
+        if mod and getattr(mod, '__file__', None) and mod.__file__.endswith('.py'):
+            try:
+                with open(mod.__file__, 'r', encoding='utf-8') as f:
+                    loaded_lines += sum(1 for _ in f)
+            except Exception:
+                pass
+    
+    # Output to stdout for the Master to capture
+    print(json.dumps({
+        "time_ms": (end_time - start_time) * 1000,
+        "peak_ram_mb": peak / (1024 * 1024),
+        "loaded_modules": len(new_modules),
+        "loaded_lines": loaded_lines
+    }))
+
+def run_master(iterations, target_module, cpu="0", csv_path=None):
+    """Orchestrates the benchmark."""
+    times, memories = [], []
+    loaded_modules_val, loaded_lines_val = 0, 0
+    
+    print(f"Profiling start... Running {iterations} cold-start iterations for {target_module}.")
+    if cpu.lower() != "none":
+        print(f"CPU Pinning enabled: Pinning processes to core {cpu} using taskset.")
+    else:
+        print("CPU Pinning disabled.")
+    
+    for i in range(iterations):
+        # Build command line
+        cmd = []
+        if cpu.lower() != "none":
+            cmd += ["taskset", "-c", cpu]
+        
+        cmd += [sys.executable, __file__, "--worker", f"--module={target_module}"]
+        
+        try:
+            result = subprocess.run(
+                cmd, capture_output=True, text=True, check=True
+            )
+            data = json.loads(result.stdout)
+            times.append(data["time_ms"])
+            memories.append(data["peak_ram_mb"])
+            loaded_modules_val = data.get("loaded_modules", 0)
+            loaded_lines_val = data.get("loaded_lines", 0)
+        except (subprocess.CalledProcessError, FileNotFoundError) as e:
+            # Fallback if taskset is not found or fails
+            if cpu.lower() != "none" and i == 0:
+                print("WARNING: taskset CPU pinning failed or is not available. Falling back to unpinned execution...")
+                # Try running without taskset
+                cmd = [sys.executable, __file__, "--worker", f"--module={target_module}"]
+                result = subprocess.run(cmd, capture_output=True, text=True, check=True)
+                data = json.loads(result.stdout)
+                times.append(data["time_ms"])
+                memories.append(data["peak_ram_mb"])
+                loaded_modules_val = data.get("loaded_modules", 0)
+                loaded_lines_val = data.get("loaded_lines", 0)
+                cpu = "none" # Disable cpu pinning for remaining iterations
+            else:
+                raise e
+        
+    # Write CSV if requested
+    if csv_path:
+        with open(csv_path, "w", newline="") as f:
+            writer = csv.writer(f)
+            writer.writerow(["Iteration", "Time (ms)", "Peak RAM (MB)"])
+            for idx, (t, m) in enumerate(zip(times, memories)):
+                writer.writerow([idx + 1, f"{t:.2f}", f"{m:.4f}"])
+        print(f"Raw metrics successfully exported to CSV: {csv_path}")
+
+    # Compute percentiles (P50, P90, P99)
+    # statistics.quantiles returns 99 cut points for n=100
+    q_time = statistics.quantiles(times, n=100)
+    q_mem = statistics.quantiles(memories, n=100)
+    
+    p50_time, p90_time, p99_time = q_time[49], q_time[89], q_time[98]
+    p50_mem, p90_mem, p99_mem = q_mem[49], q_mem[89], q_mem[98]
+
+    print(f"\n--- Results for {target_module} ({iterations} iterations) ---")
+    print(f"Code Volume (Deterministic):")
+    print(f"  Loaded Modules: {loaded_modules_val}")
+    print(f"  Loaded Lines:   {loaded_lines_val}")
+    print(f"Time (ms):")
+    print(f"  P50 (Median): {p50_time:.2f}")
+    print(f"  P90:          {p90_time:.2f}")
+    print(f"  P99:          {p99_time:.2f}")
+    print(f"  Mean:         {statistics.mean(times):.2f}")
+    print(f"  Min:          {min(times):.2f}")
+    print(f"  Max:          {max(times):.2f}")
+    if len(times) > 1:
+        print(f"  StdDev:       {statistics.stdev(times):.2f}")
+        
+    print(f"RAM (MB):")
+    print(f"  P50 (Median): {p50_mem:.4f}")
+    print(f"  P90:          {p90_mem:.4f}")
+    print(f"  P99:          {p99_mem:.4f}")
+    print(f"  Mean:         {statistics.mean(memories):.4f}")
+    print(f"  Min:          {min(memories):.4f}")
+    print(f"  Max:          {max(memories):.4f}")
+    if len(memories) > 1:
+        print(f"  StdDev:       {statistics.stdev(memories):.4f}")
+
+def run_trace(target_module):
+    """Generates importtime trace log and writes it to a file."""
+    trace_file = f"import_trace_{target_module.replace('.', '_')}.log"
+    print(f"Generating importtime trace log for {target_module} -> {trace_file}...")
+    
+    # We run: python -X importtime -c "import <module>"
+    result = subprocess.run(
+        [sys.executable, "-X", "importtime", "-c", f"import {target_module}"],
+        capture_output=True, text=True
+    )
+    
+    with open(trace_file, "w") as f:
+        f.write(result.stderr)
+        
+    print(f"Trace log successfully written to {trace_file}")
+
+def run_cprofile(target_module):
+    """Runs cProfile to capture stack traces for latency."""
+    import cProfile
+    import pstats
+    
+    prof_file = f"cprofile_{target_module.replace('.', '_')}.prof"
+    print(f"Generating cProfile data for {target_module} -> {prof_file}...")
+    
+    # Run profiling
+    pr = cProfile.Profile()
+    pr.enable()
+    importlib.import_module(target_module)
+    pr.disable()
+    
+    # Save for flame charts (e.g. via snakeviz)
+    pr.dump_stats(prof_file)
+    print(f"cProfile stats successfully written to {prof_file}")
+    
+    # Print top bottlenecks
+    print("\n--- Top 15 functions by cumulative time ---")
+    ps = pstats.Stats(pr).sort_stats(pstats.SortKey.CUMULATIVE)
+    ps.print_stats(15)
+
+def run_mprofile(target_module):
+    """Runs tracemalloc snapshot to see where memory is allocated."""
+    print(f"Generating tracemalloc memory snapshot for {target_module}...")
+    
+    tracemalloc.start()
+    importlib.import_module(target_module)
+    snapshot = tracemalloc.take_snapshot()
+    tracemalloc.stop()
+    
+    print("\n--- Top 15 memory allocations by line ---")
+    top_stats = snapshot.statistics('lineno')
+    for stat in top_stats[:15]:
+        print(stat)
+
+if __name__ == "__main__":
+    # Parse CLI arguments
+    target_module = "google.cloud.compute"
+    iterations = 50
+    trace = False
+    cprofile = False
+    mprofile = False
+    cpu = "0"
+    csv_path = None
+    
+    for arg in sys.argv[1:]:
+        if arg.startswith("--module="):
+            target_module = arg.split("=")[1]
+        elif arg.startswith("--iterations="):
+            iterations = int(arg.split("=")[1])
+        elif arg.startswith("--cpu="):
+            cpu = arg.split("=")[1]
+        elif arg.startswith("--csv="):
+            csv_path = arg.split("=")[1]
+        elif arg == "--trace":
+            trace = True
+        elif arg == "--cprofile":
+            cprofile = True
+        elif arg == "--mprofile":
+            mprofile = True
+            
+    if "--worker" in sys.argv:
+        run_worker(target_module)
+    elif trace:
+        run_trace(target_module)
+    elif cprofile:
+        run_cprofile(target_module)
+    elif mprofile:
+        run_mprofile(target_module)
+    else:
+        run_master(iterations, target_module, cpu, csv_path)

--- a/scripts/import_profiler/profiler.py
+++ b/scripts/import_profiler/profiler.py
@@ -70,6 +70,10 @@ def run_worker(target_module):
                 try:
                     file_path = importlib.util.source_from_cache(file_path)
                 except ValueError:
+                    # Raised if the .pyc path does not follow standard PEP 3147/488 conventions.
+                    # We pass silently because the unresolved file_path will still end in '.pyc', 
+                    # meaning the subsequent '.endswith('.py')' check will fail and safely skip 
+                    # trying to count lines in a binary file.
                     pass
             if file_path.endswith('.py'):
                 try:

--- a/scripts/import_profiler/profiler.py
+++ b/scripts/import_profiler/profiler.py
@@ -75,7 +75,7 @@ def run_worker(target_module):
                 try:
                     with open(file_path, 'r', encoding='utf-8', errors='ignore') as f:
                         loaded_lines += sum(1 for _ in f)
-                except Exception as e:
+                except OSError as e:
                     logging.warning(f"Failed to read lines from {file_path}: {e}")
     
     # Output to stdout for the Master to capture

--- a/scripts/import_profiler/profiler.py
+++ b/scripts/import_profiler/profiler.py
@@ -8,7 +8,6 @@ import importlib
 import importlib.util
 import csv
 import os
-import logging
 import shutil
 import pathlib
 import multiprocessing
@@ -19,14 +18,17 @@ def clean_bytecode():
     """Recursively deletes all __pycache__ directories and .pyc files to ensure disk-level cold starts."""
     print("Sweeping directory to delete __pycache__ and force bytecode recompilation...")
     count = 0
-    for p in pathlib.Path('.').rglob('__pycache__'):
-        if p.is_dir():
-            shutil.rmtree(p)
+    # Walk the directory avoiding hidden directories (e.g. .git, .venv, .nox)
+    for root, dirs, files in os.walk('.'):
+        dirs[:] = [d for d in dirs if not d.startswith('.')]
+        if '__pycache__' in dirs:
+            shutil.rmtree(os.path.join(root, '__pycache__'))
+            dirs.remove('__pycache__')
             count += 1
-    for p in pathlib.Path('.').rglob('*.pyc'):
-        if p.is_file():
-            p.unlink()
-            count += 1
+        for f in files:
+            if f.endswith('.pyc'):
+                os.remove(os.path.join(root, f))
+                count += 1
     print(f"Cleared {count} cached bytecode locations.")
 
 def get_rss_mb():
@@ -87,9 +89,11 @@ def run_worker(target_module):
                 except OSError as e:
                     logging.warning(f"Failed to read lines from {file_path}: {e}")
         except KeyError:
-            logging.debug(f"Module {m} disappeared from sys.modules during execution.")
+            # Module disappeared from sys.modules during execution
+            pass
         except AttributeError:
-            logging.debug(f"Module {m} has no __file__ attribute (likely a C-extension or built-in). Skipping.")
+            # Module has no __file__ attribute (likely a C-extension or built-in)
+            pass
     
     # Output to stdout for the Master to capture
     metrics = {
@@ -136,7 +140,8 @@ def _print_outputs(target_module, iterations, loaded_modules_val, loaded_lines_v
                    rss_memories, p50_rss, p90_rss, p99_rss):
     """Helper method to format and print the final benchmark results."""
     def _format_stats(title, data, p50, p90, p99, fmt):
-        if not data: return ""
+        if not data:
+            return ""
         std_str = f"  StdDev:       {statistics.stdev(data):{fmt}}\n" if len(data) > 1 else ""
         return f"{title}:\n  P50 (Median): {p50:{fmt}}\n  P90:          {p90:{fmt}}\n  P99:          {p99:{fmt}}\n  Mean:         {statistics.mean(data):{fmt}}\n  Min:          {min(data):{fmt}}\n  Max:          {max(data):{fmt}}\n{std_str}"
 
@@ -166,7 +171,11 @@ def run_master(iterations, target_module, cpu=0, csv_path=None, clear_cache=True
         python_exe = [sys.executable]
         
     if cpu != NO_CPU_PINNING:
-        print(f"CPU Pinning enabled: Pinning processes to core {cpu} using taskset.")
+        if not sys.platform.startswith("linux"):
+            print("WARNING: CPU pinning is only supported on Linux. Falling back to unpinned execution.")
+            cpu = NO_CPU_PINNING
+        else:
+            print(f"CPU Pinning enabled: Pinning processes to core {cpu} using taskset.")
     else:
         print("CPU Pinning disabled.")
     
@@ -316,8 +325,10 @@ if __name__ == "__main__":
     if args.worker:
         run_worker(args.module)
     elif args.trace:
+        if not args.keep_pycache: clean_bytecode()
         run_trace(args.module)
     elif args.cprofile:
+        if not args.keep_pycache: clean_bytecode()
         run_cprofile(args.module)
     elif args.mprofile:
         if not args.keep_pycache: clean_bytecode()

--- a/scripts/import_profiler/profiler.py
+++ b/scripts/import_profiler/profiler.py
@@ -13,6 +13,11 @@ import logging
 def run_worker(target_module):
     """Performs ONE import and returns metrics."""
     tracemalloc.start()
+    importlib.invalidate_caches()
+    sys.path_importer_cache.clear()
+    # We start the high-resolution timer from *inside* the already-booted worker process.
+    # This explicitly isolates the pure import latency and entirely omits the 
+    # 10ms-50ms Python VM interpreter startup overhead that would skew the metrics.
     start_time = time.perf_counter()
     
     modules_before = set(sys.modules.keys())
@@ -239,7 +244,7 @@ def run_mprofile(target_module):
 if __name__ == "__main__":
     import argparse
     parser = argparse.ArgumentParser(description="Python SDK Import Profiler")
-    parser.add_argument("--module", default="google.cloud.compute", help="Target module to profile")
+    parser.add_argument("--module", default="google.cloud.compute_v1", help="Target module to profile")
     parser.add_argument("--iterations", type=int, default=50, help="Number of iterations")
     default_cpu = "0" if sys.platform.startswith("linux") else "none"
     parser.add_argument("--cpu", default=default_cpu, help="CPU core to pin to (or 'none')")

--- a/scripts/import_profiler/profiler.py
+++ b/scripts/import_profiler/profiler.py
@@ -200,7 +200,7 @@ def run_cprofile(target_module):
     
     # Run profiling in a clean subprocess to ensure cold-start
     result = subprocess.run(
-        [sys.executable, "-m", "cProfile", "-o", prof_file, "-c", f"import importlib; importlib.import_module('{target_module}')"],
+        [sys.executable, "-m", "cProfile", "-o", prof_file, "-c", f"import importlib; importlib.import_module({json.dumps(target_module)})"],
         capture_output=True, text=True
     )
     if result.returncode != 0:

--- a/scripts/import_profiler/profiler.py
+++ b/scripts/import_profiler/profiler.py
@@ -5,8 +5,10 @@ import subprocess
 import statistics
 import tracemalloc
 import importlib
+import importlib.util
 import csv
 import os
+import logging
 
 def run_worker(target_module):
     """Performs ONE import and returns metrics."""
@@ -32,13 +34,15 @@ def run_worker(target_module):
         if mod and getattr(mod, '__file__', None):
             file_path = mod.__file__
             if file_path.endswith('.pyc'):
-                file_path = file_path[:-1]
+                try:
+                    file_path = importlib.util.source_from_cache(file_path)
+                except ValueError:
+                    pass
             if file_path.endswith('.py'):
                 try:
                     with open(file_path, 'r', encoding='utf-8') as f:
                         loaded_lines += sum(1 for _ in f)
                 except Exception as e:
-                    import logging
                     logging.warning(f"Failed to read lines from {file_path}: {e}")
     
     # Output to stdout for the Master to capture
@@ -72,7 +76,7 @@ def run_master(iterations, target_module, cpu="0", csv_path=None):
             result = subprocess.run(
                 cmd, capture_output=True, text=True, check=True
             )
-            data = json.loads(result.stdout)
+            data = json.loads(result.stdout.strip().splitlines()[-1])
             times.append(data["time_ms"])
             memories.append(data["peak_ram_mb"])
             loaded_modules_val = data.get("loaded_modules", 0)
@@ -85,7 +89,7 @@ def run_master(iterations, target_module, cpu="0", csv_path=None):
                 cmd = [sys.executable, __file__, "--worker", f"--module={target_module}"]
                 try:
                     result = subprocess.run(cmd, capture_output=True, text=True, check=True)
-                    data = json.loads(result.stdout)
+                    data = json.loads(result.stdout.strip().splitlines()[-1])
                     times.append(data["time_ms"])
                     memories.append(data["peak_ram_mb"])
                     loaded_modules_val = data.get("loaded_modules", 0)
@@ -101,7 +105,7 @@ def run_master(iterations, target_module, cpu="0", csv_path=None):
         
     # Write CSV if requested
     if csv_path:
-        with open(csv_path, "w", newline="") as f:
+        with open(csv_path, "w", newline="", encoding="utf-8") as f:
             writer = csv.writer(f)
             writer.writerow(["Iteration", "Time (ms)", "Peak RAM (MB)"])
             for idx, (t, m) in enumerate(zip(times, memories)):
@@ -157,7 +161,7 @@ def run_trace(target_module):
         capture_output=True, text=True
     )
     
-    with open(trace_file, "w") as f:
+    with open(trace_file, "w", encoding="utf-8") as f:
         f.write(result.stderr)
         
     print(f"Trace log successfully written to {trace_file}")

--- a/scripts/import_profiler/profiler.py
+++ b/scripts/import_profiler/profiler.py
@@ -174,7 +174,7 @@ def run_trace(target_module):
     trace_file = f"import_trace_{target_module.replace('.', '_')}.log"
     print(f"Generating importtime trace log for {target_module} -> {trace_file}...")
     
-    # We run: python -X importtime -c "import <module>"
+    # We run: python -X importtime -c "import importlib; importlib.import_module(...)"
     result = subprocess.run(
         [sys.executable, "-X", "importtime", "-c", f"import importlib; importlib.import_module({json.dumps(target_module)})"],
         capture_output=True, text=True
@@ -222,7 +222,7 @@ def run_mprofile(target_module):
         "import tracemalloc\n"
         "import importlib\n"
         "tracemalloc.start()\n"
-        f"importlib.import_module('{target_module}')\n"
+        f"importlib.import_module({json.dumps(target_module)})\n"
         "snapshot = tracemalloc.take_snapshot()\n"
         "tracemalloc.stop()\n"
         "top_stats = snapshot.statistics('lineno')\n"

--- a/scripts/import_profiler/profiler.py
+++ b/scripts/import_profiler/profiler.py
@@ -102,11 +102,10 @@ def run_master(iterations, target_module, cpu="0", csv_path=None):
             memories.append(data["peak_ram_mb"])
             loaded_modules_val = data["loaded_modules"]
             loaded_lines_val = data["loaded_lines"]
-        except (subprocess.CalledProcessError, FileNotFoundError) as e:
-            # Fallback if taskset is not found or fails
+        except FileNotFoundError as e:
             if cpu.lower() != "none" and i == 0:
-                print("WARNING: taskset CPU pinning failed or is not available. Falling back to unpinned execution...")
-                # Try running without taskset
+                print("WARNING: taskset CPU pinning is not available. Falling back to unpinned execution...")
+                cpu = "none"
                 cmd = [sys.executable, __file__, "--worker", f"--module={target_module}"]
                 try:
                     data = _run_worker_and_parse(cmd)
@@ -114,14 +113,14 @@ def run_master(iterations, target_module, cpu="0", csv_path=None):
                     memories.append(data["peak_ram_mb"])
                     loaded_modules_val = data["loaded_modules"]
                     loaded_lines_val = data["loaded_lines"]
-                    cpu = "none" # Disable cpu pinning for remaining iterations
                 except subprocess.CalledProcessError as err:
                     print(f"Error in worker process:\n{err.stderr}", file=sys.stderr)
                     raise err
             else:
-                if isinstance(e, subprocess.CalledProcessError):
-                    print(f"Error in worker process:\n{e.stderr}", file=sys.stderr)
                 raise e
+        except subprocess.CalledProcessError as e:
+            print(f"Error in worker process:\n{e.stderr}", file=sys.stderr)
+            raise e
         
     # Write CSV if requested
     if csv_path:
@@ -193,41 +192,49 @@ def run_trace(target_module):
     print(f"Trace log successfully written to {trace_file}")
 
 def run_cprofile(target_module):
-    """Runs cProfile to capture stack traces for latency."""
-    import cProfile
+    """Runs cProfile in a clean subprocess to capture stack traces for latency."""
     import pstats
     
     prof_file = f"cprofile_{target_module.replace('.', '_')}.prof"
     print(f"Generating cProfile data for {target_module} -> {prof_file}...")
     
-    # Run profiling
-    pr = cProfile.Profile()
-    pr.enable()
-    importlib.import_module(target_module)
-    pr.disable()
-    
-    # Save for flame charts (e.g. via snakeviz)
-    pr.dump_stats(prof_file)
+    # Run profiling in a clean subprocess to ensure cold-start
+    result = subprocess.run(
+        [sys.executable, "-m", "cProfile", "-o", prof_file, "-c", f"import importlib; importlib.import_module('{target_module}')"],
+        capture_output=True, text=True
+    )
+    if result.returncode != 0:
+        print(f"Error generating cProfile data:\n{result.stderr}", file=sys.stderr)
+        return
+
     print(f"cProfile stats successfully written to {prof_file}")
     
     # Print top bottlenecks
     print("\n--- Top 15 functions by cumulative time ---")
-    ps = pstats.Stats(pr).sort_stats(pstats.SortKey.CUMULATIVE)
+    ps = pstats.Stats(prof_file).sort_stats(pstats.SortKey.CUMULATIVE)
     ps.print_stats(15)
 
 def run_mprofile(target_module):
-    """Runs tracemalloc snapshot to see where memory is allocated."""
+    """Runs tracemalloc snapshot in a clean subprocess to see where memory is allocated."""
     print(f"Generating tracemalloc memory snapshot for {target_module}...")
     
-    tracemalloc.start()
-    importlib.import_module(target_module)
-    snapshot = tracemalloc.take_snapshot()
-    tracemalloc.stop()
-    
-    print("\n--- Top 15 memory allocations by line ---")
-    top_stats = snapshot.statistics('lineno')
-    for stat in top_stats[:15]:
-        print(stat)
+    code = (
+        "import tracemalloc\n"
+        "import importlib\n"
+        "tracemalloc.start()\n"
+        f"importlib.import_module('{target_module}')\n"
+        "snapshot = tracemalloc.take_snapshot()\n"
+        "tracemalloc.stop()\n"
+        "top_stats = snapshot.statistics('lineno')\n"
+        "for stat in top_stats[:15]:\n"
+        "    print(stat)\n"
+    )
+    result = subprocess.run([sys.executable, "-c", code], capture_output=True, text=True)
+    if result.returncode != 0:
+        print(f"Error generating memory snapshot:\n{result.stderr}", file=sys.stderr)
+    else:
+        print("\n--- Top 15 memory allocations by line ---")
+        print(result.stdout, end="")
 
 if __name__ == "__main__":
     import argparse

--- a/scripts/import_profiler/profiler.py
+++ b/scripts/import_profiler/profiler.py
@@ -11,6 +11,7 @@ import os
 import logging
 import shutil
 import pathlib
+import multiprocessing
 
 NO_CPU_PINNING = -1
 
@@ -265,27 +266,29 @@ def run_cprofile(target_module):
     ps = pstats.Stats(prof_file).sort_stats(pstats.SortKey.CUMULATIVE)
     ps.print_stats(15)
 
+def _mprofile_worker(target_module):
+    import tracemalloc
+    tracemalloc.start()
+    importlib.import_module(target_module)
+    snapshot = tracemalloc.take_snapshot()
+    tracemalloc.stop()
+    top_stats = snapshot.statistics('lineno')
+    print("\n--- Top 15 memory allocations by line ---")
+    for stat in top_stats[:15]:
+        print(stat)
+
 def run_mprofile(target_module):
     """Runs tracemalloc snapshot in a clean subprocess to see where memory is allocated."""
     print(f"Generating tracemalloc memory snapshot for {target_module}...")
     
-    code = (
-        "import tracemalloc\n"
-        "import importlib\n"
-        "tracemalloc.start()\n"
-        f"importlib.import_module({json.dumps(target_module)})\n"
-        "snapshot = tracemalloc.take_snapshot()\n"
-        "tracemalloc.stop()\n"
-        "top_stats = snapshot.statistics('lineno')\n"
-        "for stat in top_stats[:15]:\n"
-        "    print(stat)\n"
-    )
-    result = subprocess.run([sys.executable, "-c", code], capture_output=True, text=True)
-    if result.returncode != 0:
-        print(f"Error generating memory snapshot:\n{result.stderr}", file=sys.stderr)
-    else:
-        print("\n--- Top 15 memory allocations by line ---")
-        print(result.stdout, end="")
+    # Use 'spawn' to ensure a completely clean python process without inherited module caches
+    ctx = multiprocessing.get_context("spawn")
+    p = ctx.Process(target=_mprofile_worker, args=(target_module,))
+    p.start()
+    p.join()
+    
+    if p.exitcode != 0:
+        print(f"Error generating memory snapshot, process exited with code {p.exitcode}", file=sys.stderr)
 
 if __name__ == "__main__":
     import argparse

--- a/scripts/import_profiler/profiler.py
+++ b/scripts/import_profiler/profiler.py
@@ -46,12 +46,13 @@ def run_worker(target_module):
                     logging.warning(f"Failed to read lines from {file_path}: {e}")
     
     # Output to stdout for the Master to capture
-    print(json.dumps({
+    metrics = {
         "time_ms": (end_time - start_time) * 1000,
         "peak_ram_mb": peak / (1024 * 1024),
         "loaded_modules": len(new_modules),
         "loaded_lines": loaded_lines
-    }))
+    }
+    print(f"__METRICS__:{json.dumps(metrics)}")
 
 def _run_worker_and_parse(cmd):
     result = subprocess.run(cmd, capture_output=True, text=True, check=True)

--- a/scripts/import_profiler/profiler.py
+++ b/scripts/import_profiler/profiler.py
@@ -53,8 +53,27 @@ def run_worker(target_module):
         "loaded_lines": loaded_lines
     }))
 
+def _run_worker_and_parse(cmd):
+    result = subprocess.run(cmd, capture_output=True, text=True, check=True)
+    try:
+        lines = result.stdout.strip().splitlines()
+        if not lines:
+            raise ValueError("Worker produced no output on stdout.")
+        data = json.loads(lines[-1])
+        for key in ("time_ms", "peak_ram_mb", "loaded_modules", "loaded_lines"):
+            if key not in data:
+                raise KeyError(f"Missing key '{key}' in worker output")
+        return data
+    except (json.JSONDecodeError, IndexError, KeyError, ValueError) as parse_err:
+        print(f"Error parsing worker output: {parse_err}", file=sys.stderr)
+        print(f"Worker stdout:\n{result.stdout}", file=sys.stderr)
+        print(f"Worker stderr:\n{result.stderr}", file=sys.stderr)
+        raise parse_err
+
 def run_master(iterations, target_module, cpu="0", csv_path=None):
     """Orchestrates the benchmark."""
+    if iterations < 1:
+        raise ValueError("Number of iterations must be at least 1.")
     times, memories = [], []
     loaded_modules_val, loaded_lines_val = 0, 0
     
@@ -73,14 +92,11 @@ def run_master(iterations, target_module, cpu="0", csv_path=None):
         cmd += [sys.executable, __file__, "--worker", f"--module={target_module}"]
         
         try:
-            result = subprocess.run(
-                cmd, capture_output=True, text=True, check=True
-            )
-            data = json.loads(result.stdout.strip().splitlines()[-1])
+            data = _run_worker_and_parse(cmd)
             times.append(data["time_ms"])
             memories.append(data["peak_ram_mb"])
-            loaded_modules_val = data.get("loaded_modules", 0)
-            loaded_lines_val = data.get("loaded_lines", 0)
+            loaded_modules_val = data["loaded_modules"]
+            loaded_lines_val = data["loaded_lines"]
         except (subprocess.CalledProcessError, FileNotFoundError) as e:
             # Fallback if taskset is not found or fails
             if cpu.lower() != "none" and i == 0:
@@ -88,12 +104,11 @@ def run_master(iterations, target_module, cpu="0", csv_path=None):
                 # Try running without taskset
                 cmd = [sys.executable, __file__, "--worker", f"--module={target_module}"]
                 try:
-                    result = subprocess.run(cmd, capture_output=True, text=True, check=True)
-                    data = json.loads(result.stdout.strip().splitlines()[-1])
+                    data = _run_worker_and_parse(cmd)
                     times.append(data["time_ms"])
                     memories.append(data["peak_ram_mb"])
-                    loaded_modules_val = data.get("loaded_modules", 0)
-                    loaded_lines_val = data.get("loaded_lines", 0)
+                    loaded_modules_val = data["loaded_modules"]
+                    loaded_lines_val = data["loaded_lines"]
                     cpu = "none" # Disable cpu pinning for remaining iterations
                 except subprocess.CalledProcessError as err:
                     print(f"Error in worker process:\n{err.stderr}", file=sys.stderr)
@@ -160,7 +175,13 @@ def run_trace(target_module):
         [sys.executable, "-X", "importtime", "-c", f"import {target_module}"],
         capture_output=True, text=True
     )
-    
+    if result.returncode != 0:
+        print(f"WARNING: Import failed with exit code {result.returncode}. The trace log may be incomplete or contain errors.", file=sys.stderr)
+        if result.stdout:
+            print(f"Worker stdout:\n{result.stdout}", file=sys.stderr)
+        if result.stderr:
+            print(f"Worker stderr:\n{result.stderr}", file=sys.stderr)
+            
     with open(trace_file, "w", encoding="utf-8") as f:
         f.write(result.stderr)
         

--- a/scripts/import_profiler/profiler.py
+++ b/scripts/import_profiler/profiler.py
@@ -40,7 +40,7 @@ def run_worker(target_module):
                     pass
             if file_path.endswith('.py'):
                 try:
-                    with open(file_path, 'r', encoding='utf-8') as f:
+                    with open(file_path, 'r', encoding='utf-8', errors='ignore') as f:
                         loaded_lines += sum(1 for _ in f)
                 except Exception as e:
                     logging.warning(f"Failed to read lines from {file_path}: {e}")

--- a/scripts/import_profiler/profiler.py
+++ b/scripts/import_profiler/profiler.py
@@ -109,7 +109,7 @@ def _run_worker_and_parse(cmd):
         print(f"Worker stderr:\n{result.stderr}", file=sys.stderr)
         raise parse_err
 
-def run_master(iterations, target_module, cpu="0", csv_path=None, clear_cache=False):
+def run_master(iterations, target_module, cpu="0", csv_path=None, clear_cache=True):
     """Orchestrates the benchmark."""
     if iterations < 1:
         raise ValueError("Number of iterations must be at least 1.")
@@ -306,7 +306,7 @@ if __name__ == "__main__":
     parser.add_argument("--trace", action="store_true", help="Generate importtime trace log")
     parser.add_argument("--cprofile", action="store_true", help="Run cProfile")
     parser.add_argument("--mprofile", action="store_true", help="Run tracemalloc memory snapshot")
-    parser.add_argument("--clear-pycache", action="store_true", help="Delete all __pycache__ to force full disk cold-start")
+    parser.add_argument("--keep-pycache", action="store_true", help="Preserve __pycache__ and allow bytecode execution (Default: False, script automatically sweeps __pycache__ for true cold-starts)")
     parser.add_argument("--worker", action="store_true", help=argparse.SUPPRESS)
     
     args = parser.parse_args()
@@ -318,7 +318,7 @@ if __name__ == "__main__":
     elif args.cprofile:
         run_cprofile(args.module)
     elif args.mprofile:
-        if args.clear_pycache: clean_bytecode()
+        if not args.keep_pycache: clean_bytecode()
         run_mprofile(args.module)
     else:
-        run_master(args.iterations, args.module, args.cpu, args.csv, args.clear_pycache)
+        run_master(args.iterations, args.module, args.cpu, args.csv, not args.keep_pycache)

--- a/scripts/import_profiler/profiler.py
+++ b/scripts/import_profiler/profiler.py
@@ -176,7 +176,7 @@ def run_trace(target_module):
     
     # We run: python -X importtime -c "import <module>"
     result = subprocess.run(
-        [sys.executable, "-X", "importtime", "-c", f"import {target_module}"],
+        [sys.executable, "-X", "importtime", "-c", f"import importlib; importlib.import_module({json.dumps(target_module)})"],
         capture_output=True, text=True
     )
     if result.returncode != 0:

--- a/scripts/import_profiler/profiler.py
+++ b/scripts/import_profiler/profiler.py
@@ -12,6 +12,8 @@ import logging
 import shutil
 import pathlib
 
+NO_CPU_PINNING = -1
+
 def clean_bytecode():
     """Recursively deletes all __pycache__ directories and .pyc files to ensure disk-level cold starts."""
     print("Sweeping directory to delete __pycache__ and force bytecode recompilation...")
@@ -119,7 +121,7 @@ def _run_worker_and_parse(cmd):
         print(f"Worker stderr:\n{result.stderr}", file=sys.stderr)
         raise parse_err
 
-def run_master(iterations, target_module, cpu="0", csv_path=None, clear_cache=True):
+def run_master(iterations, target_module, cpu=0, csv_path=None, clear_cache=True):
     """Orchestrates the benchmark."""
     if iterations < 1:
         raise ValueError("Number of iterations must be at least 1.")
@@ -134,7 +136,7 @@ def run_master(iterations, target_module, cpu="0", csv_path=None, clear_cache=Tr
     else:
         python_exe = [sys.executable]
         
-    if cpu.lower() != "none":
+    if cpu != NO_CPU_PINNING:
         print(f"CPU Pinning enabled: Pinning processes to core {cpu} using taskset.")
     else:
         print("CPU Pinning disabled.")
@@ -142,8 +144,8 @@ def run_master(iterations, target_module, cpu="0", csv_path=None, clear_cache=Tr
     for i in range(iterations):
         # Build command line
         cmd = []
-        if cpu.lower() != "none":
-            cmd += ["taskset", "-c", cpu]
+        if cpu != NO_CPU_PINNING:
+            cmd += ["taskset", "-c", str(cpu)]
         
         cmd += python_exe + [__file__, "--worker", f"--module={target_module}"]
         
@@ -155,9 +157,9 @@ def run_master(iterations, target_module, cpu="0", csv_path=None, clear_cache=Tr
             loaded_modules_val = data["loaded_modules"]
             loaded_lines_val = data["loaded_lines"]
         except FileNotFoundError as e:
-            if cpu.lower() != "none" and i == 0:
+            if cpu != NO_CPU_PINNING and i == 0:
                 print("WARNING: taskset CPU pinning is not available. Falling back to unpinned execution...")
-                cpu = "none"
+                cpu = NO_CPU_PINNING
                 cmd = python_exe + [__file__, "--worker", f"--module={target_module}"]
                 try:
                     data = _run_worker_and_parse(cmd)
@@ -310,8 +312,8 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Python SDK Import Profiler")
     parser.add_argument("--module", default="google.cloud.compute_v1", help="Target module to profile")
     parser.add_argument("--iterations", type=int, default=50, help="Number of iterations")
-    default_cpu = "0" if sys.platform.startswith("linux") else "none"
-    parser.add_argument("--cpu", default=default_cpu, help="CPU core to pin to (or 'none')")
+    default_cpu = 0 if sys.platform.startswith("linux") else NO_CPU_PINNING
+    parser.add_argument("--cpu", type=int, default=default_cpu, help="CPU core to pin to (or -1 for no pinning)")
     parser.add_argument("--csv", help="Path to export CSV results")
     parser.add_argument("--trace", action="store_true", help="Generate importtime trace log")
     parser.add_argument("--cprofile", action="store_true", help="Run cProfile")

--- a/scripts/import_profiler/profiler.py
+++ b/scripts/import_profiler/profiler.py
@@ -157,22 +157,10 @@ def run_master(iterations, target_module, cpu=0, csv_path=None, clear_cache=True
             loaded_modules_val = data["loaded_modules"]
             loaded_lines_val = data["loaded_lines"]
         except FileNotFoundError as e:
-            if cpu != NO_CPU_PINNING and i == 0:
-                print("WARNING: taskset CPU pinning is not available. Falling back to unpinned execution...")
-                cpu = NO_CPU_PINNING
-                cmd = python_exe + [__file__, "--worker", f"--module={target_module}"]
-                try:
-                    data = _run_worker_and_parse(cmd)
-                    times.append(data["time_ms"])
-                    memories.append(data["peak_ram_mb"])
-                    rss_memories.append(data["rss_ram_mb"])
-                    loaded_modules_val = data["loaded_modules"]
-                    loaded_lines_val = data["loaded_lines"]
-                except subprocess.CalledProcessError as err:
-                    print(f"Error in worker process:\n{err.stderr}", file=sys.stderr)
-                    raise err
-            else:
-                raise e
+            if cpu != NO_CPU_PINNING and cmd and cmd[0] == "taskset":
+                print("ERROR: 'taskset' command not found. CPU pinning is enabled but taskset is not installed. "
+                      "Install taskset or disable pinning by passing --cpu=-1.", file=sys.stderr)
+            raise e
         except subprocess.CalledProcessError as e:
             print(f"Error in worker process:\n{e.stderr}", file=sys.stderr)
             raise e

--- a/scripts/import_profiler/profiler.py
+++ b/scripts/import_profiler/profiler.py
@@ -58,9 +58,13 @@ def _run_worker_and_parse(cmd):
     result = subprocess.run(cmd, capture_output=True, text=True, check=True)
     try:
         lines = result.stdout.strip().splitlines()
-        if not lines:
-            raise ValueError("Worker produced no output on stdout.")
-        data = json.loads(lines[-1])
+        data = None
+        for line in reversed(lines):
+            if line.startswith("__METRICS__:"):
+                data = json.loads(line[len("__METRICS__:"):])
+                break
+        if data is None:
+            raise ValueError("Worker did not output metrics JSON.")
         for key in ("time_ms", "peak_ram_mb", "loaded_modules", "loaded_lines"):
             if key not in data:
                 raise KeyError(f"Missing key '{key}' in worker output")

--- a/scripts/import_profiler/profiler.py
+++ b/scripts/import_profiler/profiler.py
@@ -10,6 +10,16 @@ import csv
 import os
 import logging
 
+def get_rss_mb():
+    """Gets current Resident Set Size (physical memory) in MB. Linux only."""
+    try:
+        with open('/proc/self/statm', 'r') as f:
+            rss_pages = int(f.read().split()[1])
+            page_size = os.sysconf('SC_PAGE_SIZE')
+            return (rss_pages * page_size) / (1024 * 1024)
+    except Exception:
+        return 0.0
+
 def run_worker(target_module):
     """Performs ONE import and returns metrics."""
     tracemalloc.start()
@@ -19,6 +29,7 @@ def run_worker(target_module):
     # This explicitly isolates the pure import latency and entirely omits the 
     # 10ms-50ms Python VM interpreter startup overhead that would skew the metrics.
     start_time = time.perf_counter()
+    rss_before = get_rss_mb()
     
     modules_before = set(sys.modules.keys())
     
@@ -27,6 +38,7 @@ def run_worker(target_module):
     # ---------------------
     
     end_time = time.perf_counter()
+    rss_after = get_rss_mb()
     _, peak = tracemalloc.get_traced_memory()
     tracemalloc.stop()
     
@@ -54,6 +66,7 @@ def run_worker(target_module):
     metrics = {
         "time_ms": (end_time - start_time) * 1000,
         "peak_ram_mb": peak / (1024 * 1024),
+        "rss_ram_mb": rss_after - rss_before,
         "loaded_modules": len(new_modules),
         "loaded_lines": loaded_lines
     }
@@ -70,7 +83,7 @@ def _run_worker_and_parse(cmd):
                 break
         if data is None:
             raise ValueError("Worker did not output metrics JSON.")
-        for key in ("time_ms", "peak_ram_mb", "loaded_modules", "loaded_lines"):
+        for key in ("time_ms", "peak_ram_mb", "rss_ram_mb", "loaded_modules", "loaded_lines"):
             if key not in data:
                 raise KeyError(f"Missing key '{key}' in worker output")
         return data
@@ -84,7 +97,7 @@ def run_master(iterations, target_module, cpu="0", csv_path=None):
     """Orchestrates the benchmark."""
     if iterations < 1:
         raise ValueError("Number of iterations must be at least 1.")
-    times, memories = [], []
+    times, memories, rss_memories = [], [], []
     loaded_modules_val, loaded_lines_val = 0, 0
     
     print(f"Profiling start... Running {iterations} cold-start iterations for {target_module}.")
@@ -105,6 +118,7 @@ def run_master(iterations, target_module, cpu="0", csv_path=None):
             data = _run_worker_and_parse(cmd)
             times.append(data["time_ms"])
             memories.append(data["peak_ram_mb"])
+            rss_memories.append(data["rss_ram_mb"])
             loaded_modules_val = data["loaded_modules"]
             loaded_lines_val = data["loaded_lines"]
         except FileNotFoundError as e:
@@ -116,6 +130,7 @@ def run_master(iterations, target_module, cpu="0", csv_path=None):
                     data = _run_worker_and_parse(cmd)
                     times.append(data["time_ms"])
                     memories.append(data["peak_ram_mb"])
+                    rss_memories.append(data["rss_ram_mb"])
                     loaded_modules_val = data["loaded_modules"]
                     loaded_lines_val = data["loaded_lines"]
                 except subprocess.CalledProcessError as err:
@@ -131,9 +146,9 @@ def run_master(iterations, target_module, cpu="0", csv_path=None):
     if csv_path:
         with open(csv_path, "w", newline="", encoding="utf-8") as f:
             writer = csv.writer(f)
-            writer.writerow(["Iteration", "Time (ms)", "Peak RAM (MB)"])
-            for idx, (t, m) in enumerate(zip(times, memories)):
-                writer.writerow([idx + 1, f"{t:.2f}", f"{m:.4f}"])
+            writer.writerow(["Iteration", "Time (ms)", "Tracemalloc RAM (MB)", "RSS Physical RAM (MB)"])
+            for idx, (t, m, r) in enumerate(zip(times, memories, rss_memories)):
+                writer.writerow([idx + 1, f"{t:.2f}", f"{m:.4f}", f"{r:.4f}"])
         print(f"Raw metrics successfully exported to CSV: {csv_path}")
 
     # Compute percentiles (P50, P90, P99)
@@ -150,6 +165,12 @@ def run_master(iterations, target_module, cpu="0", csv_path=None):
     else:
         p50_mem = p90_mem = p99_mem = memories[0] if memories else 0.0
 
+    if len(rss_memories) > 1:
+        q_rss = statistics.quantiles(rss_memories, n=100)
+        p50_rss, p90_rss, p99_rss = q_rss[49], q_rss[89], q_rss[98]
+    else:
+        p50_rss = p90_rss = p99_rss = rss_memories[0] if rss_memories else 0.0
+
     print(f"\n--- Results for {target_module} ({iterations} iterations) ---")
     print(f"Code Volume (Deterministic):")
     print(f"  Loaded Modules: {loaded_modules_val}")
@@ -164,7 +185,7 @@ def run_master(iterations, target_module, cpu="0", csv_path=None):
     if len(times) > 1:
         print(f"  StdDev:       {statistics.stdev(times):.2f}")
         
-    print(f"RAM (MB):")
+    print(f"Tracemalloc RAM (MB):")
     print(f"  P50 (Median): {p50_mem:.4f}")
     print(f"  P90:          {p90_mem:.4f}")
     print(f"  P99:          {p99_mem:.4f}")
@@ -173,6 +194,16 @@ def run_master(iterations, target_module, cpu="0", csv_path=None):
     print(f"  Max:          {max(memories):.4f}")
     if len(memories) > 1:
         print(f"  StdDev:       {statistics.stdev(memories):.4f}")
+
+    print(f"Physical RSS RAM (MB):")
+    print(f"  P50 (Median): {p50_rss:.4f}")
+    print(f"  P90:          {p90_rss:.4f}")
+    print(f"  P99:          {p99_rss:.4f}")
+    print(f"  Mean:         {statistics.mean(rss_memories):.4f}")
+    print(f"  Min:          {min(rss_memories):.4f}")
+    print(f"  Max:          {max(rss_memories):.4f}")
+    if len(rss_memories) > 1:
+        print(f"  StdDev:       {statistics.stdev(rss_memories):.4f}")
 
 def run_trace(target_module):
     """Generates importtime trace log and writes it to a file."""

--- a/scripts/import_profiler/profiler.py
+++ b/scripts/import_profiler/profiler.py
@@ -9,6 +9,22 @@ import importlib.util
 import csv
 import os
 import logging
+import shutil
+import pathlib
+
+def clean_bytecode():
+    """Recursively deletes all __pycache__ directories and .pyc files to ensure disk-level cold starts."""
+    print("Sweeping directory to delete __pycache__ and force bytecode recompilation...")
+    count = 0
+    for p in pathlib.Path('.').rglob('__pycache__'):
+        if p.is_dir():
+            shutil.rmtree(p)
+            count += 1
+    for p in pathlib.Path('.').rglob('*.pyc'):
+        if p.is_file():
+            p.unlink()
+            count += 1
+    print(f"Cleared {count} cached bytecode locations.")
 
 def get_rss_mb():
     """Gets current Resident Set Size (physical memory) in MB. Linux only."""
@@ -93,7 +109,7 @@ def _run_worker_and_parse(cmd):
         print(f"Worker stderr:\n{result.stderr}", file=sys.stderr)
         raise parse_err
 
-def run_master(iterations, target_module, cpu="0", csv_path=None):
+def run_master(iterations, target_module, cpu="0", csv_path=None, clear_cache=False):
     """Orchestrates the benchmark."""
     if iterations < 1:
         raise ValueError("Number of iterations must be at least 1.")
@@ -101,6 +117,13 @@ def run_master(iterations, target_module, cpu="0", csv_path=None):
     loaded_modules_val, loaded_lines_val = 0, 0
     
     print(f"Profiling start... Running {iterations} cold-start iterations for {target_module}.")
+    
+    if clear_cache:
+        clean_bytecode()
+        python_exe = [sys.executable, "-B"] # -B prevents writing .pyc files so every iteration reads raw .py
+    else:
+        python_exe = [sys.executable]
+        
     if cpu.lower() != "none":
         print(f"CPU Pinning enabled: Pinning processes to core {cpu} using taskset.")
     else:
@@ -112,7 +135,7 @@ def run_master(iterations, target_module, cpu="0", csv_path=None):
         if cpu.lower() != "none":
             cmd += ["taskset", "-c", cpu]
         
-        cmd += [sys.executable, __file__, "--worker", f"--module={target_module}"]
+        cmd += python_exe + [__file__, "--worker", f"--module={target_module}"]
         
         try:
             data = _run_worker_and_parse(cmd)
@@ -125,7 +148,7 @@ def run_master(iterations, target_module, cpu="0", csv_path=None):
             if cpu.lower() != "none" and i == 0:
                 print("WARNING: taskset CPU pinning is not available. Falling back to unpinned execution...")
                 cpu = "none"
-                cmd = [sys.executable, __file__, "--worker", f"--module={target_module}"]
+                cmd = python_exe + [__file__, "--worker", f"--module={target_module}"]
                 try:
                     data = _run_worker_and_parse(cmd)
                     times.append(data["time_ms"])
@@ -283,6 +306,7 @@ if __name__ == "__main__":
     parser.add_argument("--trace", action="store_true", help="Generate importtime trace log")
     parser.add_argument("--cprofile", action="store_true", help="Run cProfile")
     parser.add_argument("--mprofile", action="store_true", help="Run tracemalloc memory snapshot")
+    parser.add_argument("--clear-pycache", action="store_true", help="Delete all __pycache__ to force full disk cold-start")
     parser.add_argument("--worker", action="store_true", help=argparse.SUPPRESS)
     
     args = parser.parse_args()
@@ -294,6 +318,7 @@ if __name__ == "__main__":
     elif args.cprofile:
         run_cprofile(args.module)
     elif args.mprofile:
+        if args.clear_pycache: clean_bytecode()
         run_mprofile(args.module)
     else:
-        run_master(args.iterations, args.module, args.cpu, args.csv)
+        run_master(args.iterations, args.module, args.cpu, args.csv, args.clear_pycache)

--- a/scripts/import_profiler/profiler.py
+++ b/scripts/import_profiler/profiler.py
@@ -230,38 +230,26 @@ def run_mprofile(target_module):
         print(stat)
 
 if __name__ == "__main__":
-    # Parse CLI arguments
-    target_module = "google.cloud.compute"
-    iterations = 50
-    trace = False
-    cprofile = False
-    mprofile = False
-    cpu = "0"
-    csv_path = None
+    import argparse
+    parser = argparse.ArgumentParser(description="Python SDK Import Profiler")
+    parser.add_argument("--module", default="google.cloud.compute", help="Target module to profile")
+    parser.add_argument("--iterations", type=int, default=50, help="Number of iterations")
+    parser.add_argument("--cpu", default="0", help="CPU core to pin to (or 'none')")
+    parser.add_argument("--csv", help="Path to export CSV results")
+    parser.add_argument("--trace", action="store_true", help="Generate importtime trace log")
+    parser.add_argument("--cprofile", action="store_true", help="Run cProfile")
+    parser.add_argument("--mprofile", action="store_true", help="Run tracemalloc memory snapshot")
+    parser.add_argument("--worker", action="store_true", help=argparse.SUPPRESS)
     
-    for arg in sys.argv[1:]:
-        if arg.startswith("--module="):
-            target_module = arg.split("=")[1]
-        elif arg.startswith("--iterations="):
-            iterations = int(arg.split("=")[1])
-        elif arg.startswith("--cpu="):
-            cpu = arg.split("=")[1]
-        elif arg.startswith("--csv="):
-            csv_path = arg.split("=")[1]
-        elif arg == "--trace":
-            trace = True
-        elif arg == "--cprofile":
-            cprofile = True
-        elif arg == "--mprofile":
-            mprofile = True
-            
-    if "--worker" in sys.argv:
-        run_worker(target_module)
-    elif trace:
-        run_trace(target_module)
-    elif cprofile:
-        run_cprofile(target_module)
-    elif mprofile:
-        run_mprofile(target_module)
+    args = parser.parse_args()
+    
+    if args.worker:
+        run_worker(args.module)
+    elif args.trace:
+        run_trace(args.module)
+    elif args.cprofile:
+        run_cprofile(args.module)
+    elif args.mprofile:
+        run_mprofile(args.module)
     else:
-        run_master(iterations, target_module, cpu, csv_path)
+        run_master(args.iterations, args.module, args.cpu, args.csv)

--- a/scripts/import_profiler/profiler.py
+++ b/scripts/import_profiler/profiler.py
@@ -292,8 +292,15 @@ def run_mprofile(target_module):
 
 if __name__ == "__main__":
     import argparse
+
+    def validate_module_name(module_name):
+        """Validates that the input is a structurally valid Python module identifier to prevent arbitrary code execution."""
+        if not all(part.isidentifier() for part in module_name.split('.')):
+            raise argparse.ArgumentTypeError(f"'{module_name}' is not a valid Python module identifier.")
+        return module_name
+
     parser = argparse.ArgumentParser(description="Python SDK Import Profiler")
-    parser.add_argument("--module", default="google.cloud.compute_v1", help="Target module to profile")
+    parser.add_argument("--module", type=validate_module_name, default="google.cloud.compute_v1", help="Target module to profile")
     parser.add_argument("--iterations", type=int, default=50, help="Number of iterations")
     default_cpu = 0 if sys.platform.startswith("linux") else NO_CPU_PINNING
     parser.add_argument("--cpu", type=int, default=default_cpu, help="CPU core to pin to (or -1 for no pinning)")

--- a/scripts/import_profiler/profiler.py
+++ b/scripts/import_profiler/profiler.py
@@ -234,7 +234,8 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Python SDK Import Profiler")
     parser.add_argument("--module", default="google.cloud.compute", help="Target module to profile")
     parser.add_argument("--iterations", type=int, default=50, help="Number of iterations")
-    parser.add_argument("--cpu", default="0", help="CPU core to pin to (or 'none')")
+    default_cpu = "0" if sys.platform.startswith("linux") else "none"
+    parser.add_argument("--cpu", default=default_cpu, help="CPU core to pin to (or 'none')")
     parser.add_argument("--csv", help="Path to export CSV results")
     parser.add_argument("--trace", action="store_true", help="Generate importtime trace log")
     parser.add_argument("--cprofile", action="store_true", help="Run cProfile")

--- a/scripts/import_profiler/profiler.py
+++ b/scripts/import_profiler/profiler.py
@@ -29,12 +29,17 @@ def run_worker(target_module):
     loaded_lines = 0
     for m in new_modules:
         mod = sys.modules.get(m)
-        if mod and getattr(mod, '__file__', None) and mod.__file__.endswith('.py'):
-            try:
-                with open(mod.__file__, 'r', encoding='utf-8') as f:
-                    loaded_lines += sum(1 for _ in f)
-            except Exception:
-                pass
+        if mod and getattr(mod, '__file__', None):
+            file_path = mod.__file__
+            if file_path.endswith('.pyc'):
+                file_path = file_path[:-1]
+            if file_path.endswith('.py'):
+                try:
+                    with open(file_path, 'r', encoding='utf-8') as f:
+                        loaded_lines += sum(1 for _ in f)
+                except Exception as e:
+                    import logging
+                    logging.warning(f"Failed to read lines from {file_path}: {e}")
     
     # Output to stdout for the Master to capture
     print(json.dumps({
@@ -78,14 +83,20 @@ def run_master(iterations, target_module, cpu="0", csv_path=None):
                 print("WARNING: taskset CPU pinning failed or is not available. Falling back to unpinned execution...")
                 # Try running without taskset
                 cmd = [sys.executable, __file__, "--worker", f"--module={target_module}"]
-                result = subprocess.run(cmd, capture_output=True, text=True, check=True)
-                data = json.loads(result.stdout)
-                times.append(data["time_ms"])
-                memories.append(data["peak_ram_mb"])
-                loaded_modules_val = data.get("loaded_modules", 0)
-                loaded_lines_val = data.get("loaded_lines", 0)
-                cpu = "none" # Disable cpu pinning for remaining iterations
+                try:
+                    result = subprocess.run(cmd, capture_output=True, text=True, check=True)
+                    data = json.loads(result.stdout)
+                    times.append(data["time_ms"])
+                    memories.append(data["peak_ram_mb"])
+                    loaded_modules_val = data.get("loaded_modules", 0)
+                    loaded_lines_val = data.get("loaded_lines", 0)
+                    cpu = "none" # Disable cpu pinning for remaining iterations
+                except subprocess.CalledProcessError as err:
+                    print(f"Error in worker process:\n{err.stderr}", file=sys.stderr)
+                    raise err
             else:
+                if isinstance(e, subprocess.CalledProcessError):
+                    print(f"Error in worker process:\n{e.stderr}", file=sys.stderr)
                 raise e
         
     # Write CSV if requested
@@ -99,11 +110,17 @@ def run_master(iterations, target_module, cpu="0", csv_path=None):
 
     # Compute percentiles (P50, P90, P99)
     # statistics.quantiles returns 99 cut points for n=100
-    q_time = statistics.quantiles(times, n=100)
-    q_mem = statistics.quantiles(memories, n=100)
-    
-    p50_time, p90_time, p99_time = q_time[49], q_time[89], q_time[98]
-    p50_mem, p90_mem, p99_mem = q_mem[49], q_mem[89], q_mem[98]
+    if len(times) > 1:
+        q_time = statistics.quantiles(times, n=100)
+        p50_time, p90_time, p99_time = q_time[49], q_time[89], q_time[98]
+    else:
+        p50_time = p90_time = p99_time = times[0] if times else 0.0
+
+    if len(memories) > 1:
+        q_mem = statistics.quantiles(memories, n=100)
+        p50_mem, p90_mem, p99_mem = q_mem[49], q_mem[89], q_mem[98]
+    else:
+        p50_mem = p90_mem = p99_mem = memories[0] if memories else 0.0
 
     print(f"\n--- Results for {target_module} ({iterations} iterations) ---")
     print(f"Code Volume (Deterministic):")

--- a/scripts/import_profiler/profiler.py
+++ b/scripts/import_profiler/profiler.py
@@ -87,7 +87,7 @@ def run_worker(target_module):
                     with open(file_path, 'r', encoding='utf-8', errors='ignore') as f:
                         loaded_lines += sum(1 for _ in f)
                 except OSError as e:
-                    logging.warning(f"Failed to read lines from {file_path}: {e}")
+                    print(f"WARNING: Failed to read lines from {file_path}: {e}", file=sys.stderr)
         except KeyError:
             # Module disappeared from sys.modules during execution
             pass

--- a/scripts/import_profiler/profiler.py
+++ b/scripts/import_profiler/profiler.py
@@ -121,6 +121,14 @@ def _run_worker_and_parse(cmd):
         print(f"Worker stderr:\n{result.stderr}", file=sys.stderr)
         raise parse_err
 
+def _calculate_percentiles(data_list):
+    """Helper method to calculate P50, P90, P99 from a list of numbers."""
+    if len(data_list) > 1:
+        q = statistics.quantiles(data_list, n=100)
+        return q[49], q[89], q[98]
+    val = data_list[0] if data_list else 0.0
+    return val, val, val
+
 def run_master(iterations, target_module, cpu=0, csv_path=None, clear_cache=True):
     """Orchestrates the benchmark."""
     if iterations < 1:
@@ -176,23 +184,9 @@ def run_master(iterations, target_module, cpu=0, csv_path=None, clear_cache=True
 
     # Compute percentiles (P50, P90, P99)
     # statistics.quantiles returns 99 cut points for n=100
-    if len(times) > 1:
-        q_time = statistics.quantiles(times, n=100)
-        p50_time, p90_time, p99_time = q_time[49], q_time[89], q_time[98]
-    else:
-        p50_time = p90_time = p99_time = times[0] if times else 0.0
-
-    if len(memories) > 1:
-        q_mem = statistics.quantiles(memories, n=100)
-        p50_mem, p90_mem, p99_mem = q_mem[49], q_mem[89], q_mem[98]
-    else:
-        p50_mem = p90_mem = p99_mem = memories[0] if memories else 0.0
-
-    if len(rss_memories) > 1:
-        q_rss = statistics.quantiles(rss_memories, n=100)
-        p50_rss, p90_rss, p99_rss = q_rss[49], q_rss[89], q_rss[98]
-    else:
-        p50_rss = p90_rss = p99_rss = rss_memories[0] if rss_memories else 0.0
+    p50_time, p90_time, p99_time = _calculate_percentiles(times)
+    p50_mem, p90_mem, p99_mem = _calculate_percentiles(memories)
+    p50_rss, p90_rss, p99_rss = _calculate_percentiles(rss_memories)
 
     print(f"\n--- Results for {target_module} ({iterations} iterations) ---")
     print(f"Code Volume (Deterministic):")


### PR DESCRIPTION
###  Overview
This PR introduces `profiler.py`, a zero-dependency, process-isolated import profiling tool designed to benchmark Python SDK modules with extreme precision and zero dynamic cache interference. 

To evaluate authentic import initialization overhead without the "observer effect", the profiler leverages a Master/Worker architecture. The master orchestrator executes each benchmark iteration inside a completely isolated, dynamically spawned subprocess. By bypassing Python's `sys.modules` cache and sweeping disk-level `__pycache__` directories, the tool guarantees a 100% authentic "cold-start" evaluation every time.

### Key Telemetry Vectors & Features
- **Initialization Latency (ms):** Measured at high resolution natively, securely omitting VM startup skew.
- **Physical Memory Deltas (RAM):** Employs a dual-strategy approach tracking both internal block allocator shifts via `tracemalloc` (cross-platform), and pure OS-level physical memory footprints via `/proc/self/statm` deltas (Linux RSS) to catch heavy C/C++ backend extensions like `protobuf`.
- **Deterministic Code Volume (LOC):** Tracks the physical delta of `sys.modules` across the import window, traversing disk paths to aggregate the exact number of physical Lines of Code (LOC) injected into the interpreter.
- **CPU Pinning:** Binds worker processes to a single CPU core via `taskset` on Linux to eliminate OS-level context-switching jitter across iterations.
- **Diagnostic Tooling:** Supports one-off diagnostic tracing for bottleneck discovery via `--trace` (`-X importtime`) and `--cprofile`. 

*A comprehensive breakdown of the architecture, data pipeline, and trace log analysis is documented in [`scripts/import_profiler/documentation.md`](./scripts/import_profiler/documentation.md).*

### Related Links
- **Design Doc:** ` [go/sdk-performance-design](http://goto.google.com/sdk-performance-design)`
- **Related Issue:** https://github.com/googleapis/python-aiplatform/issues/4749