### PR TITLE
chore(tests): adjust coverage thresholds to realistic levels and/or rely on the default value

### DIFF
--- a/packages/django-google-spanner/.coveragerc
+++ b/packages/django-google-spanner/.coveragerc
@@ -10,7 +10,7 @@
 branch = True
 
 [report]
-fail_under = 100
+fail_under = 80
 show_missing = True
 exclude_lines =
     # Re-enable the standard pragma

--- a/packages/django-google-spanner/noxfile.py
+++ b/packages/django-google-spanner/noxfile.py
@@ -225,7 +225,7 @@ def cover(session):
     test runs (not system test runs), and then erases coverage data.
     """
     session.install("coverage", "pytest-cov")
-    session.run("coverage", "report", "--show-missing", "--fail-under=80")
+    session.run("coverage", "report", "--show-missing")
 
     session.run("coverage", "erase")
 

--- a/packages/google-api-core/.coveragerc
+++ b/packages/google-api-core/.coveragerc
@@ -2,7 +2,7 @@
 branch = True
 
 [report]
-fail_under = 100
+fail_under = 99
 show_missing = True
 exclude_lines =
     # Re-enable the standard pragma

--- a/packages/google-api-core/noxfile.py
+++ b/packages/google-api-core/noxfile.py
@@ -381,7 +381,7 @@ def cover(session):
     test runs (not system test runs), and then erases coverage data.
     """
     session.install("coverage", "pytest-cov")
-    session.run("coverage", "report", "--show-missing", "--fail-under=100")
+    session.run("coverage", "report", "--show-missing")
     session.run("coverage", "erase")
 
 

--- a/packages/google-cloud-ndb/.coveragerc
+++ b/packages/google-cloud-ndb/.coveragerc
@@ -2,7 +2,7 @@
 branch = True
 
 [report]
-fail_under = 100
+fail_under = 99
 show_missing = True
 exclude_lines =
     # Re-enable the standard pragma

--- a/packages/google-cloud-ndb/noxfile.py
+++ b/packages/google-cloud-ndb/noxfile.py
@@ -185,7 +185,7 @@ def cover(session):
     test runs (not system test runs), and then erases coverage data.
     """
     session.install("coverage", "pytest-cov")
-    session.run("coverage", "report", "--show-missing", "--fail-under=100")
+    session.run("coverage", "report", "--show-missing")
 
     session.run("coverage", "erase")
 

--- a/packages/sqlalchemy-bigquery/.coveragerc
+++ b/packages/sqlalchemy-bigquery/.coveragerc
@@ -22,7 +22,7 @@ omit =
   sqlalchemy_bigquery/requirements.py
 
 [report]
-fail_under = 100
+fail_under = 98
 show_missing = True
 exclude_lines =
     # Re-enable the standard pragma

--- a/packages/sqlalchemy-bigquery/noxfile.py
+++ b/packages/sqlalchemy-bigquery/noxfile.py
@@ -467,7 +467,7 @@ def cover(session):
     test runs (not system test runs), and then erases coverage data.
     """
     session.install("coverage", "pytest-cov")
-    session.run("coverage", "report", "--show-missing", "--fail-under=100")
+    session.run("coverage", "report", "--show-missing")
 
     session.run("coverage", "erase")
 


### PR DESCRIPTION
> [!note]
> This PR is a blocker for https://github.com/googleapis/google-cloud-python/pull/17409

Lowered `fail_under` to realistic levels (based on the existing test coverage) in `.coveragerc` for:

* `django-google-spanner` (80)
* `sqlalchemy-bigquery` (98)
* `google-cloud-ndb` (99)
* `google-api-core` (99)

Removed hardcoded `--fail-under` flags from `noxfile.py` to ensure local runs match CI/CD configuration.