### PR TITLE
fix(bigquery): close GAPIC storage transport and auth sessions to prevent socket leaks

### DIFF
--- a/packages/google-cloud-bigquery/google/cloud/bigquery/__init__.py
+++ b/packages/google-cloud-bigquery/google/cloud/bigquery/__init__.py
@@ -123,7 +123,7 @@ try:
 except ImportError:
     bigquery_magics = None
 
-if sys.version_info < (3, 10):
+if sys.version_info < (3, 10):  # pragma: NO COVER
     warnings.warn(
         "The python-bigquery library no longer supports Python <= 3.9. "
         f"Your Python version is {sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}. We "

--- a/packages/google-cloud-bigquery/google/cloud/bigquery/dbapi/connection.py
+++ b/packages/google-cloud-bigquery/google/cloud/bigquery/dbapi/connection.py
@@ -84,7 +84,7 @@ class Connection(object):
 
         if self._owns_bqstorage_client:
             # There is no close() on the BQ Storage client itself.
-            self._bqstorage_client._transport.grpc_channel.close()
+            self._bqstorage_client._transport.close()
 
         for cursor_ in self._cursors_created:
             if not cursor_._closed:

--- a/packages/google-cloud-bigquery/google/cloud/bigquery/magics/magics.py
+++ b/packages/google-cloud-bigquery/google/cloud/bigquery/magics/magics.py
@@ -773,4 +773,4 @@ def _close_transports(client, bqstorage_client):
     """
     client.close()
     if bqstorage_client is not None:
-        bqstorage_client._transport.grpc_channel.close()
+        bqstorage_client._transport.close()

--- a/packages/google-cloud-bigquery/google/cloud/bigquery/table.py
+++ b/packages/google-cloud-bigquery/google/cloud/bigquery/table.py
@@ -2353,7 +2353,9 @@ class RowIterator(HTTPIterator):
                 progress_bar.close()
         finally:
             if owns_bqstorage_client:
-                bqstorage_client._transport.close()
+                # mypy: bqstorage_client is guaranteed to be not None when owns_bqstorage_client is True,
+                # but mypy cannot infer this correlation. We ignore the union-attr error here.
+                bqstorage_client._transport.close()  # type: ignore[union-attr]
 
         if record_batches and bqstorage_client is not None:
             return pyarrow.Table.from_batches(record_batches)

--- a/packages/google-cloud-bigquery/google/cloud/bigquery/table.py
+++ b/packages/google-cloud-bigquery/google/cloud/bigquery/table.py
@@ -2353,7 +2353,7 @@ class RowIterator(HTTPIterator):
                 progress_bar.close()
         finally:
             if owns_bqstorage_client:
-                bqstorage_client._transport.grpc_channel.close()  # type: ignore
+                bqstorage_client._transport.close()
 
         if record_batches and bqstorage_client is not None:
             return pyarrow.Table.from_batches(record_batches)

--- a/packages/google-cloud-bigquery/tests/system/helpers.py
+++ b/packages/google-cloud-bigquery/tests/system/helpers.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import contextlib
 import datetime
 import decimal
 import uuid
@@ -20,7 +21,6 @@ import google.api_core.exceptions
 import test_utils.retry
 
 from google.cloud._helpers import UTC
-
 
 _naive = datetime.datetime(2016, 12, 5, 12, 41, 9)
 _naive_microseconds = datetime.datetime(2016, 12, 5, 12, 41, 9, 250000)
@@ -104,3 +104,29 @@ retry_403 = test_utils.retry.RetryErrors(
     google.api_core.exceptions.Forbidden,
     error_predicate=_rate_limit_exceeded,
 )
+
+
+@contextlib.contextmanager
+def patch_tracked_requests():
+    """Context manager to patch google-auth requests and track/close their HTTP sessions.
+
+    This prevents socket leaks in system tests that use Workload Identity or metadata server auth.
+    """
+    import google.auth.transport.requests
+
+    original_init = google.auth.transport.requests.Request.__init__
+    tracked_requests = []
+
+    def patched_init(self, session=None):
+        original_init(self, session=session)
+        if session is None:
+            tracked_requests.append(self)
+
+    google.auth.transport.requests.Request.__init__ = patched_init
+    try:
+        yield tracked_requests
+    finally:
+        google.auth.transport.requests.Request.__init__ = original_init
+        for req in tracked_requests:
+            if hasattr(req, "session") and req.session is not None:
+                req.session.close()

--- a/packages/google-cloud-bigquery/tests/system/test_client.py
+++ b/packages/google-cloud-bigquery/tests/system/test_client.py
@@ -58,7 +58,6 @@ from test_utils.system import unique_resource_id
 
 from . import helpers
 
-
 JOB_TIMEOUT = 120  # 2 minutes
 DATA_PATH = pathlib.Path(__file__).parent.parent / "data"
 
@@ -234,23 +233,29 @@ class TestBigQuery(unittest.TestCase):
 
     def test_close_releases_open_sockets(self):
         current_process = psutil.Process()
-        conn_count_start = len(current_process.net_connections())
+        conn_start = current_process.net_connections()
+        conn_count_start = len(conn_start)
 
-        client = Config.CLIENT
-        client.query(
-            """
-            SELECT
-                source_year AS year, COUNT(is_male) AS birth_count
-            FROM `bigquery-public-data.samples.natality`
-            GROUP BY year
-            ORDER BY year DESC
-            LIMIT 15
-            """
-        )
+        with helpers.patch_tracked_requests():
+            client = Config.CLIENT
+            client.query(
+                """
+                SELECT
+                    source_year AS year, COUNT(is_male) AS birth_count
+                FROM `bigquery-public-data.samples.natality`
+                GROUP BY year
+                ORDER BY year DESC
+                LIMIT 15
+                """
+            )
 
-        client.close()
+            client.close()
 
-        conn_count_end = len(current_process.net_connections())
+        import gc
+
+        gc.collect()
+        conn_end = current_process.net_connections()
+        conn_count_end = len(conn_end)
         self.assertLessEqual(conn_count_end, conn_count_start)
 
     def test_create_dataset(self):
@@ -2174,25 +2179,31 @@ class TestBigQuery(unittest.TestCase):
     def test_dbapi_connection_does_not_leak_sockets(self):
         pytest.importorskip("google.cloud.bigquery_storage")
         current_process = psutil.Process()
-        conn_count_start = len(current_process.net_connections())
+        conn_start = current_process.net_connections()
+        conn_count_start = len(conn_start)
 
-        # Provide no explicit clients, so that the connection will create and own them.
-        connection = dbapi.connect()
-        cursor = connection.cursor()
+        with helpers.patch_tracked_requests():
+            # Provide no explicit clients, so that the connection will create and own them.
+            connection = dbapi.connect()
+            cursor = connection.cursor()
 
-        cursor.execute(
+            cursor.execute(
+                """
+                SELECT id, `by`, timestamp
+                FROM `bigquery-public-data.hacker_news.full`
+                ORDER BY `id` ASC
+                LIMIT 100000
             """
-            SELECT id, `by`, timestamp
-            FROM `bigquery-public-data.hacker_news.full`
-            ORDER BY `id` ASC
-            LIMIT 100000
-        """
-        )
-        rows = cursor.fetchall()
-        self.assertEqual(len(rows), 100000)
+            )
+            rows = cursor.fetchall()
+            self.assertEqual(len(rows), 100000)
 
