### PR TITLE
chore(bigtable): fix flaky sharded query concurrency limit test by relaxing eps

### DIFF
--- a/packages/google-cloud-bigtable/tests/unit/data/_async/test_client.py
+++ b/packages/google-cloud-bigtable/tests/unit/data/_async/test_client.py
@@ -2328,7 +2328,7 @@ class TestReadRowsShardedAsync:
                         starting_timeout - kwargs["operation_timeout"]
                         for _, kwargs in read_rows.call_args_list
                     ]
-                    eps = 0.01
+                    eps = 0.2
                     # first 10 should start immediately
                     assert all(
                         rpc_start_list[i] < eps for i in range(_CONCURRENCY_LIMIT)

--- a/packages/google-cloud-bigtable/tests/unit/data/_sync_autogen/test_client.py
+++ b/packages/google-cloud-bigtable/tests/unit/data/_sync_autogen/test_client.py
@@ -1926,7 +1926,7 @@ class TestReadRowsSharded:
                         starting_timeout - kwargs["operation_timeout"]
                         for _, kwargs in read_rows.call_args_list
                     ]
-                    eps = 0.01
+                    eps = 0.2
                     assert all(
                         (rpc_start_list[i] < eps for i in range(_CONCURRENCY_LIMIT))
                     )

--- a/packages/google-cloud-bigtable/tests/unit/v2_client/test_batcher.py
+++ b/packages/google-cloud-bigtable/tests/unit/v2_client/test_batcher.py
@@ -13,8 +13,6 @@
 # limitations under the License.
 
 
-import time
-
 import mock
 import pytest
 
@@ -175,21 +173,22 @@ def test_mutations_batcher_context_manager_flushed_when_closed():
     assert table.mutation_calls == 1
 
 
-@mock.patch("google.cloud.bigtable.batcher.threading.Timer")
 @mock.patch("google.cloud.bigtable.batcher.MutationsBatcher.flush")
-def test_mutations_batcher_flush_interval(mocked_flush, mocked_timer):
+def test_mutations_batcher_flush_interval(mocked_flush):
     table = _Table(TABLE_NAME)
     flush_interval = 0.5
     mutation_batcher = MutationsBatcher(table=table, flush_interval=flush_interval)
 
-    mocked_timer.assert_called_once_with(flush_interval, mutation_batcher.flush)
-    mocked_timer.return_value.start.assert_called_once_with()
+    assert mutation_batcher._timer.interval == flush_interval
     mocked_flush.assert_not_called()
 
-    # Manually invoke the timer callback to verify it calls flush
-    timer_callback = mocked_timer.call_args[0][1]
-    timer_callback()
+    time.sleep(0.4)
+    mocked_flush.assert_not_called()
+
+    time.sleep(0.1)
     mocked_flush.assert_called_once_with()
+
+    mutation_batcher.close()
 
 
 def test_mutations_batcher_response_with_error_codes():

--- a/packages/google-cloud-bigtable/tests/unit/v2_client/test_batcher.py
+++ b/packages/google-cloud-bigtable/tests/unit/v2_client/test_batcher.py
@@ -175,22 +175,21 @@ def test_mutations_batcher_context_manager_flushed_when_closed():
     assert table.mutation_calls == 1
 
 
+@mock.patch("google.cloud.bigtable.batcher.threading.Timer")
 @mock.patch("google.cloud.bigtable.batcher.MutationsBatcher.flush")
-def test_mutations_batcher_flush_interval(mocked_flush):
+def test_mutations_batcher_flush_interval(mocked_flush, mocked_timer):
     table = _Table(TABLE_NAME)
     flush_interval = 0.5
     mutation_batcher = MutationsBatcher(table=table, flush_interval=flush_interval)
 
-    assert mutation_batcher._timer.interval == flush_interval
+    mocked_timer.assert_called_once_with(flush_interval, mutation_batcher.flush)
+    mocked_timer.return_value.start.assert_called_once_with()
     mocked_flush.assert_not_called()
 
-    time.sleep(0.4)
-    mocked_flush.assert_not_called()
-
-    time.sleep(0.1)
+    # Manually invoke the timer callback to verify it calls flush
+    timer_callback = mocked_timer.call_args[0][1]
+    timer_callback()
     mocked_flush.assert_called_once_with()
-
-    mutation_batcher.close()
 
 
 def test_mutations_batcher_response_with_error_codes():

--- a/packages/google-cloud-bigtable/tests/unit/v2_client/test_batcher.py
+++ b/packages/google-cloud-bigtable/tests/unit/v2_client/test_batcher.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 
 
+import time
+
 import mock
 import pytest
 


### PR DESCRIPTION
**Flaky tests**:

- The test `test_read_rows_sharded_concurrency_limit` was flaky under VM execution load because it checked if all of the first 10 concurrent requests were dispatched within `eps = 0.01` seconds (10 milliseconds) of the operation's start. 
Due to CPU scheduling and thread context switching overhead on virtualized CI hosts (like Kokoro), dispatching 10 concurrent threads/tasks can occasionally take slightly longer than 10ms, triggering random `AssertionError` failures.

**Solution**:

- Relaxed the threshold `eps` from `0.01` to `0.2` seconds (200 milliseconds) in:
    - The async source test file: [tests/unit/data/_async/test_client.py](file:///usr/local/google/home/omairn/git/googleapis/google-cloud-python/packages/google-cloud-bigtable/tests/unit/data/_async/test_client.py)
    - The sync auto-generated test file: [tests/unit/data/_sync_autogen/test_client.py](file:///usr/local/google/home/omairn/git/googleapis/google-cloud-python/packages/google-cloud-bigtable/tests/unit/data/_sync_autogen/test_client.py)
This allows enough scheduling margin for virtualized CI runners to pass successfully while still validating that the first 10 queries are fired concurrently without delay compared to the queued queries.
