### PR TITLE
feat: implement PEP 0810 lazy loading in operations_v1

### DIFF
--- a/packages/google-api-core/google/api_core/operations_v1/__init__.py
+++ b/packages/google-api-core/google/api_core/operations_v1/__init__.py
@@ -17,9 +17,12 @@
 import importlib.util
 from typing import Set
 
-_has_async_rest = (
-    importlib.util.find_spec("google.auth.aio.transport.sessions") is not None
-)
+try:
+    _has_async_rest = (
+        importlib.util.find_spec("google.auth.aio.transport.sessions") is not None
+    )
+except ModuleNotFoundError:
+    _has_async_rest = False
 
 # PEP 0810: Explicit Lazy Imports
 # Python 3.15+ natively intercepts and defers these imports.

--- a/packages/google-api-core/google/api_core/operations_v1/__init__.py
+++ b/packages/google-api-core/google/api_core/operations_v1/__init__.py
@@ -14,27 +14,64 @@
 
 """Package for interacting with the google.longrunning.operations meta-API."""
 
-from google.api_core.operations_v1.abstract_operations_client import AbstractOperationsClient
-from google.api_core.operations_v1.operations_async_client import OperationsAsyncClient
-from google.api_core.operations_v1.operations_client import OperationsClient
-from google.api_core.operations_v1.transports.rest import OperationsRestTransport
+import importlib.util
+from typing import Set
+
+_has_async_rest = (
+    importlib.util.find_spec("google.auth.aio.transport.sessions") is not None
+)
+
+# PEP 0810: Explicit Lazy Imports
+# Python 3.15+ natively intercepts and defers these imports.
+# Developers can disable this behavior and force eager imports.
+# For more information, see:
+# https://docs.python.org/3.15/library/sys.html#sys.set_lazy_imports_filter
+# Older Python versions safely ignore this variable.
+__lazy_modules__: Set[str] = {
+    "google.api_core.operations_v1.abstract_operations_client",
+    "google.api_core.operations_v1.operations_async_client",
+    "google.api_core.operations_v1.operations_client",
+    "google.api_core.operations_v1.transports.rest",
+}
 
 __all__ = [
     "AbstractOperationsClient",
     "OperationsAsyncClient",
     "OperationsClient",
-    "OperationsRestTransport"
+    "OperationsRestTransport",
 ]
 