-        connection.close()
-        conn_count_end = len(current_process.net_connections())
+            connection.close()
+        import gc
+
+        gc.collect()
+        conn_end = current_process.net_connections()
+        conn_count_end = len(conn_end)
         self.assertLessEqual(conn_count_end, conn_count_start)
 
     def _load_table_for_dml(self, rows, dataset_id, table_id):

--- a/packages/google-cloud-bigquery/tests/system/test_magics.py
+++ b/packages/google-cloud-bigquery/tests/system/test_magics.py
@@ -19,6 +19,7 @@ import re
 import pytest
 import psutil
 
+from . import helpers
 
 IPython = pytest.importorskip("IPython")
 io = pytest.importorskip("IPython.utils.io")
@@ -48,27 +49,30 @@ def ipython_interactive(ipython):
 def test_bigquery_magic(ipython_interactive):
     ip = IPython.get_ipython()
     current_process = psutil.Process()
-    conn_count_start = len(current_process.net_connections())
+    conn_start = current_process.net_connections()
+    conn_count_start = len(conn_start)
 
-    # Deprecated, but should still work in google-cloud-bigquery 3.x.
-    with pytest.warns(FutureWarning, match="bigquery_magics"):
-        ip.extension_manager.load_extension("google.cloud.bigquery")
+    with helpers.patch_tracked_requests():
+        # Deprecated, but should still work in google-cloud-bigquery 3.x.
+        with pytest.warns(FutureWarning, match="bigquery_magics"):
+            ip.extension_manager.load_extension("google.cloud.bigquery")
 
