### PR TITLE
fix(google-auth): add cryptography bound for Python 3.14

### DIFF
--- a/packages/google-auth/setup.py
+++ b/packages/google-auth/setup.py
@@ -19,7 +19,8 @@ from setuptools import find_namespace_packages
 from setuptools import setup
 
 cryptography_base_require = [
-    "cryptography >= 38.0.3",
+    "cryptography >= 38.0.3; python_version < '3.14'",
+    "cryptography >= 41.0.5; python_version >= '3.14'",
 ]
 
 DEPENDENCIES = (

--- a/packages/google-auth/testing/constraints-3.14.txt
+++ b/packages/google-auth/testing/constraints-3.14.txt
@@ -1,0 +1,4 @@
+# Lower-bound constraints for Python 3.14 core dependencies.
+# Used during CI unit tests to verify minimum supported package versions.
+pyasn1-modules==0.2.1
+cryptography==41.0.5


### PR DESCRIPTION
### Summary of Changes
Added `"cryptography >= 41.0.5; python_version >= '3.14'"` in `setup.py` and `cryptography==41.0.5` in `testing/constraints-3.14.txt`.
### Rationale
In Python 3.14, the legacy `setuptools` / `pkg_resources` module was removed from the standard build environment. 
Older `cryptography` versions (`< 41.0`, including `google-auth`'s default lower bound `38.0.3`) utilized `pkg_resources` in their build hooks. When building from source (sdist) or installing on custom runtimes (such as Alpine Linux, ARM64, or non-manylinux environments), `cryptography 38.0.3` fails with a `ModuleNotFoundError: No module named 'pkg_resources'` build error.
PyCA (Python Cryptography Authority) removed `pkg_resources` and updated setuptools-rust build hooks in `cryptography 41.0.5+`.
Setting `"cryptography >= 41.0.5; python_version >= '3.14'"` ensures:
1. **Python 3.10–3.13**: `google-auth` continues to support `cryptography >= 38.0.3` (zero breaking changes for existing users).
2. **Python 3.14+**: `pip` automatically selects `cryptography >= 41.0.5` so installations and builds succeed cleanly across all platforms and architectures.
---
### **How to Reproduce**
To reproduce the build failure on Python 3.14 without this fix:
1. **In a Python 3.14 environment**:
   ```bash
   pyenv activate py314
   pip install --no-binary :all: "cryptography==38.0.3"