### PR TITLE
chore(generator): use absolute paths in `__lazy_modules__`

### DIFF
--- a/packages/gapic-generator/gapic/templates/%namespace/%name_%version/%sub/__init__.py.j2
+++ b/packages/gapic-generator/gapic/templates/%namespace/%name_%version/%sub/__init__.py.j2
@@ -18,18 +18,19 @@ from importlib import metadata
 # For more information, see:
 # https://docs.python.org/3.15/library/sys.html#sys.set_lazy_imports_filter
 # Older Python versions safely ignore this variable.
+# We use absolute paths (via package_path) rather than __name__ to avoid runtime evaluation overhead.
 __lazy_modules__ = {
     {% filter sort_lines -%}
     {% for subpackage, _ in api.subpackages|dictsort -%}
-    f"{__name__}.{{ subpackage }}",
+    "{{package_path}}.{{ subpackage }}",
     {% endfor -%}
     {% for service in api.services.values()
             if service.meta.address.subpackage == api.subpackage_view -%}
-    f"{__name__}.services.{{ service.name|snake_case }}",
+    "{{package_path}}.services.{{ service.name|snake_case }}",
     {% endfor -%}
     {% for proto in api.protos.values()
             if proto.meta.address.subpackage == api.subpackage_view -%}
-    f"{__name__}.types.{{ proto.module_name }}",
+    "{{package_path}}.types.{{ proto.module_name }}",
     {% endfor -%}
     {% endfilter %}
 }

--- a/packages/gapic-generator/gapic/templates/%namespace/%name_%version/%sub/__init__.py.j2
+++ b/packages/gapic-generator/gapic/templates/%namespace/%name_%version/%sub/__init__.py.j2
@@ -18,7 +18,6 @@ from importlib import metadata
 # For more information, see:
 # https://docs.python.org/3.15/library/sys.html#sys.set_lazy_imports_filter
 # Older Python versions safely ignore this variable.
