### PR TITLE
fix(google-auth): add bounds for urllib3 and packaging dependencies

### DIFF
--- a/packages/google-auth/setup.py
+++ b/packages/google-auth/setup.py
@@ -27,7 +27,10 @@ DEPENDENCIES = (
     *cryptography_base_require,
 )
 
-requests_extra_require = ["requests >= 2.20.0, < 3.0.0"]
+requests_extra_require = [
+    "requests >= 2.20.0, < 3.0.0; python_version < '3.10'",
+    "requests >= 2.30.0, < 3.0.0; python_version >= '3.10'",
+]
 
 aiohttp_extra_require = ["aiohttp >= 3.8.0, < 4.0.0", *requests_extra_require]
 
@@ -38,7 +41,8 @@ reauth_extra_require = ["pyu2f>=0.1.5"]
 enterprise_cert_extra_require = cryptography_base_require
 
 urllib3_extra_require = [
-    "urllib3 >= 1.21.1, < 3.0.0",
+    "urllib3 >= 1.21.1, < 3.0.0; python_version < '3.10'",
+    "urllib3 >= 1.26.15, < 3.0.0; python_version >= '3.10'",
     "packaging >= 20.0",
 ]
 

--- a/packages/google-auth/setup.py
+++ b/packages/google-auth/setup.py
@@ -27,10 +27,7 @@ DEPENDENCIES = (
     *cryptography_base_require,
 )
 
-requests_extra_require = [
-    "requests >= 2.20.0, < 3.0.0; python_version < '3.10'",
-    "requests >= 2.30.0, < 3.0.0; python_version >= '3.10'",
-]
+requests_extra_require = ["requests >= 2.30.0, < 3.0.0"]
 
 aiohttp_extra_require = ["aiohttp >= 3.8.0, < 4.0.0", *requests_extra_require]
 
@@ -41,8 +38,7 @@ reauth_extra_require = ["pyu2f>=0.1.5"]
 enterprise_cert_extra_require = cryptography_base_require
 
 urllib3_extra_require = [
-    "urllib3 >= 1.21.1, < 3.0.0; python_version < '3.10'",
-    "urllib3 >= 1.26.15, < 3.0.0; python_version >= '3.10'",
+    "urllib3 >= 1.26.15, < 3.0.0",
     "packaging >= 20.0",
 ]
 

--- a/packages/google-auth/setup.py
+++ b/packages/google-auth/setup.py
@@ -37,8 +37,10 @@ reauth_extra_require = ["pyu2f>=0.1.5"]
 
 enterprise_cert_extra_require = cryptography_base_require
 
-# TODO(https://github.com/googleapis/google-auth-library-python/issues/1739): Add bounds for urllib3 and packaging dependencies.
-urllib3_extra_require = ["urllib3", "packaging"]
+urllib3_extra_require = [
+    "urllib3 >= 1.21.1, < 3.0.0",
+    "packaging >= 20.0",
+]
 
 rsa_extra_require = ["rsa>=3.1.4,<5"]
 

--- a/packages/google-auth/testing/constraints-3.10.txt
+++ b/packages/google-auth/testing/constraints-3.10.txt
@@ -9,8 +9,8 @@ pyasn1-modules==0.2.1
 setuptools==40.3.0
 cryptography==38.0.3
 aiohttp==3.8.0
-requests==2.20.0
+requests==2.30.0
 pyjwt==2.0
 grpcio==1.59.0
-urllib3==1.21.1
+urllib3==1.26.15
 packaging==20.0

--- a/packages/google-auth/testing/constraints-3.10.txt
+++ b/packages/google-auth/testing/constraints-3.10.txt
@@ -12,3 +12,5 @@ aiohttp==3.8.0
 requests==2.20.0
 pyjwt==2.0
 grpcio==1.59.0
+urllib3==1.21.1
+packaging==20.0


### PR DESCRIPTION
1. **`setup.py`**:
   - Added version bounds for `urllib3` and `packaging` in `urllib3_extra_require`:
     ```python
     urllib3_extra_require = [
         "urllib3 >= 1.26.15, < 3.0.0",
         "packaging >= 20.0",
     ]
     ```
   - Set `requests >= 2.30.0, < 3.0.0` for Python 3.10+ compatibility.
   - Resolved and removed TODO comment for issue #1739.
2. **`testing/constraints-3.10.txt`**:
   - Added `requests==2.30.0`, `urllib3==1.26.15`, and `packaging==20.0` to lower-bound CI test constraints.

Fixes #15155  🦕