### PR TITLE
ci(workflows): use librarian action for issue creation in regenerate-all

### DIFF
--- a/.github/workflows/regenerate-all.yml
+++ b/.github/workflows/regenerate-all.yml
@@ -43,44 +43,28 @@ jobs:
         run: |
           PATH=$PATH:/tmp/pandoc/bin
           librarian generate -all -v
-          git diff --exit-code
 
-      - name: Create issue on diff
-        if: failure()
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Check for generated code changes
         run: |
           if [ -n "$(git status --porcelain)" ]; then
-            TITLE="Regeneration check found diff"
-            RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-            DIFF_STAT=$(git diff --stat)
-            BODY="The post-submit [regeneration check]($RUN_URL) found a diff.
-
-            Diff summary:
-            \`\`\`
-            $DIFF_STAT
-            \`\`\`"
-
-            EXISTING_ISSUE=$(gh issue list --state open --search "in:title \"$TITLE\"" --json number --jq '.[0].number')
-            if [ -z "$EXISTING_ISSUE" ]; then
-              gh issue create --title "$TITLE" --body "$BODY"
-            else
-              echo "Issue #$EXISTING_ISSUE already exists, adding a comment."
-              gh issue comment "$EXISTING_ISSUE" --body "Another failure with diff occurred: $RUN_URL"
-            fi
+            git status
+            echo "==================== GIT DIFF ===================="
+            git diff
+            echo "=================================================="
+            echo "Regeneration produced code changes! Please run 'librarian generate -all -v' to update the generated files."
+            exit 1
           fi
-      - name: Create issue on generation failure
-        if: failure()
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          TITLE="Regeneration failed"
-          RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-          BODY="The post-submit [regeneration check]($RUN_URL) failed."
-          EXISTING_ISSUE=$(gh issue list --state open --search "in:title \"$TITLE\"" --json number --jq '.[0].number')
-          if [ -z "$EXISTING_ISSUE" ]; then
-            gh issue create --title "$TITLE" --body "$BODY"
-          else
-            echo "Issue #$EXISTING_ISSUE already exists, adding a comment."
-            gh issue comment "$EXISTING_ISSUE" --body "Another regeneration failure occurred: $RUN_URL"
-          fi
+
+      - name: Create issue if previous step fails
+        if: ${{ failure() }}
+        uses: googleapis/librarian/.github/actions/create-issue-on-failure@main
+        with:
+          title: "Regeneration failed"
+          body: |
+            The post-submit [regeneration check](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) failed.
+
+            Please investigate the failure. To keep the `main` branch healthy, please consider **reverting the triggering change** first. 
+            
+            You can identify the cause from the workflow logs:
+            - If the step 'Check for generated code changes' failed, there are pending code changes that need to be committed.
+            - If the step 'Regenerate' failed, the generation script itself encountered an error.


### PR DESCRIPTION
Refactor regenerate-all workflow to use `create-issue-on-failure` action from librarian to create and assign issue.

Replaces manual github-cli script steps with the shared `googleapis/librarian/.github/actions/create-issue-on-failure` action. Splits the regeneration execution and diff check into separate steps so it is easier to read from GHA log.

Context: https://github.com/googleapis/google-cloud-python/issues/17426 and https://github.com/googleapis/google-cloud-python/issues/17427 was created on code generation diff/failures but was left unattended. This change will create issue with assignee to last committer and add ":rotating_light: critical" label to it.

For https://github.com/googleapis/librarian/issues/6450