### PR TITLE
fix: disable RAB lookup for Domain-Wide Delegation

### DIFF
--- a/packages/google-auth/google/auth/impersonated_credentials.py
+++ b/packages/google-auth/google/auth/impersonated_credentials.py
@@ -362,8 +362,12 @@ class Credentials(
 
         Returns:
             Optional[str]: The URL for the Regional Access Boundary lookup endpoint, or None
-                 if the service account email is missing.
+                 if the service account email is missing. Returns None if the subject is populated.
         """
+        if self._subject:
+            # RAB does not apply to Workspace User Accounts via Domain-wide Delegation.
+            return None
+
         if not self.service_account_email:
             _LOGGER.error(
                 "Service account email is required to build the Regional Access Boundary lookup URL for impersonated credentials."

--- a/packages/google-auth/google/auth/jwt.py
+++ b/packages/google-auth/google/auth/jwt.py
@@ -589,6 +589,9 @@ class Credentials(
 
         Returns None if the subject is populated.
         """
+        # In jwt.Credentials, subject defaults to client_email (which is the issuer).
+        # We must check self._subject != self._issuer to correctly determine if
+        # Domain-Wide Delegation is active.
         if self._subject and self._subject != self._issuer:
             # RAB does not apply to Workspace User Accounts via Domain-wide Delegation.
             return None

--- a/packages/google-auth/google/auth/jwt.py
+++ b/packages/google-auth/google/auth/jwt.py
@@ -585,7 +585,14 @@ class Credentials(
         self.token, self.expiry = self._make_jwt()
 
     def _build_regional_access_boundary_lookup_url(self, request=None):
-        """Builds the lookup URL using the service account's email address."""
+        """Builds the lookup URL using the service account's email address.
+
+        Returns None if the subject is populated.
+        """
+        if self._subject and self._subject != self._issuer:
+            # RAB does not apply to Workspace User Accounts via Domain-wide Delegation.
+            return None
+
         if not self.signer_email:
             return None
 

--- a/packages/google-auth/google/oauth2/service_account.py
+++ b/packages/google-auth/google/oauth2/service_account.py
@@ -514,8 +514,12 @@ class Credentials(
 
         Returns:
             Optional[str]: The URL for the Regional Access Boundary lookup endpoint, or None
-                 if the service account email is missing.
+                 if the service account email is missing. Returns None if the subject is populated.
         """
+        if self._subject:
+            # RAB does not apply to Workspace User Accounts via Domain-wide Delegation.
+            return None
+
         if not self.service_account_email:
             _LOGGER.error(
                 "Service account email is required to build the Regional Access Boundary lookup URL for service account credentials."

--- a/packages/google-auth/tests/oauth2/test_service_account.py
+++ b/packages/google-auth/tests/oauth2/test_service_account.py
@@ -290,6 +290,10 @@ class TestCredentials(object):
         )
         assert url == expected_url
 
+    def test_build_regional_access_boundary_lookup_url_with_subject(self):
+        credentials = self.make_credentials().with_subject("user@example.com")
+        assert credentials._build_regional_access_boundary_lookup_url() is None
+
     def test_with_token_uri(self):
         credentials = self.make_credentials()
         new_token_uri = "https://example2.com/oauth2/token"

--- a/packages/google-auth/tests/test_impersonated_credentials.py
+++ b/packages/google-auth/tests/test_impersonated_credentials.py
@@ -759,6 +759,10 @@ class TestImpersonatedCredentials(object):
         )
         assert url == expected_url
 
+    def test_build_regional_access_boundary_lookup_url_with_subject(self):
+        credentials = self.make_credentials(subject="user@example.com")
+        assert credentials._build_regional_access_boundary_lookup_url() is None
+
     def test_with_scopes_provide_default_scopes(self):
         credentials = self.make_credentials()
         credentials._target_scopes = []

--- a/packages/google-auth/tests/test_jwt.py
+++ b/packages/google-auth/tests/test_jwt.py
@@ -559,7 +559,14 @@ class TestCredentials(object):
         # Mock check_use_client_cert to return False to simulate standard TLS
         monkeypatch.setattr(_mtls_helper, "check_use_client_cert", lambda: False)
 
-        url = self.credentials._build_regional_access_boundary_lookup_url()
+        credentials = jwt.Credentials(
+            self.credentials._signer,
+            self.credentials.signer_email,
+            self.credentials.signer_email,
+            self.credentials._audience,
+        )
+
+        url = credentials._build_regional_access_boundary_lookup_url()
         expected_url = "https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/{}/allowedLocations".format(
             self.SERVICE_ACCOUNT_EMAIL
         )
@@ -571,11 +578,27 @@ class TestCredentials(object):
         # Mock check_use_client_cert to return True to simulate mTLS
         monkeypatch.setattr(_mtls_helper, "check_use_client_cert", lambda: True)
 
-        url = self.credentials._build_regional_access_boundary_lookup_url()
+        credentials = jwt.Credentials(
+            self.credentials._signer,
+            self.credentials.signer_email,
+            self.credentials.signer_email,
+            self.credentials._audience,
+        )
+
+        url = credentials._build_regional_access_boundary_lookup_url()
         expected_url = "https://iamcredentials.mtls.googleapis.com/v1/projects/-/serviceAccounts/{}/allowedLocations".format(
             self.SERVICE_ACCOUNT_EMAIL
         )
         assert url == expected_url
+
+    def test_build_regional_access_boundary_lookup_url_with_subject(self):
+        credentials = jwt.Credentials(
+            self.credentials._signer,
+            self.credentials._issuer,
+            "user@example.com",
+            self.credentials._audience,
+        )
+        assert credentials._build_regional_access_boundary_lookup_url() is None
 
     def test_cloning_retains_rab_manager_data(self):
         self.credentials._rab_manager._data = mock.sentinel.rab_data


### PR DESCRIPTION
Updates credentials classes to  skip building the Regional Access Boundary lookup URL when Domain-Wide Delegation (DWD) is active, as RAB does not apply to Workspace User Accounts via DWD.


Fixes #17703