### PR TITLE
test(bigquery-magics): simplify IPython initialization in deprecation test

### DIFF
--- a/packages/bigquery-magics/tests/unit/bigquery/test_deprecation.py
+++ b/packages/bigquery-magics/tests/unit/bigquery/test_deprecation.py
@@ -54,13 +54,10 @@ def test_query_with_bigframes_warning(mock_ipython):
 def test_cell_magic_engine_bigframes_warning(mock_ipython):
     from unittest import mock
 
-    from IPython.testing.globalipapp import get_ipython
+    from IPython.testing.globalipapp import get_ipython, start_ipython
 
+    start_ipython()
     ip = get_ipython()
-    if ip is None:
-        from IPython.testing.globalipapp import start_ipython
-
-        ip = start_ipython()
 
     ip.extension_manager.load_extension("bigquery_magics")
 


### PR DESCRIPTION
The unit test `test_cell_magic_engine_bigframes_warning` in `test_deprecation.py` was conditionally initializing IPython. Only one of the code paths was being exercised so we were getting a coverage issue.

This change simplifies the initialization by unconditionally calling `start_ipython()` and assigning the returned instance to `ip` ensuring a clean and consistent state for the test and avoiding the need for a conditional check.

