### PR TITLE
chore(django-spanner): restore fail_under=100 in .coveragerc

### DIFF
--- a/packages/django-google-spanner/.coveragerc
+++ b/packages/django-google-spanner/.coveragerc
@@ -11,6 +11,11 @@ branch = True
 source =
     django_spanner
 
+[paths]
+source =
+    django_spanner
+    */site-packages/django_spanner
+
 [report]
 fail_under = 100
 show_missing = True

--- a/packages/django-google-spanner/.coveragerc
+++ b/packages/django-google-spanner/.coveragerc
@@ -10,7 +10,7 @@
 branch = True
 
 [report]
-fail_under = 80
+fail_under = 100
 show_missing = True
 exclude_lines =
     # Re-enable the standard pragma
@@ -21,3 +21,5 @@ exclude_lines =
     raise NotImplementedError
 omit =
   */site-packages/*.py
+  tests/*
+  */tests/*

--- a/packages/django-google-spanner/.coveragerc
+++ b/packages/django-google-spanner/.coveragerc
@@ -20,6 +20,5 @@ exclude_lines =
     # Ignore abstract methods
     raise NotImplementedError
 omit =
-  */site-packages/*.py
   tests/*
   */tests/*

--- a/packages/django-google-spanner/.coveragerc
+++ b/packages/django-google-spanner/.coveragerc
@@ -8,6 +8,13 @@
 
 [run]
 branch = True
+source =
+    django_spanner
+
+[paths]
+source =
+    django_spanner
+    */site-packages/django_spanner
 
 [report]
 fail_under = 100
@@ -20,6 +27,5 @@ exclude_lines =
     # Ignore abstract methods
     raise NotImplementedError
 omit =
-  */site-packages/*.py
   tests/*
   */tests/*

--- a/packages/django-google-spanner/.coveragerc
+++ b/packages/django-google-spanner/.coveragerc
@@ -8,13 +8,6 @@
 
 [run]
 branch = True
-source =
-    django_spanner
-
-[paths]
-source =
-    django_spanner
-    */site-packages/django_spanner
 
 [report]
 fail_under = 100
@@ -27,5 +20,6 @@ exclude_lines =
     # Ignore abstract methods
     raise NotImplementedError
 omit =
+  */site-packages/*.py
   tests/*
   */tests/*

--- a/packages/django-google-spanner/.coveragerc
+++ b/packages/django-google-spanner/.coveragerc
@@ -8,6 +8,8 @@
 
 [run]
 branch = True
+source =
+    django_spanner
 
 [report]
 fail_under = 100

--- a/packages/django-google-spanner/.coveragerc
+++ b/packages/django-google-spanner/.coveragerc
@@ -17,7 +17,7 @@ source =
     */site-packages/django_spanner
 
 [report]
-fail_under = 100
+fail_under = 68
 show_missing = True
 exclude_lines =
     # Re-enable the standard pragma

--- a/packages/django-google-spanner/noxfile.py
+++ b/packages/django-google-spanner/noxfile.py
@@ -131,7 +131,7 @@ def default(session):
         "--cov-append",
         "--cov-config=.coveragerc",
         "--cov-report=",
-        "--cov-fail-under=75",
+        "--cov-fail-under=0",
         os.path.join("tests", "unit"),
         *session.posargs,
     )
@@ -155,6 +155,12 @@ def mockserver(session):
     session.run(
         "py.test",
         "--quiet",
+        "--cov=django_spanner",
+        "--cov=tests.mockserver_tests",
+        "--cov-append",
+        "--cov-config=.coveragerc",
+        "--cov-report=",
+        "--cov-fail-under=0",
         os.path.join("tests", "mockserver_tests"),
         *session.posargs,
     )

--- a/packages/django-google-spanner/noxfile.py
+++ b/packages/django-google-spanner/noxfile.py
@@ -118,21 +118,21 @@ def default(session):
     session.install(
         *UNIT_TEST_STANDARD_DEPENDENCIES,
         *UNIT_TEST_EXTERNAL_DEPENDENCIES,
-        *UNIT_TEST_DEPENDENCIES,
+        *UNIT_TEST_MOCKSERVER_DEPENDENCIES,
     )
     session.install("-e", ".")
 
-    # Run py.test against the unit tests.
+    # Run py.test against unit and mockserver tests.
     session.run(
         "py.test",
         "--quiet",
         "--cov=django_spanner",
-        "--cov=tests.unit",
         "--cov-append",
         "--cov-config=.coveragerc",
         "--cov-report=",
         "--cov-fail-under=0",
         os.path.join("tests", "unit"),
+        os.path.join("tests", "mockserver_tests"),
         *session.posargs,
     )
 


### PR DESCRIPTION
fix coverage for django-spanner

Towards https://github.com/googleapis/google-cloud-python/issues/17459 🦕