### PR TITLE
tests: remove protobuf cpp from tests which is no longer used as of Protobuf 4.x

### DIFF
--- a/.librarian/generator-input/client-post-processing/bigtable-integration.yaml
+++ b/.librarian/generator-input/client-post-processing/bigtable-integration.yaml
@@ -568,24 +568,15 @@ replacements:
       @nox.session(python=ALL_PYTHON)
       @nox.parametrize(
           "protobuf_implementation",
-          ["python", "upb", "cpp"],
+          ["python", "upb"],
       )
       def unit(session, protobuf_implementation):
           # Install all test dependencies, then install this package in-place.
-          py_version = tuple([int(v) for v in session.python.split(".")])
-          if protobuf_implementation == "cpp" and py_version >= (3, 11):
-              session.skip("cpp implementation is not supported in python 3.11+")
 
           constraints_path = str(
               CURRENT_DIRECTORY / "testing" / f"constraints-{session.python}.txt"
           )
           install_unittest_dependencies(session, "-c", constraints_path)
-
-          # TODO(https://github.com/googleapis/synthtool/issues/1976):
-          # Remove the 'cpp' implementation once support for Protobuf 3.x is dropped.
-          # The 'cpp' implementation requires Protobuf<4.
-          if protobuf_implementation == "cpp":
-              session.install("protobuf<4")
 
           # Run py.test against the unit tests.
           session.run(
@@ -818,14 +809,10 @@ replacements:
       @nox.session(python=DEFAULT_PYTHON_VERSION)
       @nox.parametrize(
           "protobuf_implementation",
-          ["python", "upb", "cpp"],
+          ["python", "upb"],
       )
       def prerelease_deps(session, protobuf_implementation):
           """Run all tests with prerelease versions of dependencies installed."""
-
-          py_version = tuple([int(v) for v in session.python.split(".")])
-          if protobuf_implementation == "cpp" and py_version >= (3, 11):
-              session.skip("cpp implementation is not supported in python 3.11+")
 
           # Install all dependencies
           session.install("-e", ".[all, tests, tracing]")

--- a/.librarian/generator-input/client-post-processing/bigtable-integration.yaml
+++ b/.librarian/generator-input/client-post-processing/bigtable-integration.yaml
@@ -385,6 +385,7 @@ replacements:
           "3.12",
           "3.13",
           "3.14",
+          "3.15",
       ]
 
       UNIT_TEST_STANDARD_DEPENDENCIES = [
@@ -572,6 +573,11 @@ replacements:
       )
       def unit(session, protobuf_implementation):
           # Install all test dependencies, then install this package in-place.
+
+          # TODO(https://github.com/googleapis/google-cloud-python/issues/17741):
+          # Remove once `google-crc32c` wheels are published for 3.15
+          if session.python == "3.15":
+              session.skip("Skipping 3.15 until wheels are available for google-crc32c.")
 
           constraints_path = str(
               CURRENT_DIRECTORY / "testing" / f"constraints-{session.python}.txt"

--- a/.librarian/generator-input/client-post-processing/spanner-integration.yaml
+++ b/.librarian/generator-input/client-post-processing/spanner-integration.yaml
@@ -649,6 +649,7 @@ replacements:
           "3.12",
           "3.13",
           "3.14",
+          "3.15",
       ]
       UNIT_TEST_STANDARD_DEPENDENCIES = [
           "mock",
@@ -827,29 +828,15 @@ replacements:
       @nox.session(python=ALL_PYTHON)
       @nox.parametrize(
           "protobuf_implementation",
-          ["python", "upb", "cpp"],
+          ["python", "upb"],
       )
       def unit(session, protobuf_implementation):
           # Install all test dependencies, then install this package in-place.
-
-          if protobuf_implementation == "cpp" and session.python in (
-              "3.11",
-              "3.12",
-              "3.13",
-              "3.14",
-          ):
-              session.skip("cpp implementation is not supported in python 3.11+")
 
           constraints_path = str(
               CURRENT_DIRECTORY / "testing" / f"constraints-{session.python}.txt"
           )
           install_unittest_dependencies(session, "-c", constraints_path)
-
-          # TODO(https://github.com/googleapis/synthtool/issues/1976):
-          # Remove the 'cpp' implementation once support for Protobuf 3.x is dropped.
-          # The 'cpp' implementation requires Protobuf<4.
-          if protobuf_implementation == "cpp":
-              session.install("protobuf<4")
 
           # Run py.test against the unit tests.
           args = [
@@ -946,8 +933,6 @@ replacements:
               ("python", "POSTGRESQL"),
               ("upb", "GOOGLE_STANDARD_SQL"),
               ("upb", "POSTGRESQL"),
-              ("cpp", "GOOGLE_STANDARD_SQL"),
-              ("cpp", "POSTGRESQL"),
           ],
       )
       def system(session, protobuf_implementation, database_dialect):
