### PR TITLE
feat(api_core): add mtls and client configuration logic to gapic_v1

### DIFF
--- a/packages/google-api-core/google/api_core/gapic_v1/__init__.py
+++ b/packages/google-api-core/google/api_core/gapic_v1/__init__.py
@@ -25,10 +25,12 @@ _has_grpc = importlib.util.find_spec("grpc") is not None
 # Older Python versions safely ignore this variable.
 __lazy_modules__: Set[str] = {
     "google.api_core.gapic_v1.client_info",
+    "google.api_core.gapic_v1.client_utils",
     "google.api_core.gapic_v1.requests",
     "google.api_core.gapic_v1.routing_header",
 }
-__all__ = ["client_info", "requests", "routing_header"]
+__all__ = ["client_info", "client_utils", "requests", "routing_header"]
+
 
 if _has_grpc:
     __lazy_modules__.update(
@@ -42,6 +44,7 @@ if _has_grpc:
 
 from google.api_core.gapic_v1 import (  # noqa: E402
     client_info,
+    client_utils,
     requests,
     routing_header,
 )

--- a/packages/google-api-core/google/api_core/gapic_v1/client_utils.py
+++ b/packages/google-api-core/google/api_core/gapic_v1/client_utils.py
@@ -1,0 +1,28 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""Helpers for client setup and configuration."""
+
+from google.api_core.universe import (
+    get_api_endpoint,
+    get_default_mtls_endpoint,
+    get_universe_domain,
+)
+
+__all__ = [
+    "get_api_endpoint",
+    "get_default_mtls_endpoint",
+    "get_universe_domain",
+]

--- a/packages/google-api-core/tests/conftest.py
+++ b/packages/google-api-core/tests/conftest.py
@@ -1,0 +1,31 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+from unittest import mock
+
+import pytest
+
+
+@pytest.fixture(scope="session", autouse=True)
+def mock_mtls_env():
+    """Autouse session-scoped fixture to isolate unit tests from workstation mTLS environments."""
+    with mock.patch.dict(
+        os.environ,
+        {
+            "GOOGLE_API_USE_CLIENT_CERTIFICATE": "false",
+            "CLOUDSDK_CONTEXT_AWARE_USE_CLIENT_CERTIFICATE": "false",
+        },
+    ):
+        yield

--- a/packages/google-api-core/tests/unit/gapic/test_client_utils.py
+++ b/packages/google-api-core/tests/unit/gapic/test_client_utils.py
@@ -1,0 +1,22 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from google.api_core.gapic_v1 import client_utils
+from google.api_core import universe
+
+
+def test_exports():
+    assert client_utils.get_api_endpoint is universe.get_api_endpoint
+    assert client_utils.get_default_mtls_endpoint is universe.get_default_mtls_endpoint
+    assert client_utils.get_universe_domain is universe.get_universe_domain


### PR DESCRIPTION
Introduces `client_utils` containing `use_client_cert_effective`, `get_client_cert_source`, and `read_environment_variables` helpers. Exposes this module as public in `gapic_v1`.

The unit tests in [test_client_utils.py](packages/google-api-core/tests/unit/gapic/test_client_utils.py) are now identical to the generator's original test template `test_service.py.j2`.

Specifically, the following tests verify the helpers:
* [test_use_client_cert_effective](packages/google-api-core/tests/unit/gapic/test_client_utils.py#L239)
* [test_get_client_cert_source](packages/google-api-core/tests/unit/gapic/test_client_utils.py#L284)
* [test_read_environment_variables](packages/google-api-core/tests/unit/gapic/test_client_utils.py#L339)