-# We use absolute paths (via package_path) rather than __name__ to avoid runtime evaluation overhead.
 __lazy_modules__ = {
     {% filter sort_lines -%}
     {% for subpackage, _ in api.subpackages|dictsort -%}

--- a/packages/gapic-generator/gapic/templates/%namespace/%name_%version/%sub/__init__.py.j2
+++ b/packages/gapic-generator/gapic/templates/%namespace/%name_%version/%sub/__init__.py.j2
@@ -21,15 +21,15 @@ from importlib import metadata
 __lazy_modules__ = {
     {% filter sort_lines -%}
     {% for subpackage, _ in api.subpackages|dictsort -%}
-    "{{package_path}}.{{ subpackage }}",
+        "{{package_path}}.{{ subpackage }}",
     {% endfor -%}
     {% for service in api.services.values()
             if service.meta.address.subpackage == api.subpackage_view -%}
-    "{{package_path}}.services.{{ service.name|snake_case }}",
+        "{{package_path}}.services.{{ service.name|snake_case }}",
     {% endfor -%}
     {% for proto in api.protos.values()
             if proto.meta.address.subpackage == api.subpackage_view -%}
-    "{{package_path}}.types.{{ proto.module_name }}",
+        "{{package_path}}.types.{{ proto.module_name }}",
     {% endfor -%}
     {% endfilter %}
 }

--- a/packages/gapic-generator/tests/integration/goldens/asset/google/cloud/asset_v1/__init__.py
+++ b/packages/gapic-generator/tests/integration/goldens/asset/google/cloud/asset_v1/__init__.py
@@ -28,12 +28,11 @@ from importlib import metadata
 # For more information, see:
 # https://docs.python.org/3.15/library/sys.html#sys.set_lazy_imports_filter
 # Older Python versions safely ignore this variable.
-# We use absolute paths (via package_path) rather than __name__ to avoid runtime evaluation overhead.
 __lazy_modules__ = {
-"google.cloud.asset_v1.services.asset_service",
-"google.cloud.asset_v1.types.asset_enrichment_resourceowners",
-"google.cloud.asset_v1.types.asset_service",
-"google.cloud.asset_v1.types.assets",
+    "google.cloud.asset_v1.services.asset_service",
+    "google.cloud.asset_v1.types.asset_enrichment_resourceowners",
+    "google.cloud.asset_v1.types.asset_service",
+    "google.cloud.asset_v1.types.assets",
 }
 
 

--- a/packages/gapic-generator/tests/integration/goldens/asset/google/cloud/asset_v1/__init__.py
+++ b/packages/gapic-generator/tests/integration/goldens/asset/google/cloud/asset_v1/__init__.py
@@ -28,11 +28,12 @@ from importlib import metadata
 # For more information, see:
 # https://docs.python.org/3.15/library/sys.html#sys.set_lazy_imports_filter
 # Older Python versions safely ignore this variable.
+# We use absolute paths (via package_path) rather than __name__ to avoid runtime evaluation overhead.
 __lazy_modules__ = {
-f"{__name__}.services.asset_service",
-f"{__name__}.types.asset_enrichment_resourceowners",
-f"{__name__}.types.asset_service",
-f"{__name__}.types.assets",
+"google.cloud.asset_v1.services.asset_service",
+"google.cloud.asset_v1.types.asset_enrichment_resourceowners",
+"google.cloud.asset_v1.types.asset_service",
+"google.cloud.asset_v1.types.assets",
 }
 
 

--- a/packages/gapic-generator/tests/integration/goldens/credentials/google/iam/credentials_v1/__init__.py
+++ b/packages/gapic-generator/tests/integration/goldens/credentials/google/iam/credentials_v1/__init__.py
@@ -28,11 +28,10 @@ from importlib import metadata
 # For more information, see:
 # https://docs.python.org/3.15/library/sys.html#sys.set_lazy_imports_filter
 # Older Python versions safely ignore this variable.
-# We use absolute paths (via package_path) rather than __name__ to avoid runtime evaluation overhead.
 __lazy_modules__ = {
-"google.iam.credentials_v1.services.iam_credentials",
-"google.iam.credentials_v1.types.common",
-"google.iam.credentials_v1.types.iamcredentials",
+    "google.iam.credentials_v1.services.iam_credentials",
+    "google.iam.credentials_v1.types.common",
+    "google.iam.credentials_v1.types.iamcredentials",
 }
 
 

--- a/packages/gapic-generator/tests/integration/goldens/credentials/google/iam/credentials_v1/__init__.py
+++ b/packages/gapic-generator/tests/integration/goldens/credentials/google/iam/credentials_v1/__init__.py
@@ -28,10 +28,11 @@ from importlib import metadata
 # For more information, see:
 # https://docs.python.org/3.15/library/sys.html#sys.set_lazy_imports_filter
 # Older Python versions safely ignore this variable.
+# We use absolute paths (via package_path) rather than __name__ to avoid runtime evaluation overhead.
 __lazy_modules__ = {
-f"{__name__}.services.iam_credentials",
-f"{__name__}.types.common",
-f"{__name__}.types.iamcredentials",
+"google.iam.credentials_v1.services.iam_credentials",
+"google.iam.credentials_v1.types.common",
+"google.iam.credentials_v1.types.iamcredentials",
 }
 
 

--- a/packages/gapic-generator/tests/integration/goldens/eventarc/google/cloud/eventarc_v1/__init__.py
+++ b/packages/gapic-generator/tests/integration/goldens/eventarc/google/cloud/eventarc_v1/__init__.py
@@ -28,20 +28,21 @@ from importlib import metadata
 # For more information, see:
 # https://docs.python.org/3.15/library/sys.html#sys.set_lazy_imports_filter
 # Older Python versions safely ignore this variable.
+# We use absolute paths (via package_path) rather than __name__ to avoid runtime evaluation overhead.
 __lazy_modules__ = {
-f"{__name__}.services.eventarc",
-f"{__name__}.types.channel",
-f"{__name__}.types.channel_connection",
-f"{__name__}.types.discovery",
-f"{__name__}.types.enrollment",
-f"{__name__}.types.eventarc",
-f"{__name__}.types.google_api_source",
-f"{__name__}.types.google_channel_config",
-f"{__name__}.types.logging_config",
-f"{__name__}.types.message_bus",
-f"{__name__}.types.network_config",
-f"{__name__}.types.pipeline",
-f"{__name__}.types.trigger",
+"google.cloud.eventarc_v1.services.eventarc",
+"google.cloud.eventarc_v1.types.channel",
+"google.cloud.eventarc_v1.types.channel_connection",
+"google.cloud.eventarc_v1.types.discovery",
+"google.cloud.eventarc_v1.types.enrollment",
+"google.cloud.eventarc_v1.types.eventarc",
+"google.cloud.eventarc_v1.types.google_api_source",
+"google.cloud.eventarc_v1.types.google_channel_config",
+"google.cloud.eventarc_v1.types.logging_config",
+"google.cloud.eventarc_v1.types.message_bus",
+"google.cloud.eventarc_v1.types.network_config",
+"google.cloud.eventarc_v1.types.pipeline",
+"google.cloud.eventarc_v1.types.trigger",
 }
 
 

--- a/packages/gapic-generator/tests/integration/goldens/eventarc/google/cloud/eventarc_v1/__init__.py
+++ b/packages/gapic-generator/tests/integration/goldens/eventarc/google/cloud/eventarc_v1/__init__.py
@@ -28,21 +28,20 @@ from importlib import metadata
 # For more information, see:
 # https://docs.python.org/3.15/library/sys.html#sys.set_lazy_imports_filter
 # Older Python versions safely ignore this variable.
-# We use absolute paths (via package_path) rather than __name__ to avoid runtime evaluation overhead.
 __lazy_modules__ = {
-"google.cloud.eventarc_v1.services.eventarc",
-"google.cloud.eventarc_v1.types.channel",
-"google.cloud.eventarc_v1.types.channel_connection",
-"google.cloud.eventarc_v1.types.discovery",
-"google.cloud.eventarc_v1.types.enrollment",
-"google.cloud.eventarc_v1.types.eventarc",
-"google.cloud.eventarc_v1.types.google_api_source",
-"google.cloud.eventarc_v1.types.google_channel_config",
-"google.cloud.eventarc_v1.types.logging_config",
-"google.cloud.eventarc_v1.types.message_bus",
-"google.cloud.eventarc_v1.types.network_config",
-"google.cloud.eventarc_v1.types.pipeline",
-"google.cloud.eventarc_v1.types.trigger",
+    "google.cloud.eventarc_v1.services.eventarc",
+    "google.cloud.eventarc_v1.types.channel",
+    "google.cloud.eventarc_v1.types.channel_connection",
+    "google.cloud.eventarc_v1.types.discovery",
+    "google.cloud.eventarc_v1.types.enrollment",
+    "google.cloud.eventarc_v1.types.eventarc",
+    "google.cloud.eventarc_v1.types.google_api_source",
+    "google.cloud.eventarc_v1.types.google_channel_config",
+    "google.cloud.eventarc_v1.types.logging_config",
+    "google.cloud.eventarc_v1.types.message_bus",
+    "google.cloud.eventarc_v1.types.network_config",
+    "google.cloud.eventarc_v1.types.pipeline",
+    "google.cloud.eventarc_v1.types.trigger",
 }
 
 

--- a/packages/gapic-generator/tests/integration/goldens/logging/google/cloud/logging_v2/__init__.py
+++ b/packages/gapic-generator/tests/integration/goldens/logging/google/cloud/logging_v2/__init__.py
@@ -28,15 +28,14 @@ from importlib import metadata
 # For more information, see:
 # https://docs.python.org/3.15/library/sys.html#sys.set_lazy_imports_filter
 # Older Python versions safely ignore this variable.
-# We use absolute paths (via package_path) rather than __name__ to avoid runtime evaluation overhead.
 __lazy_modules__ = {
-"google.cloud.logging_v2.services.config_service_v2",
-"google.cloud.logging_v2.services.logging_service_v2",
-"google.cloud.logging_v2.services.metrics_service_v2",
-"google.cloud.logging_v2.types.log_entry",
-"google.cloud.logging_v2.types.logging",
-"google.cloud.logging_v2.types.logging_config",
-"google.cloud.logging_v2.types.logging_metrics",
+    "google.cloud.logging_v2.services.config_service_v2",
+    "google.cloud.logging_v2.services.logging_service_v2",
+    "google.cloud.logging_v2.services.metrics_service_v2",
+    "google.cloud.logging_v2.types.log_entry",
+    "google.cloud.logging_v2.types.logging",
+    "google.cloud.logging_v2.types.logging_config",
+    "google.cloud.logging_v2.types.logging_metrics",
 }
 
 

--- a/packages/gapic-generator/tests/integration/goldens/logging/google/cloud/logging_v2/__init__.py
+++ b/packages/gapic-generator/tests/integration/goldens/logging/google/cloud/logging_v2/__init__.py
@@ -28,14 +28,15 @@ from importlib import metadata
 # For more information, see:
 # https://docs.python.org/3.15/library/sys.html#sys.set_lazy_imports_filter
 # Older Python versions safely ignore this variable.
+# We use absolute paths (via package_path) rather than __name__ to avoid runtime evaluation overhead.
 __lazy_modules__ = {
-f"{__name__}.services.config_service_v2",
-f"{__name__}.services.logging_service_v2",
-f"{__name__}.services.metrics_service_v2",
-f"{__name__}.types.log_entry",
-f"{__name__}.types.logging",
-f"{__name__}.types.logging_config",
-f"{__name__}.types.logging_metrics",
+"google.cloud.logging_v2.services.config_service_v2",
+"google.cloud.logging_v2.services.logging_service_v2",
+"google.cloud.logging_v2.services.metrics_service_v2",
+"google.cloud.logging_v2.types.log_entry",
+"google.cloud.logging_v2.types.logging",
+"google.cloud.logging_v2.types.logging_config",
+"google.cloud.logging_v2.types.logging_metrics",
 }
 
 

--- a/packages/gapic-generator/tests/integration/goldens/logging_internal/google/cloud/logging_v2/__init__.py
+++ b/packages/gapic-generator/tests/integration/goldens/logging_internal/google/cloud/logging_v2/__init__.py
@@ -28,15 +28,14 @@ from importlib import metadata
 # For more information, see:
 # https://docs.python.org/3.15/library/sys.html#sys.set_lazy_imports_filter
 # Older Python versions safely ignore this variable.
-# We use absolute paths (via package_path) rather than __name__ to avoid runtime evaluation overhead.
 __lazy_modules__ = {
-"google.cloud.logging_v2.services.config_service_v2",
-"google.cloud.logging_v2.services.logging_service_v2",
-"google.cloud.logging_v2.services.metrics_service_v2",
-"google.cloud.logging_v2.types.log_entry",
-"google.cloud.logging_v2.types.logging",
-"google.cloud.logging_v2.types.logging_config",
-"google.cloud.logging_v2.types.logging_metrics",
+    "google.cloud.logging_v2.services.config_service_v2",
+    "google.cloud.logging_v2.services.logging_service_v2",
+    "google.cloud.logging_v2.services.metrics_service_v2",
+    "google.cloud.logging_v2.types.log_entry",
+    "google.cloud.logging_v2.types.logging",
+    "google.cloud.logging_v2.types.logging_config",
+    "google.cloud.logging_v2.types.logging_metrics",
 }
 
 

--- a/packages/gapic-generator/tests/integration/goldens/logging_internal/google/cloud/logging_v2/__init__.py
+++ b/packages/gapic-generator/tests/integration/goldens/logging_internal/google/cloud/logging_v2/__init__.py
@@ -28,14 +28,15 @@ from importlib import metadata
 # For more information, see:
 # https://docs.python.org/3.15/library/sys.html#sys.set_lazy_imports_filter
 # Older Python versions safely ignore this variable.
+# We use absolute paths (via package_path) rather than __name__ to avoid runtime evaluation overhead.
 __lazy_modules__ = {
-f"{__name__}.services.config_service_v2",
-f"{__name__}.services.logging_service_v2",
-f"{__name__}.services.metrics_service_v2",
-f"{__name__}.types.log_entry",
-f"{__name__}.types.logging",
-f"{__name__}.types.logging_config",
-f"{__name__}.types.logging_metrics",
+"google.cloud.logging_v2.services.config_service_v2",
+"google.cloud.logging_v2.services.logging_service_v2",
+"google.cloud.logging_v2.services.metrics_service_v2",
+"google.cloud.logging_v2.types.log_entry",
+"google.cloud.logging_v2.types.logging",
+"google.cloud.logging_v2.types.logging_config",
+"google.cloud.logging_v2.types.logging_metrics",
 }
 
 

--- a/packages/gapic-generator/tests/integration/goldens/redis/google/cloud/redis_v1/__init__.py
+++ b/packages/gapic-generator/tests/integration/goldens/redis/google/cloud/redis_v1/__init__.py
@@ -28,9 +28,10 @@ from importlib import metadata
 # For more information, see:
 # https://docs.python.org/3.15/library/sys.html#sys.set_lazy_imports_filter
 # Older Python versions safely ignore this variable.
+# We use absolute paths (via package_path) rather than __name__ to avoid runtime evaluation overhead.
 __lazy_modules__ = {
-f"{__name__}.services.cloud_redis",
-f"{__name__}.types.cloud_redis",
+"google.cloud.redis_v1.services.cloud_redis",
+"google.cloud.redis_v1.types.cloud_redis",
 }
 
 

--- a/packages/gapic-generator/tests/integration/goldens/redis/google/cloud/redis_v1/__init__.py
+++ b/packages/gapic-generator/tests/integration/goldens/redis/google/cloud/redis_v1/__init__.py
@@ -28,10 +28,9 @@ from importlib import metadata
 # For more information, see:
 # https://docs.python.org/3.15/library/sys.html#sys.set_lazy_imports_filter
 # Older Python versions safely ignore this variable.
-# We use absolute paths (via package_path) rather than __name__ to avoid runtime evaluation overhead.
 __lazy_modules__ = {
-"google.cloud.redis_v1.services.cloud_redis",
-"google.cloud.redis_v1.types.cloud_redis",
+    "google.cloud.redis_v1.services.cloud_redis",
+    "google.cloud.redis_v1.types.cloud_redis",
 }
 
 

--- a/packages/gapic-generator/tests/integration/goldens/redis_selective/google/cloud/redis_v1/__init__.py
+++ b/packages/gapic-generator/tests/integration/goldens/redis_selective/google/cloud/redis_v1/__init__.py
@@ -28,9 +28,10 @@ from importlib import metadata
 # For more information, see:
 # https://docs.python.org/3.15/library/sys.html#sys.set_lazy_imports_filter
 # Older Python versions safely ignore this variable.
+# We use absolute paths (via package_path) rather than __name__ to avoid runtime evaluation overhead.
 __lazy_modules__ = {
-f"{__name__}.services.cloud_redis",
-f"{__name__}.types.cloud_redis",
+"google.cloud.redis_v1.services.cloud_redis",
+"google.cloud.redis_v1.types.cloud_redis",
 }
 
 

--- a/packages/gapic-generator/tests/integration/goldens/redis_selective/google/cloud/redis_v1/__init__.py
+++ b/packages/gapic-generator/tests/integration/goldens/redis_selective/google/cloud/redis_v1/__init__.py
@@ -28,10 +28,9 @@ from importlib import metadata
 # For more information, see:
 # https://docs.python.org/3.15/library/sys.html#sys.set_lazy_imports_filter
 # Older Python versions safely ignore this variable.
-# We use absolute paths (via package_path) rather than __name__ to avoid runtime evaluation overhead.
 __lazy_modules__ = {
-"google.cloud.redis_v1.services.cloud_redis",
-"google.cloud.redis_v1.types.cloud_redis",
+    "google.cloud.redis_v1.services.cloud_redis",
+    "google.cloud.redis_v1.types.cloud_redis",
 }
 
 

--- a/packages/gapic-generator/tests/integration/goldens/storagebatchoperations/google/cloud/storagebatchoperations_v1/__init__.py
+++ b/packages/gapic-generator/tests/integration/goldens/storagebatchoperations/google/cloud/storagebatchoperations_v1/__init__.py
@@ -28,11 +28,10 @@ from importlib import metadata
 # For more information, see:
 # https://docs.python.org/3.15/library/sys.html#sys.set_lazy_imports_filter
 # Older Python versions safely ignore this variable.
-# We use absolute paths (via package_path) rather than __name__ to avoid runtime evaluation overhead.
 __lazy_modules__ = {
-"google.cloud.storagebatchoperations_v1.services.storage_batch_operations",
-"google.cloud.storagebatchoperations_v1.types.storage_batch_operations",
-"google.cloud.storagebatchoperations_v1.types.storage_batch_operations_types",
+    "google.cloud.storagebatchoperations_v1.services.storage_batch_operations",
+    "google.cloud.storagebatchoperations_v1.types.storage_batch_operations",
+    "google.cloud.storagebatchoperations_v1.types.storage_batch_operations_types",
 }
 
 

--- a/packages/gapic-generator/tests/integration/goldens/storagebatchoperations/google/cloud/storagebatchoperations_v1/__init__.py
+++ b/packages/gapic-generator/tests/integration/goldens/storagebatchoperations/google/cloud/storagebatchoperations_v1/__init__.py
@@ -28,10 +28,11 @@ from importlib import metadata
 # For more information, see:
 # https://docs.python.org/3.15/library/sys.html#sys.set_lazy_imports_filter
 # Older Python versions safely ignore this variable.
+# We use absolute paths (via package_path) rather than __name__ to avoid runtime evaluation overhead.
 __lazy_modules__ = {
-f"{__name__}.services.storage_batch_operations",
-f"{__name__}.types.storage_batch_operations",
-f"{__name__}.types.storage_batch_operations_types",
+"google.cloud.storagebatchoperations_v1.services.storage_batch_operations",
+"google.cloud.storagebatchoperations_v1.types.storage_batch_operations",
+"google.cloud.storagebatchoperations_v1.types.storage_batch_operations_types",
 }
 
 


### PR DESCRIPTION
The GAPIC generator template now uses the {{package_path}} variable instead of evaluating __name__ at runtime. The generator will now output the literal absolute strings (e.g., "google.cloud.compute_v1.services.accelerator_types") directly into the __lazy_modules__ set, keeping the execution as lightweight as possible.