@@ -975,14 +960,6 @@ replacements:
                   "Only run system tests on real Spanner with one protobuf implementation to speed up the build"
               )
 
-          if protobuf_implementation == "cpp" and session.python in (
-              "3.11",
-              "3.12",
-              "3.13",
-              "3.14",
-          ):
-              session.skip("cpp implementation is not supported in python 3.11+")
-
           # Install pyopenssl for mTLS testing.
           if os.environ.get("GOOGLE_API_USE_CLIENT_CERTIFICATE", "false") == "true":
               session.install("pyopenssl")
@@ -994,12 +971,6 @@ replacements:
               session.skip("System tests were not found")
 
           install_systemtest_dependencies(session, "-c", constraints_path)
-
-          # TODO(https://github.com/googleapis/synthtool/issues/1976):
-          # Remove the 'cpp' implementation once support for Protobuf 3.x is dropped.
-          # The 'cpp' implementation requires Protobuf<4.
-          if protobuf_implementation == "cpp":
-              session.install("protobuf<4")
 
           # Run py.test against the system tests.
           if system_test_exists:
@@ -1174,20 +1145,10 @@ replacements:
               ("python", "POSTGRESQL"),
               ("upb", "GOOGLE_STANDARD_SQL"),
               ("upb", "POSTGRESQL"),
-              ("cpp", "GOOGLE_STANDARD_SQL"),
-              ("cpp", "POSTGRESQL"),
           ],
       )
       def prerelease_deps(session, protobuf_implementation, database_dialect):
           """Run all tests with prerelease versions of dependencies installed."""
-
-          if protobuf_implementation == "cpp" and session.python in (
-              "3.11",
-              "3.12",
-              "3.13",
-              "3.14",
-          ):
-              session.skip("cpp implementation is not supported in python 3.11+")
 
           # Install all dependencies
           session.install("-e", ".[all, tests, tracing]")

--- a/packages/google-cloud-bigtable/noxfile.py
+++ b/packages/google-cloud-bigtable/noxfile.py
@@ -33,6 +33,7 @@ ALL_PYTHON = [
     "3.12",
     "3.13",
     "3.14",
+    "3.15",
 ]
 
 UNIT_TEST_STANDARD_DEPENDENCIES = [
@@ -220,6 +221,11 @@ def install_unittest_dependencies(session, *constraints):
 )
 def unit(session, protobuf_implementation):
     # Install all test dependencies, then install this package in-place.