-    sql = """
-        SELECT
-            CONCAT(
-            'https://stackoverflow.com/questions/',
-            CAST(id as STRING)) as url,
-            view_count
-        FROM `bigquery-public-data.stackoverflow.posts_questions`
-        WHERE tags like '%google-bigquery%'
-        ORDER BY view_count DESC
-        LIMIT 10
-    """
-    with io.capture_output() as captured:
-        result = ip.run_cell_magic("bigquery", "--use_rest_api", sql)
+        sql = """
+            SELECT
+                CONCAT(
+                'https://stackoverflow.com/questions/',
+                CAST(id as STRING)) as url,
+                view_count
+            FROM `bigquery-public-data.stackoverflow.posts_questions`
+            WHERE tags like '%google-bigquery%'
+            ORDER BY view_count DESC
+            LIMIT 10
+        """
+        with io.capture_output() as captured:
+            result = ip.run_cell_magic("bigquery", "--use_rest_api", sql)
 
-    conn_count_end = len(current_process.net_connections())
+    conn_end = current_process.net_connections()
+    conn_count_end = len(conn_end)
 
     lines = re.split("\n|\r", captured.stdout)
     # Removes blanks & terminal code (result of display clearing)

--- a/packages/google-cloud-bigquery/tests/unit/test_dbapi_connection.py
+++ b/packages/google-cloud-bigquery/tests/unit/test_dbapi_connection.py
@@ -40,7 +40,7 @@ class TestConnection(unittest.TestCase):
         from google.cloud import bigquery_storage
 
         mock_client = mock.create_autospec(bigquery_storage.BigQueryReadClient)
-        mock_client._transport = mock.Mock(spec=["channel"])
+        mock_client._transport = mock.Mock(spec=["channel", "close"])
         mock_client._transport.grpc_channel = mock.Mock(spec=["close"])
         return mock_client
 
@@ -176,7 +176,7 @@ class TestConnection(unittest.TestCase):
         connection.close()
 
         self.assertTrue(client.close.called)
-        self.assertTrue(bqstorage_client._transport.grpc_channel.close.called)
+        self.assertTrue(bqstorage_client._transport.close.called)
 
     def test_close_does_not_close_bigquery_clients_passed_to_it(self):
         pytest.importorskip("google.cloud.bigquery_storage")
@@ -187,7 +187,7 @@ class TestConnection(unittest.TestCase):
         connection.close()
 
         self.assertFalse(client.close.called)
-        self.assertFalse(bqstorage_client._transport.grpc_channel.close.called)
+        self.assertFalse(bqstorage_client._transport.close.called)
 
     def test_close_closes_all_created_cursors(self):
         connection = self._make_one(client=self._mock_client())

--- a/packages/google-cloud-bigquery/tests/unit/test_magics.py
+++ b/packages/google-cloud-bigquery/tests/unit/test_magics.py
@@ -45,7 +45,7 @@ pandas = pytest.importorskip("pandas")
 
 @pytest.fixture()
 def use_local_magics_context(monkeypatch):
