### PR TITLE
fix(auth): lower regional access boundary logs from warning to debug.

### DIFF
--- a/packages/google-auth/google/auth/_regional_access_boundary_utils.py
+++ b/packages/google-auth/google/auth/_regional_access_boundary_utils.py
@@ -219,10 +219,9 @@ class _RegionalAccessBoundaryManager(object):
         """
         # Async credentials do not support blocking lookups.
         if inspect.iscoroutinefunction(credentials._lookup_regional_access_boundary):
-            if _helpers.is_logging_enabled(_LOGGER):
-                _LOGGER.warning(
-                    "Blocking Regional Access Boundary lookup is not supported for async credentials."
-                )
+            _LOGGER.info(
+                "Blocking Regional Access Boundary lookup is not supported for async credentials."
+            )
             self.process_regional_access_boundary_info(None)
             return
 
@@ -234,12 +233,11 @@ class _RegionalAccessBoundaryManager(object):
                 credentials._lookup_regional_access_boundary(request, fail_fast=True)
             )
         except Exception as e:
-            if _helpers.is_logging_enabled(_LOGGER):
-                _LOGGER.warning(
-                    "Blocking Regional Access Boundary lookup raised an exception: %s",
-                    e,
-                    exc_info=True,
-                )
+            _LOGGER.info(
+                "Blocking Regional Access Boundary lookup raised an exception: %s",
+                e,
+                exc_info=True,
+            )
             regional_access_boundary_info = None
 
         self.process_regional_access_boundary_info(regional_access_boundary_info)
@@ -265,12 +263,11 @@ class _RegionalAccessBoundaryManager(object):
                 )
             )
         except Exception as e:
-            if _helpers.is_logging_enabled(_LOGGER):
-                _LOGGER.warning(
-                    "Regional Access Boundary lookup raised an exception: %s",
-                    e,
-                    exc_info=True,
-                )
+            _LOGGER.info(
+                "Regional Access Boundary lookup raised an exception: %s",
+                e,
+                exc_info=True,
+            )
             regional_access_boundary_info = None
 
         self.process_regional_access_boundary_info(regional_access_boundary_info)
@@ -297,14 +294,12 @@ class _RegionalAccessBoundaryManager(object):
                     cooldown_expiry=None,
                     cooldown_duration=DEFAULT_REGIONAL_ACCESS_BOUNDARY_COOLDOWN,
                 )
-                if _helpers.is_logging_enabled(_LOGGER):
-                    _LOGGER.debug("Regional Access Boundary lookup successful.")
+                _LOGGER.info("Regional Access Boundary lookup successful.")
             else:
                 # On failure, calculate cooldown and update state.
-                if _helpers.is_logging_enabled(_LOGGER):
-                    _LOGGER.warning(
-                        "Regional Access Boundary lookup failed. Entering cooldown."
-                    )
+                _LOGGER.info(
+                    "Regional Access Boundary lookup failed. Entering cooldown."
+                )
 
                 next_cooldown_expiry = (
                     _helpers.utcnow() + current_data.cooldown_duration
@@ -367,12 +362,11 @@ class _RegionalAccessBoundaryRefreshThread(threading.Thread):
                 self._credentials._lookup_regional_access_boundary(self._request)
             )
         except Exception as e:
-            if _helpers.is_logging_enabled(_LOGGER):
-                _LOGGER.warning(
-                    "Asynchronous Regional Access Boundary lookup raised an exception: %s",
-                    e,
-                    exc_info=True,
-                )
+            _LOGGER.info(
+                "Asynchronous Regional Access Boundary lookup raised an exception: %s",
+                e,
+                exc_info=True,
+            )
             regional_access_boundary_info = None
 
         self._rab_manager.process_regional_access_boundary_info(
@@ -419,13 +413,12 @@ class _RegionalAccessBoundaryRefreshManager(object):
             try:
                 copied_request = copy.deepcopy(request)
             except Exception as e:
-                if _helpers.is_logging_enabled(_LOGGER):
-                    _LOGGER.warning(
-                        "Could not deepcopy transport for background RAB refresh. "
-                        "Skipping background refresh to avoid thread safety issues. "
-                        "Exception: %s",
-                        e,
-                    )
+                _LOGGER.info(
+                    "Could not deepcopy transport for background RAB refresh. "
+                    "Skipping background refresh to avoid thread safety issues. "
+                    "Exception: %s",
+                    e,
+                )
                 return
 
             self._worker = _RegionalAccessBoundaryRefreshThread(
@@ -479,14 +472,13 @@ async def _close_cloned_request(lookup_request, is_cloned):
         if is_async := inspect.isawaitable(maybe_coro):
             await maybe_coro
     except Exception as e:
-        if _helpers.is_logging_enabled(_LOGGER):
-            adapter_type = " asynchronous " if is_async else " "
-            _LOGGER.warning(
-                "Failed to cleanly close cloned%srequest transport: %s",
-                adapter_type,
-                e,
-                exc_info=True,
-            )
+        adapter_type = " asynchronous " if is_async else " "
+        _LOGGER.info(
+            "Failed to cleanly close cloned%srequest transport: %s",
+            adapter_type,
+            e,
+            exc_info=True,
+        )
 
 
 class _AsyncRegionalAccessBoundaryRefreshManager(object):
@@ -532,12 +524,11 @@ class _AsyncRegionalAccessBoundaryRefreshManager(object):
                     is_cloned,
                 ) = _prepare_async_lookup_callable(request)
             except Exception as e:
-                if _helpers.is_logging_enabled(_LOGGER):
-                    _LOGGER.warning(
-                        "Synchronous cloning of request for Regional Access Boundary lookup failed: %s",
-                        e,
-                        exc_info=True,
-                    )
+                _LOGGER.info(
+                    "Synchronous cloning of request for Regional Access Boundary lookup failed: %s",
+                    e,
+                    exc_info=True,
+                )
                 rab_manager.process_regional_access_boundary_info(None)
                 return
 
@@ -549,12 +540,11 @@ class _AsyncRegionalAccessBoundaryRefreshManager(object):
                         )
                     )
                 except Exception as e:
-                    if _helpers.is_logging_enabled(_LOGGER):
-                        _LOGGER.warning(
-                            "Asynchronous Regional Access Boundary lookup raised an exception: %s",
-                            e,
-                            exc_info=True,
-                        )
+                    _LOGGER.info(
+                        "Asynchronous Regional Access Boundary lookup raised an exception: %s",
+                        e,
+                        exc_info=True,
+                    )
                     regional_access_boundary_info = None
                 finally:
                     await _close_cloned_request(lookup_request, is_cloned)

--- a/packages/google-auth/google/auth/_regional_access_boundary_utils.py
+++ b/packages/google-auth/google/auth/_regional_access_boundary_utils.py
@@ -219,7 +219,7 @@ class _RegionalAccessBoundaryManager(object):
         """
         # Async credentials do not support blocking lookups.
         if inspect.iscoroutinefunction(credentials._lookup_regional_access_boundary):
