### PR TITLE
fix: handle empty endpoints during cloud function reuse

### DIFF
--- a/packages/bigframes/bigframes/functions/_function_session.py
+++ b/packages/bigframes/bigframes/functions/_function_session.py
@@ -592,7 +592,9 @@ class FunctionSession:
             if reuse is not None:
                 cf_endpoint = self._function_client.get_cloud_function_endpoint(cf_name)
 
-            if cf_endpoint is None:
+            # If the endpoint is empty, the function might exist but the URL propagation is pending.
+            # Running create_cloud_function will handle AlreadyExists and retry endpoint fetching.
+            if not cf_endpoint:
                 cf_endpoint = self._function_client.create_cloud_function(
                     cf_name, cloud_func_spec
                 )

--- a/packages/bigframes/tests/system/small/functions/test_remote_function.py
+++ b/packages/bigframes/tests/system/small/functions/test_remote_function.py
@@ -168,6 +168,7 @@ def test_remote_function_direct_no_session_param(
     assert_frame_equal(bf_result, pd_result)
 
 
+@pytest.mark.skip(reason="b/525124882: connection with location test failing")
 @pytest.mark.flaky(retries=2, delay=120)
 def test_remote_function_connection_w_location(
     session,

--- a/packages/bigframes/tests/system/small/functions/test_remote_function.py
+++ b/packages/bigframes/tests/system/small/functions/test_remote_function.py
@@ -168,7 +168,6 @@ def test_remote_function_direct_no_session_param(
     assert_frame_equal(bf_result, pd_result)
 
 
-@pytest.mark.skip(reason="b/525124882: connection with location test failing")
 @pytest.mark.flaky(retries=2, delay=120)
 def test_remote_function_connection_w_location(
     session,


### PR DESCRIPTION
Fixes an issue where reusing recently created Cloud Functions during Remote Function creation would sometimes result in an empty endpoint (`endpoint=""`).

When a Cloud Function has been recently provisioned, its endpoint URI (`response.service_config.uri`) may occasionally be returned as an empty string if URL propagation is still pending. The remote function decorator previously only checked for `None`, proceeding to create the BigQuery Remote Function with `OPTIONS(endpoint='')`, which leads to validation failures when queries invoke the function.

This PR changes the check to `if not cf_endpoint:` to handle both `None` and empty strings. If the endpoint is empty, it will route to `create_cloud_function`, which catches the `AlreadyExists` exception and safely retries/waits for the endpoint URI propagation to complete.

Fixes #<525124882> 🦕