### PR TITLE
chore(api_core): use ruff for lint and format checks

### DIFF
--- a/packages/google-api-core/docs/conf.py
+++ b/packages/google-api-core/docs/conf.py
@@ -24,9 +24,9 @@
 # All configuration values have a default; values that are commented out
 # serve to show the default.
 
-import sys
 import os
 import shlex
+import sys
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the

--- a/packages/google-api-core/google/api_core/__init__.py
+++ b/packages/google-api-core/google/api_core/__init__.py
@@ -17,8 +17,7 @@
 This package contains common code and utilities used by Google client libraries.
 """
 
-from google.api_core import _python_package_support
-from google.api_core import _python_version_support
+from google.api_core import _python_package_support, _python_version_support
 from google.api_core import version as api_core_version
 
 __version__ = api_core_version.__version__

--- a/packages/google-api-core/google/api_core/_python_package_support.py
+++ b/packages/google-api-core/google/api_core/_python_package_support.py
@@ -15,16 +15,14 @@
 """Code to check versions of dependencies used by Google Cloud Client Libraries."""
 
 import warnings
-from typing import Optional, Tuple
-
 from collections import namedtuple
+from importlib import metadata
+from typing import Optional, Tuple
 
 from ._python_version_support import (
     _flatten_message,
     _get_distribution_and_import_packages,
 )
-
-from importlib import metadata
 
 ParsedVersion = Tuple[int, ...]
 

--- a/packages/google-api-core/google/api_core/_python_version_support.py
+++ b/packages/google-api-core/google/api_core/_python_version_support.py
@@ -17,13 +17,12 @@
 import datetime
 import enum
 import functools
-from importlib import metadata
 import logging
-import warnings
 import sys
 import textwrap
-from typing import Any, List, NamedTuple, Optional, Dict, Tuple
-
+import warnings
+from importlib import metadata
+from typing import Any, Dict, List, NamedTuple, Optional, Tuple
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/packages/google-api-core/google/api_core/_rest_streaming_base.py
+++ b/packages/google-api-core/google/api_core/_rest_streaming_base.py
@@ -14,13 +14,13 @@
 
 """Helpers for server-side streaming in REST."""
 
-from collections import deque
 import string
-from typing import Deque, Union
 import types
+from collections import deque
+from typing import Deque, Union
 
-import proto
 import google.protobuf.message
+import proto
 from google.protobuf.json_format import Parse
 
 

--- a/packages/google-api-core/google/api_core/bidi.py
+++ b/packages/google-api-core/google/api_core/bidi.py
@@ -113,7 +113,7 @@ class _RequestQueueGenerator(object):
             except queue_module.Empty:
                 if not self._is_active():
                     _LOGGER.debug(
-                        "Empty queue and inactive call, exiting request " "generator."
+                        "Empty queue and inactive call, exiting request generator."
                     )
                     return
                 else:

--- a/packages/google-api-core/google/api_core/bidi_async.py
+++ b/packages/google-api-core/google/api_core/bidi_async.py
@@ -18,13 +18,11 @@ import asyncio
 import logging
 from typing import Callable, Optional, Union
 
+from google.protobuf.message import Message as ProtobufMessage
 from grpc import aio
 
 from google.api_core import exceptions
 from google.api_core.bidi_base import BidiRpcBase
-
-from google.protobuf.message import Message as ProtobufMessage
-
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/packages/google-api-core/google/api_core/client_logging.py
+++ b/packages/google-api-core/google/api_core/client_logging.py
@@ -1,7 +1,6 @@
-import logging
 import json
+import logging
 import os
-
 from typing import List, Optional
 
 _LOGGING_INITIALIZED = False

--- a/packages/google-api-core/google/api_core/client_options.py
+++ b/packages/google-api-core/google/api_core/client_options.py
@@ -48,8 +48,8 @@ You can also pass a mapping object.
 
 """
 
-from typing import Callable, Mapping, Optional, Sequence, Tuple
 import warnings
+from typing import Callable, Mapping, Optional, Sequence, Tuple
 
 from google.api_core import general_helpers
 

--- a/packages/google-api-core/google/api_core/datetime_helpers.py
+++ b/packages/google-api-core/google/api_core/datetime_helpers.py
@@ -20,7 +20,6 @@ import re
 
 from google.protobuf import timestamp_pb2
 
-
 _UTC_EPOCH = datetime.datetime(1970, 1, 1, tzinfo=datetime.timezone.utc)
 _RFC3339_MICROS = "%Y-%m-%dT%H:%M:%S.%fZ"
 _RFC3339_NO_FRACTION = "%Y-%m-%dT%H:%M:%S"

--- a/packages/google-api-core/google/api_core/future/_helpers.py
+++ b/packages/google-api-core/google/api_core/future/_helpers.py
@@ -17,7 +17,6 @@
 import logging
 import threading
 
-
 _LOGGER = logging.getLogger(__name__)
 
 

--- a/packages/google-api-core/google/api_core/future/async_future.py
+++ b/packages/google-api-core/google/api_core/future/async_future.py
@@ -16,9 +16,7 @@
 
 import asyncio
 
-from google.api_core import exceptions
-from google.api_core import retry
-from google.api_core import retry_async
+from google.api_core import exceptions, retry, retry_async
 from google.api_core.future import base
 
 
@@ -101,7 +99,7 @@ class AsyncFuture(base.Future):
             await retry_(self._done_or_raise)()
         except exceptions.RetryError:
             raise asyncio.TimeoutError(
-                "Operation did not complete within the designated " "timeout."
+                "Operation did not complete within the designated timeout."
             )
 
     async def result(self, timeout=None):

--- a/packages/google-api-core/google/api_core/future/polling.py
+++ b/packages/google-api-core/google/api_core/future/polling.py
@@ -19,8 +19,7 @@ import concurrent.futures
 
 from google.api_core import exceptions
 from google.api_core import retry as retries
-from google.api_core.future import _helpers
-from google.api_core.future import base
+from google.api_core.future import _helpers, base
 
 
 class _OperationNotComplete(Exception):

--- a/packages/google-api-core/google/api_core/gapic_v1/client_info.py
+++ b/packages/google-api-core/google/api_core/gapic_v1/client_info.py
@@ -20,7 +20,6 @@ such as the library and Python version, to API services.
 
 from google.api_core import client_info
 
-
 METRICS_METADATA_KEY = "x-goog-api-client"
 
 

--- a/packages/google-api-core/google/api_core/gapic_v1/config.py
+++ b/packages/google-api-core/google/api_core/gapic_v1/config.py
@@ -22,10 +22,7 @@ import collections
 
 import grpc
 
-from google.api_core import exceptions
-from google.api_core import retry
-from google.api_core import timeout
-
+from google.api_core import exceptions, retry, timeout
 
 _MILLIS_PER_SECOND = 1000.0
 

--- a/packages/google-api-core/google/api_core/gapic_v1/method_async.py
+++ b/packages/google-api-core/google/api_core/gapic_v1/method_async.py
@@ -21,9 +21,9 @@ import functools
 
 from google.api_core import grpc_helpers_async
 from google.api_core.gapic_v1 import client_info
