### PR TITLE
fix(bigtable): populate Value type in _format_execute_query_view_params

### DIFF
--- a/packages/google-cloud-bigtable/google/cloud/bigtable/data/execute_query/_parameters_formatting.py
+++ b/packages/google-cloud-bigtable/google/cloud/bigtable/data/execute_query/_parameters_formatting.py
@@ -39,9 +39,7 @@ def _format_execute_query_view_params(
             raise TypeError(
                 f"View parameter {key} must be a string, got {type(value).__name__}"
             )
-        result_values[key] = _convert_value_to_pb_value_dict(
-            value, SqlType.String()
-        )
+        result_values[key] = _convert_value_to_pb_value_dict(value, SqlType.String())
 
     return result_values
 

--- a/packages/google-cloud-bigtable/google/cloud/bigtable/data/execute_query/_parameters_formatting.py
+++ b/packages/google-cloud-bigtable/google/cloud/bigtable/data/execute_query/_parameters_formatting.py
@@ -39,9 +39,7 @@ def _format_execute_query_view_params(
             raise TypeError(
                 f"View parameter {key} must be a string, got {type(value).__name__}"
             )
-        result_values[key] = Value(
-            string_value=value, type_=SqlType.String()._to_type_pb_dict()
-        )
+        result_values[key] = _convert_value_to_pb_value_dict(value, SqlType.String())
 
     return result_values
 

--- a/packages/google-cloud-bigtable/google/cloud/bigtable/data/execute_query/_parameters_formatting.py
+++ b/packages/google-cloud-bigtable/google/cloud/bigtable/data/execute_query/_parameters_formatting.py
@@ -39,7 +39,9 @@ def _format_execute_query_view_params(
             raise TypeError(
                 f"View parameter {key} must be a string, got {type(value).__name__}"
             )
-        result_values[key] = Value(string_value=value)
+        result_values[key] = Value(
+            string_value=value, type_=SqlType.String()._to_type_pb_dict()
+        )
 
     return result_values
 

--- a/packages/google-cloud-bigtable/google/cloud/bigtable/data/execute_query/_parameters_formatting.py
+++ b/packages/google-cloud-bigtable/google/cloud/bigtable/data/execute_query/_parameters_formatting.py
@@ -39,7 +39,9 @@ def _format_execute_query_view_params(
             raise TypeError(
                 f"View parameter {key} must be a string, got {type(value).__name__}"
             )
-        result_values[key] = _convert_value_to_pb_value_dict(value, SqlType.String())
+        result_values[key] = _convert_value_to_pb_value_dict(
+            value, SqlType.String()
+        )
 
     return result_values
 

--- a/packages/google-cloud-bigtable/tests/unit/data/_async/test_client.py
+++ b/packages/google-cloud-bigtable/tests/unit/data/_async/test_client.py
@@ -3553,9 +3553,8 @@ class TestExecuteQueryAsync:
         request = execute_query_mock.call_args[0][0]
         assert "user_id" in request.view_parameters
         assert request.view_parameters["user_id"].string_value == "alice"
-        assert type(request.view_parameters["user_id"].type_).to_dict(
-            request.view_parameters["user_id"].type_
-        ) == {"string_type": {}}
+        val_type = request.view_parameters["user_id"].type_
+        assert type(val_type).to_dict(val_type) == {"string_type": {}}
 
     @CrossSync.pytest
     async def test_execute_query_with_view_parameters_invalid_type(

--- a/packages/google-cloud-bigtable/tests/unit/data/_async/test_client.py
+++ b/packages/google-cloud-bigtable/tests/unit/data/_async/test_client.py
@@ -3558,7 +3558,12 @@ class TestExecuteQueryAsync:
         request = execute_query_mock.call_args[0][0]
         assert "user_id" in request.view_parameters
         assert request.view_parameters["user_id"].string_value == "alice"
-        assert request.view_parameters["user_id"].type_ == {"string_type": {}}
+        assert (
+            type(request.view_parameters["user_id"].type_).to_dict(
+                request.view_parameters["user_id"].type_
+            )
+            == {"string_type": {}}
+        )
 
     @CrossSync.pytest
     async def test_execute_query_with_view_parameters_invalid_type(

--- a/packages/google-cloud-bigtable/tests/unit/data/_async/test_client.py
+++ b/packages/google-cloud-bigtable/tests/unit/data/_async/test_client.py
@@ -3558,6 +3558,7 @@ class TestExecuteQueryAsync:
         request = execute_query_mock.call_args[0][0]
         assert "user_id" in request.view_parameters
         assert request.view_parameters["user_id"].string_value == "alice"
+        assert request.view_parameters["user_id"].type_ == {"string_type": {}}
 
     @CrossSync.pytest
     async def test_execute_query_with_view_parameters_invalid_type(

--- a/packages/google-cloud-bigtable/tests/unit/data/_async/test_client.py
+++ b/packages/google-cloud-bigtable/tests/unit/data/_async/test_client.py
@@ -285,10 +285,8 @@ class TestBigtableDataClientAsync:
         test ping and warm with mocked asyncio.gather
         """
         client_mock = mock.Mock()
-        client_mock._execute_ping_and_warms = (
-            lambda *args: self._get_target_class()._execute_ping_and_warms(
-                client_mock, *args
-            )
+        client_mock._execute_ping_and_warms = lambda *args: (
+            self._get_target_class()._execute_ping_and_warms(client_mock, *args)
         )
         with mock.patch.object(
             CrossSync, "gather_partials", CrossSync.Mock()
@@ -342,10 +340,8 @@ class TestBigtableDataClientAsync:
         should be able to call ping and warm with single instance
         """
         client_mock = mock.Mock()
-        client_mock._execute_ping_and_warms = (
-            lambda *args: self._get_target_class()._execute_ping_and_warms(
-                client_mock, *args
-            )
+        client_mock._execute_ping_and_warms = lambda *args: (
+            self._get_target_class()._execute_ping_and_warms(client_mock, *args)
         )
         with mock.patch.object(
             CrossSync, "gather_partials", CrossSync.Mock()
@@ -1645,11 +1641,11 @@ class TestReadRowsAsync:
     @CrossSync.convert
     def _make_table(self, *args, **kwargs):
         client_mock = mock.Mock()
-        client_mock._register_instance.side_effect = (
-            lambda *args, **kwargs: CrossSync.yield_to_event_loop()
+        client_mock._register_instance.side_effect = lambda *args, **kwargs: (
+            CrossSync.yield_to_event_loop()
         )
-        client_mock._remove_instance_registration.side_effect = (
-            lambda *args, **kwargs: CrossSync.yield_to_event_loop()
+        client_mock._remove_instance_registration.side_effect = lambda *args, **kwargs: (
+            CrossSync.yield_to_event_loop()
         )
         kwargs["instance_id"] = kwargs.get(
             "instance_id", args[0] if args else "instance"
@@ -2206,9 +2202,8 @@ class TestReadRowsShardedAsync:
                 with mock.patch.object(
                     table.client._gapic_client, "read_rows"
                 ) as read_rows:
-                    read_rows.side_effect = (
-                        lambda *args,
-                        **kwargs: CrossSync.TestReadRows._make_gapic_stream(
+                    read_rows.side_effect = lambda *args, **kwargs: (
+                        CrossSync.TestReadRows._make_gapic_stream(
                             [
                                 CrossSync.TestReadRows._make_chunk(row_key=k)
                                 for k in args[0].rows.row_keys
@@ -3558,12 +3553,9 @@ class TestExecuteQueryAsync:
         request = execute_query_mock.call_args[0][0]
         assert "user_id" in request.view_parameters
         assert request.view_parameters["user_id"].string_value == "alice"
-        assert (
-            type(request.view_parameters["user_id"].type_).to_dict(
-                request.view_parameters["user_id"].type_
-            )
-            == {"string_type": {}}
-        )
+        assert type(request.view_parameters["user_id"].type_).to_dict(
+            request.view_parameters["user_id"].type_
+        ) == {"string_type": {}}
 
     @CrossSync.pytest
     async def test_execute_query_with_view_parameters_invalid_type(

--- a/packages/google-cloud-bigtable/tests/unit/data/_async/test_client.py
+++ b/packages/google-cloud-bigtable/tests/unit/data/_async/test_client.py
@@ -285,8 +285,10 @@ class TestBigtableDataClientAsync:
         test ping and warm with mocked asyncio.gather
         """
         client_mock = mock.Mock()
-        client_mock._execute_ping_and_warms = lambda *args: (
-            self._get_target_class()._execute_ping_and_warms(client_mock, *args)
+        client_mock._execute_ping_and_warms = (
+            lambda *args: self._get_target_class()._execute_ping_and_warms(
+                client_mock, *args
+            )
         )
         with mock.patch.object(
             CrossSync, "gather_partials", CrossSync.Mock()
@@ -340,8 +342,10 @@ class TestBigtableDataClientAsync:
         should be able to call ping and warm with single instance
         """
         client_mock = mock.Mock()
-        client_mock._execute_ping_and_warms = lambda *args: (
-            self._get_target_class()._execute_ping_and_warms(client_mock, *args)
+        client_mock._execute_ping_and_warms = (
+            lambda *args: self._get_target_class()._execute_ping_and_warms(
+                client_mock, *args
+            )
         )
         with mock.patch.object(
             CrossSync, "gather_partials", CrossSync.Mock()
@@ -1641,11 +1645,11 @@ class TestReadRowsAsync:
     @CrossSync.convert
     def _make_table(self, *args, **kwargs):
         client_mock = mock.Mock()
-        client_mock._register_instance.side_effect = lambda *args, **kwargs: (
-            CrossSync.yield_to_event_loop()
+        client_mock._register_instance.side_effect = (
+            lambda *args, **kwargs: CrossSync.yield_to_event_loop()
         )
-        client_mock._remove_instance_registration.side_effect = lambda *args, **kwargs: (
-            CrossSync.yield_to_event_loop()
+        client_mock._remove_instance_registration.side_effect = (
+            lambda *args, **kwargs: CrossSync.yield_to_event_loop()
         )
         kwargs["instance_id"] = kwargs.get(
             "instance_id", args[0] if args else "instance"
@@ -2202,8 +2206,9 @@ class TestReadRowsShardedAsync:
                 with mock.patch.object(
                     table.client._gapic_client, "read_rows"
                 ) as read_rows:
-                    read_rows.side_effect = lambda *args, **kwargs: (
-                        CrossSync.TestReadRows._make_gapic_stream(
+                    read_rows.side_effect = (
+                        lambda *args,
+                        **kwargs: CrossSync.TestReadRows._make_gapic_stream(
                             [
                                 CrossSync.TestReadRows._make_chunk(row_key=k)
                                 for k in args[0].rows.row_keys

--- a/packages/google-cloud-bigtable/tests/unit/data/_sync_autogen/test_client.py
+++ b/packages/google-cloud-bigtable/tests/unit/data/_sync_autogen/test_client.py
@@ -3019,6 +3019,7 @@ class TestExecuteQuery:
         request = execute_query_mock.call_args[0][0]
         assert "user_id" in request.view_parameters
         assert request.view_parameters["user_id"].string_value == "alice"
+        assert request.view_parameters["user_id"].type_ == {"string_type": {}}
 
     def test_execute_query_with_view_parameters_invalid_type(
         self, client, execute_query_mock, prepare_mock

--- a/packages/google-cloud-bigtable/tests/unit/data/_sync_autogen/test_client.py
+++ b/packages/google-cloud-bigtable/tests/unit/data/_sync_autogen/test_client.py
@@ -3014,9 +3014,8 @@ class TestExecuteQuery:
         request = execute_query_mock.call_args[0][0]
         assert "user_id" in request.view_parameters
         assert request.view_parameters["user_id"].string_value == "alice"
-        assert type(request.view_parameters["user_id"].type_).to_dict(
-            request.view_parameters["user_id"].type_
-        ) == {"string_type": {}}
+        val_type = request.view_parameters["user_id"].type_
+        assert type(val_type).to_dict(val_type) == {"string_type": {}}
 
     def test_execute_query_with_view_parameters_invalid_type(
         self, client, execute_query_mock, prepare_mock

--- a/packages/google-cloud-bigtable/tests/unit/data/_sync_autogen/test_client.py
+++ b/packages/google-cloud-bigtable/tests/unit/data/_sync_autogen/test_client.py
@@ -3019,7 +3019,12 @@ class TestExecuteQuery:
         request = execute_query_mock.call_args[0][0]
         assert "user_id" in request.view_parameters
         assert request.view_parameters["user_id"].string_value == "alice"
-        assert request.view_parameters["user_id"].type_ == {"string_type": {}}
+        assert (
+            type(request.view_parameters["user_id"].type_).to_dict(
+                request.view_parameters["user_id"].type_
+            )
+            == {"string_type": {}}
+        )
 
     def test_execute_query_with_view_parameters_invalid_type(
         self, client, execute_query_mock, prepare_mock

--- a/packages/google-cloud-bigtable/tests/unit/data/_sync_autogen/test_client.py
+++ b/packages/google-cloud-bigtable/tests/unit/data/_sync_autogen/test_client.py
@@ -223,10 +223,8 @@ class TestBigtableDataClient:
     def test__ping_and_warm_instances(self):
         """test ping and warm with mocked asyncio.gather"""
         client_mock = mock.Mock()
-        client_mock._execute_ping_and_warms = (
-            lambda *args: self._get_target_class()._execute_ping_and_warms(
-                client_mock, *args
-            )
+        client_mock._execute_ping_and_warms = lambda *args: (
+            self._get_target_class()._execute_ping_and_warms(client_mock, *args)
         )
         with mock.patch.object(
             CrossSync._Sync_Impl, "gather_partials", CrossSync._Sync_Impl.Mock()
@@ -269,10 +267,8 @@ class TestBigtableDataClient:
     def test__ping_and_warm_single_instance(self):
         """should be able to call ping and warm with single instance"""
         client_mock = mock.Mock()
-        client_mock._execute_ping_and_warms = (
-            lambda *args: self._get_target_class()._execute_ping_and_warms(
-                client_mock, *args
-            )
+        client_mock._execute_ping_and_warms = lambda *args: (
+            self._get_target_class()._execute_ping_and_warms(client_mock, *args)
         )
         with mock.patch.object(
             CrossSync._Sync_Impl, "gather_partials", CrossSync._Sync_Impl.Mock()
@@ -1344,11 +1340,11 @@ class TestReadRows:
 
     def _make_table(self, *args, **kwargs):
         client_mock = mock.Mock()
-        client_mock._register_instance.side_effect = (
-            lambda *args, **kwargs: CrossSync._Sync_Impl.yield_to_event_loop()
+        client_mock._register_instance.side_effect = lambda *args, **kwargs: (
+            CrossSync._Sync_Impl.yield_to_event_loop()
         )
-        client_mock._remove_instance_registration.side_effect = (
-            lambda *args, **kwargs: CrossSync._Sync_Impl.yield_to_event_loop()
+        client_mock._remove_instance_registration.side_effect = lambda *args, **kwargs: (
+            CrossSync._Sync_Impl.yield_to_event_loop()
         )
         kwargs["instance_id"] = kwargs.get(
             "instance_id", args[0] if args else "instance"
@@ -1824,9 +1820,8 @@ class TestReadRowsSharded:
                 with mock.patch.object(
                     table.client._gapic_client, "read_rows"
                 ) as read_rows:
-                    read_rows.side_effect = (
-                        lambda *args,
-                        **kwargs: CrossSync._Sync_Impl.TestReadRows._make_gapic_stream(
+                    read_rows.side_effect = lambda *args, **kwargs: (
+                        CrossSync._Sync_Impl.TestReadRows._make_gapic_stream(
                             [
                                 CrossSync._Sync_Impl.TestReadRows._make_chunk(row_key=k)
                                 for k in args[0].rows.row_keys
@@ -3019,12 +3014,9 @@ class TestExecuteQuery:
         request = execute_query_mock.call_args[0][0]
         assert "user_id" in request.view_parameters
         assert request.view_parameters["user_id"].string_value == "alice"
-        assert (
-            type(request.view_parameters["user_id"].type_).to_dict(
-                request.view_parameters["user_id"].type_
-            )
-            == {"string_type": {}}
-        )
+        assert type(request.view_parameters["user_id"].type_).to_dict(
+            request.view_parameters["user_id"].type_
+        ) == {"string_type": {}}
 
     def test_execute_query_with_view_parameters_invalid_type(
         self, client, execute_query_mock, prepare_mock

--- a/packages/google-cloud-bigtable/tests/unit/data/_sync_autogen/test_client.py
+++ b/packages/google-cloud-bigtable/tests/unit/data/_sync_autogen/test_client.py
@@ -223,8 +223,10 @@ class TestBigtableDataClient:
     def test__ping_and_warm_instances(self):
         """test ping and warm with mocked asyncio.gather"""
         client_mock = mock.Mock()
-        client_mock._execute_ping_and_warms = lambda *args: (
-            self._get_target_class()._execute_ping_and_warms(client_mock, *args)
+        client_mock._execute_ping_and_warms = (
+            lambda *args: self._get_target_class()._execute_ping_and_warms(
+                client_mock, *args
+            )
         )
         with mock.patch.object(
             CrossSync._Sync_Impl, "gather_partials", CrossSync._Sync_Impl.Mock()
@@ -267,8 +269,10 @@ class TestBigtableDataClient:
     def test__ping_and_warm_single_instance(self):
         """should be able to call ping and warm with single instance"""
         client_mock = mock.Mock()
-        client_mock._execute_ping_and_warms = lambda *args: (
-            self._get_target_class()._execute_ping_and_warms(client_mock, *args)
+        client_mock._execute_ping_and_warms = (
+            lambda *args: self._get_target_class()._execute_ping_and_warms(
+                client_mock, *args
+            )
         )
         with mock.patch.object(
             CrossSync._Sync_Impl, "gather_partials", CrossSync._Sync_Impl.Mock()
@@ -1340,11 +1344,11 @@ class TestReadRows:
 
     def _make_table(self, *args, **kwargs):
         client_mock = mock.Mock()
-        client_mock._register_instance.side_effect = lambda *args, **kwargs: (
-            CrossSync._Sync_Impl.yield_to_event_loop()
+        client_mock._register_instance.side_effect = (
+            lambda *args, **kwargs: CrossSync._Sync_Impl.yield_to_event_loop()
         )
-        client_mock._remove_instance_registration.side_effect = lambda *args, **kwargs: (
-            CrossSync._Sync_Impl.yield_to_event_loop()
+        client_mock._remove_instance_registration.side_effect = (
+            lambda *args, **kwargs: CrossSync._Sync_Impl.yield_to_event_loop()
         )
         kwargs["instance_id"] = kwargs.get(
             "instance_id", args[0] if args else "instance"
@@ -1820,8 +1824,9 @@ class TestReadRowsSharded:
                 with mock.patch.object(
                     table.client._gapic_client, "read_rows"
                 ) as read_rows:
-                    read_rows.side_effect = lambda *args, **kwargs: (
-                        CrossSync._Sync_Impl.TestReadRows._make_gapic_stream(
+                    read_rows.side_effect = (
+                        lambda *args,
+                        **kwargs: CrossSync._Sync_Impl.TestReadRows._make_gapic_stream(
                             [
                                 CrossSync._Sync_Impl.TestReadRows._make_chunk(row_key=k)
                                 for k in args[0].rows.row_keys


### PR DESCRIPTION
Ensures that string view parameters construct Value objects with both string_value and explicit string_type populated.

Fixes issue where view parameters created Value objects missing the explicit type_ field.