### PR TITLE
chore(gapic-generator): use install_unittest_dependencies in noxfile

### DIFF
--- a/packages/gapic-generator/gapic/templates/noxfile.py.j2
+++ b/packages/gapic-generator/gapic/templates/noxfile.py.j2
@@ -463,12 +463,8 @@ def prerelease_deps(session, protobuf_implementation):
     `pip install --pre <package>`.
     """
 
-    # Install all dependencies
-    session.install("-e", ".")
-
-    # Install dependencies for the unit test environment
-    unit_deps_all = UNIT_TEST_STANDARD_DEPENDENCIES + UNIT_TEST_EXTERNAL_DEPENDENCIES
-    session.install(*unit_deps_all)
+    # Install all dependencies and unit test environment
+    install_unittest_dependencies(session)
 
     # Because we test minimum dependency versions on the minimum Python
     # version, the first version we test with in the unit tests sessions has a
@@ -575,12 +571,8 @@ def core_deps_from_source(session, protobuf_implementation):
     rather than pulling the dependencies from PyPI.
     """
 
-    # Install all dependencies
-    session.install("-e", ".")
-
-    # Install dependencies for the unit test environment
-    unit_deps_all = UNIT_TEST_STANDARD_DEPENDENCIES + UNIT_TEST_EXTERNAL_DEPENDENCIES
-    session.install(*unit_deps_all)
+    # Install all dependencies and unit test environment
+    install_unittest_dependencies(session)
 
     # Because we test minimum dependency versions on the minimum Python
     # version, the first version we test with in the unit tests sessions has a

--- a/packages/gapic-generator/tests/integration/goldens/asset/noxfile.py
+++ b/packages/gapic-generator/tests/integration/goldens/asset/noxfile.py
@@ -455,12 +455,8 @@ def prerelease_deps(session, protobuf_implementation):
     `pip install --pre <package>`.
     """
 
-    # Install all dependencies
-    session.install("-e", ".")
-
-    # Install dependencies for the unit test environment
-    unit_deps_all = UNIT_TEST_STANDARD_DEPENDENCIES + UNIT_TEST_EXTERNAL_DEPENDENCIES
-    session.install(*unit_deps_all)
+    # Install all dependencies and unit test environment
+    install_unittest_dependencies(session)
 
     # Because we test minimum dependency versions on the minimum Python
     # version, the first version we test with in the unit tests sessions has a
@@ -567,12 +563,8 @@ def core_deps_from_source(session, protobuf_implementation):
     rather than pulling the dependencies from PyPI.
     """
 
-    # Install all dependencies
-    session.install("-e", ".")
-
-    # Install dependencies for the unit test environment
-    unit_deps_all = UNIT_TEST_STANDARD_DEPENDENCIES + UNIT_TEST_EXTERNAL_DEPENDENCIES
-    session.install(*unit_deps_all)
+    # Install all dependencies and unit test environment
+    install_unittest_dependencies(session)
 
     # Because we test minimum dependency versions on the minimum Python
     # version, the first version we test with in the unit tests sessions has a

--- a/packages/gapic-generator/tests/integration/goldens/credentials/noxfile.py
+++ b/packages/gapic-generator/tests/integration/goldens/credentials/noxfile.py
@@ -455,12 +455,8 @@ def prerelease_deps(session, protobuf_implementation):
     `pip install --pre <package>`.
     """
 
-    # Install all dependencies
-    session.install("-e", ".")
-
-    # Install dependencies for the unit test environment
-    unit_deps_all = UNIT_TEST_STANDARD_DEPENDENCIES + UNIT_TEST_EXTERNAL_DEPENDENCIES
-    session.install(*unit_deps_all)
+    # Install all dependencies and unit test environment
+    install_unittest_dependencies(session)
 
     # Because we test minimum dependency versions on the minimum Python
     # version, the first version we test with in the unit tests sessions has a
@@ -567,12 +563,8 @@ def core_deps_from_source(session, protobuf_implementation):
     rather than pulling the dependencies from PyPI.
     """
 
-    # Install all dependencies
-    session.install("-e", ".")
-
-    # Install dependencies for the unit test environment
-    unit_deps_all = UNIT_TEST_STANDARD_DEPENDENCIES + UNIT_TEST_EXTERNAL_DEPENDENCIES
-    session.install(*unit_deps_all)
+    # Install all dependencies and unit test environment
+    install_unittest_dependencies(session)
 
     # Because we test minimum dependency versions on the minimum Python
     # version, the first version we test with in the unit tests sessions has a

