### PR TITLE
test: fix dead assert in retry streaming tests causing coverage issues

### DIFF
--- a/packages/google-api-core/tests/asyncio/retry/test_retry_streaming_async.py
+++ b/packages/google-api-core/tests/asyncio/retry/test_retry_streaming_async.py
@@ -293,7 +293,7 @@ class TestAsyncStreamingRetry(Test_BaseRetry):
         generator = await retry_(self._generator_mock)(error_on=3)
         with pytest.raises(TypeError) as exc_info:
             await generator.asend("cannot send to fresh generator")
-            assert exc_info.match("can't send non-None value")
+        assert exc_info.match("can't send non-None value")
         await generator.aclose()
 
         # error thrown on 3

--- a/packages/google-api-core/tests/unit/retry/test_retry_streaming.py
+++ b/packages/google-api-core/tests/unit/retry/test_retry_streaming.py
@@ -263,7 +263,7 @@ class TestStreamingRetry(Test_BaseRetry):
         with pytest.raises(TypeError) as exc_info:
             # calling first send with non-None input should raise a TypeError
             result.send("can not send to fresh generator")
-            assert exc_info.match("can't send non-None value")
+        assert exc_info.match("can't send non-None value")
         # initiate iteration with None
         result = retry_(self._generator_mock)(error_on=3)
         assert result.send(None) == 0


### PR DESCRIPTION
## Problem
In `test_retry_streaming.py` and `test_retry_streaming_async.py`, an assert statement was indented inside the `pytest.raises` context manager block. In Python testing with `pytest`, any code in  a pytest.raises block that follows line that raises the expected exception is NOT executed.

This meant that the assert statement intended to verify the exception message was dead code and never ran.

## Solution
The assert statement has been dedented (moved outside and after the `pytest.raises` block) to ensure it executes after the exception is caught. This allows the test to actually verify the exception message as originally intended.

## Notes to Reviewers
This fix ensures that the tests are actually checking that the exception contains the message "can't send non-None value". It also helps with code coverage metrics by removing dead code.
