### PR TITLE
[WIP] feat(auth): expand ECP custom TLS signer signature buffer for PQC

### DIFF
--- a/packages/google-auth/google/auth/transport/_custom_tls_signer.py
+++ b/packages/google-auth/google/auth/transport/_custom_tls_signer.py
@@ -156,10 +156,10 @@ def get_sign_callback(signer_lib, config_file_path):
         digest = _compute_sha256_digest(tbs, tbs_len)
         digestArray = ctypes.c_char * len(digest)
 
-        # Reserve 16384 bytes for the signature to accommodate Post-Quantum Cryptography (PQC)
-        # signatures. RSA signature is 256 bytes, EC signature is ~72 bytes, ML-DSA-65 is 3309 bytes,
-        # ML-DSA-87 is 4627 bytes, and SLH-DSA is up to 7856 bytes.
-        sig_holder_len = 16384
+        # Reserve 65536 bytes (64 KiB) for the signature, which is the maximum signature size
+        # permitted by the TLS 1.3 protocol (RFC 8446). This covers all Post-Quantum Cryptography (PQC)
+        # algorithms including ML-DSA-87 (4627 B), SLH-DSA-128f (17088 B), and SLH-DSA-256f (49856 B).
+        sig_holder_len = 65536
         sig_holder = ctypes.create_string_buffer(sig_holder_len)
 
         signature_len = signer_lib.SignForPython(
@@ -170,8 +170,12 @@ def get_sign_callback(signer_lib, config_file_path):
             sig_holder_len,  # sigHolderLen
         )
 
-        if signature_len == 0:
-            # signing failed, return 0
+        if signature_len <= 0 or signature_len > sig_holder_len:
+            _LOGGER.error(
+                "Invalid signature length %d returned from signer library (max %d)",
+                signature_len,
+                sig_holder_len,
+            )
             return 0
 
         sig_len[0] = signature_len

--- a/packages/google-auth/google/auth/transport/_custom_tls_signer.py
+++ b/packages/google-auth/google/auth/transport/_custom_tls_signer.py
@@ -156,9 +156,10 @@ def get_sign_callback(signer_lib, config_file_path):
         digest = _compute_sha256_digest(tbs, tbs_len)
         digestArray = ctypes.c_char * len(digest)
 
