### PR TITLE
chore: update librarian to v0.28.0

### DIFF
--- a/librarian.yaml
+++ b/librarian.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 language: python
-version: v0.26.0
+version: v0.28.0
 repo: googleapis/google-cloud-python
 sources:
   googleapis:


### PR DESCRIPTION
Librarian version upgrade with `generate -all`.