### PR TITLE
fix(google-auth): add extra for grpc

### DIFF
--- a/packages/google-auth/setup.py
+++ b/packages/google-auth/setup.py
@@ -37,6 +37,7 @@ reauth_extra_require = ["pyu2f>=0.1.5"]
 
 enterprise_cert_extra_require = cryptography_base_require
 
+# TODO(https://github.com/googleapis/google-auth-library-python/issues/1739): Add bounds for urllib3 and packaging dependencies.
 urllib3_extra_require = ["urllib3", "packaging"]
 
 rsa_extra_require = ["rsa>=3.1.4,<5"]

--- a/packages/google-auth/setup.py
+++ b/packages/google-auth/setup.py
@@ -37,15 +37,15 @@ reauth_extra_require = ["pyu2f>=0.1.5"]
 
 enterprise_cert_extra_require = cryptography_base_require
 
-# TODO(https://github.com/googleapis/google-auth-library-python/issues/1739): Add bounds for urllib3 and packaging dependencies.
 urllib3_extra_require = ["urllib3", "packaging"]
 
 rsa_extra_require = ["rsa>=3.1.4,<5"]
 
+grpc_extra_require = ["grpcio"]
+
 # Unit test requirements.
 testing_extra_require = [
-    # TODO(https://github.com/googleapis/google-auth-library-python/issues/1735): Remove `grpcio` from testing requirements once an extra is added for `grpcio` dependency.
-    "grpcio",
+    *grpc_extra_require,
     "flask",
     "freezegun",
     *pyjwt_extra_require,
@@ -77,8 +77,7 @@ extras = {
     "testing": testing_extra_require,
     "urllib3": urllib3_extra_require,
     "rsa": rsa_extra_require,
-    # TODO(https://github.com/googleapis/google-auth-library-python/issues/1735): Add an extra for `grpcio` dependency.
-    # TODO(https://github.com/googleapis/google-auth-library-python/issues/1736): Add an extra for `oauth2client` dependency.
+    "grpc": grpc_extra_require,
 }
 
 with io.open("README.rst", "r") as fh:

--- a/packages/google-auth/setup.py
+++ b/packages/google-auth/setup.py
@@ -41,7 +41,10 @@ urllib3_extra_require = ["urllib3", "packaging"]
 
 rsa_extra_require = ["rsa>=3.1.4,<5"]
 
-grpc_extra_require = ["grpcio"]
+grpc_extra_require = [
+    "grpcio >= 1.59.0, < 2.0.0; python_version < '3.14'",
+    "grpcio >= 1.75.1, < 2.0.0; python_version >= '3.14'",
+]
 
 # Unit test requirements.
 testing_extra_require = [

--- a/packages/google-auth/testing/constraints-3.10.txt
+++ b/packages/google-auth/testing/constraints-3.10.txt
@@ -11,3 +11,4 @@ cryptography==38.0.3
 aiohttp==3.8.0
 requests==2.20.0
 pyjwt==2.0
+grpcio==1.59.0


### PR DESCRIPTION

- Added `grpc` extra (`"grpc": ["grpcio"]`) and updated `testing_extra_require` to use `*grpc_extra_require`.
- Removed obsolete TODO comments for `grpcio`, `oauth2client`, and `urllib3` bounds.
