### PR TITLE
fix(django-google-spanner): escape backslashes in quote_value

### DIFF
--- a/packages/django-google-spanner/django_spanner/schema.py
+++ b/packages/django-google-spanner/django_spanner/schema.py
@@ -450,7 +450,10 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
     def quote_value(self, value):
         # A more complete implementation isn't currently required.
         if isinstance(value, str):
-            return "'%s'" % value.replace("'", "''")
+            # Cloud Spanner (GoogleSQL) escapes quotes with a backslash, not by
+            # doubling them, and treats backslash as an escape character. Match
+            # the escaping used for generated/db_default columns above.
+            return "'%s'" % value.replace("\\", "\\\\").replace("'", "\\'")
         if isinstance(value, bool):
             return "TRUE" if value else "FALSE"
         return str(value)

--- a/packages/django-google-spanner/tests/unit/django_spanner/test_schema.py
+++ b/packages/django-google-spanner/tests/unit/django_spanner/test_schema.py
@@ -40,6 +40,19 @@ class TestUtils(SpannerSimpleTestClass):
         schema_editor = DatabaseSchemaEditor(self.connection)
         self.assertEqual(schema_editor.quote_value(value=1.1), "1.1")
 
+    def test_quote_value_str_escaping(self):
+        """
+        String values must be escaped the GoogleSQL way (backslash), so a
+        quote or backslash in the value can't break out of the literal.
+        """
+        schema_editor = DatabaseSchemaEditor(self.connection)
+        self.assertEqual(schema_editor.quote_value(value="O'Brien"), "'O\\'Brien'")
+        self.assertEqual(schema_editor.quote_value(value="a\\b"), "'a\\\\b'")
+        self.assertEqual(
+            schema_editor.quote_value(value="\\' OR 1=1 -- "),
+            "'\\\\\\' OR 1=1 -- '",
+        )
+
     def test_skip_default(self):
         """
         Tries skipping default as Cloud spanner doesn't support it.


### PR DESCRIPTION
`DatabaseSchemaEditor.quote_value` inlines string values into DDL (Spanner doesn't accept bind parameters in those positions) and escapes them with ANSI quote doubling. Cloud Spanner runs GoogleSQL, which escapes a quote with a backslash and treats the backslash itself as an escape character, so doubling is the wrong convention here. A plain apostrophe such as a default of `O'Brien` renders as `'O''Brien'` and fails to parse, and a value that contains a backslash escapes the closing quote and runs off the end of the literal. With a crafted default like `\' OR 1=1 -- ` the output becomes `'\'' OR 1=1 -- '`, where the `\'` is an escaped quote and the following quote closes the string, leaving `OR 1=1` as live SQL. I noticed it because the generated-column and `db_default` paths a few lines up in the same file already escape the GoogleSQL way, while `quote_value` (and `prepare_default`, which calls it) still doubled. The change moves `quote_value` to the same backslash escaping so the value stays inside its literal.

- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/google-cloud-python/issues) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)