-        # reserve 2000 bytes for the signature, shoud be more then enough.
-        # RSA signature is 256 bytes, EC signature is 70~72.
-        sig_holder_len = 2000
+        # Reserve 16384 bytes for the signature to accommodate Post-Quantum Cryptography (PQC)
+        # signatures. RSA signature is 256 bytes, EC signature is ~72 bytes, ML-DSA-65 is 3309 bytes,
+        # ML-DSA-87 is 4627 bytes, and SLH-DSA is up to 7856 bytes.
+        sig_holder_len = 16384
         sig_holder = ctypes.create_string_buffer(sig_holder_len)
 
         signature_len = signer_lib.SignForPython(

--- a/packages/google-auth/tests/transport/test__custom_tls_signer.py
+++ b/packages/google-auth/tests/transport/test__custom_tls_signer.py
@@ -111,26 +111,44 @@ def test_get_sign_callback():
 
 
 def test_get_sign_callback_pqc_signature_size():
-    # ML-DSA-65 (FIPS 204) signature is 3,309 bytes; ML-DSA-87 is 4,627 bytes.
-    mock_sig_len = 3309
+    # ML-DSA-65 is 3,309 B; SLH-DSA-128f is 17,088 B; SLH-DSA-256f is 49,856 B.
+    for mock_sig_len in (3309, 17088, 49856):
+        mock_signer_lib = mock.MagicMock()
+        mock_signer_lib.SignForPython.return_value = mock_sig_len
+
+        sign_callback = _custom_tls_signer.get_sign_callback(
+            mock_signer_lib, FAKE_ENTERPRISE_CERT_FILE_PATH
+        )
+
+        to_be_signed = ctypes.POINTER(ctypes.c_ubyte)()
+        to_be_signed_len = 32
+        returned_sig_array = (ctypes.c_ubyte * mock_sig_len)()
+        mock_sig_array = ctypes.cast(returned_sig_array, ctypes.POINTER(ctypes.c_ubyte))
+        returned_sign_len = ctypes.c_ulong()
+        mock_sig_len_array = ctypes.byref(returned_sign_len)
+
+        assert sign_callback(
+            mock_sig_array, mock_sig_len_array, to_be_signed, to_be_signed_len
+        )
+        assert returned_sign_len.value == mock_sig_len
+
+
+def test_get_sign_callback_oversized_signature():
+    # Verify that signature lengths exceeding 65536 bytes fail gracefully (return 0).
     mock_signer_lib = mock.MagicMock()
-    mock_signer_lib.SignForPython.return_value = mock_sig_len
+    mock_signer_lib.SignForPython.return_value = 70000
 
     sign_callback = _custom_tls_signer.get_sign_callback(
         mock_signer_lib, FAKE_ENTERPRISE_CERT_FILE_PATH
     )
 
-    to_be_signed = ctypes.POINTER(ctypes.c_ubyte)()
-    to_be_signed_len = 32
-    returned_sig_array = (ctypes.c_ubyte * 4627)()
+    returned_sig_array = (ctypes.c_ubyte * 100)()
     mock_sig_array = ctypes.cast(returned_sig_array, ctypes.POINTER(ctypes.c_ubyte))
     returned_sign_len = ctypes.c_ulong()
-    mock_sig_len_array = ctypes.byref(returned_sign_len)
 
-    assert sign_callback(
-        mock_sig_array, mock_sig_len_array, to_be_signed, to_be_signed_len
+    assert not sign_callback(
+        mock_sig_array, ctypes.byref(returned_sign_len), None, 0
     )
-    assert returned_sign_len.value == mock_sig_len
 
 
 def test_get_sign_callback_failed_to_sign():

--- a/packages/google-auth/tests/transport/test__custom_tls_signer.py
+++ b/packages/google-auth/tests/transport/test__custom_tls_signer.py
@@ -110,6 +110,29 @@ def test_get_sign_callback():
     assert returned_sign_len.value == mock_sig_len
 
 
+def test_get_sign_callback_pqc_signature_size():
+    # ML-DSA-65 (FIPS 204) signature is 3,309 bytes; ML-DSA-87 is 4,627 bytes.
+    mock_sig_len = 3309
+    mock_signer_lib = mock.MagicMock()
+    mock_signer_lib.SignForPython.return_value = mock_sig_len
+
+    sign_callback = _custom_tls_signer.get_sign_callback(
+        mock_signer_lib, FAKE_ENTERPRISE_CERT_FILE_PATH
+    )
+
+    to_be_signed = ctypes.POINTER(ctypes.c_ubyte)()
+    to_be_signed_len = 32
+    returned_sig_array = (ctypes.c_ubyte * 4627)()
+    mock_sig_array = ctypes.cast(returned_sig_array, ctypes.POINTER(ctypes.c_ubyte))
+    returned_sign_len = ctypes.c_ulong()
+    mock_sig_len_array = ctypes.byref(returned_sign_len)
+
+    assert sign_callback(
+        mock_sig_array, mock_sig_len_array, to_be_signed, to_be_signed_len
+    )
+    assert returned_sign_len.value == mock_sig_len
+
+
 def test_get_sign_callback_failed_to_sign():
     # mock signer lib's SignForPython function. Set the sig len to be 0 to
     # indicate the signing failed.

--- a/packages/google-auth/tests/transport/test__custom_tls_signer.py
+++ b/packages/google-auth/tests/transport/test__custom_tls_signer.py
@@ -146,9 +146,7 @@ def test_get_sign_callback_oversized_signature():
     mock_sig_array = ctypes.cast(returned_sig_array, ctypes.POINTER(ctypes.c_ubyte))
     returned_sign_len = ctypes.c_ulong()
 
-    assert not sign_callback(
-        mock_sig_array, ctypes.byref(returned_sign_len), None, 0
-    )
+    assert not sign_callback(mock_sig_array, ctypes.byref(returned_sign_len), None, 0)
 
 
 def test_get_sign_callback_failed_to_sign():


### PR DESCRIPTION
This PR expands the Enterprise Certificate Proxy (ECP) custom TLS signer signature buffer (`sig_holder_len`) in `google.auth.transport._custom_tls_signer` from 2,000 bytes to 65,536 bytes (64 KiB) and adds a defensive bounds check to gracefully handle invalid signature lengths. Legacy 2,000-byte allocations were designed for classical RSA/ECDSA signatures (256–512 B) and caused C-callback IndexError exceptions during mTLS handshakes when offloading Post-Quantum Cryptography (PQC) client certificates under NIST FIPS 204 (ML-DSA-65 at 3,309 B; ML-DSA-87 at 4,627 B) and FIPS 205 (SLH-DSA-128f at 17,088 B; SLH-DSA-256f at 49,856 B). The new 64 KiB buffer size aligns with the maximum signature payload permitted by the TLS 1.3 specification (RFC 8446 Section 4.4.3), ensuring full future-proof compatibility across all FIPS-standardized PQC parameter sets without breaking or modifying non-mTLS authentication flows.