### PR TITLE
chore: prepare for initial release of new libraries

### DIFF
--- a/.release-please-bulk-manifest.json
+++ b/.release-please-bulk-manifest.json
@@ -79,7 +79,6 @@
   "packages/google-cloud-cloudcontrolspartner": "0.6.0",
   "packages/google-cloud-cloudsecuritycompliance": "0.8.0",
   "packages/google-cloud-commerce-consumer-procurement": "0.6.0",
-  "packages/google-cloud-commerceproducer": "0.0.0",
   "packages/google-cloud-common": "1.10.0",
   "packages/google-cloud-compute": "1.50.0",
   "packages/google-cloud-compute-v1beta": "0.12.1",

--- a/.release-please-individual-manifest.json
+++ b/.release-please-individual-manifest.json
@@ -1,6 +1,9 @@
 {
   "packages/bigframes": "2.46.0",
+  "packages/google-cloud-commerceproducer": "0.0.0",
+  "packages/google-cloud-productregistry": "0.0.0",
   "packages/google-crc32c": "1.8.0",
   "packages/pandas-gbq": "0.35.0",
+  "packages/google-maps-isochrones": "0.0.0",
   "packages/sqlalchemy-bigquery": "1.17.0"
 }

--- a/.release-please-individual-manifest.json
+++ b/.release-please-individual-manifest.json
@@ -3,7 +3,7 @@
   "packages/google-cloud-commerceproducer": "0.0.0",
   "packages/google-cloud-productregistry": "0.0.0",
   "packages/google-crc32c": "1.8.0",
-  "packages/pandas-gbq": "0.35.0",
   "packages/google-maps-isochrones": "0.0.0",
+  "packages/pandas-gbq": "0.35.0",
   "packages/sqlalchemy-bigquery": "1.17.0"
 }

--- a/release-please-bulk-config.json
+++ b/release-please-bulk-config.json
@@ -1019,18 +1019,6 @@
         }
       ]
     },
-    "packages/google-cloud-commerceproducer": {
-      "component": "google-cloud-commerceproducer",
-      "extra-files": [
-        "google/cloud/commerceproducer/gapic_version.py",
-        "google/cloud/commerceproducer_v1beta/gapic_version.py",
-        {
-          "jsonpath": "$.clientLibrary.version",
-          "path": "samples/generated_samples/snippet_metadata_google.cloud.commerceproducer.v1beta.json",
-          "type": "json"
-        }
-      ]
-    },
     "packages/google-cloud-common": {
       "component": "google-cloud-common",
       "extra-files": [

--- a/release-please-individual-config.json
+++ b/release-please-individual-config.json
@@ -5,8 +5,44 @@
     "packages/bigframes": {
       "component": "bigframes"
     },
+    "packages/google-cloud-commerceproducer": {
+      "component": "google-cloud-commerceproducer",
+      "extra-files": [
+        "google/cloud/commerceproducer/gapic_version.py",
+        "google/cloud/commerceproducer_v1beta/gapic_version.py",
+        {
+          "jsonpath": "$.clientLibrary.version",
+          "path": "samples/generated_samples/snippet_metadata_google.cloud.commerceproducer.v1beta.json",
+          "type": "json"
+        }
+      ]
+    },
+    "packages/google-cloud-productregistry": {
+      "component": "google-cloud-productregistry",
+      "extra-files": [
+        "google/cloud/productregistry/gapic_version.py",
+        "google/cloud/productregistry_v1/gapic_version.py",
+        {
+          "jsonpath": "$.clientLibrary.version",
+          "path": "samples/generated_samples/snippet_metadata_google.cloud.productregistry.v1.json",
+          "type": "json"
+        }
+      ]
+    },
     "packages/google-crc32c": {
       "component": "google-crc32c"
+    },
+    "packages/google-maps-isochrones": {
+      "component": "google-maps-isochrones",
+      "extra-files": [
+        "google/maps/isochrones/gapic_version.py",
+        "google/maps/isochrones_v1/gapic_version.py",
+        {
+          "jsonpath": "$.clientLibrary.version",
+          "path": "samples/generated_samples/snippet_metadata_google.maps.isochrones.v1.json",
+          "type": "json"
+        }
+      ]
     },
     "packages/pandas-gbq": {
       "component": "pandas-gbq"


### PR DESCRIPTION
Temporarily remove `packages/google-cloud-commerceproducer` , `packages/google-cloud-productregistry` and `packages/google-maps-isochrones` from the `bulk` release configuration. These will be moved back to the `bulk` release once the packages are on PyPI.

Towards b/530253265, b/533114519, b/529841877