### PR TITLE
chore(ci): remove redundant pip/setuptools/wheel upgrade step from wo…

### DIFF
--- a/.github/workflows/import-profiler.yml
+++ b/.github/workflows/import-profiler.yml
@@ -26,9 +26,6 @@ jobs:
       with:
         python-version: "3.15"
         allow-prereleases: true
-    - name: Upgrade pip, setuptools, and wheel
-      run: |
-        python -m pip install --upgrade setuptools pip wheel
     - name: Run import profiler
       env:
         BUILD_TYPE: presubmit

--- a/packages/google-cloud-api-gateway/noxfile.py
+++ b/packages/google-cloud-api-gateway/noxfile.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+# Trigger import-profile CI check
 # Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/google-cloud-api-gateway/noxfile.py
+++ b/packages/google-cloud-api-gateway/noxfile.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-# Trigger import-profile CI check
 # Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
This PR removes the redundant `Upgrade pip, setuptools, and wheel` step from the host runner environment in `.github/workflows/import-profiler.yml`.

Since `ci/run_single_test.sh` now initializes its own virtual environment and upgrades/installs `pip` and `setuptools` inside `.venv-profiler`, upgrading them in the host runner environment is redundant and has no effect on the actual profile checks.
