### PR TITLE
fix(bigframes): world-readable temp zip in create_cloud_function

### DIFF
--- a/packages/bigframes/bigframes/functions/_function_client.py
+++ b/packages/bigframes/bigframes/functions/_function_client.py
@@ -358,13 +358,22 @@ class FunctionClient:
         config = func_def
 
         # Build and deploy folder structure containing cloud function
-        with tempfile.TemporaryDirectory() as directory:
+        with tempfile.TemporaryDirectory() as scratch_dir:
+            # Keep the generated sources in a subdirectory so the archive can be
+            # written inside the 0700 TemporaryDirectory. shutil.make_archive
+            # appends ".zip" to base_name, so archiving `directory` into itself
+            # would leave a world-readable copy of the (pickled) user code as a
+            # sibling of the temp dir that also survives the cleanup.
+            directory = os.path.join(scratch_dir, "src")
+            os.mkdir(directory)
             entry_point = self._generate_cloud_function_code(
                 config.code,
                 directory,
                 udf_signature=config.signature,
             )
-            archive_path = shutil.make_archive(directory, "zip", directory)
+            archive_path = shutil.make_archive(
+                os.path.join(scratch_dir, "source"), "zip", directory
+            )
 
             # We are creating cloud function source code from the currently running
             # python version. Use the same version to deploy. This is necessary


### PR DESCRIPTION
Repro against the unpatched `create_cloud_function` archive step:

    archive_path  : /tmp/tmpXXXX.zip      # sibling of the 0700 TemporaryDirectory
    dir removed   : True
    zip remains   : True                  # survives TemporaryDirectory cleanup
    zip perms     : 0o644  world-readable: True

`shutil.make_archive(directory, "zip", directory)` appends `.zip` to `base_name`, so the archive lands at `<tempdir>.zip`, a sibling of the temp dir rather than inside it. That copy of the generated cloud function source (which embeds the cloudpickled UDF) is created mode 0644 in the shared system temp directory and is not removed when the `TemporaryDirectory` is cleaned up, so any other local user can read it.

Fix keeps the sources in a subdirectory and writes the archive inside the 0700 `TemporaryDirectory`, so it inherits the restrictive permissions and is cleaned up with the rest of the scratch space.

- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)
