### PR TITLE
test(api-core): use re.fullmatch for strict UUID validation

### DIFF
--- a/packages/google-api-core/tests/unit/gapic/test_requests.py
+++ b/packages/google-api-core/tests/unit/gapic/test_requests.py
@@ -113,3 +113,17 @@ def test_setup_request_id(request_obj, is_proto3_optional, expected):
         assert re.fullmatch(UUID_REGEX, value)
     else:
         assert value == expected
+
+
+def test_setup_request_id_assertion_strictness(mocker):
+    # Mock uuid.uuid4 to return a UUID with trailing characters
+    mock_uuid = mocker.patch("uuid.uuid4")
+    mock_uuid.return_value.__str__.return_value = (
+        "12345678-1234-4123-8123-123456789012-extra"
+    )
+
+    # We expect test_setup_request_id to fail (raise AssertionError) because the UUID is invalid.
+    # If test_setup_request_id uses re.fullmatch, it will fail (raise AssertionError), so pytest.raises passes.
+    # If test_setup_request_id uses re.match, it will NOT fail, so pytest.raises fails!
+    with pytest.raises(AssertionError):
+        test_setup_request_id(MockRequest(), is_proto3_optional=True, expected="uuid")

--- a/packages/google-api-core/tests/unit/gapic/test_requests.py
+++ b/packages/google-api-core/tests/unit/gapic/test_requests.py
@@ -110,6 +110,6 @@ def test_setup_request_id(request_obj, is_proto3_optional, expected):
     )
 
     if expected == "uuid":
-        assert re.match(UUID_REGEX, value)
+        assert re.fullmatch(UUID_REGEX, value)
     else:
         assert value == expected


### PR DESCRIPTION
### Description
This PR addresses code review feedback regarding test assertion strictness:

- Changed the regex assertion from `re.match` to `re.fullmatch` for strict UUID validation in `test_requests.py`, ensuring trailing characters are not accepted.