-from google.api_core.gapic_v1.method import (
-    DEFAULT,  # noqa: F401
-    USE_DEFAULT_METADATA,  # noqa: F401
+from google.api_core.gapic_v1.method import (  # noqa: F401
+    DEFAULT,
+    USE_DEFAULT_METADATA,
     _GapicCallable,
 )
 

--- a/packages/google-api-core/google/api_core/gapic_v1/method_async.py
+++ b/packages/google-api-core/google/api_core/gapic_v1/method_async.py
@@ -21,9 +21,11 @@ import functools
 
 from google.api_core import grpc_helpers_async
 from google.api_core.gapic_v1 import client_info
-from google.api_core.gapic_v1.method import _GapicCallable
-from google.api_core.gapic_v1.method import DEFAULT  # noqa: F401
-from google.api_core.gapic_v1.method import USE_DEFAULT_METADATA  # noqa: F401
+from google.api_core.gapic_v1.method import (
+    DEFAULT,  # noqa: F401
+    USE_DEFAULT_METADATA,  # noqa: F401
+    _GapicCallable,
+)
 
 _DEFAULT_ASYNC_TRANSPORT_KIND = "grpc_asyncio"
 

--- a/packages/google-api-core/google/api_core/grpc_helpers.py
+++ b/packages/google-api-core/google/api_core/grpc_helpers.py
@@ -13,10 +13,11 @@
 # limitations under the License.
 
 """Helpers for :mod:`grpc`."""
+
 import collections
 import functools
-from typing import Generic, Iterator, Optional, TypeVar
 import warnings
+from typing import Generic, Iterator, Optional, TypeVar
 
 import google.auth
 import google.auth.credentials
@@ -26,7 +27,6 @@ import google.protobuf
 import grpc
 
 from google.api_core import exceptions, general_helpers
-
 
 # The list of gRPC Callable interfaces that return iterators.
 _STREAM_WRAP_CLASSES = (grpc.UnaryStreamMultiCallable, grpc.StreamStreamMultiCallable)

--- a/packages/google-api-core/google/api_core/grpc_helpers_async.py
+++ b/packages/google-api-core/google/api_core/grpc_helpers_async.py
@@ -21,7 +21,6 @@ functions. This module is implementing the same surface with AsyncIO semantics.
 import asyncio
 import functools
 import warnings
-
 from typing import AsyncGenerator, Generic, Iterator, Optional, TypeVar
 
 import grpc

--- a/packages/google-api-core/google/api_core/operation.py
+++ b/packages/google-api-core/google/api_core/operation.py
@@ -39,12 +39,12 @@ Or asynchronously using callbacks and :meth:`Operation.add_done_callback`:
 import functools
 import threading
 
-from google.api_core import exceptions
-from google.api_core import protobuf_helpers
-from google.api_core.future import polling
 from google.longrunning import operations_pb2
 from google.protobuf import json_format
 from google.rpc import code_pb2
+
+from google.api_core import exceptions, protobuf_helpers
+from google.api_core.future import polling
 
 
 class Operation(polling.PollingFuture):

--- a/packages/google-api-core/google/api_core/operation_async.py
+++ b/packages/google-api-core/google/api_core/operation_async.py
@@ -39,11 +39,11 @@ Or asynchronously using callbacks and :meth:`Operation.add_done_callback`:
 import functools
 import threading
 
-from google.api_core import exceptions
-from google.api_core import protobuf_helpers
-from google.api_core.future import async_future
 from google.longrunning import operations_pb2
 from google.rpc import code_pb2
+
+from google.api_core import exceptions, protobuf_helpers
+from google.api_core.future import async_future
 
 
 class AsyncOperation(async_future.AsyncFuture):

--- a/packages/google-api-core/google/api_core/operations_v1/__init__.py
+++ b/packages/google-api-core/google/api_core/operations_v1/__init__.py
@@ -68,11 +68,11 @@ if _has_async_rest:
         # On Python 3.15+, PEP 0810 lazy loading means these imports will succeed
         # instantly (returning a lazy proxy). Any actual ImportErrors (e.g., due to
         # missing aiohttp/auth dependencies) are deferred until the proxies are accessed.
-        from google.api_core.operations_v1.transports.rest_asyncio import (  # noqa: E402, F401
-            AsyncOperationsRestTransport,
-        )
         from google.api_core.operations_v1.operations_rest_client_async import (  # noqa: E402, F401
             AsyncOperationsRestClient,
+        )
+        from google.api_core.operations_v1.transports.rest_asyncio import (  # noqa: E402, F401
+            AsyncOperationsRestTransport,
         )
 
         __all__.extend(["AsyncOperationsRestClient", "AsyncOperationsRestTransport"])

--- a/packages/google-api-core/google/api_core/operations_v1/abstract_operations_base_client.py
+++ b/packages/google-api-core/google/api_core/operations_v1/abstract_operations_base_client.py
@@ -13,9 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from collections import OrderedDict
 import os
 import re
+from collections import OrderedDict
 from typing import Dict, Optional, Type, Union
 
 from google.api_core import client_options as client_options_lib  # type: ignore
@@ -358,8 +358,7 @@ class AbstractOperationsBaseClient(metaclass=AbstractOperationsBaseClientMeta):
                 )
             if client_options.scopes:
                 raise ValueError(
-                    "When providing a transport instance, provide its scopes "
-                    "directly."
+                    "When providing a transport instance, provide its scopes directly."
                 )
             self._transport = transport
         else:

--- a/packages/google-api-core/google/api_core/operations_v1/abstract_operations_client.py
+++ b/packages/google-api-core/google/api_core/operations_v1/abstract_operations_client.py
@@ -15,21 +15,22 @@
 #
 from typing import Optional, Sequence, Tuple, Union
 
+import grpc
+from google.auth import credentials as ga_credentials  # type: ignore
+from google.longrunning import operations_pb2
+from google.oauth2 import service_account  # type: ignore
+
 from google.api_core import client_options as client_options_lib  # type: ignore
 from google.api_core import gapic_v1  # type: ignore
 from google.api_core import retry as retries  # type: ignore
 from google.api_core.operations_v1 import pagers
+from google.api_core.operations_v1.abstract_operations_base_client import (
+    AbstractOperationsBaseClient,
+)
 from google.api_core.operations_v1.transports.base import (
     DEFAULT_CLIENT_INFO,
     OperationsTransport,
 )
-from google.api_core.operations_v1.abstract_operations_base_client import (
-    AbstractOperationsBaseClient,
-)
-from google.auth import credentials as ga_credentials  # type: ignore
-from google.longrunning import operations_pb2
-from google.oauth2 import service_account  # type: ignore
-import grpc
 
 OptionalRetry = Union[retries.Retry, object]
 

--- a/packages/google-api-core/google/api_core/operations_v1/operations_async_client.py
+++ b/packages/google-api-core/google/api_core/operations_v1/operations_async_client.py
@@ -24,12 +24,13 @@
 
 import functools
 
+from google.longrunning import operations_pb2
+from grpc import Compression
+
 from google.api_core import exceptions as core_exceptions
 from google.api_core import gapic_v1, page_iterator_async
 from google.api_core import retry_async as retries
 from google.api_core import timeout as timeouts
-from google.longrunning import operations_pb2
-from grpc import Compression
 
 
 class OperationsAsyncClient:

--- a/packages/google-api-core/google/api_core/operations_v1/operations_client.py
+++ b/packages/google-api-core/google/api_core/operations_v1/operations_client.py
@@ -37,13 +37,13 @@ automatically by another client class to deal with operations.
 
 import functools
 
-from google.api_core import exceptions as core_exceptions
-from google.api_core import gapic_v1
-from google.api_core import page_iterator
-from google.api_core import retry as retries
-from google.api_core import timeout as timeouts
 from google.longrunning import operations_pb2
 from grpc import Compression
+
+from google.api_core import exceptions as core_exceptions
+from google.api_core import gapic_v1, page_iterator
+from google.api_core import retry as retries
+from google.api_core import timeout as timeouts
 
 
 class OperationsClient(object):

--- a/packages/google-api-core/google/api_core/operations_v1/operations_rest_client_async.py
+++ b/packages/google-api-core/google/api_core/operations_v1/operations_rest_client_async.py
@@ -15,17 +15,18 @@
 #
 from typing import Optional, Sequence, Tuple, Union
 
+from google.longrunning import operations_pb2
+
 from google.api_core import client_options as client_options_lib  # type: ignore
 from google.api_core import gapic_v1  # type: ignore
 from google.api_core.operations_v1 import pagers_async as pagers
+from google.api_core.operations_v1.abstract_operations_base_client import (
+    AbstractOperationsBaseClient,
+)
 from google.api_core.operations_v1.transports.base import (
     DEFAULT_CLIENT_INFO,
     OperationsTransport,
 )
-from google.api_core.operations_v1.abstract_operations_base_client import (
-    AbstractOperationsBaseClient,
-)
-from google.longrunning import operations_pb2
 
 try:
     from google.auth.aio import credentials as ga_credentials  # type: ignore

--- a/packages/google-api-core/google/api_core/operations_v1/pagers.py
+++ b/packages/google-api-core/google/api_core/operations_v1/pagers.py
@@ -21,6 +21,7 @@ from typing import (
 )
 
 from google.longrunning import operations_pb2
+
 from google.api_core.operations_v1.pagers_base import ListOperationsPagerBase
 
 