--- a/packages/gapic-generator/tests/integration/goldens/eventarc/noxfile.py
+++ b/packages/gapic-generator/tests/integration/goldens/eventarc/noxfile.py
@@ -455,12 +455,8 @@ def prerelease_deps(session, protobuf_implementation):
     `pip install --pre <package>`.
     """
 
-    # Install all dependencies
-    session.install("-e", ".")
-
-    # Install dependencies for the unit test environment
-    unit_deps_all = UNIT_TEST_STANDARD_DEPENDENCIES + UNIT_TEST_EXTERNAL_DEPENDENCIES
-    session.install(*unit_deps_all)
+    # Install all dependencies and unit test environment
+    install_unittest_dependencies(session)
 
     # Because we test minimum dependency versions on the minimum Python
     # version, the first version we test with in the unit tests sessions has a
@@ -567,12 +563,8 @@ def core_deps_from_source(session, protobuf_implementation):
     rather than pulling the dependencies from PyPI.
     """
 
-    # Install all dependencies
-    session.install("-e", ".")
-
-    # Install dependencies for the unit test environment
-    unit_deps_all = UNIT_TEST_STANDARD_DEPENDENCIES + UNIT_TEST_EXTERNAL_DEPENDENCIES
-    session.install(*unit_deps_all)
+    # Install all dependencies and unit test environment
+    install_unittest_dependencies(session)
 
     # Because we test minimum dependency versions on the minimum Python
     # version, the first version we test with in the unit tests sessions has a

--- a/packages/gapic-generator/tests/integration/goldens/logging/noxfile.py
+++ b/packages/gapic-generator/tests/integration/goldens/logging/noxfile.py
@@ -455,12 +455,8 @@ def prerelease_deps(session, protobuf_implementation):
     `pip install --pre <package>`.
     """
 
-    # Install all dependencies
-    session.install("-e", ".")
-
-    # Install dependencies for the unit test environment
-    unit_deps_all = UNIT_TEST_STANDARD_DEPENDENCIES + UNIT_TEST_EXTERNAL_DEPENDENCIES
-    session.install(*unit_deps_all)
+    # Install all dependencies and unit test environment
+    install_unittest_dependencies(session)
 
     # Because we test minimum dependency versions on the minimum Python
     # version, the first version we test with in the unit tests sessions has a
@@ -567,12 +563,8 @@ def core_deps_from_source(session, protobuf_implementation):
     rather than pulling the dependencies from PyPI.
     """
 
-    # Install all dependencies
-    session.install("-e", ".")
-
-    # Install dependencies for the unit test environment
-    unit_deps_all = UNIT_TEST_STANDARD_DEPENDENCIES + UNIT_TEST_EXTERNAL_DEPENDENCIES
-    session.install(*unit_deps_all)
+    # Install all dependencies and unit test environment
+    install_unittest_dependencies(session)
 
     # Because we test minimum dependency versions on the minimum Python
     # version, the first version we test with in the unit tests sessions has a

--- a/packages/gapic-generator/tests/integration/goldens/logging_internal/noxfile.py
+++ b/packages/gapic-generator/tests/integration/goldens/logging_internal/noxfile.py
@@ -455,12 +455,8 @@ def prerelease_deps(session, protobuf_implementation):
     `pip install --pre <package>`.
     """
 
-    # Install all dependencies
-    session.install("-e", ".")
-
-    # Install dependencies for the unit test environment
-    unit_deps_all = UNIT_TEST_STANDARD_DEPENDENCIES + UNIT_TEST_EXTERNAL_DEPENDENCIES
-    session.install(*unit_deps_all)
+    # Install all dependencies and unit test environment
+    install_unittest_dependencies(session)
 
     # Because we test minimum dependency versions on the minimum Python
     # version, the first version we test with in the unit tests sessions has a
@@ -567,12 +563,8 @@ def core_deps_from_source(session, protobuf_implementation):
     rather than pulling the dependencies from PyPI.
     """
 
-    # Install all dependencies
-    session.install("-e", ".")
-
-    # Install dependencies for the unit test environment
-    unit_deps_all = UNIT_TEST_STANDARD_DEPENDENCIES + UNIT_TEST_EXTERNAL_DEPENDENCIES
-    session.install(*unit_deps_all)
+    # Install all dependencies and unit test environment
+    install_unittest_dependencies(session)
 
     # Because we test minimum dependency versions on the minimum Python
     # version, the first version we test with in the unit tests sessions has a

