### PR TITLE
ci(google-auth): separate core vs extras lower-bound constraints

### DIFF
--- a/packages/google-auth/noxfile.py
+++ b/packages/google-auth/noxfile.py
@@ -159,12 +159,12 @@ def mypy(session):
 
 
 @nox.session(python=ALL_PYTHON)
-@nox.parametrize(["install_deprecated_extras"], (True, False))
-def unit(session, install_deprecated_extras):
+@nox.parametrize(["install_extras"], (True, False))
+def unit(session, install_extras):
     # Install all test dependencies, then install this package in-place.
 
     min_py, max_py = UNIT_TEST_PYTHON_VERSIONS[0], UNIT_TEST_PYTHON_VERSIONS[-1]
-    if not install_deprecated_extras and session.python not in (min_py, max_py):
+    if not install_extras and session.python not in (min_py, max_py):
         # only run double tests on first and last supported versions
         session.skip(
             f"Extended tests only run on boundary Python versions ({min_py}, {max_py}) to reduce CI load."
@@ -177,7 +177,7 @@ def unit(session, install_deprecated_extras):
         CURRENT_DIRECTORY / "testing" / f"constraints-extras-{session.python}.txt"
     )
 
-    if install_deprecated_extras:
+    if install_extras:
         # rsa and oauth2client were both archived and support dropped,
         # but we still  test old code paths
         session.install("oauth2client")
@@ -188,7 +188,7 @@ def unit(session, install_deprecated_extras):
     install_args = ["-e", extra_str]
     if constraints_path.exists():
         install_args.extend(["-c", str(constraints_path)])
-    if install_deprecated_extras and extras_constraints_path.exists():
+    if install_extras and extras_constraints_path.exists():
         install_args.extend(["-c", str(extras_constraints_path)])
 
     session.install(*install_args)

--- a/packages/google-auth/noxfile.py
+++ b/packages/google-auth/noxfile.py
@@ -177,19 +177,19 @@ def unit(session, install_extras):
         CURRENT_DIRECTORY / "testing" / f"constraints-extras-{session.python}.txt"
     )
 
+    install_args = []
     if install_extras:
         # rsa and oauth2client were both archived and support dropped,
         # but we still  test old code paths
         session.install("oauth2client")
-        extra_str = ".[testing,enterprise_cert,rsa]"
+        install_args.extend(["-e", ".[testing,enterprise_cert,rsa]"])
+        if extras_constraints_path.exists():
+            install_args.extend(["-c", str(extras_constraints_path)])
     else:
-        extra_str = ".[testing]"
+        install_args.extend(["-e", ".[testing]"])
 
-    install_args = ["-e", extra_str]
     if constraints_path.exists():
         install_args.extend(["-c", str(constraints_path)])
