### PR TITLE
chore(google-auth): fix aiohttp 3.10+ test compatibility

### DIFF
--- a/packages/google-auth/google/auth/aio/_helpers.py
+++ b/packages/google-auth/google/auth/aio/_helpers.py
@@ -14,7 +14,6 @@
 
 """Helper functions for commonly used utilities."""
 
-
 import logging
 from typing import Any
 
@@ -60,3 +59,13 @@ async def response_log_async(logger: logging.Logger, response: Any) -> None:
         # json_response = await _parse_response_async(response)
         json_response = None
         _helpers._response_log_base(logger, json_response)
+
+
+def _get_local_addr(connector: Any) -> Any:
+    local_addr = getattr(connector, "_local_addr", None)
+    if local_addr is not None:
+        return local_addr
+    local_addr_infos = getattr(connector, "_local_addr_infos", None)
+    if local_addr_infos:
+        return local_addr_infos[0][4]
+    return None

--- a/packages/google-auth/google/auth/aio/transport/aiohttp.py
+++ b/packages/google-auth/google/auth/aio/transport/aiohttp.py
@@ -248,7 +248,7 @@ class Request(transport.Request):
                     limit=getattr(orig_connector, "_limit", 100),
                     limit_per_host=getattr(orig_connector, "_limit_per_host", 0),
                     force_close=getattr(orig_connector, "_force_close", False),
