### PR TITLE
chore: re-generate all

### DIFF
--- a/packages/google-cloud-pubsub/README.rst
+++ b/packages/google-cloud-pubsub/README.rst
@@ -67,6 +67,10 @@ Python >= 3.10, including 3.14
 .. _active: https://devguide.python.org/devcycle/#in-development-main-branch
 .. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
 
+Unsupported Python Versions
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Python <= 3.9
+
 
 If you are using an `end-of-life`_
 version of Python, we recommend that you update as soon as possible to an actively supported version.

--- a/packages/google-cloud-pubsub/google/cloud/pubsub_v1/subscriber/_protocol/leaser.py
+++ b/packages/google-cloud-pubsub/google/cloud/pubsub_v1/subscriber/_protocol/leaser.py
@@ -20,16 +20,14 @@ import random
 import threading
 import time
 import typing
+from collections.abc import KeysView
 from typing import Dict, Iterable, Optional, Union
 
 from google.cloud.pubsub_v1.open_telemetry.subscribe_opentelemetry import (
     SubscribeOpenTelemetry,
 )
-from google.cloud.pubsub_v1.subscriber._protocol.dispatcher import _MAX_BATCH_LATENCY
-
-from collections.abc import KeysView
-
 from google.cloud.pubsub_v1.subscriber._protocol import requests
+from google.cloud.pubsub_v1.subscriber._protocol.dispatcher import _MAX_BATCH_LATENCY
 
 if typing.TYPE_CHECKING:  # pragma: NO COVER
     from google.cloud.pubsub_v1.subscriber._protocol.streaming_pull_manager import (


### PR DESCRIPTION
Re-generate all in attempt to restore repo to "clean" state where config in librarian.yaml and generated code matches.

Run below commands.
```
V=$(go run github.com/googleapis/librarian/cmd/librarian@latest config get version)
go run github.com/googleapis/librarian/tool/cmd/builddockerimages@latest --language python --version=${V} 
docker run -u $(id -u):$(id -g) -v .:/repo -v ~/.cache:/.cache -w /repo docker.io/library/librarian-python:${V}  generate -v --all
```

Fixes https://github.com/googleapis/google-cloud-python/issues/17426, https://github.com/googleapis/google-cloud-python/issues/17427
For https://github.com/googleapis/librarian/issues/6450