### PR TITLE
fix(google-auth): raise rsa extra lower bound to 4.0

### DIFF
--- a/packages/google-auth/setup.py
+++ b/packages/google-auth/setup.py
@@ -43,7 +43,7 @@ urllib3_extra_require = [
     "packaging >= 20.0",
 ]
 
-rsa_extra_require = ["rsa>=3.1.4,<5"]
+rsa_extra_require = ["rsa>=4.0.0,<5"]
 
 grpc_extra_require = [
     "grpcio >= 1.59.0, < 2.0.0; python_version < '3.14'",

--- a/packages/google-auth/testing/constraints-3.10.txt
+++ b/packages/google-auth/testing/constraints-3.10.txt
@@ -14,3 +14,4 @@ pyjwt==2.0
 grpcio==1.59.0
 urllib3==1.26.15
 packaging==20.0
+rsa==4.0.0


### PR DESCRIPTION

### Summary of Changes
1. **`setup.py`**:
   - Updated `rsa_extra_require` from `"rsa>=3.1.4,<5"` to `"rsa>=4.0.0,<5"`.
2. **`testing/constraints-3.10.txt`**:
   - Added `rsa==4.0.0` to lower-bound test constraints.
---
### Technical Rationale
**Python 3.8+ Standard Library Removal (`base64.decodestring`)**:
- In Python 3.8, the deprecated `base64.decodestring()` function was **completely removed** from Python's standard library in favor of `base64.b64decode()`.
- `rsa < 4.0.0` (such as `rsa 3.1.4` / `3.4.2`) called `base64.decodestring()` internally in `rsa/pem.py:92` during PEM certificate and key decoding.
- When running `google-auth` unit tests or loading PEM keys on supported Python versions (Python 3.10+), `rsa==3.1.4` fails with:
  ```text
  E   AttributeError: module 'base64' has no attribute 'decodestring'
  ../../../site-packages/rsa/pem.py:92: AttributeError
  
  Impact & Backward Compatibility
Non-breaking: rsa 4.0.0 was released in 2018. Virtually all active Python environments using google-auth[rsa] or google-auth[testing] already use rsa 4.x.
Primary Auth Flow Unaffected: google-auth uses cryptography as its primary required dependency for RSA/EC signing; rsa is only an optional extra (google-auth[rsa]).