-                    local_addr=getattr(orig_connector, "_local_addr", None),
+                    local_addr=_helpers_async._get_local_addr(orig_connector),
                 )
             elif getattr(aiohttp, "UnixConnector", None) and isinstance(
                 orig_connector, getattr(aiohttp, "UnixConnector")

--- a/packages/google-auth/google/auth/transport/_aiohttp_requests.py
+++ b/packages/google-auth/google/auth/transport/_aiohttp_requests.py
@@ -36,6 +36,7 @@ from google.auth.transport import requests
 
 _LOGGER = logging.getLogger(__name__)
 
+
 # Timeout can be re-defined depending on async requirement. Currently made 60s more than
 # sync timeout.
 _DEFAULT_TIMEOUT = 180  # in seconds
@@ -250,7 +251,7 @@ class Request(transport.Request):
                     limit=getattr(orig_connector, "_limit", 100),
                     limit_per_host=getattr(orig_connector, "_limit_per_host", 0),
                     force_close=getattr(orig_connector, "_force_close", False),
-                    local_addr=getattr(orig_connector, "_local_addr", None),
+                    local_addr=_helpers_async._get_local_addr(orig_connector),
                 )
             elif getattr(aiohttp, "UnixConnector", None) and isinstance(
                 orig_connector, getattr(aiohttp, "UnixConnector")

--- a/packages/google-auth/setup.py
+++ b/packages/google-auth/setup.py
@@ -59,9 +59,6 @@ testing_extra_require = [
     *aiohttp_extra_require,
     "aioresponses",
     "pytest-asyncio",
-    # TODO(https://github.com/googleapis/google-auth-library-python/issues/1722): `test_aiohttp_requests` depend on
-    # aiohttp < 3.10.0 which is a bug. Investigate and remove the pinned aiohttp version.
-    "aiohttp < 3.10.0",
 ]
 
 extras = {

--- a/packages/google-auth/tests/transport/aio/conftest.py
+++ b/packages/google-auth/tests/transport/aio/conftest.py
@@ -22,9 +22,9 @@ from aioresponses.core import RequestMatch  # type: ignore
 class _CompatClientResponse(aiohttp.ClientResponse):
     """ClientResponse subclass for aioresponses compatibility across all aiohttp versions."""
 
-    def __init__(self, *args, writer=None, stream_writer=None, **kwargs):
-        kwargs.pop("writer", None)
-        kwargs.pop("stream_writer", None)
+    def __init__(self, *args, **kwargs):
+        writer = kwargs.pop("writer", None)
+        stream_writer = kwargs.pop("stream_writer", None)
         writer_obj = stream_writer or writer or Mock()
         sig = inspect.signature(super().__init__)
         if "stream_writer" in sig.parameters:

--- a/packages/google-auth/tests/transport/aio/conftest.py
+++ b/packages/google-auth/tests/transport/aio/conftest.py
@@ -1,0 +1,46 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import inspect
+from unittest.mock import Mock
+
+import aiohttp
+from aioresponses.core import RequestMatch  # type: ignore
+
+
+class _CompatClientResponse(aiohttp.ClientResponse):
+    """ClientResponse subclass for aioresponses compatibility across all aiohttp versions."""
+
+    def __init__(self, *args, writer=None, stream_writer=None, **kwargs):
+        kwargs.pop("writer", None)
+        kwargs.pop("stream_writer", None)
+        writer_obj = stream_writer or writer or Mock()
+        sig = inspect.signature(super().__init__)
+        if "stream_writer" in sig.parameters:
+            kwargs["stream_writer"] = writer_obj
+        if "writer" in sig.parameters:
+            kwargs["writer"] = writer_obj
+        super().__init__(*args, **kwargs)
+
+
+_orig_request_match_init = RequestMatch.__init__
+
+
+def _request_match_init(self, *args, **kwargs):
+    if kwargs.get("response_class") is None:
+        kwargs["response_class"] = _CompatClientResponse
+    _orig_request_match_init(self, *args, **kwargs)
+
+
+RequestMatch.__init__ = _request_match_init

--- a/packages/google-auth/tests/transport/aio/test_aiohttp.py
+++ b/packages/google-auth/tests/transport/aio/test_aiohttp.py
@@ -234,7 +234,10 @@ class TestRequest:
         assert cloned_connector._limit == 42
         assert cloned_connector._limit_per_host == 12
         assert cloned_connector._force_close is True
-        assert cloned_connector._local_addr == ("127.0.0.2", 0)
+        cloned_local_addr = getattr(cloned_connector, "_local_addr", None)
+        if cloned_local_addr is None and hasattr(cloned_connector, "_local_addr_infos"):
+            cloned_local_addr = cloned_connector._local_addr_infos[0][4]
+        assert cloned_local_addr == ("127.0.0.2", 0)
 
         # Verify session-level configuration
         assert cloned._session._trust_env is True

--- a/packages/google-auth/tests/transport/aio/test_aiohttp.py
+++ b/packages/google-auth/tests/transport/aio/test_aiohttp.py
@@ -20,6 +20,7 @@ import pytest  # type: ignore
 import pytest_asyncio  # type: ignore
 
 from google.auth import exceptions
+from google.auth.aio import _helpers as _helpers_async
 import google.auth.aio.transport.aiohttp as auth_aiohttp
 
 try:
@@ -234,10 +235,10 @@ class TestRequest:
         assert cloned_connector._limit == 42
         assert cloned_connector._limit_per_host == 12
         assert cloned_connector._force_close is True
-        cloned_local_addr = getattr(cloned_connector, "_local_addr", None)
-        if cloned_local_addr is None and hasattr(cloned_connector, "_local_addr_infos"):
-            cloned_local_addr = cloned_connector._local_addr_infos[0][4]
-        assert cloned_local_addr == ("127.0.0.2", 0)
+        assert _helpers_async._get_local_addr(cloned_connector) == (
+            "127.0.0.2",
+            0,
+        )
 
         # Verify session-level configuration
         assert cloned._session._trust_env is True

--- a/packages/google-auth/tests_async/transport/conftest.py
+++ b/packages/google-auth/tests_async/transport/conftest.py
@@ -22,9 +22,9 @@ from aioresponses.core import RequestMatch  # type: ignore
 class _CompatClientResponse(aiohttp.ClientResponse):
     """ClientResponse subclass for aioresponses compatibility across all aiohttp versions."""
 
-    def __init__(self, *args, writer=None, stream_writer=None, **kwargs):
-        kwargs.pop("writer", None)
-        kwargs.pop("stream_writer", None)
+    def __init__(self, *args, **kwargs):
+        writer = kwargs.pop("writer", None)
+        stream_writer = kwargs.pop("stream_writer", None)
         writer_obj = stream_writer or writer or Mock()
         sig = inspect.signature(super().__init__)
         if "stream_writer" in sig.parameters:

--- a/packages/google-auth/tests_async/transport/conftest.py
+++ b/packages/google-auth/tests_async/transport/conftest.py
@@ -1,0 +1,46 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import inspect
+from unittest.mock import Mock
+
+import aiohttp
+from aioresponses.core import RequestMatch  # type: ignore
+
+
+class _CompatClientResponse(aiohttp.ClientResponse):
+    """ClientResponse subclass for aioresponses compatibility across all aiohttp versions."""
+
+    def __init__(self, *args, writer=None, stream_writer=None, **kwargs):
+        kwargs.pop("writer", None)
+        kwargs.pop("stream_writer", None)
+        writer_obj = stream_writer or writer or Mock()
+        sig = inspect.signature(super().__init__)
+        if "stream_writer" in sig.parameters:
+            kwargs["stream_writer"] = writer_obj
+        if "writer" in sig.parameters:
+            kwargs["writer"] = writer_obj
+        super().__init__(*args, **kwargs)
+
+
+_orig_request_match_init = RequestMatch.__init__
+
+
+def _request_match_init(self, *args, **kwargs):
+    if kwargs.get("response_class") is None:
+        kwargs["response_class"] = _CompatClientResponse
+    _orig_request_match_init(self, *args, **kwargs)
+
+
+RequestMatch.__init__ = _request_match_init

--- a/packages/google-auth/tests_async/transport/test_aiohttp_requests.py
+++ b/packages/google-auth/tests_async/transport/test_aiohttp_requests.py
@@ -138,7 +138,7 @@ class TestRequestResponse(async_compliance.RequestResponseTests):
     @pytest.mark.asyncio
     async def test__clone(self):
         http = mock.create_autospec(
-            aiohttp.ClientSession, instance=True, _auto_decompress=False
+            aiohttp.ClientSession, instance=True, auto_decompress=False
         )
         http._connector = mock.Mock(spec=aiohttp.TCPConnector)
         http._connector.closed = False
@@ -158,12 +158,13 @@ class TestRequestResponse(async_compliance.RequestResponseTests):
         http._json_serialize = mock.sentinel.json_serialize
 
         request = aiohttp_requests.Request(http)
-        with mock.patch(
-            "aiohttp.ClientSession", autospec=True
-        ) as session_mock, mock.patch.object(
-            aiohttp.TCPConnector, "__init__", autospec=True, return_value=None
-        ) as connector_init_mock:
-            session_mock.return_value._auto_decompress = False
+        with (
+            mock.patch("aiohttp.ClientSession", autospec=True) as session_mock,
+            mock.patch.object(
+                aiohttp.TCPConnector, "__init__", autospec=True, return_value=None
+            ) as connector_init_mock,
+        ):
+            session_mock.return_value.auto_decompress = False
             cloned = request._clone()
 
         assert isinstance(cloned, aiohttp_requests.Request)
@@ -204,7 +205,7 @@ class TestRequestResponse(async_compliance.RequestResponseTests):
     @pytest.mark.asyncio
     async def test__clone_custom_connector(self):
         http = mock.create_autospec(
-            aiohttp.ClientSession, instance=True, _auto_decompress=False
+            aiohttp.ClientSession, instance=True, auto_decompress=False
         )
         http._connector = mock.Mock()
         http._connector.closed = False
@@ -218,7 +219,7 @@ class TestRequestResponse(async_compliance.RequestResponseTests):
     @pytest.mark.asyncio
     async def test_close(self):
         http = mock.create_autospec(
-            aiohttp.ClientSession, instance=True, _auto_decompress=False
+            aiohttp.ClientSession, instance=True, auto_decompress=False
         )
         http.close = mock.AsyncMock()
         request = aiohttp_requests.Request(http)
@@ -234,7 +235,7 @@ class TestRequestResponse(async_compliance.RequestResponseTests):
     @pytest.mark.asyncio
     async def test_request_call_closed(self):
         http = mock.create_autospec(
-            aiohttp.ClientSession, instance=True, _auto_decompress=False
+            aiohttp.ClientSession, instance=True, auto_decompress=False
         )
         request = aiohttp_requests.Request(http)
         await request.close()
@@ -255,7 +256,7 @@ class TestRequestResponse(async_compliance.RequestResponseTests):
     @pytest.mark.asyncio
     async def test__clone_closed_connector(self):
         http = mock.create_autospec(
-            aiohttp.ClientSession, instance=True, _auto_decompress=False
+            aiohttp.ClientSession, instance=True, auto_decompress=False
         )
         http._connector = mock.Mock()
         http._connector.closed = True
@@ -269,7 +270,7 @@ class TestRequestResponse(async_compliance.RequestResponseTests):
 
         request = aiohttp_requests.Request(http)
         with mock.patch("aiohttp.ClientSession", autospec=True) as session_mock:
-            session_mock.return_value._auto_decompress = False
+            session_mock.return_value.auto_decompress = False
             cloned = request._clone()
 
         assert isinstance(cloned, aiohttp_requests.Request)
@@ -283,7 +284,7 @@ class TestRequestResponse(async_compliance.RequestResponseTests):
             return
 
         http = mock.create_autospec(
-            aiohttp.ClientSession, instance=True, _auto_decompress=False
+            aiohttp.ClientSession, instance=True, auto_decompress=False
         )
         http._connector = mock.Mock(spec=UnixConnector)
         http._connector.closed = False
@@ -298,7 +299,7 @@ class TestRequestResponse(async_compliance.RequestResponseTests):
 
         request = aiohttp_requests.Request(http)
         with mock.patch("aiohttp.ClientSession", autospec=True) as session_mock:
-            session_mock.return_value._auto_decompress = False
+            session_mock.return_value.auto_decompress = False
             cloned = request._clone()
 
         assert isinstance(cloned, aiohttp_requests.Request)
@@ -312,7 +313,7 @@ class TestRequestResponse(async_compliance.RequestResponseTests):
             return
 
         http = mock.create_autospec(
-            aiohttp.ClientSession, instance=True, _auto_decompress=False
+            aiohttp.ClientSession, instance=True, auto_decompress=False
         )
         http._connector = mock.Mock(spec=UnixConnector)
         http._connector.closed = False
@@ -328,12 +329,13 @@ class TestRequestResponse(async_compliance.RequestResponseTests):
         http._json_serialize = None
 
         request = aiohttp_requests.Request(http)
-        with mock.patch(
-            "aiohttp.ClientSession", autospec=True
-        ) as session_mock, mock.patch.object(
-            UnixConnector, "__init__", autospec=True, return_value=None
-        ) as connector_init_mock:
-            session_mock.return_value._auto_decompress = False
+        with (
+            mock.patch("aiohttp.ClientSession", autospec=True) as session_mock,
+            mock.patch.object(
+                UnixConnector, "__init__", autospec=True, return_value=None
+            ) as connector_init_mock,
+        ):
+            session_mock.return_value.auto_decompress = False
             cloned = request._clone()
 
         assert isinstance(cloned, aiohttp_requests.Request)


### PR DESCRIPTION
1. **Unpinned `aiohttp` in `setup.py`**:
   - Removed `"aiohttp < 3.10.0"` from `testing_extra_require` and resolved TODO comment for #1722.
2. **Added Shared `_get_local_addr` Helper**:
   - Added `_get_local_addr` in `google.auth.aio._helpers` to extract local address from `TCPConnector._local_addr` (on `aiohttp < 3.10`) or `TCPConnector._local_addr_infos` (on `aiohttp >= 3.10`).
   - Updated `google.auth.aio.transport.aiohttp` and `google.auth.transport._aiohttp_requests` to reuse this helper when cloning sessions.
3. **`_CompatClientResponse` Test Adapter in `conftest.py`**:
   - Registered a `_CompatClientResponse` class in `tests/transport/aio/conftest.py` and `tests_async/transport/conftest.py` that inspects `ClientResponse.__init__` and safely maps `writer` $\rightarrow$ `stream_writer` for `aioresponses` on `aiohttp` 3.10+.
4. **Updated Test Mocks**:
   - Refactored private `_auto_decompress` $\rightarrow$ public `auto_decompress` property in `tests_async/transport/test_aiohttp_requests.py` for `aiohttp` 3.10+ compatibility.

Fixes #1722🦕