### PR TITLE
docs: ensure that PlotAccessor is included in the API reference

### DIFF
--- a/packages/bigframes/bigframes/_tools/docs.py
+++ b/packages/bigframes/bigframes/_tools/docs.py
@@ -31,13 +31,22 @@ def inherit_docs(source_class):
                     if hasattr(source_item, "__doc__") and source_item.__doc__:
                         try:
                             target_item.__doc__ = source_item.__doc__
-                            if isinstance(target_item, property) and target_item.fget:
-                                try:
-                                    target_item.fget.__doc__ = source_item.__doc__
-                                except AttributeError:
-                                    pass
                         except AttributeError:
                             pass
+
+                        underlying = None
+                        if isinstance(target_item, property):
+                            underlying = target_item.fget
+                        elif hasattr(target_item, "__func__"):
+                            underlying = target_item.__func__
+                        elif hasattr(target_item, "func"):
+                            underlying = getattr(target_item, "func", None)
+
+                        if underlying is not None:
+                            try:
+                                underlying.__doc__ = source_item.__doc__
+                            except AttributeError:
+                                pass
 
         return target_class
 

--- a/packages/bigframes/bigframes/_tools/docs.py
+++ b/packages/bigframes/bigframes/_tools/docs.py
@@ -31,6 +31,11 @@ def inherit_docs(source_class):
                     if hasattr(source_item, "__doc__") and source_item.__doc__:
                         try:
                             target_item.__doc__ = source_item.__doc__
+                            if isinstance(target_item, property) and target_item.fget:
+                                try:
+                                    target_item.fget.__doc__ = source_item.__doc__
+                                except AttributeError:
+                                    pass
                         except AttributeError:
                             pass
 

--- a/packages/bigframes/bigframes/pandas/api/typing.py
+++ b/packages/bigframes/bigframes/pandas/api/typing.py
@@ -21,12 +21,14 @@ from bigframes.core.groupby.dataframe_group_by import DataFrameGroupBy
 from bigframes.core.groupby.series_group_by import SeriesGroupBy
 from bigframes.core.window import Window
 from bigframes.operations.datetimes import DatetimeMethods
+from bigframes.operations.plotting import PlotAccessor
 from bigframes.operations.strings import StringMethods
 from bigframes.operations.structs import StructAccessor, StructFrameAccessor
 
 __all__ = [
     "DataFrameGroupBy",
     "DatetimeMethods",
+    "PlotAccessor",
     "SeriesGroupBy",
     "StringMethods",
     "StructAccessor",

--- a/packages/bigframes/docs/templates/toc.yml
+++ b/packages/bigframes/docs/templates/toc.yml
@@ -42,7 +42,7 @@
       - name: DataFrame
         uid: bigframes.dataframe.DataFrame
       - name: PlotAccessor
-        uid: bigframes.operations.plotting.PlotAccessor
+        uid: bigframes.pandas.api.typing.PlotAccessor
       - name: StructAccessor
         uid: bigframes.operations.structs.StructFrameAccessor
       name: DataFrame
@@ -86,7 +86,7 @@
       - name: ListAccessor
         uid: bigframes.operations.lists.ListAccessor
       - name: PlotAccessor
-        uid: bigframes.operations.plotting.PlotAccessor
+        uid: bigframes.pandas.api.typing.PlotAccessor
       name: Series
     - name: Window
       uid: bigframes.core.window.Window

--- a/packages/bigframes/third_party/bigframes_vendored/pandas/core/frame.py
+++ b/packages/bigframes/third_party/bigframes_vendored/pandas/core/frame.py
@@ -7335,7 +7335,7 @@ class DataFrame(generic.NDFrame):
         Make plots of Dataframes.
 
         Returns:
-            bigframes.operations.plotting.PlotAccessor:
+            bigframes.pandas.api.typing.PlotAccessor:
                 An accessor making plots.
         """
         raise NotImplementedError(constants.ABSTRACT_METHOD_ERROR_MESSAGE)

--- a/packages/bigframes/third_party/bigframes_vendored/pandas/core/series.py
+++ b/packages/bigframes/third_party/bigframes_vendored/pandas/core/series.py
@@ -5450,7 +5450,7 @@ class Series(NDFrame):  # type: ignore[misc]
             <Axes: title={'center': 'My plot'}, ylabel='Frequency'>
 
         Returns:
-            bigframes.operations.plotting.PlotAccessor:
+            bigframes.pandas.api.typing.PlotAccessor:
                 An accessor making plots.
         """
         raise NotImplementedError(constants.ABSTRACT_METHOD_ERROR_MESSAGE)


### PR DESCRIPTION
Currently, [this page](https://dataframes.bigquery.dev/reference/api/bigframes.pandas.DataFrame.plot.html#bigframes.pandas.DataFrame.plot) is blank.

<img width="1870" height="1412" alt="image" src="https://github.com/user-attachments/assets/bfc93846-7000-4ff6-a336-a36baba324ad" />

After this change:

<img width="1870" height="1412" alt="image" src="https://github.com/user-attachments/assets/5c5f8c8e-a966-475e-845d-ec33df41455e" />

 🦕