### PR TITLE
chore(spanner): remove unused asyncio import in samples

### DIFF
--- a/packages/google-cloud-spanner/samples/samples/async_snippets.py
+++ b/packages/google-cloud-spanner/samples/samples/async_snippets.py
@@ -18,8 +18,6 @@
 Cloud Spanner.
 """
 
-import asyncio
-
 from google.cloud.spanner_v1 import AsyncClient, KeySet
 
 


### PR DESCRIPTION
Remove unused `import asyncio` from `async_snippets.py` to fix lint failure.

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/google-cloud-python/issues) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)

Fixes #<issue_number_goes_here> 🦕