### PR TITLE
test(bigquery): add debug info to socket leak test

### DIFF
--- a/packages/google-cloud-bigquery/tests/system/test_client.py
+++ b/packages/google-cloud-bigquery/tests/system/test_client.py
@@ -2213,7 +2213,26 @@ class TestBigQuery(unittest.TestCase):
                 break
             time.sleep(0.1)
 
-        self.assertLessEqual(conn_count_end, conn_count_start)
+        try:
+            self.assertLessEqual(conn_count_end, conn_count_start)
+        except AssertionError as e:
+            # Due to flakiness in this test (likely caused by OS cleanup delays or
+            # non-deterministic garbage collection of sockets), we want to capture
+            # the detailed state of connections in future failing runs to help
+            # decrease false positives and identify the root cause.
+            conn_debug = [
+                f"Status: {c.status}, Laddr: {c.laddr}, Raddr: {c.raddr}"
+                for c in current_process.net_connections()
+            ]
+            debug_msg = "\n".join(conn_debug)
+
+            raise AssertionError(
+                f"{e}\n\n"
+                f"--- Socket Leak Debug Info ---\n"
+                f"Start Count: {conn_count_start}\n"
+                f"End Count: {conn_count_end}\n"
+                f"Current Connections:\n{debug_msg}"
+            )
 
     def _load_table_for_dml(self, rows, dataset_id, table_id):
         from google.cloud._testing import _NamedTemporaryFile


### PR DESCRIPTION
## Problem
The system test `test_dbapi_connection_does_not_leak_sockets` has been failing intermittently with minor socket count discrepancies (e.g., 7 instead of 6). Previous attempts to fix this have not fully eliminated the flakiness, likely due to non-deterministic garbage collection or Operating System cleanup delays. Without knowing the exact state of these "leaked" sockets (e.g., `TIME_WAIT` vs `CLOSE_WAIT`), it is difficult to determine if this is a real resource leak in the application or just OS noise.

## Solution
This PR wraps the socket count assertion in a `try...except AssertionError` block. If the assertion fails, it captures the status, local address, and remote address of all active network connections for the current process and appends this information to the failure message.

## Notes to Reviewers
- This change does **not** attempt to fix the underlying flakiness or leak. It is purely diagnostic.
- The detailed socket state will help us distinguish between expected OS delays (`TIME_WAIT`) and real application leaks (`CLOSE_WAIT` or `ESTABLISHED`) in future CI/CD runs.
- This approach avoids running expensive system tests repeatedly to try and capture an intermittent failure manually.