### PR TITLE
fix(ci): support python 3.15 builds by exporting pyo3 compatibility flag

### DIFF
--- a/ci/run_single_test.sh
+++ b/ci/run_single_test.sh
@@ -101,6 +101,7 @@ case ${TEST_TYPE} in
             echo "Creating temporary virtualenv for import profile..."
             python3 -m venv .venv-profiler
             source .venv-profiler/bin/activate
+            export PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1
             python -m pip install --upgrade pip setuptools
             
             PACKAGE_NAME=$(basename $(pwd))


### PR DESCRIPTION
This PR fixes a GHA build issue when compiling Rust-based transitive dependencies (like `libcst` during `bigframes` installation) under Python 3.15 (`3.15.0-beta.3`).

### Key Changes
- **PyO3 Forward Compatibility**: Added `export PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1` inside the temporary virtualenv activation block in `ci/run_single_test.sh`. This ensures packages compiling with PyO3 use the stable ABI forward compatibility mode for Python 3.15.
