### PR TITLE
fix(api-core): prevent overwriting explicit empty strings for optional request_id

### DIFF
--- a/packages/google-api-core/google/api_core/gapic_v1/requests.py
+++ b/packages/google-api-core/google/api_core/gapic_v1/requests.py
@@ -65,7 +65,7 @@ def setup_request_id(
                 setattr(request, field_name, str(uuid.uuid4()))
         except (AttributeError, ValueError):
             # Proto-plus messages or other objects
-            if not getattr(request, field_name, None):
+            if getattr(request, field_name, None) is None:
                 setattr(request, field_name, str(uuid.uuid4()))
     else:
         if not getattr(request, field_name, None):

--- a/packages/google-api-core/tests/unit/gapic/test_requests.py
+++ b/packages/google-api-core/tests/unit/gapic/test_requests.py
@@ -59,6 +59,7 @@ UUID_REGEX = r"[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{1
         # MockRequest cases
         (MockRequest(), True, "uuid"),
         (MockRequest(request_id="already_set"), True, "already_set"),
+        (MockRequest(request_id=""), True, ""),
         (MockRequest(request_id=""), False, "uuid"),
         (MockRequest(request_id="already_set"), False, "already_set"),
         # MockProtoRequest cases
@@ -70,6 +71,7 @@ UUID_REGEX = r"[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{1
         ({}, True, "uuid"),
         ({"request_id": None}, True, "uuid"),
         ({"request_id": "already_set"}, True, "already_set"),
+        ({"request_id": ""}, True, ""),
         ({"request_id": ""}, False, "uuid"),
         ({"request_id": None}, False, "uuid"),
         ({"request_id": "already_set"}, False, "already_set"),
@@ -79,6 +81,7 @@ UUID_REGEX = r"[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{1
     ids=[
         "proto3_optional_not_in_request",
         "proto3_optional_already_in_request",
+        "proto3_optional_explicit_empty",
         "non_proto3_optional_empty",
         "non_proto3_optional_already_set",
         "proto3_optional_not_in_request_proto",
@@ -87,6 +90,7 @@ UUID_REGEX = r"[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{1
         "dict_proto3_optional_not_in_request",
         "dict_proto3_optional_value_none",
         "dict_proto3_optional_already_in_request",
+        "dict_proto3_optional_explicit_empty",
         "dict_non_proto3_optional_empty",
         "dict_non_proto3_optional_value_none",
         "dict_non_proto3_optional_already_set",


### PR DESCRIPTION
### Description
This PR addresses code review feedback regarding how `is_proto3_optional=True` fields are treated:

- **`requests.py`**: Changed the check `if not getattr(...)` to `if getattr(...) is None` for proto-plus messages and other objects when `is_proto3_optional=True`. This prevents overwriting an explicitly set empty string (`""`) with a generated UUID.
- **`test_requests.py`**: Added parameterized test cases for `is_proto3_optional=True` with explicit empty string values `""` to verify they are preserved and not overwritten.
