### PR TITLE
chore(api-core): restore fail_under=100 in .coveragerc

### DIFF
--- a/packages/google-api-core/.coveragerc
+++ b/packages/google-api-core/.coveragerc
@@ -2,8 +2,11 @@
 branch = True
 
 [report]
-fail_under = 99
+fail_under = 100
 show_missing = True
+omit =
+    tests/*
+    */tests/*
 exclude_lines =
     # Re-enable the standard pragma
     pragma: NO COVER

--- a/packages/google-api-core/google/api_core/gapic_v1/requests.py
+++ b/packages/google-api-core/google/api_core/gapic_v1/requests.py
@@ -21,8 +21,8 @@ before invoking API methods, such as automatically generating request IDs
 if they are not already set.
 """
 
-from typing import Union
 import uuid
+from typing import Union
 
 import google.protobuf.message
 

--- a/packages/google-api-core/noxfile.py
+++ b/packages/google-api-core/noxfile.py
@@ -389,7 +389,7 @@ def cover(session):
     test runs (not system test runs), and then erases coverage data.
     """
     session.install("coverage", "pytest-cov")
-    session.run("coverage", "report", "--show-missing", "--fail-under=100")
+    session.run("coverage", "report", "--show-missing")
     session.run("coverage", "erase")
 
 

--- a/packages/google-api-core/noxfile.py
+++ b/packages/google-api-core/noxfile.py
@@ -389,7 +389,7 @@ def cover(session):
     test runs (not system test runs), and then erases coverage data.
     """
     session.install("coverage", "pytest-cov")
-    session.run("coverage", "report", "--show-missing")
+    session.run("coverage", "report", "--show-missing", "--fail-under=100")
     session.run("coverage", "erase")
 
 

--- a/packages/google-api-core/tests/unit/gapic/test_requests.py
+++ b/packages/google-api-core/tests/unit/gapic/test_requests.py
@@ -19,7 +19,6 @@ import pytest
 
 from google.api_core.gapic_v1.requests import setup_request_id
 
-
 # --- Mock Request Helper Classes ---
 
 

--- a/packages/google-api-core/tests/unit/operations_v1/test_operations_client.py
+++ b/packages/google-api-core/tests/unit/operations_v1/test_operations_client.py
@@ -100,3 +100,38 @@ def test_cancel_operation():
 
 def test_operations_client_config():
     assert operations_client_config.config["interfaces"]
+
+
+def test_operations_v1_transport_base_to_dict_protobuf_versions(monkeypatch):
+    from google.longrunning import operations_pb2
+
+    from google.api_core.operations_v1.transports import base
+
+    message = operations_pb2.Operation(name="test_op")
+
+    monkeypatch.setattr(base, "PROTOBUF_VERSION", "3.20.0")
+    res3 = base.OperationsTransport._to_dict(message)
+    assert res3.get("name") == "test_op"
+
+    monkeypatch.setattr(base, "PROTOBUF_VERSION", "5.26.0")
+    res5 = base.OperationsTransport._to_dict(message)
+    assert res5.get("name") == "test_op"
+
+
+def test_operations_v1_init_import_error_fallback(monkeypatch):
+    import importlib
+
+    import google.api_core.operations_v1 as op_v1
+
+    orig_import = __import__
+
+    def mock_import(name, globals=None, locals=None, fromlist=(), level=0):
+        if "operations_rest_client_async" in name or (
+            fromlist and "AsyncOperationsRestClient" in fromlist
+        ):
+            raise ImportError("Simulated async rest import error")
+        return orig_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr("builtins.__import__", mock_import)
+    monkeypatch.setattr(op_v1, "_has_async_rest", True)
+    importlib.reload(op_v1)

--- a/packages/google-api-core/tests/unit/operations_v1/test_operations_client.py
+++ b/packages/google-api-core/tests/unit/operations_v1/test_operations_client.py
@@ -113,13 +113,23 @@ def test_operations_v1_transport_base_to_dict_protobuf_versions(monkeypatch):
         credentials=ga_credentials.AnonymousCredentials()
     )
 
+    calls = []
+
+    def mock_message_to_dict(*args, **kwargs):
+        calls.append(kwargs)
+        return {"name": "test_op"}
+
+    monkeypatch.setattr(base.json_format, "MessageToDict", mock_message_to_dict)
+
     monkeypatch.setattr(base, "PROTOBUF_VERSION", "3.20.0")
     res3 = transport._convert_protobuf_message_to_dict(message)
     assert res3.get("name") == "test_op"
+    assert "including_default_value_fields" in calls[-1]
 
     monkeypatch.setattr(base, "PROTOBUF_VERSION", "5.26.0")
     res5 = transport._convert_protobuf_message_to_dict(message)
     assert res5.get("name") == "test_op"
+    assert "always_print_fields_with_no_presence" in calls[-1]
 
 
 def test_operations_v1_init_import_error_fallback(monkeypatch):

--- a/packages/google-api-core/tests/unit/operations_v1/test_operations_client.py
+++ b/packages/google-api-core/tests/unit/operations_v1/test_operations_client.py
@@ -103,12 +103,15 @@ def test_operations_client_config():
 
 
 def test_operations_v1_transport_base_to_dict_protobuf_versions(monkeypatch):
+    from google.auth import credentials as ga_credentials
     from google.longrunning import operations_pb2
 
     from google.api_core.operations_v1.transports import base
 
     message = operations_pb2.Operation(name="test_op")
-    transport = base.OperationsTransport()
+    transport = base.OperationsTransport(
+        credentials=ga_credentials.AnonymousCredentials()
+    )
 
     monkeypatch.setattr(base, "PROTOBUF_VERSION", "3.20.0")
     res3 = transport._convert_protobuf_message_to_dict(message)

--- a/packages/google-api-core/tests/unit/operations_v1/test_operations_client.py
+++ b/packages/google-api-core/tests/unit/operations_v1/test_operations_client.py
@@ -108,13 +108,14 @@ def test_operations_v1_transport_base_to_dict_protobuf_versions(monkeypatch):
     from google.api_core.operations_v1.transports import base
 
     message = operations_pb2.Operation(name="test_op")
+    transport = base.OperationsTransport()
 
     monkeypatch.setattr(base, "PROTOBUF_VERSION", "3.20.0")
-    res3 = base.OperationsTransport._to_dict(message)
+    res3 = transport._convert_protobuf_message_to_dict(message)
     assert res3.get("name") == "test_op"
 
     monkeypatch.setattr(base, "PROTOBUF_VERSION", "5.26.0")
-    res5 = base.OperationsTransport._to_dict(message)
+    res5 = transport._convert_protobuf_message_to_dict(message)
     assert res5.get("name") == "test_op"
 
 


### PR DESCRIPTION
`fail_under` was previously adjusted down to `99` because coverage reports included helper lines inside test files (`tests/unit/test_operations_rest_client.py`). In non-`async_rest` matrix sessions, conditional `if GOOGLE_AUTH_AIO_INSTALLED:` checks inside test runner files were flagged as un-executed lines, artificially dragging down total reported coverage.

- Configured `omit = tests/*, */tests/*` under `[report]` in `.coveragerc` so coverage reporting evaluates threshold enforcement (`fail_under`) strictly against the `google.api_core` source library rather than test execution helper code.
- Restored `fail_under = 100` in `.coveragerc`.
Towards https://github.com/googleapis/google-cloud-python/issues/17459 🦕