### PR TITLE
fix(ci): install setuptools in temporary virtualenv for import profile

### DIFF
--- a/ci/run_single_test.sh
+++ b/ci/run_single_test.sh
@@ -110,6 +110,7 @@ case ${TEST_TYPE} in
             echo "Creating temporary virtualenv for import profile..."
             python3 -m venv .venv-profiler
             source .venv-profiler/bin/activate
+            python -m pip install --upgrade pip setuptools
             
             PACKAGE_NAME=$(basename $(pwd))
             PROFILER_TEMP_DIR=$(mktemp -d)


### PR DESCRIPTION
The import-profile CI workflow fails on Python 3.15 with:

```
ModuleNotFoundError: No module named 'google.cloud.api'. Did you mean: 'google.cloud.location'?
```

This PR installs setuptools inside the temporary .venv-profiler virtualenv created for profiling. This ensures the profiler's namespace package resolution logic works correctly on newer Python versions (3.12+) where setuptools is no longer installed by default.