### PR TITLE
chore(bigquery): centralize mypy config for bigquery

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -95,12 +95,12 @@ ignore_missing_imports = True
 ignore_missing_imports = True
 
 [mypy-google.cloud.bigtable.*]
-check_untyped_defs = True
-warn_unreachable = True
-disallow_any_generics = True
 ignore_errors = True
 
 [mypy-google.cloud.bigtable.data.*]
+check_untyped_defs = True
+warn_unreachable = True
+disallow_any_generics = True
 ignore_errors = False
 
 [mypy-google.cloud.bigtable_admin.*]

--- a/mypy.ini
+++ b/mypy.ini
@@ -14,7 +14,6 @@ exclude = (?x)(
   | (^|/)tests/unit/gapic/
   )
 
-
 # ==============================================================================
 # GLOBAL THIRD-PARTY & SHARED LIBRARY IGNORES
 # ==============================================================================
@@ -28,13 +27,7 @@ ignore_missing_imports = True
 [mypy-flask]
 ignore_missing_imports = True
 
-[mypy-google.auth.*]
-ignore_missing_imports = True
-
-[mypy-google.cloud.bigtable]
-ignore_missing_imports = True
-
-[mypy-google.cloud.pubsub]
+[mypy-google.api.*]
 ignore_missing_imports = True
 
 [mypy-google.colab]
@@ -59,6 +52,9 @@ ignore_missing_imports = True
 ignore_missing_imports = True
 
 [mypy-grpc.*]
+ignore_missing_imports = True
+
+[mypy-grpc_status]
 ignore_missing_imports = True
 
 [mypy-ibis.*]
@@ -86,15 +82,47 @@ ignore_missing_imports = True
 # ==============================================================================
 # PACKAGE-SPECIFIC OVERRIDES & EXCEPTIONS
 # ==============================================================================
-
-# --- google-cloud-bigtable ---
-[mypy-google.cloud.bigtable.*]
+# --- bigframes ---
+[mypy-bigframes_vendored.*]
 ignore_errors = True
 
-[mypy-google.cloud.bigtable.data.*]
+# --- google-auth ---
+[mypy-google.auth.*]
+ignore_missing_imports = True
+
+# --- google-cloud-bigtable ---
+[mypy-google.cloud.bigtable]
+ignore_missing_imports = True
+
+[mypy-google.cloud.bigtable.*]
 check_untyped_defs = True
 warn_unreachable = True
 disallow_any_generics = True
+ignore_errors = True
+
+[mypy-google.cloud.bigtable.data.*]
 ignore_errors = False
 
+[mypy-google.cloud.bigtable_admin.*]
+ignore_errors = True
 
+[mypy-google.cloud.bigtable_admin_v2.*]
+ignore_errors = True
+
+[mypy-google.cloud.bigtable_v2.*]
+ignore_errors = True
+
+# --- google-cloud-datastore ---
+[mypy-google.cloud.datastore.*]
+ignore_missing_imports = True
+
+[mypy-google.cloud.datastore._app_engine_key_pb2]
+ignore_errors = True
+
+# --- google-cloud-firestore ---
+[mypy-google.cloud.firestore.*]
+check_untyped_defs = True
+
+# --- google-cloud-pubsub ---
+[mypy-google.cloud.pubsub]
+ignore_missing_imports = True

--- a/packages/google-cloud-bigquery/mypy.ini
+++ b/packages/google-cloud-bigquery/mypy.ini
@@ -1,3 +1,0 @@
-[mypy]
-python_version = 3.14
-namespace_packages = True

--- a/packages/google-cloud-bigquery/noxfile.py
+++ b/packages/google-cloud-bigquery/noxfile.py
@@ -41,6 +41,18 @@ DEFAULT_PYTHON_VERSION = "3.14"
 ALL_PYTHON = ["3.10", "3.11", "3.12", "3.13", "3.14"]
 UNIT_TEST_PYTHON_VERSIONS = ALL_PYTHON
 CURRENT_DIRECTORY = pathlib.Path(__file__).parent.absolute()
+# Path to the centralized mypy configuration file at the repository root.
+# Search upwards to support running nox from both monorepo packages and integration test goldens.
+MYPY_CONFIG_FILE = next(
+    (
+        str(p / "mypy.ini")
+        for p in CURRENT_DIRECTORY.parents
+        if (p / "mypy.ini").exists()
+    ),
+    str(CURRENT_DIRECTORY.parent.parent / "mypy.ini"),
+)
+
+
 
 SYSTEM_TEST_PYTHON_VERSIONS = UNIT_TEST_PYTHON_VERSIONS
 
@@ -215,7 +227,15 @@ def mypy(session):
     )
     session.run("python", "-m", "pip", "freeze")
     with log_package_context(session):
-        session.run("mypy", "-p", "google", "--show-traceback")
+        session.run(
+            "mypy",
+            f"--config-file={MYPY_CONFIG_FILE}",
+            "-p",
+            "google",
+            "--show-traceback",
+        )
+
+
 
 
 @nox.session(python=SYSTEM_TEST_PYTHON_VERSIONS)

--- a/packages/google-cloud-bigquery/noxfile.py
+++ b/packages/google-cloud-bigquery/noxfile.py
@@ -53,7 +53,6 @@ MYPY_CONFIG_FILE = next(
 )
 
 
-
 SYSTEM_TEST_PYTHON_VERSIONS = UNIT_TEST_PYTHON_VERSIONS
 
 
@@ -234,8 +233,6 @@ def mypy(session):
             "google",
             "--show-traceback",
         )
-
-
 
 
 @nox.session(python=SYSTEM_TEST_PYTHON_VERSIONS)


### PR DESCRIPTION
* Relies on a centralized `mypy.ini` file at the root of the repository to consolidate all shared and package-specific mypy exceptions.
* Deletes the individual `mypy.ini` files from handwritten libraries, establishing the root configuration as the source of truth.
* Refactored their `noxfile.py` files to define `MYPY_CONFIG_FILE` dynamically and standardized their `session.run("mypy", ...)` invocations.

Related to: PR #17409 and PR #17641

> [!note]
> all three PRs rely on the same centralized mypy.ini config. So you may see some minor edits in the main config that are applicable to packages in one of the other PRs. This will have no effect on those packages until their noxfiles are updated to begin using the new centralized config.