### PR TITLE
chore: Remove google-maps-isochrones from bulk release

### DIFF
--- a/.release-please-bulk-manifest.json
+++ b/.release-please-bulk-manifest.json
@@ -248,7 +248,6 @@
   "packages/google-maps-fleetengine": "0.6.0",
   "packages/google-maps-fleetengine-delivery": "0.6.0",
   "packages/google-maps-geocode": "0.3.0",
-  "packages/google-maps-isochrones": "0.0.0",
   "packages/google-maps-mapmanagement": "0.1.0",
   "packages/google-maps-mapsplatformdatasets": "0.8.0",
   "packages/google-maps-navconnect": "0.2.0",

--- a/release-please-bulk-config.json
+++ b/release-please-bulk-config.json
@@ -3517,18 +3517,6 @@
         }
       ]
     },
-    "packages/google-maps-isochrones": {
-      "component": "google-maps-isochrones",
-      "extra-files": [
-        "google/maps/isochrones/gapic_version.py",
-        "google/maps/isochrones_v1/gapic_version.py",
-        {
-          "jsonpath": "$.clientLibrary.version",
-          "path": "samples/generated_samples/snippet_metadata_google.maps.isochrones.v1.json",
-          "type": "json"
-        }
-      ]
-    },
     "packages/google-maps-mapmanagement": {
       "component": "google-maps-mapmanagement",
       "extra-files": [


### PR DESCRIPTION
This is a follow up to https://github.com/googleapis/google-cloud-python/pull/17801 where `packages/google-maps-isochrones` was added to the individual release config but wasn't removed from the bulk release config.