### PR TITLE
test: allow libcst build on Python 3.15 in import-profiler workflow

### DIFF
--- a/.github/workflows/import-profiler.yml
+++ b/.github/workflows/import-profiler.yml
@@ -32,5 +32,7 @@ jobs:
         TARGET_BRANCH: ${{ github.base_ref || github.event.merge_group.base_ref }}
         TEST_TYPE: import_profile
         PY_VERSION: "3.15"
+        # Workaround: Allows libcst to compile on Python 3.15+ while PyO3 catches up
+        PYO3_USE_ABI3_FORWARD_COMPATIBILITY: "1"
       run: |
         ci/run_conditional_tests.sh


### PR DESCRIPTION
This PR resolves a CI failure in the `import-profiler` workflow when building Rust-based dependencies (such as `libcst`) on Python 3.15 (`3.15.0-beta.3`).

`pyo3` currently rejects Python 3.15 builds by default because Python 3.15 is newer than PyO3 0.26.0's maximum recognized version (3.14). Setting `PYO3_USE_ABI3_FORWARD_COMPATIBILITY="1"` allows building `libcst` against Python 3.15 using PyO3's stable ABI forward compatibility mode.

This matches the existing workaround configuration in [.github/workflows/gapic-generator-tests.yml](file:///.github/workflows/gapic-generator-tests.yml#L25).

Fixes #<535231604> 🦕