### PR TITLE
fix(ci): skip import profiler on python version mismatch during install

### DIFF
--- a/ci/run_single_test.sh
+++ b/ci/run_single_test.sh
@@ -135,9 +135,26 @@ case ${TEST_TYPE} in
                     echo "Could not find baseline commit for ${TARGET_BRANCH:-main}. Skipping baseline generation."
                 fi
             fi
+            # Run pip install and capture output to inspect for python compatibility issues
+            pip_output=$(pip install -e . 2>&1)
+            pip_retval=$?
             
-            pip install -e .
-            
+            if [ ${pip_retval} -ne 0 ]; then
+                echo "${pip_output}"
+                if echo "${pip_output}" | grep -q "requires a different Python"; then
+                    echo "WARNING: Package ${PACKAGE_NAME} is not compatible with Python ${PY_VERSION}. Skipping import profiler."
+                    deactivate
+                    rm -rf .venv-profiler
+                    rm -rf "${PROFILER_TEMP_DIR}"
+                    exit 0
+                else
+                    echo "ERROR: Failed to install package ${PACKAGE_NAME}."
+                    deactivate
+                    rm -rf .venv-profiler
+                    rm -rf "${PROFILER_TEMP_DIR}"
+                    exit ${pip_retval}
+                fi
+            fi
             if [ -f "${BASELINE_CSV}" ]; then
                 python ${PROFILER_SCRIPT} --package ${PACKAGE_NAME} --iterations 11 --fail-threshold 5000 --diff-baseline "${BASELINE_CSV}" --diff-threshold 100
             else


### PR DESCRIPTION
This PR resolves CI check failures on packages (such as `sqlalchemy-bigquery`) that restrict Python versions using `python_requires` constraints (e.g. `<3.15`) when executing the import profiler on Python 3.15.

### Key Changes
- **Python Compatibility Guard**: Updated `ci/run_single_test.sh` to capture the output of `pip install -e .` and inspect the stderr for `"requires a different Python"`.
- **Graceful Skip**: If a package is incompatible with the GHA Python runtime version, the script prints a warning and exits cleanly with status `0`, gracefully skipping the import profiler run instead of crashing the job.
- **Failure Resilience**: Any installation errors unrelated to Python version constraints will still correctly exit with a non-zero code to fail the build check.
