### PR TITLE
fix(django-google-spanner): escape tzname in datetime sql helpers

### DIFF
--- a/packages/django-google-spanner/django_spanner/operations.py
+++ b/packages/django-google-spanner/django_spanner/operations.py
@@ -22,6 +22,18 @@ from google.cloud.spanner_dbapi.parse_utils import (
 )
 
 
+def _escape_tzname(tzname):
+    """Escape a time zone name for embedding in a Spanner string literal.
+
+    The datetime helpers below inline the time zone name into a quoted
+    string literal. Cloud Spanner (GoogleSQL) uses backslash escaping inside
+    string literals, so a name containing a quote would otherwise close the
+    literal and inject SQL. Both quote characters are escaped so the result is
+    safe in single- and double-quoted contexts.
+    """
+    return tzname.replace("\\", "\\\\").replace('"', '\\"').replace("'", "\\'")
+
+
 class DatabaseOperations(BaseDatabaseOperations):
     """A Spanner-specific version of Django database operations."""
 
@@ -431,6 +443,7 @@ class DatabaseOperations(BaseDatabaseOperations):
         :returns: A SQL statement for extracting.
         """
         tzname = tzname if settings.USE_TZ and tzname else "UTC"
+        tzname = _escape_tzname(tzname)
         lookup_type = self.extract_names.get(lookup_type, lookup_type)
         return (
             'EXTRACT(%s FROM %s AT TIME ZONE "%s")'
@@ -518,6 +531,7 @@ class DatabaseOperations(BaseDatabaseOperations):
         """
         # https://cloud.google.com/spanner/docs/functions-and-operators#timestamp_trunc
         tzname = tzname if settings.USE_TZ and tzname else "UTC"
+        tzname = _escape_tzname(tzname)
         if lookup_type == "week":
             # Spanner truncates to Sunday but Django expects Monday. First,
             # subtract a day so that a Sunday will be truncated to the previous
@@ -553,6 +567,7 @@ class DatabaseOperations(BaseDatabaseOperations):
         """
         # https://cloud.google.com/spanner/docs/functions-and-operators#timestamp_trunc
         tzname = tzname if settings.USE_TZ and tzname else "UTC"
+        tzname = _escape_tzname(tzname)
         return (
             'TIMESTAMP_TRUNC(%s, %s, "%s")'
             % (
@@ -581,6 +596,7 @@ class DatabaseOperations(BaseDatabaseOperations):
         """
         # https://cloud.google.com/spanner/docs/functions-and-operators#date
         tzname = tzname if settings.USE_TZ and tzname else "UTC"
+        tzname = _escape_tzname(tzname)
         return 'DATE(%s, "%s")' % (field_name, tzname), params
 
     def datetime_cast_time_sql(self, field_name, params, tzname):
@@ -600,6 +616,7 @@ class DatabaseOperations(BaseDatabaseOperations):
         :returns: A SQL statement for casting.
         """
         tzname = tzname if settings.USE_TZ and tzname else "UTC"
+        tzname = _escape_tzname(tzname)
         # Cloud Spanner doesn't have a function for converting
         # TIMESTAMP to another time zone.
         return (

--- a/packages/django-google-spanner/tests/unit/django_spanner/test_operations.py
+++ b/packages/django-google-spanner/tests/unit/django_spanner/test_operations.py
@@ -189,6 +189,62 @@ class TestOperations(SpannerSimpleTestClass):
         )
         settings.USE_TZ = True  # reset changes.
 
+    def test_datetime_extract_sql_escapes_tzname(self):
+        settings.USE_TZ = True
+        self.assertEqual(
+            self.db_operations.datetime_extract_sql(
+                "year", "dummy_field", None, 'X" OR "a"="a'
+            ),
+            (
+                'EXTRACT(year FROM dummy_field AT TIME ZONE "X\\" OR \\"a\\"=\\"a")',
+                None,
+            ),
+        )
+
+    def test_datetime_trunc_sql_escapes_tzname(self):
+        settings.USE_TZ = True
+        self.assertEqual(
+            self.db_operations.datetime_trunc_sql(
+                "day", "dummy_field", None, 'X" OR "a"="a'
+            ),
+            (
+                'TIMESTAMP_TRUNC(dummy_field, day, "X\\" OR \\"a\\"=\\"a")',
+                None,
+            ),
+        )
+
+    def test_time_trunc_sql_escapes_tzname(self):
+        settings.USE_TZ = True
+        self.assertEqual(
+            self.db_operations.time_trunc_sql(
+                "day", "dummy_field", None, 'X" OR "a"="a'
+            ),
+            (
+                'TIMESTAMP_TRUNC(dummy_field, day, "X\\" OR \\"a\\"=\\"a")',
+                None,
+            ),
+        )
+
+    def test_datetime_cast_date_sql_escapes_tzname(self):
+        settings.USE_TZ = True
+        self.assertEqual(
+            self.db_operations.datetime_cast_date_sql(
+                "dummy_field", None, 'X" OR "a"="a'
+            ),
+            ('DATE(dummy_field, "X\\" OR \\"a\\"=\\"a")', None),
+        )
+
+    def test_datetime_cast_time_sql_escapes_tzname(self):
+        settings.USE_TZ = True
+        self.assertEqual(
+            self.db_operations.datetime_cast_time_sql("dummy_field", None, "X' || 'a"),
+            (
+                "TIMESTAMP(FORMAT_TIMESTAMP('%Y-%m-%d %R:%E9S %Z', "
+                "dummy_field, 'X\\' || \\'a'))",
+                None,
+            ),
+        )
+
     def test_date_interval_sql(self):
         self.assertEqual(
             self.db_operations.date_interval_sql(timedelta(days=1)),


### PR DESCRIPTION
Before the fix, the time zone name lands inside the quoted string literal that the datetime helpers build:

    >>> ops.datetime_extract_sql("year", "col", None, 'UTC" AS x, (SELECT secret) AS y FROM t -- ')[0]
    EXTRACT(year FROM col AT TIME ZONE "UTC" AS x, (SELECT secret) AS y FROM t -- ")

`datetime_extract_sql`, `datetime_trunc_sql`, `time_trunc_sql`, `datetime_cast_date_sql` and `datetime_cast_time_sql` inline `tzname` into a quoted literal (`... "%s"`, and `'%s'` for the `FORMAT_TIMESTAMP` one) without escaping, so a tzname carrying a quote closes the literal and the remainder runs as SQL. It is reachable when an explicit tzinfo is passed to a `Trunc`/`Extract` expression, e.g. `datetime.timezone(offset, name='UTC" ...')`, whose name Django forwards verbatim. Django core binds tzname as a query parameter for this reason; this backend inlines it, so it needs to escape it.

The fix escapes the backslash and both quote characters before interpolation, the same GoogleSQL escaping the generated-column and `db_default` paths in `schema.py` already use, so the name stays inside its literal and an invalid zone is rejected at execution instead of running as SQL.

- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/google-cloud-python/issues) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)