-    if install_extras and extras_constraints_path.exists():
-        install_args.extend(["-c", str(extras_constraints_path)])
 
     session.install(*install_args)
     session.run(

--- a/packages/google-auth/noxfile.py
+++ b/packages/google-auth/noxfile.py
@@ -159,35 +159,37 @@ def mypy(session):
 
 
 @nox.session(python=ALL_PYTHON)
-@nox.parametrize(["install_extras"], (True, False))
-def unit(session, install_extras):
+@nox.parametrize(["install_deprecated_extras"], (True, False))
+def unit(session, install_deprecated_extras):
     # Install all test dependencies, then install this package in-place.
 
     min_py, max_py = UNIT_TEST_PYTHON_VERSIONS[0], UNIT_TEST_PYTHON_VERSIONS[-1]
-    if not install_extras and session.python not in (min_py, max_py):
+    if not install_deprecated_extras and session.python not in (min_py, max_py):
         # only run double tests on first and last supported versions
         session.skip(
             f"Extended tests only run on boundary Python versions ({min_py}, {max_py}) to reduce CI load."
         )
 
-    core_constraints = (
+    constraints_path = (
         CURRENT_DIRECTORY / "testing" / f"constraints-{session.python}.txt"
     )
-    extras_constraints = (
+    extras_constraints_path = (
         CURRENT_DIRECTORY / "testing" / f"constraints-extras-{session.python}.txt"
     )
 
-    install_args = ["-e"]
-    if install_extras:
+    if install_deprecated_extras:
+        # rsa and oauth2client were both archived and support dropped,
+        # but we still  test old code paths
         session.install("oauth2client")
-        install_args.append(".[testing,enterprise_cert,rsa]")
+        extra_str = ".[testing,enterprise_cert,rsa]"
     else:
-        install_args.append(".[testing]")
+        extra_str = ".[testing]"
 
-    if core_constraints.exists():
-        install_args.extend(["-c", str(core_constraints)])
-    if install_extras and extras_constraints.exists():
-        install_args.extend(["-c", str(extras_constraints)])
+    install_args = ["-e", extra_str]
+    if constraints_path.exists():
+        install_args.extend(["-c", str(constraints_path)])
+    if install_deprecated_extras and extras_constraints_path.exists():
+        install_args.extend(["-c", str(extras_constraints_path)])
 
     session.install(*install_args)
     session.run(

--- a/packages/google-auth/noxfile.py
+++ b/packages/google-auth/noxfile.py
@@ -159,27 +159,37 @@ def mypy(session):
 
 
 @nox.session(python=ALL_PYTHON)
-@nox.parametrize(["install_deprecated_extras"], (True, False))
-def unit(session, install_deprecated_extras):
+@nox.parametrize(["install_extras"], (True, False))
+def unit(session, install_extras):
     # Install all test dependencies, then install this package in-place.
 
     min_py, max_py = UNIT_TEST_PYTHON_VERSIONS[0], UNIT_TEST_PYTHON_VERSIONS[-1]
-    if not install_deprecated_extras and session.python not in (min_py, max_py):
+    if not install_extras and session.python not in (min_py, max_py):
         # only run double tests on first and last supported versions
         session.skip(
             f"Extended tests only run on boundary Python versions ({min_py}, {max_py}) to reduce CI load."
         )
 
-    constraints_path = str(
+    core_constraints = (
         CURRENT_DIRECTORY / "testing" / f"constraints-{session.python}.txt"
     )
-    extras_str = "testing"
-    if install_deprecated_extras:
-        # rsa and oauth2client were both archived and support dropped,
-        # but we still  test old code paths
+    extras_constraints = (
+        CURRENT_DIRECTORY / "testing" / f"constraints-extras-{session.python}.txt"
+    )
+
+    install_args = ["-e"]
+    if install_extras:
         session.install("oauth2client")
-        extras_str += ",rsa"
-    session.install("-e", f".[{extras_str}]", "-c", constraints_path)
+        install_args.append(".[testing,enterprise_cert,rsa]")
+    else:
+        install_args.append(".[testing]")
+
+    if core_constraints.exists():
+        install_args.extend(["-c", str(core_constraints)])
+    if install_extras and extras_constraints.exists():
+        install_args.extend(["-c", str(extras_constraints)])
+
+    session.install(*install_args)
     session.run(
         "pytest",
         f"--junitxml=unit_{session.python}_sponge_log.xml",

--- a/packages/google-auth/setup.py
+++ b/packages/google-auth/setup.py
@@ -56,18 +56,23 @@ grpc_extra_require = [
 
 # Unit test requirements.
 testing_extra_require = [
+    # gRPC extra
     *grpc_extra_require,
+    # PyJWT extra
+    *pyjwt_extra_require,
+    # Reauth extra
+    *reauth_extra_require,
+    # urllib3 extra
+    *urllib3_extra_require,
+    # aiohttp extra
+    *aiohttp_extra_require,
+    # Test runners & mocks
     "flask",
     "freezegun",
-    *pyjwt_extra_require,
     "pytest",
     "pytest-cov",
     "pytest-localserver",
-    *reauth_extra_require,
     "responses",
-    *urllib3_extra_require,
-    # Async Dependencies
-    *aiohttp_extra_require,
     "aioresponses",
     "pytest-asyncio",
 ]

--- a/packages/google-auth/setup.py
+++ b/packages/google-auth/setup.py
@@ -56,23 +56,18 @@ grpc_extra_require = [
 
 # Unit test requirements.
 testing_extra_require = [
-    # gRPC extra
     *grpc_extra_require,
-    # PyJWT extra
-    *pyjwt_extra_require,
-    # Reauth extra
-    *reauth_extra_require,
-    # urllib3 extra
-    *urllib3_extra_require,
-    # aiohttp extra
-    *aiohttp_extra_require,
-    # Test runners & mocks
     "flask",
     "freezegun",
+    *pyjwt_extra_require,
     "pytest",
     "pytest-cov",
     "pytest-localserver",
+    *reauth_extra_require,
     "responses",
+    *urllib3_extra_require,
+    # Async Dependencies
+    *aiohttp_extra_require,
     "aioresponses",
     "pytest-asyncio",
 ]

--- a/packages/google-auth/testing/constraints-3.10.txt
+++ b/packages/google-auth/testing/constraints-3.10.txt
@@ -8,10 +8,3 @@
 pyasn1-modules==0.2.1
 setuptools==40.3.0
 cryptography==38.0.3
-aiohttp==3.8.0
-requests==2.30.0
-pyjwt==2.0
-grpcio==1.59.0
-urllib3==1.26.15
-packaging==20.0
-rsa==4.0.0

--- a/packages/google-auth/testing/constraints-3.11.txt
+++ b/packages/google-auth/testing/constraints-3.11.txt
@@ -1,3 +1,9 @@
-# Lower-bound constraints for Python 3.11 core dependencies.
+# This constraints file is used to check that lower bounds
+# are correct in setup.py
+# List *all* library dependencies and extras in this file.
+# Pin the version to the lower bound.
+#
+# e.g., if setup.py has "foo >= 1.14.0, < 2.0.0dev",
+# Then this file should have foo==1.14.0
 pyasn1-modules==0.2.1
 cryptography==38.0.3

--- a/packages/google-auth/testing/constraints-3.11.txt
+++ b/packages/google-auth/testing/constraints-3.11.txt
@@ -1,1 +1,3 @@
-urllib3>2.0.0
+# Lower-bound constraints for Python 3.11 core dependencies.
+pyasn1-modules==0.2.1
+cryptography==38.0.3

--- a/packages/google-auth/testing/constraints-3.11.txt
+++ b/packages/google-auth/testing/constraints-3.11.txt
@@ -5,5 +5,3 @@
 #
 # e.g., if setup.py has "foo >= 1.14.0, < 2.0.0dev",
 # Then this file should have foo==1.14.0
-pyasn1-modules==0.2.1
-cryptography==38.0.3

--- a/packages/google-auth/testing/constraints-3.12.txt
+++ b/packages/google-auth/testing/constraints-3.12.txt
@@ -1,3 +1,9 @@
-# Lower-bound constraints for Python 3.12 core dependencies.
+# This constraints file is used to check that lower bounds
+# are correct in setup.py
+# List *all* library dependencies and extras in this file.
+# Pin the version to the lower bound.
+#
+# e.g., if setup.py has "foo >= 1.14.0, < 2.0.0dev",
+# Then this file should have foo==1.14.0
 pyasn1-modules==0.2.1
 cryptography==38.0.3

--- a/packages/google-auth/testing/constraints-3.12.txt
+++ b/packages/google-auth/testing/constraints-3.12.txt
@@ -1,1 +1,3 @@
-urllib3>2.0.0
+# Lower-bound constraints for Python 3.12 core dependencies.
+pyasn1-modules==0.2.1
+cryptography==38.0.3

--- a/packages/google-auth/testing/constraints-3.12.txt
+++ b/packages/google-auth/testing/constraints-3.12.txt
@@ -5,5 +5,3 @@
 #
 # e.g., if setup.py has "foo >= 1.14.0, < 2.0.0dev",
 # Then this file should have foo==1.14.0
-pyasn1-modules==0.2.1
-cryptography==38.0.3

--- a/packages/google-auth/testing/constraints-3.13.txt
+++ b/packages/google-auth/testing/constraints-3.13.txt
@@ -1,0 +1,3 @@
+# Lower-bound constraints for Python 3.13 core dependencies.
+pyasn1-modules==0.2.1
+cryptography==38.0.3

--- a/packages/google-auth/testing/constraints-3.13.txt
+++ b/packages/google-auth/testing/constraints-3.13.txt
@@ -5,5 +5,3 @@
 #
 # e.g., if setup.py has "foo >= 1.14.0, < 2.0.0dev",
 # Then this file should have foo==1.14.0
-pyasn1-modules==0.2.1
-cryptography==38.0.3

--- a/packages/google-auth/testing/constraints-3.13.txt
+++ b/packages/google-auth/testing/constraints-3.13.txt
@@ -1,3 +1,9 @@
-# Lower-bound constraints for Python 3.13 core dependencies.
+# This constraints file is used to check that lower bounds
+# are correct in setup.py
+# List *all* library dependencies and extras in this file.
+# Pin the version to the lower bound.
+#
+# e.g., if setup.py has "foo >= 1.14.0, < 2.0.0dev",
+# Then this file should have foo==1.14.0
 pyasn1-modules==0.2.1
 cryptography==38.0.3

--- a/packages/google-auth/testing/constraints-3.14.txt
+++ b/packages/google-auth/testing/constraints-3.14.txt
@@ -7,4 +7,3 @@
 # Then this file should have foo==1.14.0
 pyasn1-modules==0.2.1
 cryptography==41.0.5
-aiohttp==3.9.0

--- a/packages/google-auth/testing/constraints-extras-3.10.txt
+++ b/packages/google-auth/testing/constraints-extras-3.10.txt
@@ -1,0 +1,10 @@
+# Lower-bound constraints for Python 3.10 optional extras & test dependencies.
+aiohttp==3.8.0
+requests==2.30.0
+pyjwt==2.0
+grpcio==1.59.0
+urllib3==1.26.15
+packaging==20.0
+pyu2f==0.1.5
+rsa==4.0.0
+oauth2client==4.1.3

--- a/packages/google-auth/testing/constraints-extras-3.10.txt
+++ b/packages/google-auth/testing/constraints-extras-3.10.txt
@@ -1,4 +1,10 @@
-# Lower-bound constraints for Python 3.10 optional extras & test dependencies.
+# This constraints file is used to check that lower bounds
+# are correct in setup.py
+# List *all* library dependencies and extras in this file.
+# Pin the version to the lower bound.
+#
+# e.g., if setup.py has "foo >= 1.14.0, < 2.0.0dev",
+# Then this file should have foo==1.14.0
 aiohttp==3.8.0
 requests==2.30.0
 pyjwt==2.0

--- a/packages/google-auth/testing/constraints-extras-3.10.txt
+++ b/packages/google-auth/testing/constraints-extras-3.10.txt
@@ -5,12 +5,12 @@
 #
 # e.g., if setup.py has "foo >= 1.14.0, < 2.0.0dev",
 # Then this file should have foo==1.14.0
-aiohttp==3.8.0
-requests==2.30.0
-pyjwt==2.0
-grpcio==1.59.0
-urllib3==1.26.15
-packaging==20.0
-pyu2f==0.1.5
-rsa==4.0.0
-oauth2client==4.1.3
+aiohttp==3.8.0 # aiohttp extra
+requests==2.30.0 # requests extra
+pyjwt==2.0 # pyjwt extra
+grpcio==1.59.0 # grpc extra
+urllib3==1.26.15 # urllib3 extra
+packaging==20.0 # urllib3 extra
+pyu2f==0.1.5 # reauth extra
+rsa==4.0.0 # rsa extra
+oauth2client==4.1.3 # deprecated test dependency

--- a/packages/google-auth/testing/constraints-extras-3.14.txt
+++ b/packages/google-auth/testing/constraints-extras-3.14.txt
@@ -5,12 +5,12 @@
 #
 # e.g., if setup.py has "foo >= 1.14.0, < 2.0.0dev",
 # Then this file should have foo==1.14.0
-aiohttp==3.9.0
-requests==2.30.0
-pyjwt==2.0
-grpcio==1.75.1
-urllib3==1.26.15
-packaging==20.0
-pyu2f==0.1.5
-rsa==4.0.0
-oauth2client==4.1.3
+aiohttp==3.9.0 # aiohttp extra
+requests==2.30.0 # requests extra
+pyjwt==2.0 # pyjwt extra
+grpcio==1.75.1 # grpc extra
+urllib3==1.26.15 # urllib3 extra
+packaging==20.0 # urllib3 extra
+pyu2f==0.1.5 # reauth extra
+rsa==4.0.0 # rsa extra
+oauth2client==4.1.3 # deprecated test dependency

--- a/packages/google-auth/testing/constraints-extras-3.14.txt
+++ b/packages/google-auth/testing/constraints-extras-3.14.txt
@@ -1,0 +1,10 @@
+# Lower-bound constraints for Python 3.14 optional extras & test dependencies.
+aiohttp==3.9.0
+requests==2.30.0
+pyjwt==2.0
+grpcio==1.75.1
+urllib3==2.0.0
+packaging==20.0
+pyu2f==0.1.5
+rsa==4.0.0
+oauth2client==4.1.3

--- a/packages/google-auth/testing/constraints-extras-3.14.txt
+++ b/packages/google-auth/testing/constraints-extras-3.14.txt
@@ -1,9 +1,15 @@
-# Lower-bound constraints for Python 3.14 optional extras & test dependencies.
+# This constraints file is used to check that lower bounds
+# are correct in setup.py
+# List *all* library dependencies and extras in this file.
+# Pin the version to the lower bound.
+#
+# e.g., if setup.py has "foo >= 1.14.0, < 2.0.0dev",
+# Then this file should have foo==1.14.0
 aiohttp==3.9.0
 requests==2.30.0
 pyjwt==2.0
 grpcio==1.75.1
-urllib3==2.0.0
+urllib3==1.26.15
 packaging==20.0
 pyu2f==0.1.5
 rsa==4.0.0


### PR DESCRIPTION
Core vs. Extras Constraints Separation:
- `constraints-*.txt`: Core lower bounds only (pyasn1-modules, cryptography).
- `constraints-extras-*.txt`: Extras lower bounds (aiohttp, grpcio, requests, pyjwt, urllib3, packaging, rsa, etc.).