### PR TITLE
chore: fix bigtable authorized view routing

### DIFF
--- a/packages/google-cloud-bigtable/tests/system/data/test_system_async.py
+++ b/packages/google-cloud-bigtable/tests/system/data/test_system_async.py
@@ -19,12 +19,11 @@ import uuid
 import pytest
 from google.api_core import retry
 from google.api_core.exceptions import ClientError, PermissionDenied
-from google.cloud.environment_vars import BIGTABLE_EMULATOR
-from google.type import date_pb2
-
 from google.cloud.bigtable.data._cross_sync import CrossSync
 from google.cloud.bigtable.data.execute_query.metadata import SqlType
 from google.cloud.bigtable.data.read_modify_write_rules import _MAX_INCREMENT_VALUE
+from google.cloud.environment_vars import BIGTABLE_EMULATOR
+from google.type import date_pb2
 
 from . import TEST_AGGREGATE_FAMILY, TEST_FAMILY, TEST_FAMILY_2, SystemTestRunner
 
@@ -68,7 +67,7 @@ class TempRowBuilderAsync:
         elif isinstance(value, int):
             value = value.to_bytes(8, byteorder="big", signed=True)
         request = {
-            "table_name": self.target.table_name,
+            **self.target._request_path,
             "row_key": row_key,
             "mutations": [
                 {
@@ -88,7 +87,7 @@ class TempRowBuilderAsync:
         self, row_key, *, family=TEST_AGGREGATE_FAMILY, qualifier=b"q", input=0
     ):
         request = {
-            "table_name": self.target.table_name,
+            **self.target._request_path,
             "row_key": row_key,
             "mutations": [
                 {
@@ -108,7 +107,7 @@ class TempRowBuilderAsync:
     async def delete_rows(self):
         if self.rows:
             request = {
-                "table_name": self.target.table_name,
+                **self.target._request_path,
                 "entries": [
                     {"row_key": row, "mutations": [{"delete_from_row": {}}]}
                     for row in self.rows

--- a/packages/google-cloud-bigtable/tests/system/data/test_system_autogen.py
+++ b/packages/google-cloud-bigtable/tests/system/data/test_system_autogen.py
@@ -22,15 +22,14 @@ import uuid
 import pytest
 from google.api_core import retry
 from google.api_core.exceptions import ClientError, PermissionDenied
-from google.cloud.environment_vars import BIGTABLE_EMULATOR
-from google.type import date_pb2
-
 from google.cloud.bigtable.data._cross_sync import CrossSync
 from google.cloud.bigtable.data.execute_query.metadata import SqlType
 from google.cloud.bigtable.data.read_modify_write_rules import _MAX_INCREMENT_VALUE
 from google.cloud.bigtable_v2.services.bigtable.transports.grpc import (
     _LoggingClientInterceptor as GapicInterceptor,
 )
+from google.cloud.environment_vars import BIGTABLE_EMULATOR
+from google.type import date_pb2
 
 from . import TEST_AGGREGATE_FAMILY, TEST_FAMILY, TEST_FAMILY_2, SystemTestRunner
 
@@ -57,7 +56,7 @@ class TempRowBuilder:
         elif isinstance(value, int):
             value = value.to_bytes(8, byteorder="big", signed=True)
         request = {
-            "table_name": self.target.table_name,
+            **self.target._request_path,
             "row_key": row_key,
             "mutations": [
                 {
@@ -76,7 +75,7 @@ class TempRowBuilder:
         self, row_key, *, family=TEST_AGGREGATE_FAMILY, qualifier=b"q", input=0
     ):
         request = {
-            "table_name": self.target.table_name,
+            **self.target._request_path,
             "row_key": row_key,
             "mutations": [
                 {
@@ -95,7 +94,7 @@ class TempRowBuilder:
     def delete_rows(self):
         if self.rows:
             request = {
-                "table_name": self.target.table_name,
+                **self.target._request_path,
                 "entries": [
                     {"row_key": row, "mutations": [{"delete_from_row": {}}]}
                     for row in self.rows


### PR DESCRIPTION
## Problem
Bigtable system tests were failing with timeout errors (`DeadlineExceeded`) when testing Authorized Views because a test helper (`TempRowBuilder`) was hardcoded to only use the table name, ignoring the view identifier.

## Solution
Updated the test helper in the Bigtable package to dynamically use either the table name or the authorized view name depending on the test target by utilizing the internal `_request_path` property. This ensures requests are routed correctly to the intended target.

## Notes to Reviewers
> [!note]
> Changes in the `test_system_autogen.py` file are auto-generated via `CrossSync` and are simply synchronous versions of the async tests in `test_system_async.py`. Comments related to the content of `test_system_async.py` will be automatically added to `test_system_autogen.py`






