### PR TITLE
ci: enable pip caching in import profiler workflow

### DIFF
--- a/.github/workflows/import-profiler.yml
+++ b/.github/workflows/import-profiler.yml
@@ -26,6 +26,7 @@ jobs:
       with:
         python-version: "3.15"
         allow-prereleases: true
+        cache: 'pip'
     - name: Run import profiler
       env:
         BUILD_TYPE: presubmit


### PR DESCRIPTION
This PR enables pip package dependency caching inside the `import-profiler` GHA workflow, improving setup and execution speed.