### PR TITLE
chore: librarian release pull request: 20260615T173024Z

### DIFF
--- a/.librarian/state.yaml
+++ b/.librarian/state.yaml
@@ -387,7 +387,7 @@ libraries:
       - packages/google-area120-tables/docs/
     tag_format: '{id}-v{version}'
   - id: google-auth
-    version: 2.54.0
+    version: 2.55.0
     last_generated_commit: ""
     apis: []
     source_roots:

--- a/librarian.yaml
+++ b/librarian.yaml
@@ -228,7 +228,7 @@ libraries:
       metadata_name_override: area120tables
       default_version: v1alpha1
   - name: google-auth
-    version: 2.54.0
+    version: 2.55.0
     python:
       library_type: AUTH
   - name: google-auth-httplib2

--- a/packages/google-auth/CHANGELOG.md
+++ b/packages/google-auth/CHANGELOG.md
@@ -4,6 +4,18 @@
 
 [1]: https://pypi.org/project/google-auth/#history
 
+## [2.55.0](https://github.com/googleapis/google-cloud-python/compare/google-auth-v2.54.0...google-auth-v2.55.0) (2026-06-15)
+
+
+### Features
+
+* make RAB feature production ready (#17390) ([af193931e4e38c4b59751edb8e915ae3388b8524](https://github.com/googleapis/google-cloud-python/commit/af193931e4e38c4b59751edb8e915ae3388b8524))
+
+
+### Bug Fixes
+
+* run async background boundary refresh on detached session (#17441) ([56cbea8509c66889485b43f2d98d60210eae81bc](https://github.com/googleapis/google-cloud-python/commit/56cbea8509c66889485b43f2d98d60210eae81bc))
+
 ## [2.54.0](https://github.com/googleapis/google-cloud-python/compare/google-auth-v2.53.0...google-auth-v2.54.0) (2026-06-11)
 
 

--- a/packages/google-auth/google/auth/version.py
+++ b/packages/google-auth/google/auth/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "2.54.0"
+__version__ = "2.55.0"


### PR DESCRIPTION
PR created by the Librarian CLI to initialize a release. Merging this PR will auto trigger a release.

Librarian Version: v0.19.0
Language Image: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/python-librarian-generator@sha256:234b9d1f2ddb057ed7ac6a38db0bf8163d839c65c6cf88ade52530cddebce59e
<details><summary>google-auth: v2.55.0</summary>

## [v2.55.0](https://github.com/googleapis/google-cloud-python/compare/google-auth-v2.54.0...google-auth-v2.55.0) (2026-06-15)

### Features

* make RAB feature production ready (#17390) ([af193931](https://github.com/googleapis/google-cloud-python/commit/af193931))

### Bug Fixes

* run async background boundary refresh on detached session (#17441) ([56cbea85](https://github.com/googleapis/google-cloud-python/commit/56cbea85))

</details>