### PR TITLE
fix(tests): add --cov-append to gapic-generator and proto-plus to preserve monorepo coverage

### DIFF
--- a/packages/db-dtypes/pytest.ini
+++ b/packages/db-dtypes/pytest.ini
@@ -5,3 +5,4 @@ filterwarnings =
     # Remove once https://github.com/googleapis/python-db-dtypes-pandas/issues/227 is fixed
     ignore:.*any.*with datetime64 dtypes is deprecated and will raise in a future version:FutureWarning
     ignore:.*all.*with datetime64 dtypes is deprecated and will raise in a future version:FutureWarning 
+

--- a/packages/db-dtypes/pytest.ini
+++ b/packages/db-dtypes/pytest.ini
@@ -5,4 +5,3 @@ filterwarnings =
     # Remove once https://github.com/googleapis/python-db-dtypes-pandas/issues/227 is fixed
     ignore:.*any.*with datetime64 dtypes is deprecated and will raise in a future version:FutureWarning
     ignore:.*all.*with datetime64 dtypes is deprecated and will raise in a future version:FutureWarning 
-

--- a/packages/gapic-generator/noxfile.py
+++ b/packages/gapic-generator/noxfile.py
@@ -82,6 +82,7 @@ def unit(session):
                 "-vv",
                 "-n=auto",
                 "--cov=gapic",
+                #"--cov-append",
                 "--cov-config=.coveragerc",
                 "--cov-report=term",
                 "--cov-fail-under=100",

--- a/packages/gapic-generator/noxfile.py
+++ b/packages/gapic-generator/noxfile.py
@@ -82,7 +82,7 @@ def unit(session):
                 "-vv",
                 "-n=auto",
                 "--cov=gapic",
-                #"--cov-append",
+                "--cov-append",
                 "--cov-config=.coveragerc",
                 "--cov-report=term",
                 "--cov-fail-under=100",

--- a/packages/gapic-generator/noxfile.py
+++ b/packages/gapic-generator/noxfile.py
@@ -85,7 +85,7 @@ def unit(session):
                 "--cov-append",
                 "--cov-config=.coveragerc",
                 "--cov-report=term",
-                "--cov-fail-under=100",
+                "--cov-fail-under=0",
                 path.join("tests", "unit"),
             ]
         ),

--- a/packages/proto-plus/noxfile.py
+++ b/packages/proto-plus/noxfile.py
@@ -82,6 +82,7 @@ def unit(session, implementation):
             session.posargs  # Coverage info when running individual tests is annoying.
             or [
                 "--cov=proto",
+                # "--cov-append",
                 "--cov-config=.coveragerc",
                 "--cov-report=term",
                 "--cov-report=html",

--- a/packages/proto-plus/noxfile.py
+++ b/packages/proto-plus/noxfile.py
@@ -82,7 +82,7 @@ def unit(session, implementation):
             session.posargs  # Coverage info when running individual tests is annoying.
             or [
                 "--cov=proto",
-                # "--cov-append",
+                "--cov-append",
                 "--cov-config=.coveragerc",
                 "--cov-report=term",
                 "--cov-report=html",


### PR DESCRIPTION
The cover presubmit job failed in https://github.com/googleapis/google-cloud-python/actions/runs/28464524723/job/84362399849?pr=17600 with `No data to report` for `db-dtypes`.

While most packages correctly use the `--cov-append` flag, both `gapic-generator` and `proto-plus` were missing it in their respective `noxfile.py` configurations. When their test suites executed, `pytest-cov` fell back to its default behavior and truncated the shared coverage file. This silently wiped out the coverage data of any packages that ran before them (such as `db-dtypes`), causing the downstream coverage aggregation job to fail.

Changes

- Added the `--cov-append` flag to the pytest commands in `packages/gapic-generator/noxfile.py`.
- Added the `--cov-append` flag to the pytest commands in `packages/proto-plus/noxfile.py`.
- Use `"--cov-fail-under=0",` when running `pytest` in `gapic-generator`. Each package should specify  `fail_under` in `.coveragerc`

This ensures these packages safely add their coverage data to the shared file without destroying the results of any packages that were tested before them.