### PR TITLE
chore(bigquery): add dynamic logging banner to nox mypy session

### DIFF
--- a/packages/google-cloud-bigquery/noxfile.py
+++ b/packages/google-cloud-bigquery/noxfile.py
@@ -90,8 +90,7 @@ def log_package_context(session: nox.Session) -> Generator[None, None, None]:
     even if the session fails or raises an exception.
     """
     # Dynamically extract current folder name (e.g., 'google-cloud-bigquery')
-    # Falls back to the root directory name if run from the repo root
-    package_name = os.path.basename(os.getcwd())
+    package_name = CURRENT_DIRECTORY.name
 
     try:
         # Hands control back to the session code block

--- a/packages/google-cloud-bigquery/noxfile.py
+++ b/packages/google-cloud-bigquery/noxfile.py
@@ -14,9 +14,11 @@
 
 from __future__ import absolute_import
 
+import contextlib
 from functools import wraps
 import os
 import pathlib
+from typing import Generator
 import re
 import shutil
 import time
@@ -78,6 +80,26 @@ nox.options.sessions = [
     "core_deps_from_source",
     "format",
 ]
+
+
+@contextlib.contextmanager
+def log_package_context(session: nox.Session) -> Generator[None, None, None]:
+    """Logs a highly visible package context banner right before a session exits.
+
+    Ensures metadata is printed adjacent to Nox's final status log,
+    even if the session fails or raises an exception.
+    """
+    # Dynamically extract current folder name (e.g., 'google-cloud-bigquery')
+    # Falls back to the root directory name if run from the repo root
+    package_name = os.path.basename(os.getcwd())
+
+    try:
+        # Hands control back to the session code block
+        yield
+    finally:
+        # This executes AFTER test output finishes, immediately above Nox's summary line
+        banner_text = f"Finished session for {package_name.lower()}"
+        session.log(banner_text)
 
 
 def default(session, install_extras=True):
@@ -193,7 +215,8 @@ def mypy(session):
         "types-setuptools",
     )
     session.run("python", "-m", "pip", "freeze")
-    session.run("mypy", "-p", "google", "--show-traceback")
+    with log_package_context(session):
+        session.run("mypy", "-p", "google", "--show-traceback")
 
 
 @nox.session(python=SYSTEM_TEST_PYTHON_VERSIONS)


### PR DESCRIPTION
This PR adds a dynamic logging banner
`Finished session for <package>`
to nox `mypy` sessions in `bigquery` to simplify troubleshooting.

Currently when a nox session runs, there may be many lines of text between a reference to which package is being tested and the result summary line. This can make it more difficult to determine which package is affected without a lot of manual scrolling (every time you need to trouble shoot an issue). This is especially true if you use `Ctrl+F` to zoom over to summaries with words like `failed`.

```
change detected in packages/bigframes/
[many lines of text...]
2547 passed, 157 skipped, 9 xfailed, 1 xpassed, 586 warnings in 136.68s (0:02:16)
nox > Session unit-3.11(test_extra=True) failed in 3 minutes.
```

The PR adds a banner line  right before the nox result summary:
```
change detected in packages/bigframes/
[many lines of text...]
2547 passed, 157 skipped, 9 xfailed, 1 xpassed, 586 warnings in 136.68s (0:02:16)
nox > Finished session for bigframes      # NEW LINE, right before the summary line
nox > Session unit-3.11(test_extra=True) failed in 3 minutes.
```
> [!note]
> There is no convenient way to inject a log line into the nox session and have it print **exactly** where you want. Also, because the long term intent is to add this to all nox sessions I included an easy to apply `contextmanager` to ensure the correct placement of the new logging banner.

> [!note]
> This PR only adds this capability to a single nox session (`mypy`) and a single handwritten package (`bigquery`). I did not want to invest a lot of time unless the team feels it is beneficial. In which case, we can add a task the next sprint to make this a global change.


