### PR TITLE
chore(api-core): remove dead `__contains__` methods from MockRequest

### DIFF
--- a/packages/google-api-core/tests/unit/gapic/test_requests.py
+++ b/packages/google-api-core/tests/unit/gapic/test_requests.py
@@ -27,9 +27,6 @@ class MockRequest:
         for k, v in kwargs.items():
             setattr(self, k, v)
 
-    def __contains__(self, key):
-        return hasattr(self, key)
-
 
 class MockProtoRequest:
     def __init__(self, **kwargs):
@@ -43,9 +40,6 @@ class MockProtoRequest:
 class MockValueErrorRequest:
     def HasField(self, key):
         raise ValueError("Mismatched field")
-
-    def __contains__(self, key):
-        return hasattr(self, key)
 
 
 # --- Parameterized Test ---


### PR DESCRIPTION
### Description
This PR addresses code review feedback by removing unused/dead mock helper methods:

- Removed `__contains__` methods from `MockRequest` and `MockValueErrorRequest` classes in `test_requests.py`, as the `in` operator is only used on `dict` type checks inside `setup_request_id`.