-            _LOGGER.info(
+            _LOGGER.debug(
                 "Blocking Regional Access Boundary lookup is not supported for async credentials."
             )
             self.process_regional_access_boundary_info(None)
@@ -233,7 +233,7 @@ class _RegionalAccessBoundaryManager(object):
                 credentials._lookup_regional_access_boundary(request, fail_fast=True)
             )
         except Exception as e:
-            _LOGGER.info(
+            _LOGGER.debug(
                 "Blocking Regional Access Boundary lookup raised an exception: %s",
                 e,
                 exc_info=True,
@@ -263,7 +263,7 @@ class _RegionalAccessBoundaryManager(object):
                 )
             )
         except Exception as e:
-            _LOGGER.info(
+            _LOGGER.debug(
                 "Regional Access Boundary lookup raised an exception: %s",
                 e,
                 exc_info=True,
@@ -294,10 +294,10 @@ class _RegionalAccessBoundaryManager(object):
                     cooldown_expiry=None,
                     cooldown_duration=DEFAULT_REGIONAL_ACCESS_BOUNDARY_COOLDOWN,
                 )
-                _LOGGER.info("Regional Access Boundary lookup successful.")
+                _LOGGER.debug("Regional Access Boundary lookup successful.")
             else:
                 # On failure, calculate cooldown and update state.
-                _LOGGER.info(
+                _LOGGER.debug(
                     "Regional Access Boundary lookup failed. Entering cooldown."
                 )
 
@@ -362,7 +362,7 @@ class _RegionalAccessBoundaryRefreshThread(threading.Thread):
                 self._credentials._lookup_regional_access_boundary(self._request)
             )
         except Exception as e:
-            _LOGGER.info(
+            _LOGGER.debug(
                 "Asynchronous Regional Access Boundary lookup raised an exception: %s",
                 e,
                 exc_info=True,
@@ -413,7 +413,7 @@ class _RegionalAccessBoundaryRefreshManager(object):
             try:
                 copied_request = copy.deepcopy(request)
             except Exception as e:
-                _LOGGER.info(
+                _LOGGER.debug(
                     "Could not deepcopy transport for background RAB refresh. "
                     "Skipping background refresh to avoid thread safety issues. "
                     "Exception: %s",
@@ -473,7 +473,7 @@ async def _close_cloned_request(lookup_request, is_cloned):
             await maybe_coro
     except Exception as e:
         adapter_type = " asynchronous " if is_async else " "
-        _LOGGER.info(
+        _LOGGER.debug(
             "Failed to cleanly close cloned%srequest transport: %s",
             adapter_type,
             e,
@@ -524,7 +524,7 @@ class _AsyncRegionalAccessBoundaryRefreshManager(object):
                     is_cloned,
                 ) = _prepare_async_lookup_callable(request)
             except Exception as e:
-                _LOGGER.info(
+                _LOGGER.debug(
                     "Synchronous cloning of request for Regional Access Boundary lookup failed: %s",
                     e,
                     exc_info=True,
@@ -540,7 +540,7 @@ class _AsyncRegionalAccessBoundaryRefreshManager(object):
                         )
                     )
                 except Exception as e:
-                    _LOGGER.info(
+                    _LOGGER.debug(
                         "Asynchronous Regional Access Boundary lookup raised an exception: %s",
                         e,
                         exc_info=True,

--- a/packages/google-auth/google/auth/compute_engine/credentials.py
+++ b/packages/google-auth/google/auth/compute_engine/credentials.py
@@ -219,7 +219,7 @@ class Credentials(
                 return None
 
         if not _metadata._is_service_account_email(self.service_account_email):
-            _LOGGER.info(
+            _LOGGER.debug(
                 "Service account email '%s' is not a valid email. Skipping Regional Access Boundary lookup.",
                 self.service_account_email,
             )

--- a/packages/google-auth/google/auth/credentials.py
+++ b/packages/google-auth/google/auth/credentials.py
@@ -535,7 +535,7 @@ class CredentialsWithRegionalAccessBoundary(Credentials):
 
         url = self._build_regional_access_boundary_lookup_url(request=request)
         if not url:
-            _LOGGER.warning("Failed to build Regional Access Boundary lookup URL.")
+            _LOGGER.info("Failed to build Regional Access Boundary lookup URL.")
             return None
 
         headers: Dict[str, str] = {}

--- a/packages/google-auth/google/auth/credentials.py
+++ b/packages/google-auth/google/auth/credentials.py
@@ -535,7 +535,7 @@ class CredentialsWithRegionalAccessBoundary(Credentials):
 
         url = self._build_regional_access_boundary_lookup_url(request=request)
         if not url:
-            _LOGGER.info("Failed to build Regional Access Boundary lookup URL.")
+            _LOGGER.debug("Failed to build Regional Access Boundary lookup URL.")
             return None
 
         headers: Dict[str, str] = {}

--- a/packages/google-auth/google/oauth2/_client.py
+++ b/packages/google-auth/google/oauth2/_client.py
@@ -582,7 +582,7 @@ def _lookup_regional_access_boundary_request(
         request, url, can_retry=can_retry, headers=headers, fail_fast=fail_fast
     )
     if not response_status_ok:
-        _LOGGER.info(
+        _LOGGER.debug(
             "Regional Access Boundary HTTP request failed after retries: response_data=%s, retryable_error=%s",
             response_data,
             retryable_error,

--- a/packages/google-auth/google/oauth2/_client.py
+++ b/packages/google-auth/google/oauth2/_client.py
@@ -582,7 +582,7 @@ def _lookup_regional_access_boundary_request(
         request, url, can_retry=can_retry, headers=headers, fail_fast=fail_fast
     )
     if not response_status_ok:
-        _LOGGER.warning(
+        _LOGGER.info(
             "Regional Access Boundary HTTP request failed after retries: response_data=%s, retryable_error=%s",
             response_data,
             retryable_error,

--- a/packages/google-auth/google/oauth2/_client_async.py
+++ b/packages/google-auth/google/oauth2/_client_async.py
@@ -356,7 +356,7 @@ async def _lookup_regional_access_boundary_request(
         request, url, can_retry=can_retry, headers=headers, fail_fast=fail_fast
     )
     if not response_status_ok:
-        client._LOGGER.info(
+        client._LOGGER.debug(
             "Regional Access Boundary HTTP request failed after retries: response_data=%s, retryable_error=%s",
             response_data,
             retryable_error,

--- a/packages/google-auth/google/oauth2/_client_async.py
+++ b/packages/google-auth/google/oauth2/_client_async.py
@@ -356,7 +356,7 @@ async def _lookup_regional_access_boundary_request(
         request, url, can_retry=can_retry, headers=headers, fail_fast=fail_fast
     )
     if not response_status_ok:
-        client._LOGGER.warning(
+        client._LOGGER.info(
             "Regional Access Boundary HTTP request failed after retries: response_data=%s, retryable_error=%s",
             response_data,
             retryable_error,

--- a/packages/google-auth/tests/test__regional_access_boundary_utils.py
+++ b/packages/google-auth/tests/test__regional_access_boundary_utils.py
@@ -29,7 +29,9 @@ from google.oauth2 import credentials as oauth2_credentials
 def rab_caplog(caplog):
     """Fixture to configure logging capture and ensure propagation for RAB utilities."""
 
-    caplog.set_level(logging.INFO, logger="google.auth._regional_access_boundary_utils")
+    caplog.set_level(
+        logging.DEBUG, logger="google.auth._regional_access_boundary_utils"
+    )
 
     google_logger = logging.getLogger("google")
     original_propagate = google_logger.propagate

--- a/packages/google-auth/tests/test__regional_access_boundary_utils.py
+++ b/packages/google-auth/tests/test__regional_access_boundary_utils.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import datetime
+import logging
 from unittest import mock
 
 import pytest  # type: ignore
@@ -22,6 +23,21 @@ from google.auth import _helpers
 from google.auth import _regional_access_boundary_utils
 from google.auth import credentials
 from google.oauth2 import credentials as oauth2_credentials
+
+
+@pytest.fixture
+def rab_caplog(caplog):
+    """Fixture to configure logging capture and ensure propagation for RAB utilities."""
+
+    caplog.set_level(logging.INFO, logger="google.auth._regional_access_boundary_utils")
+
+    google_logger = logging.getLogger("google")
+    original_propagate = google_logger.propagate
+    google_logger.propagate = True
+    try:
+        yield caplog
+    finally:
+        google_logger.propagate = original_propagate
 
 
 class CredentialsImpl(credentials.CredentialsWithRegionalAccessBoundary):
@@ -379,7 +395,7 @@ class TestCredentialsWithRegionalAccessBoundary(object):
         assert rab_manager._data.cooldown_expiry is None
 
     @mock.patch.object(CredentialsImpl, "_lookup_regional_access_boundary")
-    def test_lookup_regional_access_boundary_failure(self, mock_lookup_rab):
+    def test_lookup_regional_access_boundary_failure(self, mock_lookup_rab, rab_caplog):
         creds = CredentialsImpl()
         request = mock.Mock()
         rab_manager = _regional_access_boundary_utils._RegionalAccessBoundaryManager()
@@ -395,6 +411,14 @@ class TestCredentialsWithRegionalAccessBoundary(object):
         assert rab_manager._data.encoded_locations is None
         assert rab_manager._data.expiry is None
         assert rab_manager._data.cooldown_expiry is not None
+
+        assert (
+            "Regional Access Boundary lookup failed. Entering cooldown."
+            in rab_caplog.text
+        )
+        # RAB failures should be logged at INFO level.
+        warning_logs = [t for t in rab_caplog.record_tuples if t[1] == logging.WARNING]
+        assert not warning_logs, f"Unexpected warnings emitted: {warning_logs}"
 
     def test_lookup_regional_access_boundary_null_url(self):
         creds = oauth2_credentials.Credentials(token="token")
@@ -441,7 +465,9 @@ class TestCredentialsWithRegionalAccessBoundary(object):
         assert rab_manager._data.cooldown_expiry is None
 
     @mock.patch("google.auth._helpers.utcnow")
-    def test_regional_access_boundary_refresh_thread_run_failure(self, mock_utcnow):
+    def test_regional_access_boundary_refresh_thread_run_failure(
+        self, mock_utcnow, rab_caplog
+    ):
         mock_now = datetime.datetime(2025, 1, 1, 12, 0, 0)
         mock_utcnow.return_value = mock_now
 
@@ -465,6 +491,18 @@ class TestCredentialsWithRegionalAccessBoundary(object):
         expected_cooldown_expiry = mock_now + initial_cooldown
         assert rab_manager._data.cooldown_expiry == expected_cooldown_expiry
         assert rab_manager._data.cooldown_duration == initial_cooldown * 2
+
+        assert (
+            "Asynchronous Regional Access Boundary lookup raised an exception"
+            in rab_caplog.text
+        )
+        assert (
+            "Regional Access Boundary lookup failed. Entering cooldown."
+            in rab_caplog.text
+        )
+        # RAB failures should be logged at INFO level.
+        warning_logs = [t for t in rab_caplog.record_tuples if t[1] == logging.WARNING]
+        assert not warning_logs, f"Unexpected warnings emitted: {warning_logs}"
 
     @mock.patch("google.auth._helpers.utcnow")
     def test_regional_access_boundary_refresh_thread_run_failure_hard_expiry(

--- a/packages/google-auth/tests/test__regional_access_boundary_utils.py
+++ b/packages/google-auth/tests/test__regional_access_boundary_utils.py
@@ -414,13 +414,12 @@ class TestCredentialsWithRegionalAccessBoundary(object):
         assert rab_manager._data.expiry is None
         assert rab_manager._data.cooldown_expiry is not None
 
-        assert (
-            "Regional Access Boundary lookup failed. Entering cooldown."
-            in rab_caplog.text
+        # RAB failures should be logged at DEBUG level.
+        assert any(
+            t[1] == logging.DEBUG
+            and "Regional Access Boundary lookup failed. Entering cooldown." in t[2]
+            for t in rab_caplog.record_tuples
         )
-        # RAB failures should be logged at INFO level.
-        warning_logs = [t for t in rab_caplog.record_tuples if t[1] == logging.WARNING]
-        assert not warning_logs, f"Unexpected warnings emitted: {warning_logs}"
 
     def test_lookup_regional_access_boundary_null_url(self):
         creds = oauth2_credentials.Credentials(token="token")
@@ -494,17 +493,17 @@ class TestCredentialsWithRegionalAccessBoundary(object):
         assert rab_manager._data.cooldown_expiry == expected_cooldown_expiry
         assert rab_manager._data.cooldown_duration == initial_cooldown * 2
 
-        assert (
-            "Asynchronous Regional Access Boundary lookup raised an exception"
-            in rab_caplog.text
+        # RAB failures should be logged at DEBUG level.
+        assert any(
+            t[1] == logging.DEBUG
+            and "Asynchronous Regional Access Boundary lookup raised an exception" in t[2]
+            for t in rab_caplog.record_tuples
         )
-        assert (
-            "Regional Access Boundary lookup failed. Entering cooldown."
-            in rab_caplog.text
+        assert any(
+            t[1] == logging.DEBUG
+            and "Regional Access Boundary lookup failed. Entering cooldown." in t[2]
+            for t in rab_caplog.record_tuples
         )
-        # RAB failures should be logged at INFO level.
-        warning_logs = [t for t in rab_caplog.record_tuples if t[1] == logging.WARNING]
-        assert not warning_logs, f"Unexpected warnings emitted: {warning_logs}"
 
     @mock.patch("google.auth._helpers.utcnow")
     def test_regional_access_boundary_refresh_thread_run_failure_hard_expiry(

--- a/packages/google-auth/tests/test__regional_access_boundary_utils.py
+++ b/packages/google-auth/tests/test__regional_access_boundary_utils.py
@@ -496,7 +496,8 @@ class TestCredentialsWithRegionalAccessBoundary(object):
         # RAB failures should be logged at DEBUG level.
         assert any(
             t[1] == logging.DEBUG
-            and "Asynchronous Regional Access Boundary lookup raised an exception" in t[2]
+            and "Asynchronous Regional Access Boundary lookup raised an exception"
+            in t[2]
             for t in rab_caplog.record_tuples
         )
         assert any(

--- a/packages/google-auth/tests_async/test__regional_access_boundary_utils.py
+++ b/packages/google-auth/tests_async/test__regional_access_boundary_utils.py
@@ -195,7 +195,7 @@ def test_async_refresh_manager_pickle():
 
 
 @pytest.mark.asyncio
-async def test_async_worker_exception_logging_enabled(monkeypatch):
+async def test_async_worker_exception_logging():
     credentials = mock.AsyncMock()
     credentials._lookup_regional_access_boundary.side_effect = Exception("lookup fail")
 
@@ -203,55 +203,18 @@ async def test_async_worker_exception_logging_enabled(monkeypatch):
     request._clone.return_value = request
     rab_manager = mock.Mock()
 
-    # Force is_logging_enabled to return True
-    monkeypatch.setattr(
-        _regional_access_boundary_utils._helpers,
-        "is_logging_enabled",
-        lambda logger: True,
-    )
-
     manager = (
         _regional_access_boundary_utils._AsyncRegionalAccessBoundaryRefreshManager()
     )
 
     with mock.patch.object(
-        _regional_access_boundary_utils._LOGGER, "warning"
-    ) as mock_warning:
+        _regional_access_boundary_utils._LOGGER, "info"
+    ) as mock_info:
         manager.start_refresh(credentials, request, rab_manager)
         await manager._worker_task
 
-        mock_warning.assert_called_once()
-        assert "lookup raised an exception" in mock_warning.call_args[0][0]
-        rab_manager.process_regional_access_boundary_info.assert_called_once_with(None)
-
-
-@pytest.mark.asyncio
-async def test_async_worker_exception_logging_disabled(monkeypatch):
-    credentials = mock.AsyncMock()
-    credentials._lookup_regional_access_boundary.side_effect = Exception("lookup fail")
-
-    request = mock.Mock()
-    request._clone.return_value = request
-    rab_manager = mock.Mock()
-
-    # Force is_logging_enabled to return False
-    monkeypatch.setattr(
-        _regional_access_boundary_utils._helpers,
-        "is_logging_enabled",
-        lambda logger: False,
-    )
-
-    manager = (
-        _regional_access_boundary_utils._AsyncRegionalAccessBoundaryRefreshManager()
-    )
-
-    with mock.patch.object(
-        _regional_access_boundary_utils._LOGGER, "warning"
-    ) as mock_warning:
-        manager.start_refresh(credentials, request, rab_manager)
-        await manager._worker_task
-
-        mock_warning.assert_not_called()
+        mock_info.assert_called_once()
+        assert "lookup raised an exception" in mock_info.call_args[0][0]
         rab_manager.process_regional_access_boundary_info.assert_called_once_with(None)
 
 

--- a/packages/google-auth/tests_async/test__regional_access_boundary_utils.py
+++ b/packages/google-auth/tests_async/test__regional_access_boundary_utils.py
@@ -208,13 +208,13 @@ async def test_async_worker_exception_logging():
     )
 
     with mock.patch.object(
-        _regional_access_boundary_utils._LOGGER, "info"
-    ) as mock_info:
+        _regional_access_boundary_utils._LOGGER, "debug"
+    ) as mock_debug:
         manager.start_refresh(credentials, request, rab_manager)
         await manager._worker_task
 
-        mock_info.assert_called_once()
-        assert "lookup raised an exception" in mock_info.call_args[0][0]
+        mock_debug.assert_called_once()
+        assert "lookup raised an exception" in mock_debug.call_args[0][0]
         rab_manager.process_regional_access_boundary_info.assert_called_once_with(None)
 
 


### PR DESCRIPTION
When the library tries to look up Regional Access Boundaries in the background and fails, it used to print a "WARNING" message. Because these lookups are optional and failing is not considered fatal or blocking, omitting warnings creates a lot of log noise for the users. This change lowers those messages to the "DEBUG" level so they stay out of the way by default.

fixes #17515 