--- a/packages/gapic-generator/tests/integration/goldens/redis/noxfile.py
+++ b/packages/gapic-generator/tests/integration/goldens/redis/noxfile.py
@@ -455,12 +455,8 @@ def prerelease_deps(session, protobuf_implementation):
     `pip install --pre <package>`.
     """
 
-    # Install all dependencies
-    session.install("-e", ".")
-
-    # Install dependencies for the unit test environment
-    unit_deps_all = UNIT_TEST_STANDARD_DEPENDENCIES + UNIT_TEST_EXTERNAL_DEPENDENCIES
-    session.install(*unit_deps_all)
+    # Install all dependencies and unit test environment
+    install_unittest_dependencies(session)
 
     # Because we test minimum dependency versions on the minimum Python
     # version, the first version we test with in the unit tests sessions has a
@@ -567,12 +563,8 @@ def core_deps_from_source(session, protobuf_implementation):
     rather than pulling the dependencies from PyPI.
     """
 
-    # Install all dependencies
-    session.install("-e", ".")
-
-    # Install dependencies for the unit test environment
-    unit_deps_all = UNIT_TEST_STANDARD_DEPENDENCIES + UNIT_TEST_EXTERNAL_DEPENDENCIES
-    session.install(*unit_deps_all)
+    # Install all dependencies and unit test environment
+    install_unittest_dependencies(session)
 
     # Because we test minimum dependency versions on the minimum Python
     # version, the first version we test with in the unit tests sessions has a

--- a/packages/gapic-generator/tests/integration/goldens/redis_selective/noxfile.py
+++ b/packages/gapic-generator/tests/integration/goldens/redis_selective/noxfile.py
@@ -455,12 +455,8 @@ def prerelease_deps(session, protobuf_implementation):
     `pip install --pre <package>`.
     """
 
-    # Install all dependencies
-    session.install("-e", ".")
-
-    # Install dependencies for the unit test environment
-    unit_deps_all = UNIT_TEST_STANDARD_DEPENDENCIES + UNIT_TEST_EXTERNAL_DEPENDENCIES
-    session.install(*unit_deps_all)
+    # Install all dependencies and unit test environment
+    install_unittest_dependencies(session)
 
     # Because we test minimum dependency versions on the minimum Python
     # version, the first version we test with in the unit tests sessions has a
@@ -567,12 +563,8 @@ def core_deps_from_source(session, protobuf_implementation):
     rather than pulling the dependencies from PyPI.
     """
 
-    # Install all dependencies
-    session.install("-e", ".")
-
-    # Install dependencies for the unit test environment
-    unit_deps_all = UNIT_TEST_STANDARD_DEPENDENCIES + UNIT_TEST_EXTERNAL_DEPENDENCIES
-    session.install(*unit_deps_all)
+    # Install all dependencies and unit test environment
+    install_unittest_dependencies(session)
 
     # Because we test minimum dependency versions on the minimum Python
     # version, the first version we test with in the unit tests sessions has a

--- a/packages/gapic-generator/tests/integration/goldens/storagebatchoperations/noxfile.py
+++ b/packages/gapic-generator/tests/integration/goldens/storagebatchoperations/noxfile.py
@@ -455,12 +455,8 @@ def prerelease_deps(session, protobuf_implementation):
     `pip install --pre <package>`.
     """
 
-    # Install all dependencies
-    session.install("-e", ".")
-
-    # Install dependencies for the unit test environment
-    unit_deps_all = UNIT_TEST_STANDARD_DEPENDENCIES + UNIT_TEST_EXTERNAL_DEPENDENCIES
-    session.install(*unit_deps_all)
+    # Install all dependencies and unit test environment
+    install_unittest_dependencies(session)
 
     # Because we test minimum dependency versions on the minimum Python
     # version, the first version we test with in the unit tests sessions has a
@@ -567,12 +563,8 @@ def core_deps_from_source(session, protobuf_implementation):
     rather than pulling the dependencies from PyPI.
     """
 
-    # Install all dependencies
-    session.install("-e", ".")
-
-    # Install dependencies for the unit test environment
-    unit_deps_all = UNIT_TEST_STANDARD_DEPENDENCIES + UNIT_TEST_EXTERNAL_DEPENDENCIES
-    session.install(*unit_deps_all)
+    # Install all dependencies and unit test environment
+    install_unittest_dependencies(session)
 
     # Because we test minimum dependency versions on the minimum Python
     # version, the first version we test with in the unit tests sessions has a


### PR DESCRIPTION
Fixes https://github.com/googleapis/google-cloud-python/issues/17531 🦕