-    if magics is not None:
+    if magics is not None:  # pragma: NO COVER
         local_context = magics.Context()
         local_context._project = "unit-test-project"
         mock_credentials = mock.create_autospec(
@@ -2195,13 +2195,10 @@ def test_bigquery_magic_create_dataset_fails(monkeypatch):
 
 
 @pytest.mark.usefixtures("ipython_interactive")
-def test_bigquery_magic_with_location(monkeypatch):
+def test_bigquery_magic_with_location(monkeypatch, use_local_magics_context):
     ip = IPython.get_ipython()
     monkeypatch.setattr(bigquery, "bigquery_magics", None)
     bigquery.load_ipython_extension(ip)
-    magics.context.credentials = mock.create_autospec(
-        google.auth.credentials.Credentials, instance=True
-    )
 
     run_query_patch = mock.patch(
         "google.cloud.bigquery.magics.magics._run_query", autospec=True

--- a/packages/google-cloud-bigquery/tests/unit/test_table.py
+++ b/packages/google-cloud-bigquery/tests/unit/test_table.py
@@ -79,6 +79,82 @@ class TestEncryptionConfiguration(unittest.TestCase):
         self.assertEqual(encryption_config.kms_key_name, self.KMS_KEY_NAME)
 
 
+class TestPropertyGraphReference(unittest.TestCase):
+    PROJECT = "my-project"
+    DATASET_ID = "my_dataset"
+    PROPERTY_GRAPH_ID = "my_pg"
+
+    def _get_target_class(self):
+        from google.cloud.bigquery.table import PropertyGraphReference
+
+        return PropertyGraphReference
+
+    def _make_one(self, *args, **kw):
+        return self._get_target_class()(*args, **kw)
+
+    def test_ctor(self):
+        dataset_ref = DatasetReference(self.PROJECT, self.DATASET_ID)
+        ref = self._make_one(dataset_ref, self.PROPERTY_GRAPH_ID)
+        self.assertEqual(ref.project, self.PROJECT)
+        self.assertEqual(ref.dataset_id, self.DATASET_ID)
+        self.assertEqual(ref.property_graph_id, self.PROPERTY_GRAPH_ID)
+
+    def test_from_api_repr(self):
+        resource = {
+            "projectId": self.PROJECT,
+            "datasetId": self.DATASET_ID,
+            "propertyGraphId": self.PROPERTY_GRAPH_ID,
+        }
+        ref = self._get_target_class().from_api_repr(resource)
+        self.assertEqual(ref.project, self.PROJECT)
+        self.assertEqual(ref.dataset_id, self.DATASET_ID)
+        self.assertEqual(ref.property_graph_id, self.PROPERTY_GRAPH_ID)
+
+    def test_to_api_repr(self):
+        dataset_ref = DatasetReference(self.PROJECT, self.DATASET_ID)
+        ref = self._make_one(dataset_ref, self.PROPERTY_GRAPH_ID)
+        resource = ref.to_api_repr()
+        expected = {
+            "projectId": self.PROJECT,
+            "datasetId": self.DATASET_ID,
+            "propertyGraphId": self.PROPERTY_GRAPH_ID,
+        }
+        self.assertEqual(resource, expected)
+
+    def test___str__(self):
+        dataset_ref = DatasetReference(self.PROJECT, self.DATASET_ID)
+        ref = self._make_one(dataset_ref, self.PROPERTY_GRAPH_ID)
+        self.assertEqual(
+            str(ref), f"{self.PROJECT}.{self.DATASET_ID}.{self.PROPERTY_GRAPH_ID}"
+        )
+
+    def test___repr__(self):
+        dataset_ref = DatasetReference(self.PROJECT, self.DATASET_ID)
+        ref = self._make_one(dataset_ref, self.PROPERTY_GRAPH_ID)
+        expected = (
+            f"PropertyGraphReference({dataset_ref!r}, '{self.PROPERTY_GRAPH_ID}')"
+        )
+        self.assertEqual(repr(ref), expected)
+
+    def test___eq__(self):
+        dataset_ref1 = DatasetReference(self.PROJECT, self.DATASET_ID)
+        ref1 = self._make_one(dataset_ref1, self.PROPERTY_GRAPH_ID)
+        dataset_ref2 = DatasetReference(self.PROJECT, self.DATASET_ID)
+        ref2 = self._make_one(dataset_ref2, self.PROPERTY_GRAPH_ID)
+        self.assertEqual(ref1, ref2)
+
+        ref3 = self._make_one(dataset_ref1, "other_pg")
+        self.assertNotEqual(ref1, ref3)
+        self.assertNotEqual(ref1, object())
+
+    def test___hash__(self):
+        dataset_ref1 = DatasetReference(self.PROJECT, self.DATASET_ID)
+        ref1 = self._make_one(dataset_ref1, self.PROPERTY_GRAPH_ID)
+        dataset_ref2 = DatasetReference(self.PROJECT, self.DATASET_ID)
+        ref2 = self._make_one(dataset_ref2, self.PROPERTY_GRAPH_ID)
+        self.assertEqual(hash(ref1), hash(ref2))
+
+
 class TestTableBase:
     @staticmethod
     def _get_target_class():

--- a/packages/google-cloud-bigquery/tests/unit/test_table.py
+++ b/packages/google-cloud-bigquery/tests/unit/test_table.py
@@ -3048,7 +3048,7 @@ class TestRowIterator(unittest.TestCase):
             self.assertEqual(record_batch, expected_record_batch)
 
         # Don't close the client if it was passed in.
-        bqstorage_client._transport.grpc_channel.close.assert_not_called()
+        bqstorage_client._transport.close.assert_not_called()
 
     def test_to_arrow(self):
         pytest.importorskip("numpy")
@@ -3424,7 +3424,7 @@ class TestRowIterator(unittest.TestCase):
         self.assertEqual(actual_tbl.num_rows, total_rows)
 
         # Don't close the client if it was passed in.
-        bqstorage_client._transport.grpc_channel.close.assert_not_called()
+        bqstorage_client._transport.close.assert_not_called()
 
     def test_to_arrow_w_bqstorage_creates_client(self):
         pytest.importorskip("numpy")
@@ -3458,7 +3458,7 @@ class TestRowIterator(unittest.TestCase):
         )
         row_iterator.to_arrow(create_bqstorage_client=True)
         mock_client._ensure_bqstorage_client.assert_called_once()
-        bqstorage_client._transport.grpc_channel.close.assert_called_once()
+        bqstorage_client._transport.close.assert_called_once()
 
     def test_to_arrow_ensure_bqstorage_client_wo_bqstorage(self):
         pytest.importorskip("numpy")
@@ -3741,7 +3741,7 @@ class TestRowIterator(unittest.TestCase):
         self.assertEqual(len(got), total_pages)
 
         # Don't close the client if it was passed in.
-        bqstorage_client._transport.grpc_channel.close.assert_not_called()
+        bqstorage_client._transport.close.assert_not_called()
 
     def test_to_dataframe_iterable_w_bqstorage_max_results_warning(self):
         pytest.importorskip("numpy")
@@ -4807,7 +4807,7 @@ class TestRowIterator(unittest.TestCase):
         )
         row_iterator.to_dataframe(create_bqstorage_client=True)
         mock_client._ensure_bqstorage_client.assert_called_once()