--- a/packages/google-api-core/google/api_core/operations_v1/pagers_async.py
+++ b/packages/google-api-core/google/api_core/operations_v1/pagers_async.py
@@ -14,13 +14,14 @@
 # limitations under the License.
 #
 from typing import (
-    Callable,
     AsyncIterator,
+    Callable,
     Sequence,
     Tuple,
 )
 
 from google.longrunning import operations_pb2
+
 from google.api_core.operations_v1.pagers_base import ListOperationsPagerBase
 
 

--- a/packages/google-api-core/google/api_core/operations_v1/transports/__init__.py
+++ b/packages/google-api-core/google/api_core/operations_v1/transports/__init__.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 from collections import OrderedDict
-from typing import cast, Dict, Tuple
+from typing import Dict, Tuple, cast
 
 from .base import OperationsTransport
 from .rest import OperationsRestTransport

--- a/packages/google-api-core/google/api_core/operations_v1/transports/base.py
+++ b/packages/google-api-core/google/api_core/operations_v1/transports/base.py
@@ -15,23 +15,25 @@
 #
 import abc
 import re
-from typing import Awaitable, Callable, Optional, Sequence, Union
 import warnings
+from typing import Awaitable, Callable, Optional, Sequence, Union
 
 import google.auth  # type: ignore
+import google.protobuf
 from google.auth import credentials as ga_credentials  # type: ignore
 from google.longrunning import operations_pb2
 from google.oauth2 import service_account  # type: ignore
-import google.protobuf
 from google.protobuf import empty_pb2, json_format  # type: ignore
 from grpc import Compression
 
 import google.api_core  # type: ignore
 from google.api_core import exceptions as core_exceptions  # type: ignore
-from google.api_core import gapic_v1  # type: ignore
-from google.api_core import general_helpers
+from google.api_core import (
+    gapic_v1,  # type: ignore
+    general_helpers,
+    version,
+)
 from google.api_core import retry as retries  # type: ignore
-from google.api_core import version
 
 PROTOBUF_VERSION = google.protobuf.__version__
 

--- a/packages/google-api-core/google/api_core/operations_v1/transports/rest.py
+++ b/packages/google-api-core/google/api_core/operations_v1/transports/rest.py
@@ -14,23 +14,27 @@
 # limitations under the License.
 #
 
-from typing import Callable, Dict, Optional, Sequence, Tuple, Union
 import warnings
+from typing import Callable, Dict, Optional, Sequence, Tuple, Union
 
+import google.protobuf
+import grpc
 from google.auth import credentials as ga_credentials  # type: ignore
 from google.auth.transport.requests import AuthorizedSession  # type: ignore
 from google.longrunning import operations_pb2  # type: ignore
-import google.protobuf
-from google.protobuf import empty_pb2  # type: ignore
-from google.protobuf import json_format  # type: ignore
-import grpc
+from google.protobuf import (
+    empty_pb2,  # type: ignore
+    json_format,  # type: ignore
+)
 from requests import __version__ as requests_version
 
 from google.api_core import exceptions as core_exceptions  # type: ignore
-from google.api_core import gapic_v1  # type: ignore
-from google.api_core import general_helpers
-from google.api_core import path_template  # type: ignore
-from google.api_core import rest_helpers  # type: ignore
+from google.api_core import (
+    gapic_v1,  # type: ignore
+    general_helpers,
+    path_template,  # type: ignore
+    rest_helpers,  # type: ignore
+)
 from google.api_core import retry as retries  # type: ignore
 
 from .base import DEFAULT_CLIENT_INFO as BASE_DEFAULT_CLIENT_INFO

--- a/packages/google-api-core/google/api_core/operations_v1/transports/rest_asyncio.py
+++ b/packages/google-api-core/google/api_core/operations_v1/transports/rest_asyncio.py
@@ -15,31 +15,39 @@
 #
 
 import json
-from typing import Any, Callable, Coroutine, Dict, Optional, Sequence, Tuple
 import warnings
+from typing import Any, Callable, Coroutine, Dict, Optional, Sequence, Tuple
 
 from google.auth import __version__ as auth_version
 
 try:
-    from google.auth.aio.transport.sessions import AsyncAuthorizedSession  # type: ignore
+    from google.auth.aio.transport.sessions import (
+        AsyncAuthorizedSession,  # type: ignore
+    )
 except ImportError as e:  # pragma: NO COVER
     raise ImportError(
         "The `async_rest` extra of `google-api-core` is required to use long-running operations.  Install it by running "
         "`pip install google-api-core[async_rest]`."
     ) from e
 
-from google.api_core import exceptions as core_exceptions  # type: ignore
-from google.api_core import gapic_v1  # type: ignore
-from google.api_core import general_helpers
-from google.api_core import path_template  # type: ignore
-from google.api_core import rest_helpers  # type: ignore
-from google.api_core import retry_async as retries_async  # type: ignore
 from google.auth.aio import credentials as ga_credentials_async  # type: ignore
 from google.longrunning import operations_pb2  # type: ignore
-from google.protobuf import empty_pb2  # type: ignore
-from google.protobuf import json_format  # type: ignore
+from google.protobuf import (
+    empty_pb2,  # type: ignore
+    json_format,  # type: ignore
+)
 
-from .base import DEFAULT_CLIENT_INFO as BASE_DEFAULT_CLIENT_INFO, OperationsTransport
+from google.api_core import exceptions as core_exceptions  # type: ignore
+from google.api_core import (
+    gapic_v1,  # type: ignore
+    general_helpers,
+    path_template,  # type: ignore
+    rest_helpers,  # type: ignore
+)
+from google.api_core import retry_async as retries_async  # type: ignore
+
+from .base import DEFAULT_CLIENT_INFO as BASE_DEFAULT_CLIENT_INFO
+from .base import OperationsTransport
 
 DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
     gapic_version=BASE_DEFAULT_CLIENT_INFO.gapic_version,
@@ -307,7 +315,9 @@ class AsyncOperationsRestTransport(OperationsTransport):
         if response.status_code >= 400:
             payload = json.loads(content.decode("utf-8"))
             request_url = "{host}{uri}".format(host=self._host, uri=uri)
-            raise core_exceptions.format_http_response_error(response, method, request_url, payload)  # type: ignore
+            raise core_exceptions.format_http_response_error(
+                response, method, request_url, payload
+            )  # type: ignore
 
         # Return the response
         api_response = operations_pb2.ListOperationsResponse()
@@ -385,7 +395,9 @@ class AsyncOperationsRestTransport(OperationsTransport):
         if response.status_code >= 400:
             payload = json.loads(content.decode("utf-8"))
             request_url = "{host}{uri}".format(host=self._host, uri=uri)
-            raise core_exceptions.format_http_response_error(response, method, request_url, payload)  # type: ignore
+            raise core_exceptions.format_http_response_error(
+                response, method, request_url, payload
+            )  # type: ignore
 
         # Return the response
         api_response = operations_pb2.Operation()
@@ -459,7 +471,9 @@ class AsyncOperationsRestTransport(OperationsTransport):
             content = await response.read()
             payload = json.loads(content.decode("utf-8"))
             request_url = "{host}{uri}".format(host=self._host, uri=uri)
-            raise core_exceptions.format_http_response_error(response, method, request_url, payload)  # type: ignore
+            raise core_exceptions.format_http_response_error(
+                response, method, request_url, payload
+            )  # type: ignore
 
         return empty_pb2.Empty()
 
@@ -539,7 +553,9 @@ class AsyncOperationsRestTransport(OperationsTransport):
             content = await response.read()
             payload = json.loads(content.decode("utf-8"))
             request_url = "{host}{uri}".format(host=self._host, uri=uri)
-            raise core_exceptions.format_http_response_error(response, method, request_url, payload)  # type: ignore
+            raise core_exceptions.format_http_response_error(
+                response, method, request_url, payload
+            )  # type: ignore
 
         return empty_pb2.Empty()
 

--- a/packages/google-api-core/google/api_core/path_template.py
+++ b/packages/google-api-core/google/api_core/path_template.py
@@ -25,10 +25,10 @@ in Google APIs for `resource names`_.
 
 from __future__ import unicode_literals
 
-from collections import deque
 import copy
 import functools
 import re