+
+    # TODO(https://github.com/googleapis/google-cloud-python/issues/17741):
+    # Remove once `google-crc32c` wheels are published for 3.15
+    if session.python == "3.15":
+        session.skip("Skipping 3.15 until wheels are available for google-crc32c.")
 
     constraints_path = str(
         CURRENT_DIRECTORY / "testing" / f"constraints-{session.python}.txt"

--- a/packages/google-cloud-bigtable/noxfile.py
+++ b/packages/google-cloud-bigtable/noxfile.py
@@ -216,24 +216,15 @@ def install_unittest_dependencies(session, *constraints):
 @nox.session(python=ALL_PYTHON)
 @nox.parametrize(
     "protobuf_implementation",
-    ["python", "upb", "cpp"],
+    ["python", "upb"],
 )
 def unit(session, protobuf_implementation):
     # Install all test dependencies, then install this package in-place.
-    py_version = tuple([int(v) for v in session.python.split(".")])
-    if protobuf_implementation == "cpp" and py_version >= (3, 11):
-        session.skip("cpp implementation is not supported in python 3.11+")
 
     constraints_path = str(
         CURRENT_DIRECTORY / "testing" / f"constraints-{session.python}.txt"
     )
     install_unittest_dependencies(session, "-c", constraints_path)
-
-    # TODO(https://github.com/googleapis/synthtool/issues/1976):
-    # Remove the 'cpp' implementation once support for Protobuf 3.x is dropped.
-    # The 'cpp' implementation requires Protobuf<4.
-    if protobuf_implementation == "cpp":
-        session.install("protobuf<4")
 
     # Run py.test against the unit tests.
     session.run(
@@ -466,14 +457,10 @@ def docfx(session):
 @nox.session(python=DEFAULT_PYTHON_VERSION)
 @nox.parametrize(
     "protobuf_implementation",
-    ["python", "upb", "cpp"],
+    ["python", "upb"],
 )
 def prerelease_deps(session, protobuf_implementation):
     """Run all tests with prerelease versions of dependencies installed."""
-
-    py_version = tuple([int(v) for v in session.python.split(".")])
-    if protobuf_implementation == "cpp" and py_version >= (3, 11):
-        session.skip("cpp implementation is not supported in python 3.11+")
 
     # Install all dependencies
     session.install("-e", ".[all, tests, tracing]")

--- a/packages/google-cloud-spanner/noxfile.py
+++ b/packages/google-cloud-spanner/noxfile.py
@@ -36,6 +36,7 @@ ALL_PYTHON: List[str] = [
     "3.12",
     "3.13",
     "3.14",
+    "3.15",
 ]
 UNIT_TEST_STANDARD_DEPENDENCIES = [
     "mock",
@@ -214,29 +215,15 @@ def install_unittest_dependencies(session, *constraints):
 @nox.session(python=ALL_PYTHON)
 @nox.parametrize(
     "protobuf_implementation",
-    ["python", "upb", "cpp"],
+    ["python", "upb"],
 )
 def unit(session, protobuf_implementation):
     # Install all test dependencies, then install this package in-place.
-
-    if protobuf_implementation == "cpp" and session.python in (
-        "3.11",
-        "3.12",
-        "3.13",
-        "3.14",
-    ):
-        session.skip("cpp implementation is not supported in python 3.11+")
 
     constraints_path = str(
         CURRENT_DIRECTORY / "testing" / f"constraints-{session.python}.txt"
     )
     install_unittest_dependencies(session, "-c", constraints_path)
-
-    # TODO(https://github.com/googleapis/synthtool/issues/1976):
-    # Remove the 'cpp' implementation once support for Protobuf 3.x is dropped.
-    # The 'cpp' implementation requires Protobuf<4.
-    if protobuf_implementation == "cpp":
-        session.install("protobuf<4")
 
     # Run py.test against the unit tests.
     args = [
@@ -333,8 +320,6 @@ def install_systemtest_dependencies(session, *constraints):
         ("python", "POSTGRESQL"),
         ("upb", "GOOGLE_STANDARD_SQL"),
         ("upb", "POSTGRESQL"),
-        ("cpp", "GOOGLE_STANDARD_SQL"),
-        ("cpp", "POSTGRESQL"),
     ],
 )
 def system(session, protobuf_implementation, database_dialect):
@@ -362,14 +347,6 @@ def system(session, protobuf_implementation, database_dialect):
             "Only run system tests on real Spanner with one protobuf implementation to speed up the build"
         )
 
-    if protobuf_implementation == "cpp" and session.python in (
-        "3.11",
-        "3.12",
-        "3.13",
-        "3.14",
-    ):
-        session.skip("cpp implementation is not supported in python 3.11+")
-
     # Install pyopenssl for mTLS testing.
     if os.environ.get("GOOGLE_API_USE_CLIENT_CERTIFICATE", "false") == "true":
         session.install("pyopenssl")
@@ -381,12 +358,6 @@ def system(session, protobuf_implementation, database_dialect):
         session.skip("System tests were not found")
 
     install_systemtest_dependencies(session, "-c", constraints_path)
-
-    # TODO(https://github.com/googleapis/synthtool/issues/1976):
-    # Remove the 'cpp' implementation once support for Protobuf 3.x is dropped.
-    # The 'cpp' implementation requires Protobuf<4.
-    if protobuf_implementation == "cpp":
-        session.install("protobuf<4")
 
     # Run py.test against the system tests.
     if system_test_exists:
@@ -561,20 +532,10 @@ def docfx(session):
         ("python", "POSTGRESQL"),
         ("upb", "GOOGLE_STANDARD_SQL"),
         ("upb", "POSTGRESQL"),
-        ("cpp", "GOOGLE_STANDARD_SQL"),
-        ("cpp", "POSTGRESQL"),
     ],
 )
 def prerelease_deps(session, protobuf_implementation, database_dialect):
     """Run all tests with prerelease versions of dependencies installed."""
-
-    if protobuf_implementation == "cpp" and session.python in (
-        "3.11",
-        "3.12",
-        "3.13",
-        "3.14",
-    ):
-        session.skip("cpp implementation is not supported in python 3.11+")
 
     # Install all dependencies
     session.install("-e", ".[all, tests, tracing]")


### PR DESCRIPTION
Both `google-cloud-spanner` and `google-cloud-bigtable` only support Protobuf 6.x+ . The tests for protobuf implementation backend `cpp` are no longer needed .

https://github.com/googleapis/google-cloud-python/blob/2c3c213998b3f3aa1cf490dfbf824d160544b732/packages/google-cloud-spanner/setup.py#L54

https://github.com/googleapis/google-cloud-python/blob/2c3c213998b3f3aa1cf490dfbf824d160544b732/packages/google-cloud-bigtable/setup.py#L52

This PR also skips Python 3.15 testing for `google-cloud-bigtable` because it depends on 3.15 wheels from `google-crc32c`. The follow up work is tracked in https://github.com/googleapis/google-cloud-python/issues/17741

Note: Python 3.15 tests are not enabled yet. That will be part of https://github.com/googleapis/google-cloud-python/pull/17585