### PR TITLE
fix(api-core): address PR review comments for requests.py and test_requests

### DIFF
--- a/packages/google-api-core/google/api_core/gapic_v1/requests.py
+++ b/packages/google-api-core/google/api_core/gapic_v1/requests.py
@@ -65,7 +65,7 @@ def setup_request_id(
                 setattr(request, field_name, str(uuid.uuid4()))
         except (AttributeError, ValueError):
             # Proto-plus messages or other objects
-            if not getattr(request, field_name, None):
+            if getattr(request, field_name, None) is None:
                 setattr(request, field_name, str(uuid.uuid4()))
     else:
         if not getattr(request, field_name, None):

--- a/packages/google-api-core/tests/unit/gapic/test_requests.py
+++ b/packages/google-api-core/tests/unit/gapic/test_requests.py
@@ -27,9 +27,6 @@ class MockRequest:
         for k, v in kwargs.items():
             setattr(self, k, v)
 
-    def __contains__(self, key):
-        return hasattr(self, key)
-
 
 class MockProtoRequest:
     def __init__(self, **kwargs):
@@ -44,9 +41,6 @@ class MockValueErrorRequest:
     def HasField(self, key):
         raise ValueError("Mismatched field")
 
-    def __contains__(self, key):
-        return hasattr(self, key)
-
 
 # --- Parameterized Test ---
 
@@ -59,6 +53,7 @@ UUID_REGEX = r"[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{1
         # MockRequest cases
         (MockRequest(), True, "uuid"),
         (MockRequest(request_id="already_set"), True, "already_set"),
+        (MockRequest(request_id=""), True, ""),
         (MockRequest(request_id=""), False, "uuid"),
         (MockRequest(request_id="already_set"), False, "already_set"),
         # MockProtoRequest cases
@@ -70,6 +65,7 @@ UUID_REGEX = r"[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{1
         ({}, True, "uuid"),
         ({"request_id": None}, True, "uuid"),
         ({"request_id": "already_set"}, True, "already_set"),
+        ({"request_id": ""}, True, ""),
         ({"request_id": ""}, False, "uuid"),
         ({"request_id": None}, False, "uuid"),
         ({"request_id": "already_set"}, False, "already_set"),
@@ -79,6 +75,7 @@ UUID_REGEX = r"[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{1
     ids=[
         "proto3_optional_not_in_request",
         "proto3_optional_already_in_request",
+        "proto3_optional_explicit_empty",
         "non_proto3_optional_empty",
         "non_proto3_optional_already_set",
         "proto3_optional_not_in_request_proto",
@@ -87,6 +84,7 @@ UUID_REGEX = r"[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{1
         "dict_proto3_optional_not_in_request",
         "dict_proto3_optional_value_none",
         "dict_proto3_optional_already_in_request",
+        "dict_proto3_optional_explicit_empty",
         "dict_non_proto3_optional_empty",
         "dict_non_proto3_optional_value_none",
         "dict_non_proto3_optional_already_set",
@@ -110,6 +108,6 @@ def test_setup_request_id(request_obj, is_proto3_optional, expected):
     )
 
     if expected == "uuid":
-        assert re.match(UUID_REGEX, value)
+        assert re.fullmatch(UUID_REGEX, value)
     else:
         assert value == expected


### PR DESCRIPTION
### Description
This PR addresses code review feedback regarding edge cases and test coverage in `requests.py` and `test_requests.py`:

1. **`requests.py`**: Updated fallback logic for proto-plus messages/other objects when `is_proto3_optional=True` from `if not getattr(...)` to `if getattr(...) is None`. This distinguishes missing fields from fields explicitly set to empty values (e.g., `""`), matching the dictionary handling behavior.
2. **`test_requests.py`**: Removed the unused `__contains__` mock helper methods from `MockRequest` and `MockValueErrorRequest` since the helper uses the `in` operator only for dictionaries.
3. **`test_requests.py`**: Added parameterized test cases for `is_proto3_optional=True` with explicit empty string values `""` to verify they are preserved and not overwritten.
4. **`test_requests.py`**: Changed test assertions to use `re.fullmatch` instead of `re.match` to guarantee strict UUID format validation.
