### PR TITLE
chore: move sqlalchemy-bigquery to bulk release

### DIFF
--- a/.release-please-bulk-manifest.json
+++ b/.release-please-bulk-manifest.json
@@ -277,5 +277,6 @@
   "packages/grafeas": "1.23.0",
   "packages/grpc-google-iam-v1": "0.14.4",
   "packages/proto-plus": "1.28.1",
+  "packages/sqlalchemy-bigquery": "1.17.0",
   "packages/sqlalchemy-spanner": "1.19.0"
 }

--- a/.release-please-individual-manifest.json
+++ b/.release-please-individual-manifest.json
@@ -4,6 +4,5 @@
   "packages/google-cloud-productregistry": "0.0.0",
   "packages/google-crc32c": "1.8.0",
   "packages/google-maps-isochrones": "0.0.0",
-  "packages/pandas-gbq": "0.35.0",
-  "packages/sqlalchemy-bigquery": "1.17.0"
+  "packages/pandas-gbq": "0.35.0"
 }

--- a/release-please-bulk-config.json
+++ b/release-please-bulk-config.json
@@ -3896,6 +3896,9 @@
     "packages/proto-plus": {
       "component": "proto-plus"
     },
+    "packages/sqlalchemy-bigquery": {
+      "component": "sqlalchemy-bigquery"
+    },
     "packages/sqlalchemy-spanner": {
       "component": "sqlalchemy-spanner"
     }

--- a/release-please-individual-config.json
+++ b/release-please-individual-config.json
@@ -46,9 +46,6 @@
     },
     "packages/pandas-gbq": {
       "component": "pandas-gbq"
-    },
-    "packages/sqlalchemy-bigquery": {
-      "component": "sqlalchemy-bigquery"
     }
   },
   "release-type": "python-librarian",


### PR DESCRIPTION
Unblock releases for `sqlalchemy-bigquery` .

Releases were originally blocked in https://github.com/googleapis/google-cloud-python/pull/17289 due to https://github.com/googleapis/google-cloud-python/issues/17287, which was fixed in https://github.com/googleapis/google-cloud-python/pull/17769