### PR TITLE
fix(gapic): mock os.path.exists in mTLS tests to support newer google auth

### DIFF
--- a/packages/gapic-generator/gapic/templates/tests/unit/gapic/%name_%version/%sub/test_%service.py.j2
+++ b/packages/gapic-generator/gapic/templates/tests/unit/gapic/%name_%version/%sub/test_%service.py.j2
@@ -900,7 +900,7 @@ def test_{{ service.client_name|snake_case }}_get_mtls_endpoint_and_cert_source(
                     config_filename = "mock_certificate_config.json"
                     config_file_content = json.dumps(config_data)
                     m = mock.mock_open(read_data=config_file_content)
-                    with mock.patch("builtins.open", m), mock.patch("os.path.exists", return_value=True):
+                    with mock.patch("builtins.open", m), mock.patch("os.path.exists", side_effect=lambda path: os.path.basename(path) == config_filename):
                         with mock.patch.dict(
                             os.environ, {"GOOGLE_API_CERTIFICATE_CONFIG": config_filename}
                         ):
@@ -947,7 +947,7 @@ def test_{{ service.client_name|snake_case }}_get_mtls_endpoint_and_cert_source(
                     config_filename = "mock_certificate_config.json"
                     config_file_content = json.dumps(config_data)
                     m = mock.mock_open(read_data=config_file_content)
-                    with mock.patch("builtins.open", m), mock.patch("os.path.exists", return_value=True):
+                    with mock.patch("builtins.open", m), mock.patch("os.path.exists", side_effect=lambda path: os.path.basename(path) == config_filename):
                         with mock.patch.dict(
                             os.environ, {"GOOGLE_API_CERTIFICATE_CONFIG": config_filename}
                         ):

--- a/packages/gapic-generator/gapic/templates/tests/unit/gapic/%name_%version/%sub/test_%service.py.j2
+++ b/packages/gapic-generator/gapic/templates/tests/unit/gapic/%name_%version/%sub/test_%service.py.j2
@@ -174,13 +174,13 @@ def test__get_default_mtls_endpoint():
 
 def test__read_environment_variables():
     assert {{ service.client_name }}._read_environment_variables() == (False, "auto", None)
-    
+
     with mock.patch.dict(os.environ, {"GOOGLE_API_USE_CLIENT_CERTIFICATE": "true"}):
         assert {{ service.client_name }}._read_environment_variables() == (True, "auto", None)
-    
+
     with mock.patch.dict(os.environ, {"GOOGLE_API_USE_CLIENT_CERTIFICATE": "false"}):
         assert {{ service.client_name }}._read_environment_variables() == (False, "auto", None)
-    
+
     with mock.patch.dict(
         os.environ, {"GOOGLE_API_USE_CLIENT_CERTIFICATE": "Unsupported"}
     ):
@@ -200,10 +200,10 @@ def test__read_environment_variables():
 
     with mock.patch.dict(os.environ, {"GOOGLE_API_USE_MTLS_ENDPOINT": "never"}):
         assert {{ service.client_name }}._read_environment_variables() == (False, "never", None)
-    
+
     with mock.patch.dict(os.environ, {"GOOGLE_API_USE_MTLS_ENDPOINT": "always"}):
         assert {{ service.client_name }}._read_environment_variables() == (False, "always", None)
-    
+
     with mock.patch.dict(os.environ, {"GOOGLE_API_USE_MTLS_ENDPOINT": "auto"}):
         assert {{ service.client_name }}._read_environment_variables() == (False, "auto", None)
 
@@ -293,7 +293,7 @@ def test_use_client_cert_effective():
             assert {{ service.client_name }}._use_client_cert_effective() is False
 
     # Test case 12: Test when `should_use_client_cert` is available and the
-    # `GOOGLE_API_USE_CLIENT_CERTIFICATE` environment variable is unset. Also, 
+    # `GOOGLE_API_USE_CLIENT_CERTIFICATE` environment variable is unset. Also,
     # the GOOGLE_API_CONFIG environment variable is unset.
     if  hasattr(google.auth.transport.mtls, "should_use_client_cert"):
         with mock.patch.dict(os.environ, {"GOOGLE_API_USE_CLIENT_CERTIFICATE": ""}):
@@ -303,7 +303,7 @@ def test_use_client_cert_effective():
 def test__get_client_cert_source():
     mock_provided_cert_source = mock.Mock()
     mock_default_cert_source = mock.Mock()
-    
+
     assert {{ service.client_name }}._get_client_cert_source(None, False) is None
     assert {{ service.client_name }}._get_client_cert_source(mock_provided_cert_source, False) is None
     assert {{ service.client_name }}._get_client_cert_source(mock_provided_cert_source, True) == mock_provided_cert_source
@@ -867,7 +867,7 @@ def test_{{ service.client_name|snake_case }}_get_mtls_endpoint_and_cert_source(
             )
             assert api_endpoint == mock_api_endpoint
             assert cert_source is None
-   
+
     # Test cases for mTLS enablement when GOOGLE_API_USE_CLIENT_CERTIFICATE is unset.
     test_cases = [
         (
@@ -900,7 +900,7 @@ def test_{{ service.client_name|snake_case }}_get_mtls_endpoint_and_cert_source(
                     config_filename = "mock_certificate_config.json"
                     config_file_content = json.dumps(config_data)
                     m = mock.mock_open(read_data=config_file_content)
-                    with mock.patch("builtins.open", m):
+                    with mock.patch("builtins.open", m), mock.patch("os.path.exists", return_value=True):
                         with mock.patch.dict(
                             os.environ, {"GOOGLE_API_CERTIFICATE_CONFIG": config_filename}
                         ):
@@ -929,10 +929,10 @@ def test_{{ service.client_name|snake_case }}_get_mtls_endpoint_and_cert_source(
                 },
             },
             mock_client_cert_source,
-        ),   
+        ),
         (
             # With workloads not present in config, mTLS is disabled.
-            {   
+            {
                 "version": 1,
                 "cert_configs": {},
             },
@@ -947,7 +947,7 @@ def test_{{ service.client_name|snake_case }}_get_mtls_endpoint_and_cert_source(
                     config_filename = "mock_certificate_config.json"
                     config_file_content = json.dumps(config_data)
                     m = mock.mock_open(read_data=config_file_content)
-                    with mock.patch("builtins.open", m):
+                    with mock.patch("builtins.open", m), mock.patch("os.path.exists", return_value=True):
                         with mock.patch.dict(
                             os.environ, {"GOOGLE_API_CERTIFICATE_CONFIG": config_filename}
                         ):
@@ -994,7 +994,7 @@ def test_{{ service.client_name|snake_case }}_get_mtls_endpoint_and_cert_source(
     with mock.patch.dict(os.environ, {"GOOGLE_API_USE_MTLS_ENDPOINT": "Unsupported"}):
         with pytest.raises(MutualTLSChannelError) as excinfo:
             client_class.get_mtls_endpoint_and_cert_source()
-        
+
         assert str(excinfo.value) == "Environment variable `GOOGLE_API_USE_MTLS_ENDPOINT` must be `never`, `auto` or `always`"
 
 @pytest.mark.parametrize("client_class", [
@@ -1059,7 +1059,7 @@ def test_{{ service.client_name|snake_case }}_client_api_endpoint(client_class):
     with mock.patch.dict(os.environ, {"GOOGLE_API_USE_MTLS_ENDPOINT": "never"}):
         client = client_class(client_options=options, credentials=ga_credentials.AnonymousCredentials())
         assert client.api_endpoint == default_endpoint
-        
+
 
 @pytest.mark.parametrize("client_class,transport_class,transport_name", [
     {% if 'grpc' in opts.transport %}

--- a/packages/gapic-generator/tests/integration/goldens/asset/tests/unit/gapic/asset_v1/test_asset_service.py
+++ b/packages/gapic-generator/tests/integration/goldens/asset/tests/unit/gapic/asset_v1/test_asset_service.py
@@ -13,26 +13,23 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-import os
 import asyncio
+import json
+import math
+import os
+from collections.abc import AsyncIterable, Iterable, Mapping, Sequence
 from unittest import mock
 from unittest.mock import AsyncMock
 
 import grpc
-from grpc.experimental import aio
-from collections.abc import Iterable, AsyncIterable
-from google.protobuf import json_format
-import json
-import math
 import pytest
-from collections.abc import Sequence, Mapping
 from google.api_core import api_core_version
-from proto.marshal.rules.dates import DurationRule, TimestampRule
-from proto.marshal.rules import wrappers
-from requests import Response
-from requests import Request, PreparedRequest
-from requests.sessions import Session
 from google.protobuf import json_format
+from grpc.experimental import aio
+from proto.marshal.rules import wrappers
+from proto.marshal.rules.dates import DurationRule, TimestampRule
+from requests import PreparedRequest, Request, Response
+from requests.sessions import Session
 
 try:
     from google.auth.aio import credentials as ga_credentials_async
@@ -40,26 +37,6 @@ try:
 except ImportError: # pragma: NO COVER
     HAS_GOOGLE_AUTH_AIO = False
 
-from google.api_core import client_options
-from google.api_core import exceptions as core_exceptions
-from google.api_core import future
-from google.api_core import gapic_v1
-from google.api_core import grpc_helpers
-from google.api_core import grpc_helpers_async
-from google.api_core import operation
-from google.api_core import operations_v1
-from google.api_core import path_template
-from google.api_core import retry as retries
-from google.auth import credentials as ga_credentials
-from google.auth.exceptions import MutualTLSChannelError
-from google.cloud.asset_v1.services.asset_service import AssetServiceAsyncClient
-from google.cloud.asset_v1.services.asset_service import AssetServiceClient
-from google.cloud.asset_v1.services.asset_service import pagers
-from google.cloud.asset_v1.services.asset_service import transports
-from google.cloud.asset_v1.types import asset_service
-from google.cloud.asset_v1.types import assets
-from google.longrunning import operations_pb2 # type: ignore
-from google.oauth2 import service_account
 import google.api_core.operation_async as operation_async  # type: ignore
 import google.auth
 import google.protobuf.duration_pb2 as duration_pb2  # type: ignore
@@ -67,8 +44,29 @@ import google.protobuf.field_mask_pb2 as field_mask_pb2  # type: ignore
 import google.protobuf.timestamp_pb2 as timestamp_pb2  # type: ignore
 import google.rpc.status_pb2 as status_pb2  # type: ignore
 import google.type.expr_pb2 as expr_pb2  # type: ignore
-
-
+from google.api_core import (
+    client_options,
+    future,
+    gapic_v1,
+    grpc_helpers,
+    grpc_helpers_async,
+    operation,
+    operations_v1,
+    path_template,
+)
+from google.api_core import exceptions as core_exceptions
+from google.api_core import retry as retries
+from google.auth import credentials as ga_credentials
+from google.auth.exceptions import MutualTLSChannelError
+from google.cloud.asset_v1.services.asset_service import (
+    AssetServiceAsyncClient,
+    AssetServiceClient,
+    pagers,
+    transports,
+)
+from google.cloud.asset_v1.types import asset_service, assets
+from google.longrunning import operations_pb2  # type: ignore
+from google.oauth2 import service_account
 
 CRED_INFO_JSON = {
     "credential_source": "/path/to/file",
@@ -700,7 +698,7 @@ def test_asset_service_client_get_mtls_endpoint_and_cert_source(client_class):
                     config_filename = "mock_certificate_config.json"
                     config_file_content = json.dumps(config_data)
                     m = mock.mock_open(read_data=config_file_content)
-                    with mock.patch("builtins.open", m), mock.patch("os.path.exists", return_value=True):
+                    with mock.patch("builtins.open", m), mock.patch("os.path.exists", side_effect=lambda path: os.path.basename(path) == config_filename):
                         with mock.patch.dict(
                             os.environ, {"GOOGLE_API_CERTIFICATE_CONFIG": config_filename}
                         ):
@@ -747,7 +745,7 @@ def test_asset_service_client_get_mtls_endpoint_and_cert_source(client_class):
                     config_filename = "mock_certificate_config.json"
                     config_file_content = json.dumps(config_data)
                     m = mock.mock_open(read_data=config_file_content)
-                    with mock.patch("builtins.open", m), mock.patch("os.path.exists", return_value=True):
+                    with mock.patch("builtins.open", m), mock.patch("os.path.exists", side_effect=lambda path: os.path.basename(path) == config_filename):
                         with mock.patch.dict(
                             os.environ, {"GOOGLE_API_CERTIFICATE_CONFIG": config_filename}
                         ):

--- a/packages/gapic-generator/tests/integration/goldens/asset/tests/unit/gapic/asset_v1/test_asset_service.py
+++ b/packages/gapic-generator/tests/integration/goldens/asset/tests/unit/gapic/asset_v1/test_asset_service.py
@@ -700,7 +700,7 @@ def test_asset_service_client_get_mtls_endpoint_and_cert_source(client_class):
                     config_filename = "mock_certificate_config.json"
                     config_file_content = json.dumps(config_data)
                     m = mock.mock_open(read_data=config_file_content)
-                    with mock.patch("builtins.open", m):
+                    with mock.patch("builtins.open", m), mock.patch("os.path.exists", return_value=True):
                         with mock.patch.dict(
                             os.environ, {"GOOGLE_API_CERTIFICATE_CONFIG": config_filename}
                         ):
@@ -747,7 +747,7 @@ def test_asset_service_client_get_mtls_endpoint_and_cert_source(client_class):
                     config_filename = "mock_certificate_config.json"
                     config_file_content = json.dumps(config_data)
                     m = mock.mock_open(read_data=config_file_content)
-                    with mock.patch("builtins.open", m):
+                    with mock.patch("builtins.open", m), mock.patch("os.path.exists", return_value=True):
                         with mock.patch.dict(
                             os.environ, {"GOOGLE_API_CERTIFICATE_CONFIG": config_filename}
                         ):

--- a/packages/gapic-generator/tests/integration/goldens/asset/tests/unit/gapic/asset_v1/test_asset_service.py
+++ b/packages/gapic-generator/tests/integration/goldens/asset/tests/unit/gapic/asset_v1/test_asset_service.py
@@ -13,23 +13,26 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-import asyncio
-import json
-import math
 import os
-from collections.abc import AsyncIterable, Iterable, Mapping, Sequence
+import asyncio
 from unittest import mock
 from unittest.mock import AsyncMock
 
 import grpc
-import pytest
-from google.api_core import api_core_version
-from google.protobuf import json_format
 from grpc.experimental import aio
-from proto.marshal.rules import wrappers
+from collections.abc import Iterable, AsyncIterable
+from google.protobuf import json_format
+import json
+import math
+import pytest
+from collections.abc import Sequence, Mapping
+from google.api_core import api_core_version
 from proto.marshal.rules.dates import DurationRule, TimestampRule
-from requests import PreparedRequest, Request, Response
+from proto.marshal.rules import wrappers
+from requests import Response
+from requests import Request, PreparedRequest
 from requests.sessions import Session
+from google.protobuf import json_format
 
 try:
     from google.auth.aio import credentials as ga_credentials_async
@@ -37,6 +40,26 @@ try:
 except ImportError: # pragma: NO COVER
     HAS_GOOGLE_AUTH_AIO = False
 
+from google.api_core import client_options
+from google.api_core import exceptions as core_exceptions
+from google.api_core import future
+from google.api_core import gapic_v1
+from google.api_core import grpc_helpers
+from google.api_core import grpc_helpers_async
+from google.api_core import operation
+from google.api_core import operations_v1
+from google.api_core import path_template
+from google.api_core import retry as retries
+from google.auth import credentials as ga_credentials
+from google.auth.exceptions import MutualTLSChannelError
+from google.cloud.asset_v1.services.asset_service import AssetServiceAsyncClient
+from google.cloud.asset_v1.services.asset_service import AssetServiceClient
+from google.cloud.asset_v1.services.asset_service import pagers
+from google.cloud.asset_v1.services.asset_service import transports
+from google.cloud.asset_v1.types import asset_service
+from google.cloud.asset_v1.types import assets
+from google.longrunning import operations_pb2 # type: ignore
+from google.oauth2 import service_account
 import google.api_core.operation_async as operation_async  # type: ignore
 import google.auth
 import google.protobuf.duration_pb2 as duration_pb2  # type: ignore
@@ -44,29 +67,8 @@ import google.protobuf.field_mask_pb2 as field_mask_pb2  # type: ignore
 import google.protobuf.timestamp_pb2 as timestamp_pb2  # type: ignore
 import google.rpc.status_pb2 as status_pb2  # type: ignore
 import google.type.expr_pb2 as expr_pb2  # type: ignore
-from google.api_core import (
-    client_options,
-    future,
-    gapic_v1,
-    grpc_helpers,
-    grpc_helpers_async,
-    operation,
-    operations_v1,
-    path_template,
-)
-from google.api_core import exceptions as core_exceptions
-from google.api_core import retry as retries
-from google.auth import credentials as ga_credentials
-from google.auth.exceptions import MutualTLSChannelError
-from google.cloud.asset_v1.services.asset_service import (
-    AssetServiceAsyncClient,
-    AssetServiceClient,
-    pagers,
-    transports,
-)
-from google.cloud.asset_v1.types import asset_service, assets
-from google.longrunning import operations_pb2  # type: ignore
-from google.oauth2 import service_account
+
+
 
 CRED_INFO_JSON = {
     "credential_source": "/path/to/file",

--- a/packages/gapic-generator/tests/integration/goldens/credentials/tests/unit/gapic/credentials_v1/test_iam_credentials.py
+++ b/packages/gapic-generator/tests/integration/goldens/credentials/tests/unit/gapic/credentials_v1/test_iam_credentials.py
@@ -13,23 +13,26 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-import asyncio
-import json
-import math
 import os
-from collections.abc import AsyncIterable, Iterable, Mapping, Sequence
+import asyncio
 from unittest import mock
 from unittest.mock import AsyncMock
 
 import grpc
-import pytest
-from google.api_core import api_core_version
-from google.protobuf import json_format
 from grpc.experimental import aio
-from proto.marshal.rules import wrappers
+from collections.abc import Iterable, AsyncIterable
+from google.protobuf import json_format
+import json
+import math
+import pytest
+from collections.abc import Sequence, Mapping
+from google.api_core import api_core_version
 from proto.marshal.rules.dates import DurationRule, TimestampRule
-from requests import PreparedRequest, Request, Response
+from proto.marshal.rules import wrappers
+from requests import Response
+from requests import Request, PreparedRequest
 from requests.sessions import Session
+from google.protobuf import json_format
 
 try:
     from google.auth.aio import credentials as ga_credentials_async
@@ -37,27 +40,25 @@ try:
 except ImportError: # pragma: NO COVER
     HAS_GOOGLE_AUTH_AIO = False
 
-import google.auth
-import google.protobuf.duration_pb2 as duration_pb2  # type: ignore
-import google.protobuf.timestamp_pb2 as timestamp_pb2  # type: ignore
-from google.api_core import (
-    client_options,
-    gapic_v1,
-    grpc_helpers,
-    grpc_helpers_async,
-    path_template,
-)
+from google.api_core import client_options
 from google.api_core import exceptions as core_exceptions
+from google.api_core import gapic_v1
+from google.api_core import grpc_helpers
+from google.api_core import grpc_helpers_async
+from google.api_core import path_template
 from google.api_core import retry as retries
 from google.auth import credentials as ga_credentials
 from google.auth.exceptions import MutualTLSChannelError
-from google.iam.credentials_v1.services.iam_credentials import (
-    IAMCredentialsAsyncClient,
-    IAMCredentialsClient,
-    transports,
-)
+from google.iam.credentials_v1.services.iam_credentials import IAMCredentialsAsyncClient
+from google.iam.credentials_v1.services.iam_credentials import IAMCredentialsClient
+from google.iam.credentials_v1.services.iam_credentials import transports
 from google.iam.credentials_v1.types import common
 from google.oauth2 import service_account
+import google.auth
+import google.protobuf.duration_pb2 as duration_pb2  # type: ignore
+import google.protobuf.timestamp_pb2 as timestamp_pb2  # type: ignore
+
+
 
 CRED_INFO_JSON = {
     "credential_source": "/path/to/file",

--- a/packages/gapic-generator/tests/integration/goldens/credentials/tests/unit/gapic/credentials_v1/test_iam_credentials.py
+++ b/packages/gapic-generator/tests/integration/goldens/credentials/tests/unit/gapic/credentials_v1/test_iam_credentials.py
@@ -13,26 +13,23 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-import os
 import asyncio
+import json
+import math
+import os
+from collections.abc import AsyncIterable, Iterable, Mapping, Sequence
 from unittest import mock
 from unittest.mock import AsyncMock
 
 import grpc
-from grpc.experimental import aio
-from collections.abc import Iterable, AsyncIterable
-from google.protobuf import json_format
-import json
-import math
 import pytest
-from collections.abc import Sequence, Mapping
 from google.api_core import api_core_version
-from proto.marshal.rules.dates import DurationRule, TimestampRule
-from proto.marshal.rules import wrappers
-from requests import Response
-from requests import Request, PreparedRequest
-from requests.sessions import Session
 from google.protobuf import json_format
+from grpc.experimental import aio
+from proto.marshal.rules import wrappers
+from proto.marshal.rules.dates import DurationRule, TimestampRule
+from requests import PreparedRequest, Request, Response
+from requests.sessions import Session
 
 try:
     from google.auth.aio import credentials as ga_credentials_async
@@ -40,25 +37,27 @@ try:
 except ImportError: # pragma: NO COVER
     HAS_GOOGLE_AUTH_AIO = False
 
-from google.api_core import client_options
-from google.api_core import exceptions as core_exceptions
-from google.api_core import gapic_v1
-from google.api_core import grpc_helpers
-from google.api_core import grpc_helpers_async
-from google.api_core import path_template
-from google.api_core import retry as retries
-from google.auth import credentials as ga_credentials
-from google.auth.exceptions import MutualTLSChannelError
-from google.iam.credentials_v1.services.iam_credentials import IAMCredentialsAsyncClient
-from google.iam.credentials_v1.services.iam_credentials import IAMCredentialsClient
-from google.iam.credentials_v1.services.iam_credentials import transports
-from google.iam.credentials_v1.types import common
-from google.oauth2 import service_account
 import google.auth
 import google.protobuf.duration_pb2 as duration_pb2  # type: ignore
 import google.protobuf.timestamp_pb2 as timestamp_pb2  # type: ignore
-
-
+from google.api_core import (
+    client_options,
+    gapic_v1,
+    grpc_helpers,
+    grpc_helpers_async,
+    path_template,
+)
+from google.api_core import exceptions as core_exceptions
+from google.api_core import retry as retries
+from google.auth import credentials as ga_credentials
+from google.auth.exceptions import MutualTLSChannelError
+from google.iam.credentials_v1.services.iam_credentials import (
+    IAMCredentialsAsyncClient,
+    IAMCredentialsClient,
+    transports,
+)
+from google.iam.credentials_v1.types import common
+from google.oauth2 import service_account
 
 CRED_INFO_JSON = {
     "credential_source": "/path/to/file",
@@ -690,7 +689,7 @@ def test_iam_credentials_client_get_mtls_endpoint_and_cert_source(client_class):
                     config_filename = "mock_certificate_config.json"
                     config_file_content = json.dumps(config_data)
                     m = mock.mock_open(read_data=config_file_content)
-                    with mock.patch("builtins.open", m), mock.patch("os.path.exists", return_value=True):
+                    with mock.patch("builtins.open", m), mock.patch("os.path.exists", side_effect=lambda path: os.path.basename(path) == config_filename):
                         with mock.patch.dict(
                             os.environ, {"GOOGLE_API_CERTIFICATE_CONFIG": config_filename}
                         ):
@@ -737,7 +736,7 @@ def test_iam_credentials_client_get_mtls_endpoint_and_cert_source(client_class):
                     config_filename = "mock_certificate_config.json"
                     config_file_content = json.dumps(config_data)
                     m = mock.mock_open(read_data=config_file_content)
-                    with mock.patch("builtins.open", m), mock.patch("os.path.exists", return_value=True):
+                    with mock.patch("builtins.open", m), mock.patch("os.path.exists", side_effect=lambda path: os.path.basename(path) == config_filename):
                         with mock.patch.dict(
                             os.environ, {"GOOGLE_API_CERTIFICATE_CONFIG": config_filename}
                         ):

--- a/packages/gapic-generator/tests/integration/goldens/credentials/tests/unit/gapic/credentials_v1/test_iam_credentials.py
+++ b/packages/gapic-generator/tests/integration/goldens/credentials/tests/unit/gapic/credentials_v1/test_iam_credentials.py
@@ -690,7 +690,7 @@ def test_iam_credentials_client_get_mtls_endpoint_and_cert_source(client_class):
                     config_filename = "mock_certificate_config.json"
                     config_file_content = json.dumps(config_data)
                     m = mock.mock_open(read_data=config_file_content)
-                    with mock.patch("builtins.open", m):
+                    with mock.patch("builtins.open", m), mock.patch("os.path.exists", return_value=True):
                         with mock.patch.dict(
                             os.environ, {"GOOGLE_API_CERTIFICATE_CONFIG": config_filename}
                         ):
@@ -737,7 +737,7 @@ def test_iam_credentials_client_get_mtls_endpoint_and_cert_source(client_class):
                     config_filename = "mock_certificate_config.json"
                     config_file_content = json.dumps(config_data)
                     m = mock.mock_open(read_data=config_file_content)
-                    with mock.patch("builtins.open", m):
+                    with mock.patch("builtins.open", m), mock.patch("os.path.exists", return_value=True):
                         with mock.patch.dict(
                             os.environ, {"GOOGLE_API_CERTIFICATE_CONFIG": config_filename}
                         ):

--- a/packages/gapic-generator/tests/integration/goldens/eventarc/tests/unit/gapic/eventarc_v1/test_eventarc.py
+++ b/packages/gapic-generator/tests/integration/goldens/eventarc/tests/unit/gapic/eventarc_v1/test_eventarc.py
@@ -13,26 +13,23 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-import os
 import asyncio
+import json
+import math
+import os
+from collections.abc import AsyncIterable, Iterable, Mapping, Sequence
 from unittest import mock
 from unittest.mock import AsyncMock
 
 import grpc
-from grpc.experimental import aio
-from collections.abc import Iterable, AsyncIterable
-from google.protobuf import json_format
-import json
-import math
 import pytest
-from collections.abc import Sequence, Mapping
 from google.api_core import api_core_version
-from proto.marshal.rules.dates import DurationRule, TimestampRule
-from proto.marshal.rules import wrappers
-from requests import Response
-from requests import Request, PreparedRequest
-from requests.sessions import Session
 from google.protobuf import json_format
+from grpc.experimental import aio
+from proto.marshal.rules import wrappers
+from proto.marshal.rules.dates import DurationRule, TimestampRule
+from requests import PreparedRequest, Request, Response
+from requests.sessions import Session
 
 try:
     from google.auth.aio import credentials as ga_credentials_async
@@ -40,56 +37,64 @@ try:
 except ImportError: # pragma: NO COVER
     HAS_GOOGLE_AUTH_AIO = False
 
-from google.api_core import client_options
-from google.api_core import exceptions as core_exceptions
-from google.api_core import future
-from google.api_core import gapic_v1
-from google.api_core import grpc_helpers
-from google.api_core import grpc_helpers_async
-from google.api_core import operation
-from google.api_core import operations_v1
-from google.api_core import path_template
-from google.api_core import retry as retries
-from google.auth import credentials as ga_credentials
-from google.auth.exceptions import MutualTLSChannelError
-from google.cloud.eventarc_v1.services.eventarc import EventarcAsyncClient
-from google.cloud.eventarc_v1.services.eventarc import EventarcClient
-from google.cloud.eventarc_v1.services.eventarc import pagers
-from google.cloud.eventarc_v1.services.eventarc import transports
-from google.cloud.eventarc_v1.types import channel
-from google.cloud.eventarc_v1.types import channel as gce_channel
-from google.cloud.eventarc_v1.types import channel_connection
-from google.cloud.eventarc_v1.types import channel_connection as gce_channel_connection
-from google.cloud.eventarc_v1.types import discovery
-from google.cloud.eventarc_v1.types import enrollment
-from google.cloud.eventarc_v1.types import enrollment as gce_enrollment
-from google.cloud.eventarc_v1.types import eventarc
-from google.cloud.eventarc_v1.types import google_api_source
-from google.cloud.eventarc_v1.types import google_api_source as gce_google_api_source
-from google.cloud.eventarc_v1.types import google_channel_config
-from google.cloud.eventarc_v1.types import google_channel_config as gce_google_channel_config
-from google.cloud.eventarc_v1.types import logging_config
-from google.cloud.eventarc_v1.types import message_bus
-from google.cloud.eventarc_v1.types import message_bus as gce_message_bus
-from google.cloud.eventarc_v1.types import network_config
-from google.cloud.eventarc_v1.types import pipeline
-from google.cloud.eventarc_v1.types import pipeline as gce_pipeline
-from google.cloud.eventarc_v1.types import trigger
-from google.cloud.eventarc_v1.types import trigger as gce_trigger
-from google.cloud.location import locations_pb2
-from google.iam.v1 import iam_policy_pb2  # type: ignore
-from google.iam.v1 import options_pb2  # type: ignore
-from google.iam.v1 import policy_pb2  # type: ignore
-from google.longrunning import operations_pb2 # type: ignore
-from google.oauth2 import service_account
 import google.api_core.operation_async as operation_async  # type: ignore
 import google.auth
 import google.protobuf.duration_pb2 as duration_pb2  # type: ignore
 import google.protobuf.field_mask_pb2 as field_mask_pb2  # type: ignore
 import google.protobuf.timestamp_pb2 as timestamp_pb2  # type: ignore
 import google.rpc.code_pb2 as code_pb2  # type: ignore
-
-
+from google.api_core import (
+    client_options,
+    future,
+    gapic_v1,
+    grpc_helpers,
+    grpc_helpers_async,
+    operation,
+    operations_v1,
+    path_template,
+)
+from google.api_core import exceptions as core_exceptions
+from google.api_core import retry as retries
+from google.auth import credentials as ga_credentials
+from google.auth.exceptions import MutualTLSChannelError
+from google.cloud.eventarc_v1.services.eventarc import (
+    EventarcAsyncClient,
+    EventarcClient,
+    pagers,
+    transports,
+)
+from google.cloud.eventarc_v1.types import (
+    channel,
+    channel_connection,
+    discovery,
+    enrollment,
+    eventarc,
+    google_api_source,
+    google_channel_config,
+    logging_config,
+    message_bus,
+    network_config,
+    pipeline,
+    trigger,
+)
+from google.cloud.eventarc_v1.types import channel as gce_channel
+from google.cloud.eventarc_v1.types import channel_connection as gce_channel_connection
+from google.cloud.eventarc_v1.types import enrollment as gce_enrollment
+from google.cloud.eventarc_v1.types import google_api_source as gce_google_api_source
+from google.cloud.eventarc_v1.types import (
+    google_channel_config as gce_google_channel_config,
+)
+from google.cloud.eventarc_v1.types import message_bus as gce_message_bus
+from google.cloud.eventarc_v1.types import pipeline as gce_pipeline
+from google.cloud.eventarc_v1.types import trigger as gce_trigger
+from google.cloud.location import locations_pb2
+from google.iam.v1 import (
+    iam_policy_pb2,  # type: ignore
+    options_pb2,  # type: ignore
+    policy_pb2,  # type: ignore
+)
+from google.longrunning import operations_pb2  # type: ignore
+from google.oauth2 import service_account
 
 CRED_INFO_JSON = {
     "credential_source": "/path/to/file",
@@ -721,7 +726,7 @@ def test_eventarc_client_get_mtls_endpoint_and_cert_source(client_class):
                     config_filename = "mock_certificate_config.json"
                     config_file_content = json.dumps(config_data)
                     m = mock.mock_open(read_data=config_file_content)
-                    with mock.patch("builtins.open", m), mock.patch("os.path.exists", return_value=True):
+                    with mock.patch("builtins.open", m), mock.patch("os.path.exists", side_effect=lambda path: os.path.basename(path) == config_filename):
                         with mock.patch.dict(
                             os.environ, {"GOOGLE_API_CERTIFICATE_CONFIG": config_filename}
                         ):
@@ -768,7 +773,7 @@ def test_eventarc_client_get_mtls_endpoint_and_cert_source(client_class):
                     config_filename = "mock_certificate_config.json"
                     config_file_content = json.dumps(config_data)
                     m = mock.mock_open(read_data=config_file_content)
-                    with mock.patch("builtins.open", m), mock.patch("os.path.exists", return_value=True):
+                    with mock.patch("builtins.open", m), mock.patch("os.path.exists", side_effect=lambda path: os.path.basename(path) == config_filename):
                         with mock.patch.dict(
                             os.environ, {"GOOGLE_API_CERTIFICATE_CONFIG": config_filename}
                         ):

--- a/packages/gapic-generator/tests/integration/goldens/eventarc/tests/unit/gapic/eventarc_v1/test_eventarc.py
+++ b/packages/gapic-generator/tests/integration/goldens/eventarc/tests/unit/gapic/eventarc_v1/test_eventarc.py
@@ -721,7 +721,7 @@ def test_eventarc_client_get_mtls_endpoint_and_cert_source(client_class):
                     config_filename = "mock_certificate_config.json"
                     config_file_content = json.dumps(config_data)
                     m = mock.mock_open(read_data=config_file_content)
-                    with mock.patch("builtins.open", m):
+                    with mock.patch("builtins.open", m), mock.patch("os.path.exists", return_value=True):
                         with mock.patch.dict(
                             os.environ, {"GOOGLE_API_CERTIFICATE_CONFIG": config_filename}
                         ):
@@ -768,7 +768,7 @@ def test_eventarc_client_get_mtls_endpoint_and_cert_source(client_class):
                     config_filename = "mock_certificate_config.json"
                     config_file_content = json.dumps(config_data)
                     m = mock.mock_open(read_data=config_file_content)
-                    with mock.patch("builtins.open", m):
+                    with mock.patch("builtins.open", m), mock.patch("os.path.exists", return_value=True):
                         with mock.patch.dict(
                             os.environ, {"GOOGLE_API_CERTIFICATE_CONFIG": config_filename}
                         ):

--- a/packages/gapic-generator/tests/integration/goldens/eventarc/tests/unit/gapic/eventarc_v1/test_eventarc.py
+++ b/packages/gapic-generator/tests/integration/goldens/eventarc/tests/unit/gapic/eventarc_v1/test_eventarc.py
@@ -13,23 +13,26 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-import asyncio
-import json
-import math
 import os
-from collections.abc import AsyncIterable, Iterable, Mapping, Sequence
+import asyncio
 from unittest import mock
 from unittest.mock import AsyncMock
 
 import grpc
-import pytest
-from google.api_core import api_core_version
-from google.protobuf import json_format
 from grpc.experimental import aio
-from proto.marshal.rules import wrappers
+from collections.abc import Iterable, AsyncIterable
+from google.protobuf import json_format
+import json
+import math
+import pytest
+from collections.abc import Sequence, Mapping
+from google.api_core import api_core_version
 from proto.marshal.rules.dates import DurationRule, TimestampRule
-from requests import PreparedRequest, Request, Response
+from proto.marshal.rules import wrappers
+from requests import Response
+from requests import Request, PreparedRequest
 from requests.sessions import Session
+from google.protobuf import json_format
 
 try:
     from google.auth.aio import credentials as ga_credentials_async
@@ -37,64 +40,56 @@ try:
 except ImportError: # pragma: NO COVER
     HAS_GOOGLE_AUTH_AIO = False
 
+from google.api_core import client_options
+from google.api_core import exceptions as core_exceptions
+from google.api_core import future
+from google.api_core import gapic_v1
+from google.api_core import grpc_helpers
+from google.api_core import grpc_helpers_async
+from google.api_core import operation
+from google.api_core import operations_v1
+from google.api_core import path_template
+from google.api_core import retry as retries
+from google.auth import credentials as ga_credentials
+from google.auth.exceptions import MutualTLSChannelError
+from google.cloud.eventarc_v1.services.eventarc import EventarcAsyncClient
+from google.cloud.eventarc_v1.services.eventarc import EventarcClient
+from google.cloud.eventarc_v1.services.eventarc import pagers
+from google.cloud.eventarc_v1.services.eventarc import transports
+from google.cloud.eventarc_v1.types import channel
+from google.cloud.eventarc_v1.types import channel as gce_channel
+from google.cloud.eventarc_v1.types import channel_connection
+from google.cloud.eventarc_v1.types import channel_connection as gce_channel_connection
+from google.cloud.eventarc_v1.types import discovery
+from google.cloud.eventarc_v1.types import enrollment
+from google.cloud.eventarc_v1.types import enrollment as gce_enrollment
+from google.cloud.eventarc_v1.types import eventarc
+from google.cloud.eventarc_v1.types import google_api_source
+from google.cloud.eventarc_v1.types import google_api_source as gce_google_api_source
+from google.cloud.eventarc_v1.types import google_channel_config
+from google.cloud.eventarc_v1.types import google_channel_config as gce_google_channel_config
+from google.cloud.eventarc_v1.types import logging_config
+from google.cloud.eventarc_v1.types import message_bus
+from google.cloud.eventarc_v1.types import message_bus as gce_message_bus
+from google.cloud.eventarc_v1.types import network_config
+from google.cloud.eventarc_v1.types import pipeline
+from google.cloud.eventarc_v1.types import pipeline as gce_pipeline
+from google.cloud.eventarc_v1.types import trigger
+from google.cloud.eventarc_v1.types import trigger as gce_trigger
+from google.cloud.location import locations_pb2
+from google.iam.v1 import iam_policy_pb2  # type: ignore
+from google.iam.v1 import options_pb2  # type: ignore
+from google.iam.v1 import policy_pb2  # type: ignore
+from google.longrunning import operations_pb2 # type: ignore
+from google.oauth2 import service_account
 import google.api_core.operation_async as operation_async  # type: ignore
 import google.auth
 import google.protobuf.duration_pb2 as duration_pb2  # type: ignore
 import google.protobuf.field_mask_pb2 as field_mask_pb2  # type: ignore
 import google.protobuf.timestamp_pb2 as timestamp_pb2  # type: ignore
 import google.rpc.code_pb2 as code_pb2  # type: ignore
-from google.api_core import (
-    client_options,
-    future,
-    gapic_v1,
-    grpc_helpers,
-    grpc_helpers_async,
-    operation,
-    operations_v1,
-    path_template,
-)
-from google.api_core import exceptions as core_exceptions
-from google.api_core import retry as retries
-from google.auth import credentials as ga_credentials
-from google.auth.exceptions import MutualTLSChannelError
-from google.cloud.eventarc_v1.services.eventarc import (
-    EventarcAsyncClient,
-    EventarcClient,
-    pagers,
-    transports,
-)
-from google.cloud.eventarc_v1.types import (
-    channel,
-    channel_connection,
-    discovery,
-    enrollment,
-    eventarc,
-    google_api_source,
-    google_channel_config,
-    logging_config,
-    message_bus,
-    network_config,
-    pipeline,
-    trigger,
-)
-from google.cloud.eventarc_v1.types import channel as gce_channel
-from google.cloud.eventarc_v1.types import channel_connection as gce_channel_connection
-from google.cloud.eventarc_v1.types import enrollment as gce_enrollment
-from google.cloud.eventarc_v1.types import google_api_source as gce_google_api_source
-from google.cloud.eventarc_v1.types import (
-    google_channel_config as gce_google_channel_config,
-)
-from google.cloud.eventarc_v1.types import message_bus as gce_message_bus
-from google.cloud.eventarc_v1.types import pipeline as gce_pipeline
-from google.cloud.eventarc_v1.types import trigger as gce_trigger
-from google.cloud.location import locations_pb2
-from google.iam.v1 import (
-    iam_policy_pb2,  # type: ignore
-    options_pb2,  # type: ignore
-    policy_pb2,  # type: ignore
-)
-from google.longrunning import operations_pb2  # type: ignore
-from google.oauth2 import service_account
+
+
 
 CRED_INFO_JSON = {
     "credential_source": "/path/to/file",

--- a/packages/gapic-generator/tests/integration/goldens/logging/tests/unit/gapic/logging_v2/test_config_service_v2.py
+++ b/packages/gapic-generator/tests/integration/goldens/logging/tests/unit/gapic/logging_v2/test_config_service_v2.py
@@ -13,20 +13,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-import os
 import asyncio
+import json
+import math
+import os
+from collections.abc import Mapping, Sequence
 from unittest import mock
 from unittest.mock import AsyncMock
 
 import grpc
-from grpc.experimental import aio
-import json
-import math
 import pytest
-from collections.abc import Sequence, Mapping
 from google.api_core import api_core_version
-from proto.marshal.rules.dates import DurationRule, TimestampRule
+from grpc.experimental import aio
 from proto.marshal.rules import wrappers
+from proto.marshal.rules.dates import DurationRule, TimestampRule
 
 try:
     from google.auth.aio import credentials as ga_credentials_async
@@ -34,32 +34,34 @@ try:
 except ImportError: # pragma: NO COVER
     HAS_GOOGLE_AUTH_AIO = False
 
-from google.api_core import client_options
-from google.api_core import exceptions as core_exceptions
-from google.api_core import future
-from google.api_core import gapic_v1
-from google.api_core import grpc_helpers
-from google.api_core import grpc_helpers_async
-from google.api_core import operation
-from google.api_core import operations_v1
-from google.api_core import path_template
-from google.api_core import retry as retries
-from google.auth import credentials as ga_credentials
-from google.auth.exceptions import MutualTLSChannelError
-from google.cloud.logging_v2.services.config_service_v2 import ConfigServiceV2AsyncClient
-from google.cloud.logging_v2.services.config_service_v2 import ConfigServiceV2Client
-from google.cloud.logging_v2.services.config_service_v2 import pagers
-from google.cloud.logging_v2.services.config_service_v2 import transports
-from google.cloud.logging_v2.types import logging_config
-from google.longrunning import operations_pb2 # type: ignore
-from google.oauth2 import service_account
 import google.api_core.operation_async as operation_async  # type: ignore
 import google.auth
 import google.protobuf.empty_pb2 as empty_pb2  # type: ignore
 import google.protobuf.field_mask_pb2 as field_mask_pb2  # type: ignore
 import google.protobuf.timestamp_pb2 as timestamp_pb2  # type: ignore
-
-
+from google.api_core import (
+    client_options,
+    future,
+    gapic_v1,
+    grpc_helpers,
+    grpc_helpers_async,
+    operation,
+    operations_v1,
+    path_template,
+)
+from google.api_core import exceptions as core_exceptions
+from google.api_core import retry as retries
+from google.auth import credentials as ga_credentials
+from google.auth.exceptions import MutualTLSChannelError
+from google.cloud.logging_v2.services.config_service_v2 import (
+    ConfigServiceV2AsyncClient,
+    ConfigServiceV2Client,
+    pagers,
+    transports,
+)
+from google.cloud.logging_v2.types import logging_config
+from google.longrunning import operations_pb2  # type: ignore
+from google.oauth2 import service_account
 
 CRED_INFO_JSON = {
     "credential_source": "/path/to/file",
@@ -678,7 +680,7 @@ def test_config_service_v2_client_get_mtls_endpoint_and_cert_source(client_class
                     config_filename = "mock_certificate_config.json"
                     config_file_content = json.dumps(config_data)
                     m = mock.mock_open(read_data=config_file_content)
-                    with mock.patch("builtins.open", m), mock.patch("os.path.exists", return_value=True):
+                    with mock.patch("builtins.open", m), mock.patch("os.path.exists", side_effect=lambda path: os.path.basename(path) == config_filename):
                         with mock.patch.dict(
                             os.environ, {"GOOGLE_API_CERTIFICATE_CONFIG": config_filename}
                         ):
@@ -725,7 +727,7 @@ def test_config_service_v2_client_get_mtls_endpoint_and_cert_source(client_class
                     config_filename = "mock_certificate_config.json"
                     config_file_content = json.dumps(config_data)
                     m = mock.mock_open(read_data=config_file_content)
-                    with mock.patch("builtins.open", m), mock.patch("os.path.exists", return_value=True):
+                    with mock.patch("builtins.open", m), mock.patch("os.path.exists", side_effect=lambda path: os.path.basename(path) == config_filename):
                         with mock.patch.dict(
                             os.environ, {"GOOGLE_API_CERTIFICATE_CONFIG": config_filename}
                         ):

--- a/packages/gapic-generator/tests/integration/goldens/logging/tests/unit/gapic/logging_v2/test_config_service_v2.py
+++ b/packages/gapic-generator/tests/integration/goldens/logging/tests/unit/gapic/logging_v2/test_config_service_v2.py
@@ -13,20 +13,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-import asyncio
-import json
-import math
 import os
-from collections.abc import Mapping, Sequence
+import asyncio
 from unittest import mock
 from unittest.mock import AsyncMock
 
 import grpc
-import pytest
-from google.api_core import api_core_version
 from grpc.experimental import aio
-from proto.marshal.rules import wrappers
+import json
+import math
+import pytest
+from collections.abc import Sequence, Mapping
+from google.api_core import api_core_version
 from proto.marshal.rules.dates import DurationRule, TimestampRule
+from proto.marshal.rules import wrappers
 
 try:
     from google.auth.aio import credentials as ga_credentials_async
@@ -34,34 +34,32 @@ try:
 except ImportError: # pragma: NO COVER
     HAS_GOOGLE_AUTH_AIO = False
 
+from google.api_core import client_options
+from google.api_core import exceptions as core_exceptions
+from google.api_core import future
+from google.api_core import gapic_v1
+from google.api_core import grpc_helpers
+from google.api_core import grpc_helpers_async
+from google.api_core import operation
+from google.api_core import operations_v1
+from google.api_core import path_template
+from google.api_core import retry as retries
+from google.auth import credentials as ga_credentials
+from google.auth.exceptions import MutualTLSChannelError
+from google.cloud.logging_v2.services.config_service_v2 import ConfigServiceV2AsyncClient
+from google.cloud.logging_v2.services.config_service_v2 import ConfigServiceV2Client
+from google.cloud.logging_v2.services.config_service_v2 import pagers
+from google.cloud.logging_v2.services.config_service_v2 import transports
+from google.cloud.logging_v2.types import logging_config
+from google.longrunning import operations_pb2 # type: ignore
+from google.oauth2 import service_account
 import google.api_core.operation_async as operation_async  # type: ignore
 import google.auth
 import google.protobuf.empty_pb2 as empty_pb2  # type: ignore
 import google.protobuf.field_mask_pb2 as field_mask_pb2  # type: ignore
 import google.protobuf.timestamp_pb2 as timestamp_pb2  # type: ignore
-from google.api_core import (
-    client_options,
-    future,
-    gapic_v1,
-    grpc_helpers,
-    grpc_helpers_async,
-    operation,
-    operations_v1,
-    path_template,
-)
-from google.api_core import exceptions as core_exceptions
-from google.api_core import retry as retries
-from google.auth import credentials as ga_credentials
-from google.auth.exceptions import MutualTLSChannelError
-from google.cloud.logging_v2.services.config_service_v2 import (
-    ConfigServiceV2AsyncClient,
-    ConfigServiceV2Client,
-    pagers,
-    transports,
-)
-from google.cloud.logging_v2.types import logging_config
-from google.longrunning import operations_pb2  # type: ignore
-from google.oauth2 import service_account
+
+
 
 CRED_INFO_JSON = {
     "credential_source": "/path/to/file",

--- a/packages/gapic-generator/tests/integration/goldens/logging/tests/unit/gapic/logging_v2/test_config_service_v2.py
+++ b/packages/gapic-generator/tests/integration/goldens/logging/tests/unit/gapic/logging_v2/test_config_service_v2.py
@@ -678,7 +678,7 @@ def test_config_service_v2_client_get_mtls_endpoint_and_cert_source(client_class
                     config_filename = "mock_certificate_config.json"
                     config_file_content = json.dumps(config_data)
                     m = mock.mock_open(read_data=config_file_content)
-                    with mock.patch("builtins.open", m):
+                    with mock.patch("builtins.open", m), mock.patch("os.path.exists", return_value=True):
                         with mock.patch.dict(
                             os.environ, {"GOOGLE_API_CERTIFICATE_CONFIG": config_filename}
                         ):
@@ -725,7 +725,7 @@ def test_config_service_v2_client_get_mtls_endpoint_and_cert_source(client_class
                     config_filename = "mock_certificate_config.json"
                     config_file_content = json.dumps(config_data)
                     m = mock.mock_open(read_data=config_file_content)
-                    with mock.patch("builtins.open", m):
+                    with mock.patch("builtins.open", m), mock.patch("os.path.exists", return_value=True):
                         with mock.patch.dict(
                             os.environ, {"GOOGLE_API_CERTIFICATE_CONFIG": config_filename}
                         ):

--- a/packages/gapic-generator/tests/integration/goldens/logging/tests/unit/gapic/logging_v2/test_logging_service_v2.py
+++ b/packages/gapic-generator/tests/integration/goldens/logging/tests/unit/gapic/logging_v2/test_logging_service_v2.py
@@ -13,20 +13,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-import os
 import asyncio
+import json
+import math
+import os
+from collections.abc import Mapping, Sequence
 from unittest import mock
 from unittest.mock import AsyncMock
 
 import grpc
-from grpc.experimental import aio
-import json
-import math
 import pytest
-from collections.abc import Sequence, Mapping
 from google.api_core import api_core_version
-from proto.marshal.rules.dates import DurationRule, TimestampRule
+from grpc.experimental import aio
 from proto.marshal.rules import wrappers
+from proto.marshal.rules.dates import DurationRule, TimestampRule
 
 try:
     from google.auth.aio import credentials as ga_credentials_async
@@ -34,23 +34,6 @@ try:
 except ImportError: # pragma: NO COVER
     HAS_GOOGLE_AUTH_AIO = False
 
-from google.api_core import client_options
-from google.api_core import exceptions as core_exceptions
-from google.api_core import gapic_v1
-from google.api_core import grpc_helpers
-from google.api_core import grpc_helpers_async
-from google.api_core import path_template
-from google.api_core import retry as retries
-from google.auth import credentials as ga_credentials
-from google.auth.exceptions import MutualTLSChannelError
-from google.cloud.logging_v2.services.logging_service_v2 import LoggingServiceV2AsyncClient
-from google.cloud.logging_v2.services.logging_service_v2 import LoggingServiceV2Client
-from google.cloud.logging_v2.services.logging_service_v2 import pagers
-from google.cloud.logging_v2.services.logging_service_v2 import transports
-from google.cloud.logging_v2.types import log_entry
-from google.cloud.logging_v2.types import logging
-from google.longrunning import operations_pb2 # type: ignore
-from google.oauth2 import service_account
 import google.api.monitored_resource_pb2 as monitored_resource_pb2  # type: ignore
 import google.auth
 import google.logging.type.http_request_pb2 as http_request_pb2  # type: ignore
@@ -59,8 +42,26 @@ import google.protobuf.any_pb2 as any_pb2  # type: ignore
 import google.protobuf.duration_pb2 as duration_pb2  # type: ignore
 import google.protobuf.struct_pb2 as struct_pb2  # type: ignore
 import google.protobuf.timestamp_pb2 as timestamp_pb2  # type: ignore
-
-
+from google.api_core import (
+    client_options,
+    gapic_v1,
+    grpc_helpers,
+    grpc_helpers_async,
+    path_template,
+)
+from google.api_core import exceptions as core_exceptions
+from google.api_core import retry as retries
+from google.auth import credentials as ga_credentials
+from google.auth.exceptions import MutualTLSChannelError
+from google.cloud.logging_v2.services.logging_service_v2 import (
+    LoggingServiceV2AsyncClient,
+    LoggingServiceV2Client,
+    pagers,
+    transports,
+)
+from google.cloud.logging_v2.types import log_entry, logging
+from google.longrunning import operations_pb2  # type: ignore
+from google.oauth2 import service_account
 
 CRED_INFO_JSON = {
     "credential_source": "/path/to/file",
@@ -679,7 +680,7 @@ def test_logging_service_v2_client_get_mtls_endpoint_and_cert_source(client_clas
                     config_filename = "mock_certificate_config.json"
                     config_file_content = json.dumps(config_data)
                     m = mock.mock_open(read_data=config_file_content)
-                    with mock.patch("builtins.open", m), mock.patch("os.path.exists", return_value=True):
+                    with mock.patch("builtins.open", m), mock.patch("os.path.exists", side_effect=lambda path: os.path.basename(path) == config_filename):
                         with mock.patch.dict(
                             os.environ, {"GOOGLE_API_CERTIFICATE_CONFIG": config_filename}
                         ):
@@ -726,7 +727,7 @@ def test_logging_service_v2_client_get_mtls_endpoint_and_cert_source(client_clas
                     config_filename = "mock_certificate_config.json"
                     config_file_content = json.dumps(config_data)
                     m = mock.mock_open(read_data=config_file_content)
-                    with mock.patch("builtins.open", m), mock.patch("os.path.exists", return_value=True):
+                    with mock.patch("builtins.open", m), mock.patch("os.path.exists", side_effect=lambda path: os.path.basename(path) == config_filename):
                         with mock.patch.dict(
                             os.environ, {"GOOGLE_API_CERTIFICATE_CONFIG": config_filename}
                         ):

--- a/packages/gapic-generator/tests/integration/goldens/logging/tests/unit/gapic/logging_v2/test_logging_service_v2.py
+++ b/packages/gapic-generator/tests/integration/goldens/logging/tests/unit/gapic/logging_v2/test_logging_service_v2.py
@@ -13,20 +13,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-import asyncio
-import json
-import math
 import os
-from collections.abc import Mapping, Sequence
+import asyncio
 from unittest import mock
 from unittest.mock import AsyncMock
 
 import grpc
-import pytest
-from google.api_core import api_core_version
 from grpc.experimental import aio
-from proto.marshal.rules import wrappers
+import json
+import math
+import pytest
+from collections.abc import Sequence, Mapping
+from google.api_core import api_core_version
 from proto.marshal.rules.dates import DurationRule, TimestampRule
+from proto.marshal.rules import wrappers
 
 try:
     from google.auth.aio import credentials as ga_credentials_async
@@ -34,6 +34,23 @@ try:
 except ImportError: # pragma: NO COVER
     HAS_GOOGLE_AUTH_AIO = False
 
+from google.api_core import client_options
+from google.api_core import exceptions as core_exceptions
+from google.api_core import gapic_v1
+from google.api_core import grpc_helpers
+from google.api_core import grpc_helpers_async
+from google.api_core import path_template
+from google.api_core import retry as retries
+from google.auth import credentials as ga_credentials
+from google.auth.exceptions import MutualTLSChannelError
+from google.cloud.logging_v2.services.logging_service_v2 import LoggingServiceV2AsyncClient
+from google.cloud.logging_v2.services.logging_service_v2 import LoggingServiceV2Client
+from google.cloud.logging_v2.services.logging_service_v2 import pagers
+from google.cloud.logging_v2.services.logging_service_v2 import transports
+from google.cloud.logging_v2.types import log_entry
+from google.cloud.logging_v2.types import logging
+from google.longrunning import operations_pb2 # type: ignore
+from google.oauth2 import service_account
 import google.api.monitored_resource_pb2 as monitored_resource_pb2  # type: ignore
 import google.auth
 import google.logging.type.http_request_pb2 as http_request_pb2  # type: ignore
@@ -42,26 +59,8 @@ import google.protobuf.any_pb2 as any_pb2  # type: ignore
 import google.protobuf.duration_pb2 as duration_pb2  # type: ignore
 import google.protobuf.struct_pb2 as struct_pb2  # type: ignore
 import google.protobuf.timestamp_pb2 as timestamp_pb2  # type: ignore
-from google.api_core import (
-    client_options,
-    gapic_v1,
-    grpc_helpers,
-    grpc_helpers_async,
-    path_template,
-)
-from google.api_core import exceptions as core_exceptions
-from google.api_core import retry as retries
-from google.auth import credentials as ga_credentials
-from google.auth.exceptions import MutualTLSChannelError
-from google.cloud.logging_v2.services.logging_service_v2 import (
-    LoggingServiceV2AsyncClient,
-    LoggingServiceV2Client,
-    pagers,
-    transports,
-)
-from google.cloud.logging_v2.types import log_entry, logging
-from google.longrunning import operations_pb2  # type: ignore
-from google.oauth2 import service_account
+
+
 
 CRED_INFO_JSON = {
     "credential_source": "/path/to/file",

--- a/packages/gapic-generator/tests/integration/goldens/logging/tests/unit/gapic/logging_v2/test_logging_service_v2.py
+++ b/packages/gapic-generator/tests/integration/goldens/logging/tests/unit/gapic/logging_v2/test_logging_service_v2.py
@@ -679,7 +679,7 @@ def test_logging_service_v2_client_get_mtls_endpoint_and_cert_source(client_clas
                     config_filename = "mock_certificate_config.json"
                     config_file_content = json.dumps(config_data)
                     m = mock.mock_open(read_data=config_file_content)
-                    with mock.patch("builtins.open", m):
+                    with mock.patch("builtins.open", m), mock.patch("os.path.exists", return_value=True):
                         with mock.patch.dict(
                             os.environ, {"GOOGLE_API_CERTIFICATE_CONFIG": config_filename}
                         ):
@@ -726,7 +726,7 @@ def test_logging_service_v2_client_get_mtls_endpoint_and_cert_source(client_clas
                     config_filename = "mock_certificate_config.json"
                     config_file_content = json.dumps(config_data)
                     m = mock.mock_open(read_data=config_file_content)
-                    with mock.patch("builtins.open", m):
+                    with mock.patch("builtins.open", m), mock.patch("os.path.exists", return_value=True):
                         with mock.patch.dict(
                             os.environ, {"GOOGLE_API_CERTIFICATE_CONFIG": config_filename}
                         ):

--- a/packages/gapic-generator/tests/integration/goldens/logging/tests/unit/gapic/logging_v2/test_metrics_service_v2.py
+++ b/packages/gapic-generator/tests/integration/goldens/logging/tests/unit/gapic/logging_v2/test_metrics_service_v2.py
@@ -13,20 +13,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-import os
 import asyncio
+import json
+import math
+import os
+from collections.abc import Mapping, Sequence
 from unittest import mock
 from unittest.mock import AsyncMock
 
 import grpc
-from grpc.experimental import aio
-import json
-import math
 import pytest
-from collections.abc import Sequence, Mapping
 from google.api_core import api_core_version
-from proto.marshal.rules.dates import DurationRule, TimestampRule
+from grpc.experimental import aio
 from proto.marshal.rules import wrappers
+from proto.marshal.rules.dates import DurationRule, TimestampRule
 
 try:
     from google.auth.aio import credentials as ga_credentials_async
@@ -34,22 +34,6 @@ try:
 except ImportError: # pragma: NO COVER
     HAS_GOOGLE_AUTH_AIO = False
 
-from google.api_core import client_options
-from google.api_core import exceptions as core_exceptions
-from google.api_core import gapic_v1
-from google.api_core import grpc_helpers
-from google.api_core import grpc_helpers_async
-from google.api_core import path_template
-from google.api_core import retry as retries
-from google.auth import credentials as ga_credentials
-from google.auth.exceptions import MutualTLSChannelError
-from google.cloud.logging_v2.services.metrics_service_v2 import MetricsServiceV2AsyncClient
-from google.cloud.logging_v2.services.metrics_service_v2 import MetricsServiceV2Client
-from google.cloud.logging_v2.services.metrics_service_v2 import pagers
-from google.cloud.logging_v2.services.metrics_service_v2 import transports
-from google.cloud.logging_v2.types import logging_metrics
-from google.longrunning import operations_pb2 # type: ignore
-from google.oauth2 import service_account
 import google.api.distribution_pb2 as distribution_pb2  # type: ignore
 import google.api.label_pb2 as label_pb2  # type: ignore
 import google.api.launch_stage_pb2 as launch_stage_pb2  # type: ignore
@@ -57,8 +41,26 @@ import google.api.metric_pb2 as metric_pb2  # type: ignore
 import google.auth
 import google.protobuf.duration_pb2 as duration_pb2  # type: ignore
 import google.protobuf.timestamp_pb2 as timestamp_pb2  # type: ignore
-
-
+from google.api_core import (
+    client_options,
+    gapic_v1,
+    grpc_helpers,
+    grpc_helpers_async,
+    path_template,
+)
+from google.api_core import exceptions as core_exceptions
+from google.api_core import retry as retries
+from google.auth import credentials as ga_credentials
+from google.auth.exceptions import MutualTLSChannelError
+from google.cloud.logging_v2.services.metrics_service_v2 import (
+    MetricsServiceV2AsyncClient,
+    MetricsServiceV2Client,
+    pagers,
+    transports,
+)
+from google.cloud.logging_v2.types import logging_metrics
+from google.longrunning import operations_pb2  # type: ignore
+from google.oauth2 import service_account
 
 CRED_INFO_JSON = {
     "credential_source": "/path/to/file",
@@ -677,7 +679,7 @@ def test_metrics_service_v2_client_get_mtls_endpoint_and_cert_source(client_clas
                     config_filename = "mock_certificate_config.json"
                     config_file_content = json.dumps(config_data)
                     m = mock.mock_open(read_data=config_file_content)
-                    with mock.patch("builtins.open", m), mock.patch("os.path.exists", return_value=True):
+                    with mock.patch("builtins.open", m), mock.patch("os.path.exists", side_effect=lambda path: os.path.basename(path) == config_filename):
                         with mock.patch.dict(
                             os.environ, {"GOOGLE_API_CERTIFICATE_CONFIG": config_filename}
                         ):
@@ -724,7 +726,7 @@ def test_metrics_service_v2_client_get_mtls_endpoint_and_cert_source(client_clas
                     config_filename = "mock_certificate_config.json"
                     config_file_content = json.dumps(config_data)
                     m = mock.mock_open(read_data=config_file_content)
-                    with mock.patch("builtins.open", m), mock.patch("os.path.exists", return_value=True):
+                    with mock.patch("builtins.open", m), mock.patch("os.path.exists", side_effect=lambda path: os.path.basename(path) == config_filename):
                         with mock.patch.dict(
                             os.environ, {"GOOGLE_API_CERTIFICATE_CONFIG": config_filename}
                         ):

--- a/packages/gapic-generator/tests/integration/goldens/logging/tests/unit/gapic/logging_v2/test_metrics_service_v2.py
+++ b/packages/gapic-generator/tests/integration/goldens/logging/tests/unit/gapic/logging_v2/test_metrics_service_v2.py
@@ -677,7 +677,7 @@ def test_metrics_service_v2_client_get_mtls_endpoint_and_cert_source(client_clas
                     config_filename = "mock_certificate_config.json"
                     config_file_content = json.dumps(config_data)
                     m = mock.mock_open(read_data=config_file_content)
-                    with mock.patch("builtins.open", m):
+                    with mock.patch("builtins.open", m), mock.patch("os.path.exists", return_value=True):
                         with mock.patch.dict(
                             os.environ, {"GOOGLE_API_CERTIFICATE_CONFIG": config_filename}
                         ):
@@ -724,7 +724,7 @@ def test_metrics_service_v2_client_get_mtls_endpoint_and_cert_source(client_clas
                     config_filename = "mock_certificate_config.json"
                     config_file_content = json.dumps(config_data)
                     m = mock.mock_open(read_data=config_file_content)
-                    with mock.patch("builtins.open", m):
+                    with mock.patch("builtins.open", m), mock.patch("os.path.exists", return_value=True):
                         with mock.patch.dict(
                             os.environ, {"GOOGLE_API_CERTIFICATE_CONFIG": config_filename}
                         ):

--- a/packages/gapic-generator/tests/integration/goldens/logging/tests/unit/gapic/logging_v2/test_metrics_service_v2.py
+++ b/packages/gapic-generator/tests/integration/goldens/logging/tests/unit/gapic/logging_v2/test_metrics_service_v2.py
@@ -13,20 +13,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-import asyncio
-import json
-import math
 import os
-from collections.abc import Mapping, Sequence
+import asyncio
 from unittest import mock
 from unittest.mock import AsyncMock
 
 import grpc
-import pytest
-from google.api_core import api_core_version
 from grpc.experimental import aio
-from proto.marshal.rules import wrappers
+import json
+import math
+import pytest
+from collections.abc import Sequence, Mapping
+from google.api_core import api_core_version
 from proto.marshal.rules.dates import DurationRule, TimestampRule
+from proto.marshal.rules import wrappers
 
 try:
     from google.auth.aio import credentials as ga_credentials_async
@@ -34,6 +34,22 @@ try:
 except ImportError: # pragma: NO COVER
     HAS_GOOGLE_AUTH_AIO = False
 
+from google.api_core import client_options
+from google.api_core import exceptions as core_exceptions
+from google.api_core import gapic_v1
+from google.api_core import grpc_helpers
+from google.api_core import grpc_helpers_async
+from google.api_core import path_template
+from google.api_core import retry as retries
+from google.auth import credentials as ga_credentials
+from google.auth.exceptions import MutualTLSChannelError
+from google.cloud.logging_v2.services.metrics_service_v2 import MetricsServiceV2AsyncClient
+from google.cloud.logging_v2.services.metrics_service_v2 import MetricsServiceV2Client
+from google.cloud.logging_v2.services.metrics_service_v2 import pagers
+from google.cloud.logging_v2.services.metrics_service_v2 import transports
+from google.cloud.logging_v2.types import logging_metrics
+from google.longrunning import operations_pb2 # type: ignore
+from google.oauth2 import service_account
 import google.api.distribution_pb2 as distribution_pb2  # type: ignore
 import google.api.label_pb2 as label_pb2  # type: ignore
 import google.api.launch_stage_pb2 as launch_stage_pb2  # type: ignore
@@ -41,26 +57,8 @@ import google.api.metric_pb2 as metric_pb2  # type: ignore
 import google.auth
 import google.protobuf.duration_pb2 as duration_pb2  # type: ignore
 import google.protobuf.timestamp_pb2 as timestamp_pb2  # type: ignore
-from google.api_core import (
-    client_options,
-    gapic_v1,
-    grpc_helpers,
-    grpc_helpers_async,
-    path_template,
-)
-from google.api_core import exceptions as core_exceptions
-from google.api_core import retry as retries
-from google.auth import credentials as ga_credentials
-from google.auth.exceptions import MutualTLSChannelError
-from google.cloud.logging_v2.services.metrics_service_v2 import (
-    MetricsServiceV2AsyncClient,
-    MetricsServiceV2Client,
-    pagers,
-    transports,
-)
-from google.cloud.logging_v2.types import logging_metrics
-from google.longrunning import operations_pb2  # type: ignore
-from google.oauth2 import service_account
+
+
 
 CRED_INFO_JSON = {
     "credential_source": "/path/to/file",

--- a/packages/gapic-generator/tests/integration/goldens/logging_internal/tests/unit/gapic/logging_v2/test_config_service_v2.py
+++ b/packages/gapic-generator/tests/integration/goldens/logging_internal/tests/unit/gapic/logging_v2/test_config_service_v2.py
@@ -13,20 +13,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-import os
 import asyncio
+import json
+import math
+import os
+from collections.abc import Mapping, Sequence
 from unittest import mock
 from unittest.mock import AsyncMock
 
 import grpc
-from grpc.experimental import aio
-import json
-import math
 import pytest
-from collections.abc import Sequence, Mapping
 from google.api_core import api_core_version
-from proto.marshal.rules.dates import DurationRule, TimestampRule
+from grpc.experimental import aio
 from proto.marshal.rules import wrappers
+from proto.marshal.rules.dates import DurationRule, TimestampRule
 
 try:
     from google.auth.aio import credentials as ga_credentials_async
@@ -34,32 +34,34 @@ try:
 except ImportError: # pragma: NO COVER
     HAS_GOOGLE_AUTH_AIO = False
 
-from google.api_core import client_options
-from google.api_core import exceptions as core_exceptions
-from google.api_core import future
-from google.api_core import gapic_v1
-from google.api_core import grpc_helpers
-from google.api_core import grpc_helpers_async
-from google.api_core import operation
-from google.api_core import operations_v1
-from google.api_core import path_template
-from google.api_core import retry as retries
-from google.auth import credentials as ga_credentials
-from google.auth.exceptions import MutualTLSChannelError
-from google.cloud.logging_v2.services.config_service_v2 import BaseConfigServiceV2AsyncClient
-from google.cloud.logging_v2.services.config_service_v2 import BaseConfigServiceV2Client
-from google.cloud.logging_v2.services.config_service_v2 import pagers
-from google.cloud.logging_v2.services.config_service_v2 import transports
-from google.cloud.logging_v2.types import logging_config
-from google.longrunning import operations_pb2 # type: ignore
-from google.oauth2 import service_account
 import google.api_core.operation_async as operation_async  # type: ignore
 import google.auth
 import google.protobuf.empty_pb2 as empty_pb2  # type: ignore
 import google.protobuf.field_mask_pb2 as field_mask_pb2  # type: ignore
 import google.protobuf.timestamp_pb2 as timestamp_pb2  # type: ignore
-
-
+from google.api_core import (
+    client_options,
+    future,
+    gapic_v1,
+    grpc_helpers,
+    grpc_helpers_async,
+    operation,
+    operations_v1,
+    path_template,
+)
+from google.api_core import exceptions as core_exceptions
+from google.api_core import retry as retries
+from google.auth import credentials as ga_credentials
+from google.auth.exceptions import MutualTLSChannelError
+from google.cloud.logging_v2.services.config_service_v2 import (
+    BaseConfigServiceV2AsyncClient,
+    BaseConfigServiceV2Client,
+    pagers,
+    transports,
+)
+from google.cloud.logging_v2.types import logging_config
+from google.longrunning import operations_pb2  # type: ignore
+from google.oauth2 import service_account
 
 CRED_INFO_JSON = {
     "credential_source": "/path/to/file",
@@ -678,7 +680,7 @@ def test_base_config_service_v2_client_get_mtls_endpoint_and_cert_source(client_
                     config_filename = "mock_certificate_config.json"
                     config_file_content = json.dumps(config_data)
                     m = mock.mock_open(read_data=config_file_content)
-                    with mock.patch("builtins.open", m), mock.patch("os.path.exists", return_value=True):
+                    with mock.patch("builtins.open", m), mock.patch("os.path.exists", side_effect=lambda path: os.path.basename(path) == config_filename):
                         with mock.patch.dict(
                             os.environ, {"GOOGLE_API_CERTIFICATE_CONFIG": config_filename}
                         ):
@@ -725,7 +727,7 @@ def test_base_config_service_v2_client_get_mtls_endpoint_and_cert_source(client_
                     config_filename = "mock_certificate_config.json"
                     config_file_content = json.dumps(config_data)
                     m = mock.mock_open(read_data=config_file_content)
-                    with mock.patch("builtins.open", m), mock.patch("os.path.exists", return_value=True):
+                    with mock.patch("builtins.open", m), mock.patch("os.path.exists", side_effect=lambda path: os.path.basename(path) == config_filename):
                         with mock.patch.dict(
                             os.environ, {"GOOGLE_API_CERTIFICATE_CONFIG": config_filename}
                         ):

--- a/packages/gapic-generator/tests/integration/goldens/logging_internal/tests/unit/gapic/logging_v2/test_config_service_v2.py
+++ b/packages/gapic-generator/tests/integration/goldens/logging_internal/tests/unit/gapic/logging_v2/test_config_service_v2.py
@@ -13,20 +13,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-import asyncio
-import json
-import math
 import os
-from collections.abc import Mapping, Sequence
+import asyncio
 from unittest import mock
 from unittest.mock import AsyncMock
 
 import grpc
-import pytest
-from google.api_core import api_core_version
 from grpc.experimental import aio
-from proto.marshal.rules import wrappers
+import json
+import math
+import pytest
+from collections.abc import Sequence, Mapping
+from google.api_core import api_core_version
 from proto.marshal.rules.dates import DurationRule, TimestampRule
+from proto.marshal.rules import wrappers
 
 try:
     from google.auth.aio import credentials as ga_credentials_async
@@ -34,34 +34,32 @@ try:
 except ImportError: # pragma: NO COVER
     HAS_GOOGLE_AUTH_AIO = False
 
+from google.api_core import client_options
+from google.api_core import exceptions as core_exceptions
+from google.api_core import future
+from google.api_core import gapic_v1
+from google.api_core import grpc_helpers
+from google.api_core import grpc_helpers_async
+from google.api_core import operation
+from google.api_core import operations_v1
+from google.api_core import path_template
+from google.api_core import retry as retries
+from google.auth import credentials as ga_credentials
+from google.auth.exceptions import MutualTLSChannelError
+from google.cloud.logging_v2.services.config_service_v2 import BaseConfigServiceV2AsyncClient
+from google.cloud.logging_v2.services.config_service_v2 import BaseConfigServiceV2Client
+from google.cloud.logging_v2.services.config_service_v2 import pagers
+from google.cloud.logging_v2.services.config_service_v2 import transports
+from google.cloud.logging_v2.types import logging_config
+from google.longrunning import operations_pb2 # type: ignore
+from google.oauth2 import service_account
 import google.api_core.operation_async as operation_async  # type: ignore
 import google.auth
 import google.protobuf.empty_pb2 as empty_pb2  # type: ignore
 import google.protobuf.field_mask_pb2 as field_mask_pb2  # type: ignore
 import google.protobuf.timestamp_pb2 as timestamp_pb2  # type: ignore
-from google.api_core import (
-    client_options,
-    future,
-    gapic_v1,
-    grpc_helpers,
-    grpc_helpers_async,
-    operation,
-    operations_v1,
-    path_template,
-)
-from google.api_core import exceptions as core_exceptions
-from google.api_core import retry as retries
-from google.auth import credentials as ga_credentials
-from google.auth.exceptions import MutualTLSChannelError
-from google.cloud.logging_v2.services.config_service_v2 import (
-    BaseConfigServiceV2AsyncClient,
-    BaseConfigServiceV2Client,
-    pagers,
-    transports,
-)
-from google.cloud.logging_v2.types import logging_config
-from google.longrunning import operations_pb2  # type: ignore
-from google.oauth2 import service_account
+
+
 
 CRED_INFO_JSON = {
     "credential_source": "/path/to/file",

--- a/packages/gapic-generator/tests/integration/goldens/logging_internal/tests/unit/gapic/logging_v2/test_config_service_v2.py
+++ b/packages/gapic-generator/tests/integration/goldens/logging_internal/tests/unit/gapic/logging_v2/test_config_service_v2.py
@@ -678,7 +678,7 @@ def test_base_config_service_v2_client_get_mtls_endpoint_and_cert_source(client_
                     config_filename = "mock_certificate_config.json"
                     config_file_content = json.dumps(config_data)
                     m = mock.mock_open(read_data=config_file_content)
-                    with mock.patch("builtins.open", m):
+                    with mock.patch("builtins.open", m), mock.patch("os.path.exists", return_value=True):
                         with mock.patch.dict(
                             os.environ, {"GOOGLE_API_CERTIFICATE_CONFIG": config_filename}
                         ):
@@ -725,7 +725,7 @@ def test_base_config_service_v2_client_get_mtls_endpoint_and_cert_source(client_
                     config_filename = "mock_certificate_config.json"
                     config_file_content = json.dumps(config_data)
                     m = mock.mock_open(read_data=config_file_content)
-                    with mock.patch("builtins.open", m):
+                    with mock.patch("builtins.open", m), mock.patch("os.path.exists", return_value=True):
                         with mock.patch.dict(
                             os.environ, {"GOOGLE_API_CERTIFICATE_CONFIG": config_filename}
                         ):

--- a/packages/gapic-generator/tests/integration/goldens/logging_internal/tests/unit/gapic/logging_v2/test_logging_service_v2.py
+++ b/packages/gapic-generator/tests/integration/goldens/logging_internal/tests/unit/gapic/logging_v2/test_logging_service_v2.py
@@ -13,20 +13,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-import os
 import asyncio
+import json
+import math
+import os
+from collections.abc import Mapping, Sequence
 from unittest import mock
 from unittest.mock import AsyncMock
 
 import grpc
-from grpc.experimental import aio
-import json
-import math
 import pytest
-from collections.abc import Sequence, Mapping
 from google.api_core import api_core_version
-from proto.marshal.rules.dates import DurationRule, TimestampRule
+from grpc.experimental import aio
 from proto.marshal.rules import wrappers
+from proto.marshal.rules.dates import DurationRule, TimestampRule
 
 try:
     from google.auth.aio import credentials as ga_credentials_async
@@ -34,23 +34,6 @@ try:
 except ImportError: # pragma: NO COVER
     HAS_GOOGLE_AUTH_AIO = False
 
-from google.api_core import client_options
-from google.api_core import exceptions as core_exceptions
-from google.api_core import gapic_v1
-from google.api_core import grpc_helpers
-from google.api_core import grpc_helpers_async
-from google.api_core import path_template
-from google.api_core import retry as retries
-from google.auth import credentials as ga_credentials
-from google.auth.exceptions import MutualTLSChannelError
-from google.cloud.logging_v2.services.logging_service_v2 import LoggingServiceV2AsyncClient
-from google.cloud.logging_v2.services.logging_service_v2 import LoggingServiceV2Client
-from google.cloud.logging_v2.services.logging_service_v2 import pagers
-from google.cloud.logging_v2.services.logging_service_v2 import transports
-from google.cloud.logging_v2.types import log_entry
-from google.cloud.logging_v2.types import logging
-from google.longrunning import operations_pb2 # type: ignore
-from google.oauth2 import service_account
 import google.api.monitored_resource_pb2 as monitored_resource_pb2  # type: ignore
 import google.auth
 import google.logging.type.http_request_pb2 as http_request_pb2  # type: ignore
@@ -59,8 +42,26 @@ import google.protobuf.any_pb2 as any_pb2  # type: ignore
 import google.protobuf.duration_pb2 as duration_pb2  # type: ignore
 import google.protobuf.struct_pb2 as struct_pb2  # type: ignore
 import google.protobuf.timestamp_pb2 as timestamp_pb2  # type: ignore
-
-
+from google.api_core import (
+    client_options,
+    gapic_v1,
+    grpc_helpers,
+    grpc_helpers_async,
+    path_template,
+)
+from google.api_core import exceptions as core_exceptions
+from google.api_core import retry as retries
+from google.auth import credentials as ga_credentials
+from google.auth.exceptions import MutualTLSChannelError
+from google.cloud.logging_v2.services.logging_service_v2 import (
+    LoggingServiceV2AsyncClient,
+    LoggingServiceV2Client,
+    pagers,
+    transports,
+)
+from google.cloud.logging_v2.types import log_entry, logging
+from google.longrunning import operations_pb2  # type: ignore
+from google.oauth2 import service_account
 
 CRED_INFO_JSON = {
     "credential_source": "/path/to/file",
@@ -679,7 +680,7 @@ def test_logging_service_v2_client_get_mtls_endpoint_and_cert_source(client_clas
                     config_filename = "mock_certificate_config.json"
                     config_file_content = json.dumps(config_data)
                     m = mock.mock_open(read_data=config_file_content)
-                    with mock.patch("builtins.open", m), mock.patch("os.path.exists", return_value=True):
+                    with mock.patch("builtins.open", m), mock.patch("os.path.exists", side_effect=lambda path: os.path.basename(path) == config_filename):
                         with mock.patch.dict(
                             os.environ, {"GOOGLE_API_CERTIFICATE_CONFIG": config_filename}
                         ):
@@ -726,7 +727,7 @@ def test_logging_service_v2_client_get_mtls_endpoint_and_cert_source(client_clas
                     config_filename = "mock_certificate_config.json"
                     config_file_content = json.dumps(config_data)
                     m = mock.mock_open(read_data=config_file_content)
-                    with mock.patch("builtins.open", m), mock.patch("os.path.exists", return_value=True):
+                    with mock.patch("builtins.open", m), mock.patch("os.path.exists", side_effect=lambda path: os.path.basename(path) == config_filename):
                         with mock.patch.dict(
                             os.environ, {"GOOGLE_API_CERTIFICATE_CONFIG": config_filename}
                         ):

--- a/packages/gapic-generator/tests/integration/goldens/logging_internal/tests/unit/gapic/logging_v2/test_logging_service_v2.py
+++ b/packages/gapic-generator/tests/integration/goldens/logging_internal/tests/unit/gapic/logging_v2/test_logging_service_v2.py
@@ -13,20 +13,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-import asyncio
-import json
-import math
 import os
-from collections.abc import Mapping, Sequence
+import asyncio
 from unittest import mock
 from unittest.mock import AsyncMock
 
 import grpc
-import pytest
-from google.api_core import api_core_version
 from grpc.experimental import aio
-from proto.marshal.rules import wrappers
+import json
+import math
+import pytest
+from collections.abc import Sequence, Mapping
+from google.api_core import api_core_version
 from proto.marshal.rules.dates import DurationRule, TimestampRule
+from proto.marshal.rules import wrappers
 
 try:
     from google.auth.aio import credentials as ga_credentials_async
@@ -34,6 +34,23 @@ try:
 except ImportError: # pragma: NO COVER
     HAS_GOOGLE_AUTH_AIO = False
 
+from google.api_core import client_options
+from google.api_core import exceptions as core_exceptions
+from google.api_core import gapic_v1
+from google.api_core import grpc_helpers
+from google.api_core import grpc_helpers_async
+from google.api_core import path_template
+from google.api_core import retry as retries
+from google.auth import credentials as ga_credentials
+from google.auth.exceptions import MutualTLSChannelError
+from google.cloud.logging_v2.services.logging_service_v2 import LoggingServiceV2AsyncClient
+from google.cloud.logging_v2.services.logging_service_v2 import LoggingServiceV2Client
+from google.cloud.logging_v2.services.logging_service_v2 import pagers
+from google.cloud.logging_v2.services.logging_service_v2 import transports
+from google.cloud.logging_v2.types import log_entry
+from google.cloud.logging_v2.types import logging
+from google.longrunning import operations_pb2 # type: ignore
+from google.oauth2 import service_account
 import google.api.monitored_resource_pb2 as monitored_resource_pb2  # type: ignore
 import google.auth
 import google.logging.type.http_request_pb2 as http_request_pb2  # type: ignore
@@ -42,26 +59,8 @@ import google.protobuf.any_pb2 as any_pb2  # type: ignore
 import google.protobuf.duration_pb2 as duration_pb2  # type: ignore
 import google.protobuf.struct_pb2 as struct_pb2  # type: ignore
 import google.protobuf.timestamp_pb2 as timestamp_pb2  # type: ignore
-from google.api_core import (
-    client_options,
-    gapic_v1,
-    grpc_helpers,
-    grpc_helpers_async,
-    path_template,
-)
-from google.api_core import exceptions as core_exceptions
-from google.api_core import retry as retries
-from google.auth import credentials as ga_credentials
-from google.auth.exceptions import MutualTLSChannelError
-from google.cloud.logging_v2.services.logging_service_v2 import (
-    LoggingServiceV2AsyncClient,
-    LoggingServiceV2Client,
-    pagers,
-    transports,
-)
-from google.cloud.logging_v2.types import log_entry, logging
-from google.longrunning import operations_pb2  # type: ignore
-from google.oauth2 import service_account
+
+
 
 CRED_INFO_JSON = {
     "credential_source": "/path/to/file",

--- a/packages/gapic-generator/tests/integration/goldens/logging_internal/tests/unit/gapic/logging_v2/test_logging_service_v2.py
+++ b/packages/gapic-generator/tests/integration/goldens/logging_internal/tests/unit/gapic/logging_v2/test_logging_service_v2.py
@@ -679,7 +679,7 @@ def test_logging_service_v2_client_get_mtls_endpoint_and_cert_source(client_clas
                     config_filename = "mock_certificate_config.json"
                     config_file_content = json.dumps(config_data)
                     m = mock.mock_open(read_data=config_file_content)
-                    with mock.patch("builtins.open", m):
+                    with mock.patch("builtins.open", m), mock.patch("os.path.exists", return_value=True):
                         with mock.patch.dict(
                             os.environ, {"GOOGLE_API_CERTIFICATE_CONFIG": config_filename}
                         ):
@@ -726,7 +726,7 @@ def test_logging_service_v2_client_get_mtls_endpoint_and_cert_source(client_clas
                     config_filename = "mock_certificate_config.json"
                     config_file_content = json.dumps(config_data)
                     m = mock.mock_open(read_data=config_file_content)
-                    with mock.patch("builtins.open", m):
+                    with mock.patch("builtins.open", m), mock.patch("os.path.exists", return_value=True):
                         with mock.patch.dict(
                             os.environ, {"GOOGLE_API_CERTIFICATE_CONFIG": config_filename}
                         ):

--- a/packages/gapic-generator/tests/integration/goldens/logging_internal/tests/unit/gapic/logging_v2/test_metrics_service_v2.py
+++ b/packages/gapic-generator/tests/integration/goldens/logging_internal/tests/unit/gapic/logging_v2/test_metrics_service_v2.py
@@ -677,7 +677,7 @@ def test_base_metrics_service_v2_client_get_mtls_endpoint_and_cert_source(client
                     config_filename = "mock_certificate_config.json"
                     config_file_content = json.dumps(config_data)
                     m = mock.mock_open(read_data=config_file_content)
-                    with mock.patch("builtins.open", m):
+                    with mock.patch("builtins.open", m), mock.patch("os.path.exists", return_value=True):
                         with mock.patch.dict(
                             os.environ, {"GOOGLE_API_CERTIFICATE_CONFIG": config_filename}
                         ):
@@ -724,7 +724,7 @@ def test_base_metrics_service_v2_client_get_mtls_endpoint_and_cert_source(client
                     config_filename = "mock_certificate_config.json"
                     config_file_content = json.dumps(config_data)
                     m = mock.mock_open(read_data=config_file_content)
-                    with mock.patch("builtins.open", m):
+                    with mock.patch("builtins.open", m), mock.patch("os.path.exists", return_value=True):
                         with mock.patch.dict(
                             os.environ, {"GOOGLE_API_CERTIFICATE_CONFIG": config_filename}
                         ):

--- a/packages/gapic-generator/tests/integration/goldens/logging_internal/tests/unit/gapic/logging_v2/test_metrics_service_v2.py
+++ b/packages/gapic-generator/tests/integration/goldens/logging_internal/tests/unit/gapic/logging_v2/test_metrics_service_v2.py
@@ -13,20 +13,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-import asyncio
-import json
-import math
 import os
-from collections.abc import Mapping, Sequence
+import asyncio
 from unittest import mock
 from unittest.mock import AsyncMock
 
 import grpc
-import pytest
-from google.api_core import api_core_version
 from grpc.experimental import aio
-from proto.marshal.rules import wrappers
+import json
+import math
+import pytest
+from collections.abc import Sequence, Mapping
+from google.api_core import api_core_version
 from proto.marshal.rules.dates import DurationRule, TimestampRule
+from proto.marshal.rules import wrappers
 
 try:
     from google.auth.aio import credentials as ga_credentials_async
@@ -34,6 +34,22 @@ try:
 except ImportError: # pragma: NO COVER
     HAS_GOOGLE_AUTH_AIO = False
 
+from google.api_core import client_options
+from google.api_core import exceptions as core_exceptions
+from google.api_core import gapic_v1
+from google.api_core import grpc_helpers
+from google.api_core import grpc_helpers_async
+from google.api_core import path_template
+from google.api_core import retry as retries
+from google.auth import credentials as ga_credentials
+from google.auth.exceptions import MutualTLSChannelError
+from google.cloud.logging_v2.services.metrics_service_v2 import BaseMetricsServiceV2AsyncClient
+from google.cloud.logging_v2.services.metrics_service_v2 import BaseMetricsServiceV2Client
+from google.cloud.logging_v2.services.metrics_service_v2 import pagers
+from google.cloud.logging_v2.services.metrics_service_v2 import transports
+from google.cloud.logging_v2.types import logging_metrics
+from google.longrunning import operations_pb2 # type: ignore
+from google.oauth2 import service_account
 import google.api.distribution_pb2 as distribution_pb2  # type: ignore
 import google.api.label_pb2 as label_pb2  # type: ignore
 import google.api.launch_stage_pb2 as launch_stage_pb2  # type: ignore
@@ -41,26 +57,8 @@ import google.api.metric_pb2 as metric_pb2  # type: ignore
 import google.auth
 import google.protobuf.duration_pb2 as duration_pb2  # type: ignore
 import google.protobuf.timestamp_pb2 as timestamp_pb2  # type: ignore
-from google.api_core import (
-    client_options,
-    gapic_v1,
-    grpc_helpers,
-    grpc_helpers_async,
-    path_template,
-)
-from google.api_core import exceptions as core_exceptions
-from google.api_core import retry as retries
-from google.auth import credentials as ga_credentials
-from google.auth.exceptions import MutualTLSChannelError
-from google.cloud.logging_v2.services.metrics_service_v2 import (
-    BaseMetricsServiceV2AsyncClient,
-    BaseMetricsServiceV2Client,
-    pagers,
-    transports,
-)
-from google.cloud.logging_v2.types import logging_metrics
-from google.longrunning import operations_pb2  # type: ignore
-from google.oauth2 import service_account
+
+
 
 CRED_INFO_JSON = {
     "credential_source": "/path/to/file",

--- a/packages/gapic-generator/tests/integration/goldens/logging_internal/tests/unit/gapic/logging_v2/test_metrics_service_v2.py
+++ b/packages/gapic-generator/tests/integration/goldens/logging_internal/tests/unit/gapic/logging_v2/test_metrics_service_v2.py
@@ -13,20 +13,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-import os
 import asyncio
+import json
+import math
+import os
+from collections.abc import Mapping, Sequence
 from unittest import mock
 from unittest.mock import AsyncMock
 
 import grpc
-from grpc.experimental import aio
-import json
-import math
 import pytest
-from collections.abc import Sequence, Mapping
 from google.api_core import api_core_version
-from proto.marshal.rules.dates import DurationRule, TimestampRule
+from grpc.experimental import aio
 from proto.marshal.rules import wrappers
+from proto.marshal.rules.dates import DurationRule, TimestampRule
 
 try:
     from google.auth.aio import credentials as ga_credentials_async
@@ -34,22 +34,6 @@ try:
 except ImportError: # pragma: NO COVER
     HAS_GOOGLE_AUTH_AIO = False
 
-from google.api_core import client_options
-from google.api_core import exceptions as core_exceptions
-from google.api_core import gapic_v1
-from google.api_core import grpc_helpers
-from google.api_core import grpc_helpers_async
-from google.api_core import path_template
-from google.api_core import retry as retries
-from google.auth import credentials as ga_credentials
-from google.auth.exceptions import MutualTLSChannelError
-from google.cloud.logging_v2.services.metrics_service_v2 import BaseMetricsServiceV2AsyncClient
-from google.cloud.logging_v2.services.metrics_service_v2 import BaseMetricsServiceV2Client
-from google.cloud.logging_v2.services.metrics_service_v2 import pagers
-from google.cloud.logging_v2.services.metrics_service_v2 import transports
-from google.cloud.logging_v2.types import logging_metrics
-from google.longrunning import operations_pb2 # type: ignore
-from google.oauth2 import service_account
 import google.api.distribution_pb2 as distribution_pb2  # type: ignore
 import google.api.label_pb2 as label_pb2  # type: ignore
 import google.api.launch_stage_pb2 as launch_stage_pb2  # type: ignore
@@ -57,8 +41,26 @@ import google.api.metric_pb2 as metric_pb2  # type: ignore
 import google.auth
 import google.protobuf.duration_pb2 as duration_pb2  # type: ignore
 import google.protobuf.timestamp_pb2 as timestamp_pb2  # type: ignore
-
-
+from google.api_core import (
+    client_options,
+    gapic_v1,
+    grpc_helpers,
+    grpc_helpers_async,
+    path_template,
+)
+from google.api_core import exceptions as core_exceptions
+from google.api_core import retry as retries
+from google.auth import credentials as ga_credentials
+from google.auth.exceptions import MutualTLSChannelError
+from google.cloud.logging_v2.services.metrics_service_v2 import (
+    BaseMetricsServiceV2AsyncClient,
+    BaseMetricsServiceV2Client,
+    pagers,
+    transports,
+)
+from google.cloud.logging_v2.types import logging_metrics
+from google.longrunning import operations_pb2  # type: ignore
+from google.oauth2 import service_account
 
 CRED_INFO_JSON = {
     "credential_source": "/path/to/file",
@@ -677,7 +679,7 @@ def test_base_metrics_service_v2_client_get_mtls_endpoint_and_cert_source(client
                     config_filename = "mock_certificate_config.json"
                     config_file_content = json.dumps(config_data)
                     m = mock.mock_open(read_data=config_file_content)
-                    with mock.patch("builtins.open", m), mock.patch("os.path.exists", return_value=True):
+                    with mock.patch("builtins.open", m), mock.patch("os.path.exists", side_effect=lambda path: os.path.basename(path) == config_filename):
                         with mock.patch.dict(
                             os.environ, {"GOOGLE_API_CERTIFICATE_CONFIG": config_filename}
                         ):
@@ -724,7 +726,7 @@ def test_base_metrics_service_v2_client_get_mtls_endpoint_and_cert_source(client
                     config_filename = "mock_certificate_config.json"
                     config_file_content = json.dumps(config_data)
                     m = mock.mock_open(read_data=config_file_content)
-                    with mock.patch("builtins.open", m), mock.patch("os.path.exists", return_value=True):
+                    with mock.patch("builtins.open", m), mock.patch("os.path.exists", side_effect=lambda path: os.path.basename(path) == config_filename):
                         with mock.patch.dict(
                             os.environ, {"GOOGLE_API_CERTIFICATE_CONFIG": config_filename}
                         ):

--- a/packages/gapic-generator/tests/integration/goldens/redis/tests/unit/gapic/redis_v1/test_cloud_redis.py
+++ b/packages/gapic-generator/tests/integration/goldens/redis/tests/unit/gapic/redis_v1/test_cloud_redis.py
@@ -13,33 +13,32 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-import os
 import asyncio
+import json
+import math
+import os
+from collections.abc import AsyncIterable, Iterable, Mapping, Sequence
 from unittest import mock
 from unittest.mock import AsyncMock
 
 import grpc
-from grpc.experimental import aio
-from collections.abc import Iterable, AsyncIterable
-from google.protobuf import json_format
-import json
-import math
 import pytest
-from collections.abc import Sequence, Mapping
 from google.api_core import api_core_version
-from proto.marshal.rules.dates import DurationRule, TimestampRule
+from google.protobuf import json_format
+from grpc.experimental import aio
 from proto.marshal.rules import wrappers
+from proto.marshal.rules.dates import DurationRule, TimestampRule
+
 try:
     import aiohttp  # type: ignore
-    from google.auth.aio.transport.sessions import AsyncAuthorizedSession
     from google.api_core.operations_v1 import AsyncOperationsRestClient
+    from google.auth.aio.transport.sessions import AsyncAuthorizedSession
     HAS_ASYNC_REST_EXTRA = True
 except ImportError: # pragma: NO COVER
     HAS_ASYNC_REST_EXTRA = False
-from requests import Response
-from requests import Request, PreparedRequest
-from requests.sessions import Session
 from google.protobuf import json_format
+from requests import PreparedRequest, Request, Response
+from requests.sessions import Session
 
 try:
     from google.auth.aio import credentials as ga_credentials_async
@@ -47,26 +46,6 @@ try:
 except ImportError: # pragma: NO COVER
     HAS_GOOGLE_AUTH_AIO = False
 
-from google.api_core import client_options
-from google.api_core import exceptions as core_exceptions
-from google.api_core import future
-from google.api_core import gapic_v1
-from google.api_core import grpc_helpers
-from google.api_core import grpc_helpers_async
-from google.api_core import operation
-from google.api_core import operations_v1
-from google.api_core import path_template
-from google.api_core import retry as retries
-from google.auth import credentials as ga_credentials
-from google.auth.exceptions import MutualTLSChannelError
-from google.cloud.location import locations_pb2
-from google.cloud.redis_v1.services.cloud_redis import CloudRedisAsyncClient
-from google.cloud.redis_v1.services.cloud_redis import CloudRedisClient
-from google.cloud.redis_v1.services.cloud_redis import pagers
-from google.cloud.redis_v1.services.cloud_redis import transports
-from google.cloud.redis_v1.types import cloud_redis
-from google.longrunning import operations_pb2 # type: ignore
-from google.oauth2 import service_account
 import google.api_core.operation_async as operation_async  # type: ignore
 import google.auth
 import google.protobuf.duration_pb2 as duration_pb2  # type: ignore
@@ -75,8 +54,30 @@ import google.protobuf.field_mask_pb2 as field_mask_pb2  # type: ignore
 import google.protobuf.timestamp_pb2 as timestamp_pb2  # type: ignore
 import google.type.dayofweek_pb2 as dayofweek_pb2  # type: ignore
 import google.type.timeofday_pb2 as timeofday_pb2  # type: ignore
-
-
+from google.api_core import (
+    client_options,
+    future,
+    gapic_v1,
+    grpc_helpers,
+    grpc_helpers_async,
+    operation,
+    operations_v1,
+    path_template,
+)
+from google.api_core import exceptions as core_exceptions
+from google.api_core import retry as retries
+from google.auth import credentials as ga_credentials
+from google.auth.exceptions import MutualTLSChannelError
+from google.cloud.location import locations_pb2
+from google.cloud.redis_v1.services.cloud_redis import (
+    CloudRedisAsyncClient,
+    CloudRedisClient,
+    pagers,
+    transports,
+)
+from google.cloud.redis_v1.types import cloud_redis
+from google.longrunning import operations_pb2  # type: ignore
+from google.oauth2 import service_account
 
 CRED_INFO_JSON = {
     "credential_source": "/path/to/file",
@@ -708,7 +709,7 @@ def test_cloud_redis_client_get_mtls_endpoint_and_cert_source(client_class):
                     config_filename = "mock_certificate_config.json"
                     config_file_content = json.dumps(config_data)
                     m = mock.mock_open(read_data=config_file_content)
-                    with mock.patch("builtins.open", m), mock.patch("os.path.exists", return_value=True):
+                    with mock.patch("builtins.open", m), mock.patch("os.path.exists", side_effect=lambda path: os.path.basename(path) == config_filename):
                         with mock.patch.dict(
                             os.environ, {"GOOGLE_API_CERTIFICATE_CONFIG": config_filename}
                         ):
@@ -755,7 +756,7 @@ def test_cloud_redis_client_get_mtls_endpoint_and_cert_source(client_class):
                     config_filename = "mock_certificate_config.json"
                     config_file_content = json.dumps(config_data)
                     m = mock.mock_open(read_data=config_file_content)
-                    with mock.patch("builtins.open", m), mock.patch("os.path.exists", return_value=True):
+                    with mock.patch("builtins.open", m), mock.patch("os.path.exists", side_effect=lambda path: os.path.basename(path) == config_filename):
                         with mock.patch.dict(
                             os.environ, {"GOOGLE_API_CERTIFICATE_CONFIG": config_filename}
                         ):

--- a/packages/gapic-generator/tests/integration/goldens/redis/tests/unit/gapic/redis_v1/test_cloud_redis.py
+++ b/packages/gapic-generator/tests/integration/goldens/redis/tests/unit/gapic/redis_v1/test_cloud_redis.py
@@ -13,32 +13,33 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-import asyncio
-import json
-import math
 import os
-from collections.abc import AsyncIterable, Iterable, Mapping, Sequence
+import asyncio
 from unittest import mock
 from unittest.mock import AsyncMock
 
 import grpc
-import pytest
-from google.api_core import api_core_version
-from google.protobuf import json_format
 from grpc.experimental import aio
-from proto.marshal.rules import wrappers
+from collections.abc import Iterable, AsyncIterable
+from google.protobuf import json_format
+import json
+import math
+import pytest
+from collections.abc import Sequence, Mapping
+from google.api_core import api_core_version
 from proto.marshal.rules.dates import DurationRule, TimestampRule
-
+from proto.marshal.rules import wrappers
 try:
     import aiohttp  # type: ignore
-    from google.api_core.operations_v1 import AsyncOperationsRestClient
     from google.auth.aio.transport.sessions import AsyncAuthorizedSession
+    from google.api_core.operations_v1 import AsyncOperationsRestClient
     HAS_ASYNC_REST_EXTRA = True
 except ImportError: # pragma: NO COVER
     HAS_ASYNC_REST_EXTRA = False
-from google.protobuf import json_format
-from requests import PreparedRequest, Request, Response
+from requests import Response
+from requests import Request, PreparedRequest
 from requests.sessions import Session
+from google.protobuf import json_format
 
 try:
     from google.auth.aio import credentials as ga_credentials_async
@@ -46,6 +47,26 @@ try:
 except ImportError: # pragma: NO COVER
     HAS_GOOGLE_AUTH_AIO = False
 
+from google.api_core import client_options
+from google.api_core import exceptions as core_exceptions
+from google.api_core import future
+from google.api_core import gapic_v1
+from google.api_core import grpc_helpers
+from google.api_core import grpc_helpers_async
+from google.api_core import operation
+from google.api_core import operations_v1
+from google.api_core import path_template
+from google.api_core import retry as retries
+from google.auth import credentials as ga_credentials
+from google.auth.exceptions import MutualTLSChannelError
+from google.cloud.location import locations_pb2
+from google.cloud.redis_v1.services.cloud_redis import CloudRedisAsyncClient
+from google.cloud.redis_v1.services.cloud_redis import CloudRedisClient
+from google.cloud.redis_v1.services.cloud_redis import pagers
+from google.cloud.redis_v1.services.cloud_redis import transports
+from google.cloud.redis_v1.types import cloud_redis
+from google.longrunning import operations_pb2 # type: ignore
+from google.oauth2 import service_account
 import google.api_core.operation_async as operation_async  # type: ignore
 import google.auth
 import google.protobuf.duration_pb2 as duration_pb2  # type: ignore
@@ -54,30 +75,8 @@ import google.protobuf.field_mask_pb2 as field_mask_pb2  # type: ignore
 import google.protobuf.timestamp_pb2 as timestamp_pb2  # type: ignore
 import google.type.dayofweek_pb2 as dayofweek_pb2  # type: ignore
 import google.type.timeofday_pb2 as timeofday_pb2  # type: ignore
-from google.api_core import (
-    client_options,
-    future,
-    gapic_v1,
-    grpc_helpers,
-    grpc_helpers_async,
-    operation,
-    operations_v1,
-    path_template,
-)
-from google.api_core import exceptions as core_exceptions
-from google.api_core import retry as retries
-from google.auth import credentials as ga_credentials
-from google.auth.exceptions import MutualTLSChannelError
-from google.cloud.location import locations_pb2
-from google.cloud.redis_v1.services.cloud_redis import (
-    CloudRedisAsyncClient,
-    CloudRedisClient,
-    pagers,
-    transports,
-)
-from google.cloud.redis_v1.types import cloud_redis
-from google.longrunning import operations_pb2  # type: ignore
-from google.oauth2 import service_account
+
+
 
 CRED_INFO_JSON = {
     "credential_source": "/path/to/file",

--- a/packages/gapic-generator/tests/integration/goldens/redis/tests/unit/gapic/redis_v1/test_cloud_redis.py
+++ b/packages/gapic-generator/tests/integration/goldens/redis/tests/unit/gapic/redis_v1/test_cloud_redis.py
@@ -708,7 +708,7 @@ def test_cloud_redis_client_get_mtls_endpoint_and_cert_source(client_class):
                     config_filename = "mock_certificate_config.json"
                     config_file_content = json.dumps(config_data)
                     m = mock.mock_open(read_data=config_file_content)
-                    with mock.patch("builtins.open", m):
+                    with mock.patch("builtins.open", m), mock.patch("os.path.exists", return_value=True):
                         with mock.patch.dict(
                             os.environ, {"GOOGLE_API_CERTIFICATE_CONFIG": config_filename}
                         ):
@@ -755,7 +755,7 @@ def test_cloud_redis_client_get_mtls_endpoint_and_cert_source(client_class):
                     config_filename = "mock_certificate_config.json"
                     config_file_content = json.dumps(config_data)
                     m = mock.mock_open(read_data=config_file_content)
-                    with mock.patch("builtins.open", m):
+                    with mock.patch("builtins.open", m), mock.patch("os.path.exists", return_value=True):
                         with mock.patch.dict(
                             os.environ, {"GOOGLE_API_CERTIFICATE_CONFIG": config_filename}
                         ):

--- a/packages/gapic-generator/tests/integration/goldens/redis_selective/tests/unit/gapic/redis_v1/test_cloud_redis.py
+++ b/packages/gapic-generator/tests/integration/goldens/redis_selective/tests/unit/gapic/redis_v1/test_cloud_redis.py
@@ -13,33 +13,32 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-import os
 import asyncio
+import json
+import math
+import os
+from collections.abc import AsyncIterable, Iterable, Mapping, Sequence
 from unittest import mock
 from unittest.mock import AsyncMock
 
 import grpc
-from grpc.experimental import aio
-from collections.abc import Iterable, AsyncIterable
-from google.protobuf import json_format
-import json
-import math
 import pytest
-from collections.abc import Sequence, Mapping
 from google.api_core import api_core_version
-from proto.marshal.rules.dates import DurationRule, TimestampRule
+from google.protobuf import json_format
+from grpc.experimental import aio
 from proto.marshal.rules import wrappers
+from proto.marshal.rules.dates import DurationRule, TimestampRule
+
 try:
     import aiohttp  # type: ignore
-    from google.auth.aio.transport.sessions import AsyncAuthorizedSession
     from google.api_core.operations_v1 import AsyncOperationsRestClient
+    from google.auth.aio.transport.sessions import AsyncAuthorizedSession
     HAS_ASYNC_REST_EXTRA = True
 except ImportError: # pragma: NO COVER
     HAS_ASYNC_REST_EXTRA = False
-from requests import Response
-from requests import Request, PreparedRequest
-from requests.sessions import Session
 from google.protobuf import json_format
+from requests import PreparedRequest, Request, Response
+from requests.sessions import Session
 
 try:
     from google.auth.aio import credentials as ga_credentials_async
@@ -47,26 +46,6 @@ try:
 except ImportError: # pragma: NO COVER
     HAS_GOOGLE_AUTH_AIO = False
 
-from google.api_core import client_options
-from google.api_core import exceptions as core_exceptions
-from google.api_core import future
-from google.api_core import gapic_v1
-from google.api_core import grpc_helpers
-from google.api_core import grpc_helpers_async
-from google.api_core import operation
-from google.api_core import operations_v1
-from google.api_core import path_template
-from google.api_core import retry as retries
-from google.auth import credentials as ga_credentials
-from google.auth.exceptions import MutualTLSChannelError
-from google.cloud.location import locations_pb2
-from google.cloud.redis_v1.services.cloud_redis import CloudRedisAsyncClient
-from google.cloud.redis_v1.services.cloud_redis import CloudRedisClient
-from google.cloud.redis_v1.services.cloud_redis import pagers
-from google.cloud.redis_v1.services.cloud_redis import transports
-from google.cloud.redis_v1.types import cloud_redis
-from google.longrunning import operations_pb2 # type: ignore
-from google.oauth2 import service_account
 import google.api_core.operation_async as operation_async  # type: ignore
 import google.auth
 import google.protobuf.duration_pb2 as duration_pb2  # type: ignore
@@ -75,8 +54,30 @@ import google.protobuf.field_mask_pb2 as field_mask_pb2  # type: ignore
 import google.protobuf.timestamp_pb2 as timestamp_pb2  # type: ignore
 import google.type.dayofweek_pb2 as dayofweek_pb2  # type: ignore
 import google.type.timeofday_pb2 as timeofday_pb2  # type: ignore
-
-
+from google.api_core import (
+    client_options,
+    future,
+    gapic_v1,
+    grpc_helpers,
+    grpc_helpers_async,
+    operation,
+    operations_v1,
+    path_template,
+)
+from google.api_core import exceptions as core_exceptions
+from google.api_core import retry as retries
+from google.auth import credentials as ga_credentials
+from google.auth.exceptions import MutualTLSChannelError
+from google.cloud.location import locations_pb2
+from google.cloud.redis_v1.services.cloud_redis import (
+    CloudRedisAsyncClient,
+    CloudRedisClient,
+    pagers,
+    transports,
+)
+from google.cloud.redis_v1.types import cloud_redis
+from google.longrunning import operations_pb2  # type: ignore
+from google.oauth2 import service_account
 
 CRED_INFO_JSON = {
     "credential_source": "/path/to/file",
@@ -708,7 +709,7 @@ def test_cloud_redis_client_get_mtls_endpoint_and_cert_source(client_class):
                     config_filename = "mock_certificate_config.json"
                     config_file_content = json.dumps(config_data)
                     m = mock.mock_open(read_data=config_file_content)
-                    with mock.patch("builtins.open", m), mock.patch("os.path.exists", return_value=True):
+                    with mock.patch("builtins.open", m), mock.patch("os.path.exists", side_effect=lambda path: os.path.basename(path) == config_filename):
                         with mock.patch.dict(
                             os.environ, {"GOOGLE_API_CERTIFICATE_CONFIG": config_filename}
                         ):
@@ -755,7 +756,7 @@ def test_cloud_redis_client_get_mtls_endpoint_and_cert_source(client_class):
                     config_filename = "mock_certificate_config.json"
                     config_file_content = json.dumps(config_data)
                     m = mock.mock_open(read_data=config_file_content)
-                    with mock.patch("builtins.open", m), mock.patch("os.path.exists", return_value=True):
+                    with mock.patch("builtins.open", m), mock.patch("os.path.exists", side_effect=lambda path: os.path.basename(path) == config_filename):
                         with mock.patch.dict(
                             os.environ, {"GOOGLE_API_CERTIFICATE_CONFIG": config_filename}
                         ):

--- a/packages/gapic-generator/tests/integration/goldens/redis_selective/tests/unit/gapic/redis_v1/test_cloud_redis.py
+++ b/packages/gapic-generator/tests/integration/goldens/redis_selective/tests/unit/gapic/redis_v1/test_cloud_redis.py
@@ -13,32 +13,33 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-import asyncio
-import json
-import math
 import os
-from collections.abc import AsyncIterable, Iterable, Mapping, Sequence
+import asyncio
 from unittest import mock
 from unittest.mock import AsyncMock
 
 import grpc
-import pytest
-from google.api_core import api_core_version
-from google.protobuf import json_format
 from grpc.experimental import aio
-from proto.marshal.rules import wrappers
+from collections.abc import Iterable, AsyncIterable
+from google.protobuf import json_format
+import json
+import math
+import pytest
+from collections.abc import Sequence, Mapping
+from google.api_core import api_core_version
 from proto.marshal.rules.dates import DurationRule, TimestampRule
-
+from proto.marshal.rules import wrappers
 try:
     import aiohttp  # type: ignore
-    from google.api_core.operations_v1 import AsyncOperationsRestClient
     from google.auth.aio.transport.sessions import AsyncAuthorizedSession
+    from google.api_core.operations_v1 import AsyncOperationsRestClient
     HAS_ASYNC_REST_EXTRA = True
 except ImportError: # pragma: NO COVER
     HAS_ASYNC_REST_EXTRA = False
-from google.protobuf import json_format
-from requests import PreparedRequest, Request, Response
+from requests import Response
+from requests import Request, PreparedRequest
 from requests.sessions import Session
+from google.protobuf import json_format
 
 try:
     from google.auth.aio import credentials as ga_credentials_async
@@ -46,6 +47,26 @@ try:
 except ImportError: # pragma: NO COVER
     HAS_GOOGLE_AUTH_AIO = False
 
+from google.api_core import client_options
+from google.api_core import exceptions as core_exceptions
+from google.api_core import future
+from google.api_core import gapic_v1
+from google.api_core import grpc_helpers
+from google.api_core import grpc_helpers_async
+from google.api_core import operation
+from google.api_core import operations_v1
+from google.api_core import path_template
+from google.api_core import retry as retries
+from google.auth import credentials as ga_credentials
+from google.auth.exceptions import MutualTLSChannelError
+from google.cloud.location import locations_pb2
+from google.cloud.redis_v1.services.cloud_redis import CloudRedisAsyncClient
+from google.cloud.redis_v1.services.cloud_redis import CloudRedisClient
+from google.cloud.redis_v1.services.cloud_redis import pagers
+from google.cloud.redis_v1.services.cloud_redis import transports
+from google.cloud.redis_v1.types import cloud_redis
+from google.longrunning import operations_pb2 # type: ignore
+from google.oauth2 import service_account
 import google.api_core.operation_async as operation_async  # type: ignore
 import google.auth
 import google.protobuf.duration_pb2 as duration_pb2  # type: ignore
@@ -54,30 +75,8 @@ import google.protobuf.field_mask_pb2 as field_mask_pb2  # type: ignore
 import google.protobuf.timestamp_pb2 as timestamp_pb2  # type: ignore
 import google.type.dayofweek_pb2 as dayofweek_pb2  # type: ignore
 import google.type.timeofday_pb2 as timeofday_pb2  # type: ignore
-from google.api_core import (
-    client_options,
-    future,
-    gapic_v1,
-    grpc_helpers,
-    grpc_helpers_async,
-    operation,
-    operations_v1,
-    path_template,
-)
-from google.api_core import exceptions as core_exceptions
-from google.api_core import retry as retries
-from google.auth import credentials as ga_credentials
-from google.auth.exceptions import MutualTLSChannelError
-from google.cloud.location import locations_pb2
-from google.cloud.redis_v1.services.cloud_redis import (
-    CloudRedisAsyncClient,
-    CloudRedisClient,
-    pagers,
-    transports,
-)
-from google.cloud.redis_v1.types import cloud_redis
-from google.longrunning import operations_pb2  # type: ignore
-from google.oauth2 import service_account
+
+
 
 CRED_INFO_JSON = {
     "credential_source": "/path/to/file",

--- a/packages/gapic-generator/tests/integration/goldens/redis_selective/tests/unit/gapic/redis_v1/test_cloud_redis.py
+++ b/packages/gapic-generator/tests/integration/goldens/redis_selective/tests/unit/gapic/redis_v1/test_cloud_redis.py
@@ -708,7 +708,7 @@ def test_cloud_redis_client_get_mtls_endpoint_and_cert_source(client_class):
                     config_filename = "mock_certificate_config.json"
                     config_file_content = json.dumps(config_data)
                     m = mock.mock_open(read_data=config_file_content)
-                    with mock.patch("builtins.open", m):
+                    with mock.patch("builtins.open", m), mock.patch("os.path.exists", return_value=True):
                         with mock.patch.dict(
                             os.environ, {"GOOGLE_API_CERTIFICATE_CONFIG": config_filename}
                         ):
@@ -755,7 +755,7 @@ def test_cloud_redis_client_get_mtls_endpoint_and_cert_source(client_class):
                     config_filename = "mock_certificate_config.json"
                     config_file_content = json.dumps(config_data)
                     m = mock.mock_open(read_data=config_file_content)
-                    with mock.patch("builtins.open", m):
+                    with mock.patch("builtins.open", m), mock.patch("os.path.exists", return_value=True):
                         with mock.patch.dict(
                             os.environ, {"GOOGLE_API_CERTIFICATE_CONFIG": config_filename}
                         ):

--- a/packages/gapic-generator/tests/integration/goldens/storagebatchoperations/tests/unit/gapic/storagebatchoperations_v1/test_storage_batch_operations.py
+++ b/packages/gapic-generator/tests/integration/goldens/storagebatchoperations/tests/unit/gapic/storagebatchoperations_v1/test_storage_batch_operations.py
@@ -776,7 +776,7 @@ def test_storage_batch_operations_client_get_mtls_endpoint_and_cert_source(clien
                     config_filename = "mock_certificate_config.json"
                     config_file_content = json.dumps(config_data)
                     m = mock.mock_open(read_data=config_file_content)
-                    with mock.patch("builtins.open", m):
+                    with mock.patch("builtins.open", m), mock.patch("os.path.exists", return_value=True):
                         with mock.patch.dict(
                             os.environ, {"GOOGLE_API_CERTIFICATE_CONFIG": config_filename}
                         ):
@@ -823,7 +823,7 @@ def test_storage_batch_operations_client_get_mtls_endpoint_and_cert_source(clien
                     config_filename = "mock_certificate_config.json"
                     config_file_content = json.dumps(config_data)
                     m = mock.mock_open(read_data=config_file_content)
-                    with mock.patch("builtins.open", m):
+                    with mock.patch("builtins.open", m), mock.patch("os.path.exists", return_value=True):
                         with mock.patch.dict(
                             os.environ, {"GOOGLE_API_CERTIFICATE_CONFIG": config_filename}
                         ):

--- a/packages/gapic-generator/tests/integration/goldens/storagebatchoperations/tests/unit/gapic/storagebatchoperations_v1/test_storage_batch_operations.py
+++ b/packages/gapic-generator/tests/integration/goldens/storagebatchoperations/tests/unit/gapic/storagebatchoperations_v1/test_storage_batch_operations.py
@@ -13,24 +13,27 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-import asyncio
-import json
-import math
 import os
+import asyncio
 import re
-from collections.abc import AsyncIterable, Iterable, Mapping, Sequence
 from unittest import mock
 from unittest.mock import AsyncMock
 
 import grpc
-import pytest
-from google.api_core import api_core_version
-from google.protobuf import json_format
 from grpc.experimental import aio
-from proto.marshal.rules import wrappers
+from collections.abc import Iterable, AsyncIterable
+from google.protobuf import json_format
+import json
+import math
+import pytest
+from collections.abc import Sequence, Mapping
+from google.api_core import api_core_version
 from proto.marshal.rules.dates import DurationRule, TimestampRule
-from requests import PreparedRequest, Request, Response
+from proto.marshal.rules import wrappers
+from requests import Response
+from requests import Request, PreparedRequest
 from requests.sessions import Session
+from google.protobuf import json_format
 
 try:
     from google.auth.aio import credentials as ga_credentials_async
@@ -38,37 +41,33 @@ try:
 except ImportError: # pragma: NO COVER
     HAS_GOOGLE_AUTH_AIO = False
 
-import google.api_core.operation_async as operation_async  # type: ignore
-import google.auth
-import google.protobuf.timestamp_pb2 as timestamp_pb2  # type: ignore
-import google.rpc.code_pb2 as code_pb2  # type: ignore
-from google.api_core import (
-    client_options,
-    future,
-    gapic_v1,
-    grpc_helpers,
-    grpc_helpers_async,
-    operation,
-    operations_v1,
-    path_template,
-)
+from google.api_core import client_options
 from google.api_core import exceptions as core_exceptions
+from google.api_core import future
+from google.api_core import gapic_v1
+from google.api_core import grpc_helpers
+from google.api_core import grpc_helpers_async
+from google.api_core import operation
+from google.api_core import operations_v1
+from google.api_core import path_template
 from google.api_core import retry as retries
 from google.auth import credentials as ga_credentials
 from google.auth.exceptions import MutualTLSChannelError
 from google.cloud.location import locations_pb2
-from google.cloud.storagebatchoperations_v1.services.storage_batch_operations import (
-    StorageBatchOperationsAsyncClient,
-    StorageBatchOperationsClient,
-    pagers,
-    transports,
-)
-from google.cloud.storagebatchoperations_v1.types import (
-    storage_batch_operations,
-    storage_batch_operations_types,
-)
-from google.longrunning import operations_pb2  # type: ignore
+from google.cloud.storagebatchoperations_v1.services.storage_batch_operations import StorageBatchOperationsAsyncClient
+from google.cloud.storagebatchoperations_v1.services.storage_batch_operations import StorageBatchOperationsClient
+from google.cloud.storagebatchoperations_v1.services.storage_batch_operations import pagers
+from google.cloud.storagebatchoperations_v1.services.storage_batch_operations import transports
+from google.cloud.storagebatchoperations_v1.types import storage_batch_operations
+from google.cloud.storagebatchoperations_v1.types import storage_batch_operations_types
+from google.longrunning import operations_pb2 # type: ignore
 from google.oauth2 import service_account
+import google.api_core.operation_async as operation_async  # type: ignore
+import google.auth
+import google.protobuf.timestamp_pb2 as timestamp_pb2  # type: ignore
+import google.rpc.code_pb2 as code_pb2  # type: ignore
+
+
 
 CRED_INFO_JSON = {
     "credential_source": "/path/to/file",

--- a/packages/gapic-generator/tests/integration/goldens/storagebatchoperations/tests/unit/gapic/storagebatchoperations_v1/test_storage_batch_operations.py
+++ b/packages/gapic-generator/tests/integration/goldens/storagebatchoperations/tests/unit/gapic/storagebatchoperations_v1/test_storage_batch_operations.py
@@ -13,27 +13,24 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-import os
 import asyncio
+import json
+import math
+import os
 import re
+from collections.abc import AsyncIterable, Iterable, Mapping, Sequence
 from unittest import mock
 from unittest.mock import AsyncMock
 
 import grpc
-from grpc.experimental import aio
-from collections.abc import Iterable, AsyncIterable
-from google.protobuf import json_format
-import json
-import math
 import pytest
-from collections.abc import Sequence, Mapping
 from google.api_core import api_core_version
-from proto.marshal.rules.dates import DurationRule, TimestampRule
-from proto.marshal.rules import wrappers
-from requests import Response
-from requests import Request, PreparedRequest
-from requests.sessions import Session
 from google.protobuf import json_format
+from grpc.experimental import aio
+from proto.marshal.rules import wrappers
+from proto.marshal.rules.dates import DurationRule, TimestampRule
+from requests import PreparedRequest, Request, Response
+from requests.sessions import Session
 
 try:
     from google.auth.aio import credentials as ga_credentials_async
@@ -41,33 +38,37 @@ try:
 except ImportError: # pragma: NO COVER
     HAS_GOOGLE_AUTH_AIO = False
 
-from google.api_core import client_options
-from google.api_core import exceptions as core_exceptions
-from google.api_core import future
-from google.api_core import gapic_v1
-from google.api_core import grpc_helpers
-from google.api_core import grpc_helpers_async
-from google.api_core import operation
-from google.api_core import operations_v1
-from google.api_core import path_template
-from google.api_core import retry as retries
-from google.auth import credentials as ga_credentials
-from google.auth.exceptions import MutualTLSChannelError
-from google.cloud.location import locations_pb2
-from google.cloud.storagebatchoperations_v1.services.storage_batch_operations import StorageBatchOperationsAsyncClient
-from google.cloud.storagebatchoperations_v1.services.storage_batch_operations import StorageBatchOperationsClient
-from google.cloud.storagebatchoperations_v1.services.storage_batch_operations import pagers
-from google.cloud.storagebatchoperations_v1.services.storage_batch_operations import transports
-from google.cloud.storagebatchoperations_v1.types import storage_batch_operations
-from google.cloud.storagebatchoperations_v1.types import storage_batch_operations_types
-from google.longrunning import operations_pb2 # type: ignore
-from google.oauth2 import service_account
 import google.api_core.operation_async as operation_async  # type: ignore
 import google.auth
 import google.protobuf.timestamp_pb2 as timestamp_pb2  # type: ignore
 import google.rpc.code_pb2 as code_pb2  # type: ignore
-
-
+from google.api_core import (
+    client_options,
+    future,
+    gapic_v1,
+    grpc_helpers,
+    grpc_helpers_async,
+    operation,
+    operations_v1,
+    path_template,
+)
+from google.api_core import exceptions as core_exceptions
+from google.api_core import retry as retries
+from google.auth import credentials as ga_credentials
+from google.auth.exceptions import MutualTLSChannelError
+from google.cloud.location import locations_pb2
+from google.cloud.storagebatchoperations_v1.services.storage_batch_operations import (
+    StorageBatchOperationsAsyncClient,
+    StorageBatchOperationsClient,
+    pagers,
+    transports,
+)
+from google.cloud.storagebatchoperations_v1.types import (
+    storage_batch_operations,
+    storage_batch_operations_types,
+)
+from google.longrunning import operations_pb2  # type: ignore
+from google.oauth2 import service_account
 
 CRED_INFO_JSON = {
     "credential_source": "/path/to/file",
@@ -776,7 +777,7 @@ def test_storage_batch_operations_client_get_mtls_endpoint_and_cert_source(clien
                     config_filename = "mock_certificate_config.json"
                     config_file_content = json.dumps(config_data)
                     m = mock.mock_open(read_data=config_file_content)
-                    with mock.patch("builtins.open", m), mock.patch("os.path.exists", return_value=True):
+                    with mock.patch("builtins.open", m), mock.patch("os.path.exists", side_effect=lambda path: os.path.basename(path) == config_filename):
                         with mock.patch.dict(
                             os.environ, {"GOOGLE_API_CERTIFICATE_CONFIG": config_filename}
                         ):
@@ -823,7 +824,7 @@ def test_storage_batch_operations_client_get_mtls_endpoint_and_cert_source(clien
                     config_filename = "mock_certificate_config.json"
                     config_file_content = json.dumps(config_data)
                     m = mock.mock_open(read_data=config_file_content)
-                    with mock.patch("builtins.open", m), mock.patch("os.path.exists", return_value=True):
+                    with mock.patch("builtins.open", m), mock.patch("os.path.exists", side_effect=lambda path: os.path.basename(path) == config_filename):
                         with mock.patch.dict(
                             os.environ, {"GOOGLE_API_CERTIFICATE_CONFIG": config_filename}
                         ):


### PR DESCRIPTION
This PR fixes a test failure in the generated goldens related to mTLS (mutual Transport Layer Security) configuration.

## Problem

A recent update to the `google-auth` library (specifically how it discovers certificates) introduced stricter checks using `os.path.exists()`. Our generated tests were only mocking `builtins.open()` to simulate configuration files. As a result, the new existence checks failed during tests because the mocked files didn't actually exist on disk, causing assertions to fail.

## Solution

1.  **Updated Generator Template**: Modified the generator template (`packages/gapic-generator/gapic/templates/tests/unit/gapic/%name_%version/%sub/test_%service.py.j2`) to mock both `builtins.open()` and `os.path.exists()` in the relevant test blocks.
2.  **Regenerated Goldens**: Updated the generated tests across the codebase to include these new mocks.

## Notes to Reviewers

*   This is a technical fix to adapt our testing infrastructure to newer dependency versions.
*   The actual business logic of the generated clients is unaffected.
*   This fixes failures seen in pre-release dependency testing.

Fixes # (No specific issue reported, but addresses failures seen in CI/CD)