-try:
-    from google.api_core.operations_v1.transports.rest_asyncio import (
-        AsyncOperationsRestTransport,
+if _has_async_rest:
+    __lazy_modules__.update(
+        {
+            "google.api_core.operations_v1.transports.rest_asyncio",
+            "google.api_core.operations_v1.operations_rest_client_async",
+        }
     )
-    from google.api_core.operations_v1.operations_rest_client_async import AsyncOperationsRestClient
 
-    __all__ += ["AsyncOperationsRestClient", "AsyncOperationsRestTransport"]
-except ImportError:
-    # This import requires the `async_rest` extra.
-    # Don't raise an exception if `AsyncOperationsRestTransport` cannot be imported
-    # as other transports are still available.
-    pass
+from google.api_core.operations_v1.abstract_operations_client import (  # noqa: E402
+    AbstractOperationsClient,
+)
+from google.api_core.operations_v1.operations_async_client import (  # noqa: E402
+    OperationsAsyncClient,
+)
+from google.api_core.operations_v1.operations_client import (  # noqa: E402
+    OperationsClient,
+)
+from google.api_core.operations_v1.transports.rest import (  # noqa: E402
+    OperationsRestTransport,
+)
+
+if _has_async_rest:
+    try:
+        from google.api_core.operations_v1.transports.rest_asyncio import (  # noqa: E402, F401
+            AsyncOperationsRestTransport,
+        )
+        from google.api_core.operations_v1.operations_rest_client_async import (  # noqa: E402, F401
+            AsyncOperationsRestClient,
+        )
+
+        __all__.extend(["AsyncOperationsRestClient", "AsyncOperationsRestTransport"])
+    except ImportError:
+        # Fallback for older python/environments when importlib find_spec succeeds but actual import fails
+        pass

--- a/packages/google-api-core/google/api_core/operations_v1/__init__.py
+++ b/packages/google-api-core/google/api_core/operations_v1/__init__.py
@@ -30,11 +30,16 @@ except ModuleNotFoundError:
 # For more information, see:
 # https://docs.python.org/3.15/library/sys.html#sys.set_lazy_imports_filter
 # Older Python versions safely ignore this variable.
+# NOTE: We statically define all modules here (including async ones) to ensure 
+# static analysis tools (mypy, pyright, Ruff) can easily parse them. If async
+# support is not present, the imports are ignored, making their presence safe.
 __lazy_modules__: Set[str] = {
     "google.api_core.operations_v1.abstract_operations_client",
     "google.api_core.operations_v1.operations_async_client",
     "google.api_core.operations_v1.operations_client",
     "google.api_core.operations_v1.transports.rest",
+    "google.api_core.operations_v1.transports.rest_asyncio",
+    "google.api_core.operations_v1.operations_rest_client_async",
 }
 
 __all__ = [

--- a/packages/google-api-core/google/api_core/operations_v1/__init__.py
+++ b/packages/google-api-core/google/api_core/operations_v1/__init__.py
@@ -72,6 +72,9 @@ from google.api_core.operations_v1.transports.rest import (  # noqa: E402
 
 if _has_async_rest:
     try:
+        # On Python 3.15+, PEP 0810 lazy loading means these imports will succeed 
+        # instantly (returning a lazy proxy). Any actual ImportErrors (e.g., due to 
+        # missing aiohttp/auth dependencies) are deferred until the proxies are accessed.
         from google.api_core.operations_v1.transports.rest_asyncio import (  # noqa: E402, F401
             AsyncOperationsRestTransport,
         )

--- a/packages/google-api-core/google/api_core/operations_v1/__init__.py
+++ b/packages/google-api-core/google/api_core/operations_v1/__init__.py
@@ -30,7 +30,7 @@ except ModuleNotFoundError:
 # For more information, see:
 # https://docs.python.org/3.15/library/sys.html#sys.set_lazy_imports_filter
 # Older Python versions safely ignore this variable.
-# NOTE: We statically define all modules here (including async ones) to ensure 
+# NOTE: We statically define all modules here (including async ones) to ensure
 # static analysis tools (mypy, pyright, Ruff) can easily parse them. If async
 # support is not present, the imports are ignored, making their presence safe.
 __lazy_modules__: Set[str] = {
@@ -65,8 +65,8 @@ from google.api_core.operations_v1.transports.rest import (  # noqa: E402
 
 if _has_async_rest:
     try:
-        # On Python 3.15+, PEP 0810 lazy loading means these imports will succeed 
-        # instantly (returning a lazy proxy). Any actual ImportErrors (e.g., due to 
+        # On Python 3.15+, PEP 0810 lazy loading means these imports will succeed
+        # instantly (returning a lazy proxy). Any actual ImportErrors (e.g., due to
         # missing aiohttp/auth dependencies) are deferred until the proxies are accessed.
         from google.api_core.operations_v1.transports.rest_asyncio import (  # noqa: E402, F401
             AsyncOperationsRestTransport,

--- a/packages/google-api-core/google/api_core/operations_v1/__init__.py
+++ b/packages/google-api-core/google/api_core/operations_v1/__init__.py
@@ -49,13 +49,6 @@ __all__ = [
     "OperationsRestTransport",
 ]
 
-if _has_async_rest:
-    __lazy_modules__.update(
-        {
-            "google.api_core.operations_v1.transports.rest_asyncio",
-            "google.api_core.operations_v1.operations_rest_client_async",
-        }
-    )
 
 from google.api_core.operations_v1.abstract_operations_client import (  # noqa: E402
     AbstractOperationsClient,


### PR DESCRIPTION
This PR implements PEP 0810 explicit lazy imports in `google-api-core`'s `operations_v1` package.

On Python 3.15+, this defers loading of long-running operations clients and transports to avoid eagerly importing heavy dependencies like `grpcio` and `cryptography` during import time. This falls back safely to eager execution on Python 3.14 and below with zero backwards-compatibility risk.

### Related Links
- **Design Doc**: go/sdk:api-core-lazy-loading
- **GAPIC Implementation PR**: #17591