+from collections import deque
 
 # Regular expression for extracting variable parts from a path template.
 # The variables can be expressed as:
@@ -321,8 +321,7 @@ def transcode(http_options, message=None, **request_kwargs):
         return request
 
     bindings_description = [
-        '\n\tURI: "{}"'
-        "\n\tRequired request fields:\n\t\t{}".format(
+        '\n\tURI: "{}"\n\tRequired request fields:\n\t\t{}'.format(
             uri,
             "\n\t\t".join(
                 [

--- a/packages/google-api-core/google/api_core/protobuf_helpers.py
+++ b/packages/google-api-core/google/api_core/protobuf_helpers.py
@@ -19,10 +19,7 @@ import collections.abc
 import copy
 import inspect
 
-from google.protobuf import field_mask_pb2
-from google.protobuf import message
-from google.protobuf import wrappers_pb2
-
+from google.protobuf import field_mask_pb2, message, wrappers_pb2
 
 _SENTINEL = object()
 _WRAPPER_TYPES = (

--- a/packages/google-api-core/google/api_core/rest_streaming.py
+++ b/packages/google-api-core/google/api_core/rest_streaming.py
@@ -16,9 +16,10 @@
 
 from typing import Union
 
+import google.protobuf.message
 import proto
 import requests
-import google.protobuf.message
+
 from google.api_core._rest_streaming_base import BaseResponseIterator
 
 

--- a/packages/google-api-core/google/api_core/rest_streaming_async.py
+++ b/packages/google-api-core/google/api_core/rest_streaming_async.py
@@ -28,6 +28,7 @@ except ImportError as e:  # pragma: NO COVER
     ) from e
 
 import google.protobuf.message
+
 from google.api_core._rest_streaming_base import BaseResponseIterator
 
 

--- a/packages/google-api-core/google/api_core/retry/__init__.py
+++ b/packages/google-api-core/google/api_core/retry/__init__.py
@@ -14,26 +14,29 @@
 
 """Retry implementation for Google API client libraries."""
 
-from .retry_base import exponential_sleep_generator
-from .retry_base import if_exception_type
-from .retry_base import if_transient_error
-from .retry_base import build_retry_error
-from .retry_base import RetryFailureReason
-from .retry_unary import Retry
-from .retry_unary import retry_target
-from .retry_unary_async import AsyncRetry
-from .retry_unary_async import retry_target as retry_target_async
-from .retry_streaming import StreamingRetry
-from .retry_streaming import retry_target_stream
-from .retry_streaming_async import AsyncStreamingRetry
-from .retry_streaming_async import retry_target_stream as retry_target_stream_async
+from google.auth import exceptions as auth_exceptions  # noqa: F401
 
 # The following imports are for backwards compatibility with https://github.com/googleapis/python-api-core/blob/4d7d2edee2c108d43deb151e6e0fdceb56b73275/google/api_core/retry.py
 #
 # TODO: Revert these imports on the next major version release (https://github.com/googleapis/python-api-core/issues/576)
-from google.api_core import datetime_helpers  # noqa: F401
-from google.api_core import exceptions  # noqa: F401
-from google.auth import exceptions as auth_exceptions  # noqa: F401
+from google.api_core import (
+    datetime_helpers,  # noqa: F401
+    exceptions,  # noqa: F401
+)
+
+from .retry_base import (
+    RetryFailureReason,
+    build_retry_error,
+    exponential_sleep_generator,
+    if_exception_type,
+    if_transient_error,
+)
+from .retry_streaming import StreamingRetry, retry_target_stream
+from .retry_streaming_async import AsyncStreamingRetry
+from .retry_streaming_async import retry_target_stream as retry_target_stream_async
+from .retry_unary import Retry, retry_target
+from .retry_unary_async import AsyncRetry
+from .retry_unary_async import retry_target as retry_target_async
 
 __all__ = (
     "exponential_sleep_generator",

--- a/packages/google-api-core/google/api_core/retry/__init__.py
+++ b/packages/google-api-core/google/api_core/retry/__init__.py
@@ -19,9 +19,9 @@ from google.auth import exceptions as auth_exceptions  # noqa: F401
 # The following imports are for backwards compatibility with https://github.com/googleapis/python-api-core/blob/4d7d2edee2c108d43deb151e6e0fdceb56b73275/google/api_core/retry.py
 #
 # TODO: Revert these imports on the next major version release (https://github.com/googleapis/python-api-core/issues/576)
-from google.api_core import (
-    datetime_helpers,  # noqa: F401
-    exceptions,  # noqa: F401
+from google.api_core import (  # noqa: F401
+    datetime_helpers,
+    exceptions,
 )
 
 from .retry_base import (

--- a/packages/google-api-core/google/api_core/retry/retry_base.py
+++ b/packages/google-api-core/google/api_core/retry/retry_base.py
@@ -23,14 +23,13 @@ from __future__ import annotations
 import logging
 import random
 import time
-
 from enum import Enum
-from typing import Any, Callable, Optional, Iterator, TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, Callable, Iterator, Optional
 
 import requests.exceptions
+from google.auth import exceptions as auth_exceptions
 
 from google.api_core import exceptions
-from google.auth import exceptions as auth_exceptions
 
 if TYPE_CHECKING:
     import sys

--- a/packages/google-api-core/google/api_core/retry/retry_streaming.py
+++ b/packages/google-api-core/google/api_core/retry/retry_streaming.py
@@ -15,29 +15,30 @@
 """
 Generator wrapper for retryable streaming RPCs.
 """
+
 from __future__ import annotations
 
-from typing import (
-    Callable,
-    Optional,
-    List,
-    Tuple,
-    Iterable,
-    Generator,
-    TypeVar,
-    Any,
-    TYPE_CHECKING,
-)
-
+import functools
 import sys
 import time
-import functools
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Callable,
+    Generator,
+    Iterable,
+    List,
+    Optional,
+    Tuple,
+    TypeVar,
+)
 
-from google.api_core.retry.retry_base import _BaseRetry
-from google.api_core.retry.retry_base import _retry_error_helper
-from google.api_core.retry import exponential_sleep_generator
-from google.api_core.retry import build_retry_error
-from google.api_core.retry import RetryFailureReason
+from google.api_core.retry import (
+    RetryFailureReason,
+    build_retry_error,
+    exponential_sleep_generator,
+)
+from google.api_core.retry.retry_base import _BaseRetry, _retry_error_helper
 
 if TYPE_CHECKING:
     if sys.version_info >= (3, 10):

--- a/packages/google-api-core/google/api_core/retry/retry_streaming_async.py
+++ b/packages/google-api-core/google/api_core/retry/retry_streaming_async.py
@@ -15,32 +15,32 @@
 """
 Generator wrapper for retryable async streaming RPCs.
 """
+
 from __future__ import annotations
 
+import asyncio
+import functools
+import sys
+import time
 from typing import (
-    cast,
+    TYPE_CHECKING,
     Any,
+    AsyncGenerator,
+    AsyncIterable,
+    AsyncIterator,
+    Awaitable,
     Callable,
     Iterable,
-    AsyncIterator,
-    AsyncIterable,
-    Awaitable,
     TypeVar,
-    AsyncGenerator,
-    TYPE_CHECKING,
+    cast,
 )
 
-import asyncio
-import time
-import sys
-import functools
-
-from google.api_core.retry.retry_base import _BaseRetry
-from google.api_core.retry.retry_base import _retry_error_helper
-from google.api_core.retry import exponential_sleep_generator
-from google.api_core.retry import build_retry_error
-from google.api_core.retry import RetryFailureReason
-
+from google.api_core.retry import (
+    RetryFailureReason,
+    build_retry_error,
+    exponential_sleep_generator,
+)
+from google.api_core.retry.retry_base import _BaseRetry, _retry_error_helper
 
 if TYPE_CHECKING:
     if sys.version_info >= (3, 10):

--- a/packages/google-api-core/google/api_core/retry/retry_unary.py
+++ b/packages/google-api-core/google/api_core/retry/retry_unary.py
@@ -57,18 +57,19 @@ a ``retry`` parameter that allows you to configure the behavior:
 from __future__ import annotations
 
 import functools
+import inspect
 import sys
 import time
-import inspect
 import warnings
-from typing import Any, Callable, Iterable, TypeVar, TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, Callable, Iterable, TypeVar
 
-from google.api_core.retry.retry_base import _BaseRetry
-from google.api_core.retry.retry_base import _retry_error_helper
-from google.api_core.retry.retry_base import exponential_sleep_generator
-from google.api_core.retry.retry_base import build_retry_error
-from google.api_core.retry.retry_base import RetryFailureReason
-
+from google.api_core.retry.retry_base import (
+    RetryFailureReason,
+    _BaseRetry,
+    _retry_error_helper,
+    build_retry_error,
+    exponential_sleep_generator,
+)
 
 if TYPE_CHECKING:
     if sys.version_info >= (3, 10):

--- a/packages/google-api-core/google/api_core/retry/retry_unary_async.py
+++ b/packages/google-api-core/google/api_core/retry/retry_unary_async.py
@@ -54,26 +54,27 @@ a ``retry`` parameter that allows you to configure the behavior:
 from __future__ import annotations
 
 import asyncio
-import time
 import functools
+import time
 from typing import (
-    Awaitable,
+    TYPE_CHECKING,
     Any,
+    Awaitable,
     Callable,
     Iterable,
     TypeVar,
-    TYPE_CHECKING,
 )
 
-from google.api_core.retry.retry_base import _BaseRetry
-from google.api_core.retry.retry_base import _retry_error_helper
-from google.api_core.retry.retry_base import exponential_sleep_generator
-from google.api_core.retry.retry_base import build_retry_error
-from google.api_core.retry.retry_base import RetryFailureReason
-
 # for backwards compatibility, expose helpers in this module
-from google.api_core.retry.retry_base import if_exception_type  # noqa
-from google.api_core.retry.retry_base import if_transient_error  # noqa
+from google.api_core.retry.retry_base import (
+    RetryFailureReason,
+    _BaseRetry,
+    _retry_error_helper,
+    build_retry_error,
+    exponential_sleep_generator,
+    if_exception_type,  # noqa
+    if_transient_error,  # noqa
+)
 
 if TYPE_CHECKING:
     import sys

--- a/packages/google-api-core/google/api_core/retry/retry_unary_async.py
+++ b/packages/google-api-core/google/api_core/retry/retry_unary_async.py
@@ -66,14 +66,14 @@ from typing import (
 )
 
 # for backwards compatibility, expose helpers in this module
-from google.api_core.retry.retry_base import (
+from google.api_core.retry.retry_base import (  # noqa: F401
     RetryFailureReason,
     _BaseRetry,
     _retry_error_helper,
     build_retry_error,
     exponential_sleep_generator,
-    if_exception_type,  # noqa
-    if_transient_error,  # noqa
+    if_exception_type,
+    if_transient_error,
 )
 
 if TYPE_CHECKING:

--- a/packages/google-api-core/google/api_core/retry_async.py
+++ b/packages/google-api-core/google/api_core/retry_async.py
@@ -15,13 +15,16 @@
 # The following imports are for backwards compatibility with https://github.com/googleapis/python-api-core/blob/4d7d2edee2c108d43deb151e6e0fdceb56b73275/google/api_core/retry_async.py
 #
 # TODO: Revert these imports on the next major version release (https://github.com/googleapis/python-api-core/issues/576)
-from google.api_core import datetime_helpers  # noqa: F401
-from google.api_core import exceptions  # noqa: F401
-from google.api_core.retry import exponential_sleep_generator  # noqa: F401
-from google.api_core.retry import if_exception_type  # noqa: F401
-from google.api_core.retry import if_transient_error  # noqa: F401
-from google.api_core.retry.retry_unary_async import AsyncRetry
-from google.api_core.retry.retry_unary_async import retry_target
+from google.api_core import (
+    datetime_helpers,  # noqa: F401
+    exceptions,  # noqa: F401
+)
+from google.api_core.retry import (
+    exponential_sleep_generator,  # noqa: F401
+    if_exception_type,  # noqa: F401
+    if_transient_error,  # noqa: F401
+)
+from google.api_core.retry.retry_unary_async import AsyncRetry, retry_target
 
 __all__ = (
     "AsyncRetry",

--- a/packages/google-api-core/noxfile.py
+++ b/packages/google-api-core/noxfile.py
@@ -28,11 +28,8 @@ import unittest
 # https://github.com/google/importlab/issues/25
 import nox
 
-BLACK_VERSION = "black==23.7.0"
 RUFF_VERSION = "ruff==0.14.14"
-BLACK_PATHS = ["docs", "google", "tests", "noxfile.py", "setup.py"]
-# Black and flake8 clash on the syntax for ignoring flake8's F401 in this file.
-BLACK_EXCLUDES = ["--exclude", "^/google/api_core/operations_v1/__init__.py"]
+LINT_PATHS = ["docs", "google", "tests", "noxfile.py", "setup.py"]
 
 ALL_PYTHON = ["3.10", "3.11", "3.12", "3.13", "3.14"]
 SUPPORTED_PYTHON_VERSIONS = ["3.10", "3.11", "3.12", "3.13", "3.14"]
@@ -52,25 +49,36 @@ def lint(session):
     Returns a failure if the linters find linting errors or sufficiently
     serious code quality issues.
     """
-    session.install("flake8", BLACK_VERSION)
-    session.install(".")
+    session.install("flake8", RUFF_VERSION)
+
     session.run(
-        "black",
+        "ruff",
+        "format",
         "--check",
-        *BLACK_EXCLUDES,
-        *BLACK_PATHS,
+        f"--target-version=py{ALL_PYTHON[0].replace('.', '')}",
+        "--line-length=88",
+        *LINT_PATHS,
     )
+
     session.run("flake8", "google", "tests")
 
 
 @nox.session(python=DEFAULT_PYTHON_VERSION)
 def blacken(session):
-    """Run black.
+    """(Deprecated) Legacy session. Please use 'nox -s format'."""
+    session.log(
+        "WARNING: The 'blacken' session is deprecated and will be removed in a future release. Please use 'nox -s format' in the future."
+    )
 
-    Format code to uniform standard.
-    """
-    session.install(BLACK_VERSION)
-    session.run("black", *BLACK_EXCLUDES, *BLACK_PATHS)
+    # Just run the ruff formatter (keeping legacy behavior of only formatting, not sorting imports)
+    session.install(RUFF_VERSION)
+    session.run(
+        "ruff",
+        "format",
+        f"--target-version=py{ALL_PYTHON[0].replace('.', '')}",
+        "--line-length=88",
+        *LINT_PATHS,
+    )
 
 
 @nox.session(python=DEFAULT_PYTHON_VERSION)
@@ -90,7 +98,7 @@ def format(session):
         "--fix",
         f"--target-version=py{ALL_PYTHON[0].replace('.', '')}",
         "--line-length=88",
-        *BLACK_PATHS,
+        *LINT_PATHS,
     )
 
     # 3. Run Ruff to format code
@@ -99,7 +107,7 @@ def format(session):
         "format",
         f"--target-version=py{ALL_PYTHON[0].replace('.', '')}",
         "--line-length=88",
-        *BLACK_PATHS,
+        *LINT_PATHS,
     )
 
 

--- a/packages/google-api-core/setup.py
+++ b/packages/google-api-core/setup.py
@@ -14,5 +14,4 @@
 
 import setuptools
 
-
 setuptools.setup()

--- a/packages/google-api-core/tests/asyncio/gapic/test_config_async.py
+++ b/packages/google-api-core/tests/asyncio/gapic/test_config_async.py
@@ -23,7 +23,6 @@ except ImportError:
 from google.api_core import exceptions
 from google.api_core.gapic_v1 import config_async
 
-
 INTERFACE_CONFIG = {
     "retry_codes": {
         "idempotent": ["DEADLINE_EXCEEDED", "UNAVAILABLE"],

--- a/packages/google-api-core/tests/asyncio/gapic/test_method_async.py
+++ b/packages/google-api-core/tests/asyncio/gapic/test_method_async.py
@@ -22,15 +22,17 @@ except ImportError:  # pragma: NO COVER
 import pytest
 
 try:
-    from grpc import aio, Compression
+    from grpc import Compression, aio
 except ImportError:
     pytest.skip("No GRPC", allow_module_level=True)
 
-from google.api_core import exceptions
-from google.api_core import gapic_v1
-from google.api_core import grpc_helpers_async
-from google.api_core import retry_async
-from google.api_core import timeout
+from google.api_core import (
+    exceptions,
+    gapic_v1,
+    grpc_helpers_async,
+    retry_async,
+    timeout,
+)
 
 
 def _utcnow_monotonic():

--- a/packages/google-api-core/tests/asyncio/operations_v1/test_operations_async_client.py
+++ b/packages/google-api-core/tests/asyncio/operations_v1/test_operations_async_client.py
@@ -17,15 +17,14 @@ from unittest import mock
 import pytest
 
 try:
-    from grpc import aio, Compression
+    from grpc import Compression, aio
 except ImportError:  # pragma: NO COVER
     pytest.skip("No GRPC", allow_module_level=True)
 
-from google.api_core import grpc_helpers_async
-from google.api_core import operations_v1
-from google.api_core import page_iterator_async
 from google.longrunning import operations_pb2
 from google.protobuf import empty_pb2
+
+from google.api_core import grpc_helpers_async, operations_v1, page_iterator_async
 
 
 def _mock_grpc_objects(response):

--- a/packages/google-api-core/tests/asyncio/retry/test_retry_streaming_async.py
+++ b/packages/google-api-core/tests/asyncio/retry/test_retry_streaming_async.py
@@ -24,8 +24,7 @@ except ImportError:  # pragma: NO COVER
 
 import pytest
 
-from google.api_core import exceptions
-from google.api_core import retry_async
+from google.api_core import exceptions, retry_async
 from google.api_core.retry import retry_streaming_async
 
 from ...unit.retry.test_retry_base import Test_BaseRetry
@@ -46,6 +45,7 @@ async def test_retry_streaming_target_dynamic_backoff(sleep):
     sleep_generator should be iterated after on_error, to support dynamic backoff
     """
     from functools import partial
+
     from google.api_core.retry.retry_streaming_async import retry_target_stream
 
     sleep.side_effect = RuntimeError("stop after sleep")
@@ -558,6 +558,7 @@ class TestAsyncStreamingRetry(Test_BaseRetry):
         test when timeout is exceeded
         """
         import time
+
         from google.api_core.retry import RetryFailureReason
         from google.api_core.retry.retry_streaming_async import retry_target_stream
 

--- a/packages/google-api-core/tests/asyncio/retry/test_retry_unary_async.py
+++ b/packages/google-api-core/tests/asyncio/retry/test_retry_unary_async.py
@@ -22,8 +22,7 @@ except ImportError:  # pragma: NO COVER
     import mock  # type: ignore
 import pytest
 
-from google.api_core import exceptions
-from google.api_core import retry_async
+from google.api_core import exceptions, retry_async
 
 from ...unit.retry.test_retry_base import Test_BaseRetry
 

--- a/packages/google-api-core/tests/asyncio/test_bidi_async.py
+++ b/packages/google-api-core/tests/asyncio/test_bidi_async.py
@@ -14,7 +14,6 @@
 
 
 import asyncio
-
 from unittest import mock
 
 try:
@@ -30,8 +29,7 @@ try:
 except ImportError:  # pragma: NO COVER
     pytest.skip("No GRPC", allow_module_level=True)
 
-from google.api_core import bidi_async
-from google.api_core import exceptions
+from google.api_core import bidi_async, exceptions
 
 
 @pytest.mark.asyncio

--- a/packages/google-api-core/tests/asyncio/test_grpc_helpers_async.py
+++ b/packages/google-api-core/tests/asyncio/test_grpc_helpers_async.py
@@ -17,8 +17,9 @@ try:
     from unittest.mock import AsyncMock  # pragma: NO COVER  # noqa: F401
 except ImportError:  # pragma: NO COVER
     import mock  # type: ignore
-from ..helpers import warn_deprecated_credentials_file
 import pytest  # noqa: I202
+
+from ..helpers import warn_deprecated_credentials_file
 
 try:
     import grpc
@@ -31,9 +32,9 @@ if grpc is None:  # pragma: NO COVER
     pytest.skip("No GRPC", allow_module_level=True)
 
 
-from google.api_core import exceptions
-from google.api_core import grpc_helpers_async
 import google.auth.credentials
+
+from google.api_core import exceptions, grpc_helpers_async
 
 
 class RpcErrorImpl(grpc.RpcError, grpc.Call):

--- a/packages/google-api-core/tests/asyncio/test_operation_async.py
+++ b/packages/google-api-core/tests/asyncio/test_operation_async.py
@@ -26,14 +26,11 @@ try:
 except ImportError:  # pragma: NO COVER
     pytest.skip("No GRPC", allow_module_level=True)
 
-from google.api_core import exceptions
-from google.api_core import operation_async
-from google.api_core import operations_v1
-from google.api_core import retry_async
 from google.longrunning import operations_pb2
 from google.protobuf import struct_pb2
-from google.rpc import code_pb2
-from google.rpc import status_pb2
+from google.rpc import code_pb2, status_pb2
+
+from google.api_core import exceptions, operation_async, operations_v1, retry_async
 
 TEST_OPERATION_NAME = "test/operation"
 

--- a/packages/google-api-core/tests/asyncio/test_rest_streaming_async.py
+++ b/packages/google-api-core/tests/asyncio/test_rest_streaming_async.py
@@ -19,7 +19,7 @@ import datetime
 import logging
 import random
 import time
-from typing import List, AsyncIterator
+from typing import AsyncIterator, List
 
 try:
     from unittest import mock
@@ -27,9 +27,8 @@ try:
 except ImportError:  # pragma: NO COVER
     import mock  # type: ignore
 
-import pytest  # noqa: I202
-
 import proto
+import pytest  # noqa: I202
 
 try:
     from google.auth.aio.transport import Response
@@ -39,13 +38,11 @@ except ImportError:
         allow_module_level=True,
     )
 
+from google.api import http_pb2, httpbody_pb2
+
 from google.api_core import rest_streaming_async
-from google.api import http_pb2
-from google.api import httpbody_pb2
 
-
-from ..helpers import Composer, Song, EchoResponse, parse_responses
-
+from ..helpers import Composer, EchoResponse, Song, parse_responses
 
 __protobuf__ = proto.module(package=__name__)
 SEED = int(time.time())

--- a/packages/google-api-core/tests/helpers.py
+++ b/packages/google-api-core/tests/helpers.py
@@ -16,13 +16,11 @@
 
 import functools
 import logging
-import pytest  # noqa: I202
 from typing import List
 
 import proto
-
-from google.protobuf import duration_pb2
-from google.protobuf import timestamp_pb2
+import pytest  # noqa: I202
+from google.protobuf import duration_pb2, timestamp_pb2
 from google.protobuf.json_format import MessageToJson
 
 

--- a/packages/google-api-core/tests/unit/gapic/test_config.py
+++ b/packages/google-api-core/tests/unit/gapic/test_config.py
@@ -22,7 +22,6 @@ except ImportError:
 from google.api_core import exceptions
 from google.api_core.gapic_v1 import config
 
-
 INTERFACE_CONFIG = {
     "retry_codes": {
         "idempotent": ["DEADLINE_EXCEEDED", "UNAVAILABLE"],

--- a/packages/google-api-core/tests/unit/gapic/test_method.py
+++ b/packages/google-api-core/tests/unit/gapic/test_method.py
@@ -23,12 +23,10 @@ except ImportError:
     pytest.skip("No GRPC", allow_module_level=True)
 
 
-from google.api_core import exceptions
-from google.api_core import retry
-from google.api_core import timeout
 import google.api_core.gapic_v1.client_info
 import google.api_core.gapic_v1.method
 import google.api_core.page_iterator
+from google.api_core import exceptions, retry, timeout
 
 
 def _utcnow_monotonic():

--- a/packages/google-api-core/tests/unit/operations_v1/test_operations_client.py
+++ b/packages/google-api-core/tests/unit/operations_v1/test_operations_client.py
@@ -19,12 +19,11 @@ try:
 except ImportError:  # pragma: NO COVER
     pytest.skip("No GRPC", allow_module_level=True)
 
-from google.api_core import grpc_helpers
-from google.api_core import operations_v1
-from google.api_core import page_iterator
-from google.api_core.operations_v1 import operations_client_config
 from google.longrunning import operations_pb2
 from google.protobuf import empty_pb2
+
+from google.api_core import grpc_helpers, operations_v1, page_iterator
+from google.api_core.operations_v1 import operations_client_config
 
 
 def test_get_operation():

--- a/packages/google-api-core/tests/unit/operations_v1/test_operations_rest_client.py
+++ b/packages/google-api-core/tests/unit/operations_v1/test_operations_rest_client.py
@@ -21,8 +21,10 @@ try:
 except ImportError:  # pragma: NO COVER
     import mock  # type: ignore
 
-import pytest
 from typing import Any, List
+
+import pytest
+
 from ...helpers import warn_deprecated_credentials_file
 
 try:
@@ -53,9 +55,10 @@ from google.rpc import status_pb2  # type: ignore
 try:
     import aiohttp  # noqa: F401
     import google.auth.aio.transport
-    from google.auth.aio.transport.sessions import AsyncAuthorizedSession
-    from google.api_core.operations_v1 import AsyncOperationsRestClient
     from google.auth.aio import credentials as ga_credentials_async
+    from google.auth.aio.transport.sessions import AsyncAuthorizedSession
+
+    from google.api_core.operations_v1 import AsyncOperationsRestClient
 
     GOOGLE_AUTH_AIO_INSTALLED = True
 except ImportError:
@@ -1195,11 +1198,14 @@ def test_operations_base_transport():
 
 def test_operations_base_transport_with_credentials_file():
     # Instantiate the base transport with a credentials file
-    with mock.patch.object(
-        google.auth, "load_credentials_from_file", autospec=True
-    ) as load_creds, mock.patch(
-        "google.api_core.operations_v1.transports.OperationsTransport._prep_wrapped_messages"
-    ) as Transport:
+    with (
+        mock.patch.object(
+            google.auth, "load_credentials_from_file", autospec=True
+        ) as load_creds,
+        mock.patch(
+            "google.api_core.operations_v1.transports.OperationsTransport._prep_wrapped_messages"
+        ) as Transport,
+    ):
         Transport.return_value = None
         load_creds.return_value = (ga_credentials.AnonymousCredentials(), None)
         with warn_deprecated_credentials_file():
@@ -1217,9 +1223,12 @@ def test_operations_base_transport_with_credentials_file():
 
 def test_operations_base_transport_with_adc():
     # Test the default credentials are used if credentials and credentials_file are None.
-    with mock.patch.object(google.auth, "default", autospec=True) as adc, mock.patch(
-        "google.api_core.operations_v1.transports.OperationsTransport._prep_wrapped_messages"
-    ) as Transport:
+    with (
+        mock.patch.object(google.auth, "default", autospec=True) as adc,
+        mock.patch(
+            "google.api_core.operations_v1.transports.OperationsTransport._prep_wrapped_messages"
+        ) as Transport,
+    ):
         Transport.return_value = None
         adc.return_value = (ga_credentials.AnonymousCredentials(), None)
         transports.OperationsTransport()

--- a/packages/google-api-core/tests/unit/retry/test_retry_base.py
+++ b/packages/google-api-core/tests/unit/retry/test_retry_base.py
@@ -18,10 +18,9 @@ from unittest import mock
 
 import pytest
 import requests.exceptions
-
-from google.api_core import exceptions
-from google.api_core import retry
 from google.auth import exceptions as auth_exceptions
+
+from google.api_core import exceptions, retry
 
 
 def test_if_exception_type():
@@ -64,8 +63,7 @@ def test_build_retry_error_empty_list():
     attempt to build a retry error with no errors encountered
     should return a generic RetryError
     """
-    from google.api_core.retry import build_retry_error
-    from google.api_core.retry import RetryFailureReason
+    from google.api_core.retry import RetryFailureReason, build_retry_error
 
     reason = RetryFailureReason.NON_RETRYABLE_ERROR
     src, cause = build_retry_error([], reason, 10)
@@ -78,8 +76,7 @@ def test_build_retry_error_preserves_cause():
     """
     build_retry_error should preserve __cause__ from chained exceptions.
     """
-    from google.api_core.retry import build_retry_error
-    from google.api_core.retry import RetryFailureReason
+    from google.api_core.retry import RetryFailureReason, build_retry_error
 
     # Create an exception with explicit cause
     cause = ValueError("root cause")
@@ -98,8 +95,7 @@ def test_build_retry_error_timeout_message():
     """
     should provide helpful error message when timeout is reached
     """
-    from google.api_core.retry import build_retry_error
-    from google.api_core.retry import RetryFailureReason
+    from google.api_core.retry import RetryFailureReason, build_retry_error
 
     reason = RetryFailureReason.TIMEOUT
     cause = RuntimeError("timeout")
@@ -115,8 +111,7 @@ def test_build_retry_error_empty_timeout():
     attempt to build a retry error when timeout is None
     should return a generic timeout error message
     """
-    from google.api_core.retry import build_retry_error
-    from google.api_core.retry import RetryFailureReason
+    from google.api_core.retry import RetryFailureReason, build_retry_error
 
     reason = RetryFailureReason.TIMEOUT
     src, _ = build_retry_error([], reason, None)

--- a/packages/google-api-core/tests/unit/retry/test_retry_imports.py
+++ b/packages/google-api-core/tests/unit/retry/test_retry_imports.py
@@ -17,9 +17,11 @@ def test_legacy_imports_retry_unary_sync():
     # TODO: Delete this test when when we revert these imports on the
     #       next major version release
     #       (https://github.com/googleapis/python-api-core/issues/576)
-    from google.api_core.retry import datetime_helpers  # noqa: F401
-    from google.api_core.retry import exceptions  # noqa: F401
-    from google.api_core.retry import auth_exceptions  # noqa: F401
+    from google.api_core.retry import (
+        auth_exceptions,  # noqa: F401
+        datetime_helpers,  # noqa: F401
+        exceptions,  # noqa: F401
+    )
 
 
 def test_legacy_imports_retry_unary_async():

--- a/packages/google-api-core/tests/unit/retry/test_retry_imports.py
+++ b/packages/google-api-core/tests/unit/retry/test_retry_imports.py
@@ -17,10 +17,10 @@ def test_legacy_imports_retry_unary_sync():
     # TODO: Delete this test when when we revert these imports on the
     #       next major version release
     #       (https://github.com/googleapis/python-api-core/issues/576)
-    from google.api_core.retry import (
-        auth_exceptions,  # noqa: F401
-        datetime_helpers,  # noqa: F401
-        exceptions,  # noqa: F401
+    from google.api_core.retry import (  # noqa: F401
+        auth_exceptions,
+        datetime_helpers,
+        exceptions,
     )
 
 

--- a/packages/google-api-core/tests/unit/retry/test_retry_streaming.py
+++ b/packages/google-api-core/tests/unit/retry/test_retry_streaming.py
@@ -22,8 +22,7 @@ except ImportError:  # pragma: NO COVER
 
 import pytest
 
-from google.api_core import exceptions
-from google.api_core import retry
+from google.api_core import exceptions, retry
 from google.api_core.retry import retry_streaming
 
 from .test_retry_base import Test_BaseRetry
@@ -127,8 +126,8 @@ class TestStreamingRetry(Test_BaseRetry):
         Test that a retry-decorated generator yields values as expected
         This test checks a generator with no issues
         """
-        import types
         import collections
+        import types
 
         retry_ = retry_streaming.StreamingRetry()
 
@@ -461,6 +460,7 @@ class TestStreamingRetry(Test_BaseRetry):
         test when timeout is exceeded
         """
         import time
+
         from google.api_core.retry import RetryFailureReason
         from google.api_core.retry.retry_streaming import retry_target_stream
 

--- a/packages/google-api-core/tests/unit/retry/test_retry_unary.py
+++ b/packages/google-api-core/tests/unit/retry/test_retry_unary.py
@@ -13,8 +13,9 @@
 # limitations under the License.
 
 import datetime
-import pytest
 import re
+
+import pytest
 
 try:
     from unittest import mock
@@ -22,8 +23,7 @@ try:
 except ImportError:  # pragma: NO COVER
     import mock  # type: ignore
 
-from google.api_core import exceptions
-from google.api_core import retry
+from google.api_core import exceptions, retry
 
 from .test_retry_base import Test_BaseRetry
 

--- a/packages/google-api-core/tests/unit/test_bidi.py
+++ b/packages/google-api-core/tests/unit/test_bidi.py
@@ -31,8 +31,7 @@ try:
 except ImportError:  # pragma: NO COVER
     pytest.skip("No GRPC", allow_module_level=True)
 
-from google.api_core import bidi
-from google.api_core import exceptions
+from google.api_core import bidi, exceptions
 
 
 class Test_RequestQueueGenerator(object):

--- a/packages/google-api-core/tests/unit/test_client_logging.py
+++ b/packages/google-api-core/tests/unit/test_client_logging.py
@@ -3,9 +3,9 @@ import logging
 from unittest import mock
 
 from google.api_core.client_logging import (
-    setup_logging,
-    initialize_logging,
     StructuredLogFormatter,
+    initialize_logging,
+    setup_logging,
 )
 
 

--- a/packages/google-api-core/tests/unit/test_client_options.py
+++ b/packages/google-api-core/tests/unit/test_client_options.py
@@ -13,10 +13,12 @@
 # limitations under the License.
 
 from re import match
+
 import pytest
-from ..helpers import warn_deprecated_credentials_file
 
 from google.api_core import client_options
+
+from ..helpers import warn_deprecated_credentials_file
 
 
 def get_client_cert():

--- a/packages/google-api-core/tests/unit/test_datetime_helpers.py
+++ b/packages/google-api-core/tests/unit/test_datetime_helpers.py
@@ -16,10 +16,9 @@ import calendar
 import datetime
 
 import pytest
-
-from google.api_core import datetime_helpers
 from google.protobuf import timestamp_pb2
 
+from google.api_core import datetime_helpers
 
 ONE_MINUTE_IN_MICROSECONDS = 60 * 1e6
 

--- a/packages/google-api-core/tests/unit/test_extended_operation.py
+++ b/packages/google-api-core/tests/unit/test_extended_operation.py
@@ -19,9 +19,7 @@ from unittest import mock
 
 import pytest
 
-from google.api_core import exceptions
-from google.api_core import extended_operation
-from google.api_core import retry
+from google.api_core import exceptions, extended_operation, retry
 
 TEST_OPERATION_NAME = "test/extended_operation"
 

--- a/packages/google-api-core/tests/unit/test_grpc_helpers.py
+++ b/packages/google-api-core/tests/unit/test_grpc_helpers.py
@@ -15,6 +15,7 @@
 from unittest import mock
 
 import pytest
+
 from ..helpers import warn_deprecated_credentials_file
 
 try:
@@ -22,10 +23,10 @@ try:
 except ImportError:  # pragma: NO COVER
     pytest.skip("No GRPC", allow_module_level=True)
 
-from google.api_core import exceptions
-from google.api_core import grpc_helpers
 import google.auth.credentials
 from google.longrunning import operations_pb2
+
+from google.api_core import exceptions, grpc_helpers
 
 
 def test__patch_callable_name():

--- a/packages/google-api-core/tests/unit/test_iam.py
+++ b/packages/google-api-core/tests/unit/test_iam.py
@@ -277,7 +277,7 @@ class TestPolicy:
         assert dict(policy) == {}
 
     def test_from_api_repr_complete(self):
-        from google.api_core.iam import OWNER_ROLE, EDITOR_ROLE, VIEWER_ROLE
+        from google.api_core.iam import EDITOR_ROLE, OWNER_ROLE, VIEWER_ROLE
 
         OWNER1 = "group:cloud-logs@google.com"
         OWNER2 = "user:phred@example.com"
@@ -354,7 +354,8 @@ class TestPolicy:
 
     def test_to_api_repr_full(self):
         import operator
-        from google.api_core.iam import OWNER_ROLE, EDITOR_ROLE, VIEWER_ROLE
+
+        from google.api_core.iam import EDITOR_ROLE, OWNER_ROLE, VIEWER_ROLE
 
         OWNER1 = "group:cloud-logs@google.com"
         OWNER2 = "user:phred@example.com"

--- a/packages/google-api-core/tests/unit/test_operation.py
+++ b/packages/google-api-core/tests/unit/test_operation.py
@@ -22,14 +22,11 @@ try:
 except ImportError:  # pragma: NO COVER
     pytest.skip("No GRPC", allow_module_level=True)
 
-from google.api_core import exceptions
-from google.api_core import operation
-from google.api_core import operations_v1
-from google.api_core import retry
 from google.longrunning import operations_pb2
 from google.protobuf import struct_pb2
-from google.rpc import code_pb2
-from google.rpc import status_pb2
+from google.rpc import code_pb2, status_pb2
+
+from google.api_core import exceptions, operation, operations_v1, retry
 
 TEST_OPERATION_NAME = "test/operation"
 

--- a/packages/google-api-core/tests/unit/test_path_template.py
+++ b/packages/google-api-core/tests/unit/test_path_template.py
@@ -13,11 +13,12 @@
 # limitations under the License.
 
 from __future__ import unicode_literals
+
 from unittest import mock
 
 import pytest
-
 from google.api import auth_pb2
+
 from google.api_core import path_template
 
 

--- a/packages/google-api-core/tests/unit/test_protobuf_helpers.py
+++ b/packages/google-api-core/tests/unit/test_protobuf_helpers.py
@@ -12,22 +12,23 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import pytest
 import re
 
+import pytest
 from google.api import http_pb2
-from google.api_core import protobuf_helpers
 from google.longrunning import operations_pb2
-from google.protobuf import any_pb2
-from google.protobuf import message
-from google.protobuf import source_context_pb2
-from google.protobuf import struct_pb2
-from google.protobuf import timestamp_pb2
-from google.protobuf import type_pb2
-from google.protobuf import wrappers_pb2
-from google.type import color_pb2
-from google.type import date_pb2
-from google.type import timeofday_pb2
+from google.protobuf import (
+    any_pb2,
+    message,
+    source_context_pb2,
+    struct_pb2,
+    timestamp_pb2,
+    type_pb2,
+    wrappers_pb2,
+)
+from google.type import color_pb2, date_pb2, timeofday_pb2
+
+from google.api_core import protobuf_helpers
 
 
 def test_from_any_pb_success():

--- a/packages/google-api-core/tests/unit/test_python_package_support.py
+++ b/packages/google-api-core/tests/unit/test_python_package_support.py
@@ -18,12 +18,12 @@ from unittest.mock import patch
 import pytest
 
 from google.api_core._python_package_support import (
-    parse_version_to_tuple,
-    get_dependency_version,
-    warn_deprecation_for_versions_less_than,
-    check_dependency_versions,
     DependencyConstraint,
     DependencyVersion,
+    check_dependency_versions,
+    get_dependency_version,
+    parse_version_to_tuple,
+    warn_deprecation_for_versions_less_than,
 )
 
 

--- a/packages/google-api-core/tests/unit/test_rest_streaming.py
+++ b/packages/google-api-core/tests/unit/test_rest_streaming.py
@@ -22,13 +22,11 @@ from unittest.mock import patch
 import proto
 import pytest
 import requests
+from google.api import http_pb2, httpbody_pb2
 
 from google.api_core import rest_streaming
-from google.api import http_pb2
-from google.api import httpbody_pb2
 
-from ..helpers import Composer, Song, EchoResponse, parse_responses
-
+from ..helpers import Composer, EchoResponse, Song, parse_responses
 
 __protobuf__ = proto.module(package=__name__)
 SEED = int(time.time())

--- a/packages/google-api-core/tests/unit/test_timeout.py
+++ b/packages/google-api-core/tests/unit/test_timeout.py
@@ -14,8 +14,9 @@
 
 import datetime
 import itertools
-import pytest
 from unittest import mock
+
+import pytest
 
 from google.api_core import timeout as timeouts
 

--- a/packages/google-api-core/tests/unit/test_universe.py
+++ b/packages/google-api-core/tests/unit/test_universe.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import pytest
+
 from google.api_core import universe
 
 


### PR DESCRIPTION
Updates the noxfile to use ruff in place of black, to align with other libraries. Also update codebase to conform to new format

For a cleaner diff, look at individual commits