-        bqstorage_client._transport.grpc_channel.close.assert_called_once()
+        bqstorage_client._transport.close.assert_called_once()
 
     def test_to_dataframe_w_bqstorage_no_streams(self):
         pytest.importorskip("numpy")
@@ -4999,7 +4999,7 @@ class TestRowIterator(unittest.TestCase):
         self.assertEqual(len(got.index), total_rows)
 
         # Don't close the client if it was passed in.
-        bqstorage_client._transport.grpc_channel.close.assert_not_called()
+        bqstorage_client._transport.close.assert_not_called()
 
     def test_to_dataframe_w_bqstorage_multiple_streams_return_unique_index(self):
         pytest.importorskip("numpy")
@@ -5421,7 +5421,7 @@ class TestRowIterator(unittest.TestCase):
         )
 
         # Don't close the client if it was passed in.
-        bqstorage_client._transport.grpc_channel.close.assert_not_called()
+        bqstorage_client._transport.close.assert_not_called()
 
     def test_to_dataframe_geography_as_object(self):
         pandas = pytest.importorskip("pandas")


### PR DESCRIPTION
This PR resolves resource leaks (specifically open sockets left in the `ESTABLISHED` state) that occur during client lifecycle operations and credential refreshing in system/unit tests. 

### The Problem
1. **Transport Lifecycle:** When closing the BigQuery Storage client, calling `_transport.grpc_channel.close()` was insufficient for releasing all network resources. The full `_transport.close()` method needs to be invoked to tear down the underlying transport channel correctly.

2. **Dynamic Auth Sessions:** Under certain authentication environments (like Workload Identity/GCE Metadata server inside Kokoro CI), the `google-auth` library dynamically instantiates helper HTTP sessions to fetch access tokens. These sessions are not owned by the BigQuery client and are not closed automatically, leading to leaked sockets.

3. **Flaky Test Assertions:** Socket count assertions in system tests were flaky because Python's garbage collection is non-deterministic, meaning sockets remained open in the operating system even after client close calls until a garbage collection cycle swept them.

### Changes
* **Client & Transport Lifecycle:**
  * Updated [connection.py](file:///usr/local/google/home/chalmerlowe/titan-src/projects/google-cloud-python/main/packages/google-cloud-bigquery/google/cloud/bigquery/dbapi/connection.py), [magics.py](file:///usr/local/google/home/chalmerlowe/titan-src/projects/google-cloud-python/main/packages/google-cloud-bigquery/google/cloud/bigquery/magics/magics.py), and [table.py](file:///usr/local/google/home/chalmerlowe/titan-src/projects/google-cloud-python/main/packages/google-cloud-bigquery/google/cloud/bigquery/table.py) to close the BigQuery Storage transport using `_transport.close()` instead of `_transport.grpc_channel.close()`.

* **Testing Improvements:**
  * Added `patch_tracked_requests` interceptor to system/unit tests to track and explicitly close all dynamically spawned credential-refreshing HTTP sessions when the test context exits.
  * Added explicit `gc.collect()` calls to socket leak verification tests to force synchronous sweeping of unreferenced socket objects before asserting final socket counts.

* **Code Coverage:**
  * Appended `# pragma: NO COVER` to Python version checks in [`__init__.py`](file:///usr/local/google/home/chalmerlowe/titan-src/projects/google-cloud-python/main/packages/google-cloud-bigquery/google/cloud/bigquery/__init__.py) for code paths that render a deprecation warning code if attempted to run on Python runtimes <3.10 test matrix (these paths do not run in our CI/CD since we never execute code with the older runtimes).