### PR TITLE
feat(google/cloud/agentidentitycredentials/v1beta): add new v1beta1 version

### DIFF
--- a/librarian.yaml
+++ b/librarian.yaml
@@ -290,6 +290,7 @@ libraries:
     version: 0.1.0
     apis:
       - path: google/cloud/agentidentitycredentials/v1
+      - path: google/cloud/agentidentitycredentials/v1beta
     copyright_year: "2026"
     python:
       default_version: v1

--- a/packages/google-cloud-agentidentitycredentials/docs/agentidentitycredentials_v1beta/auth_provider_credentials_service.rst
+++ b/packages/google-cloud-agentidentitycredentials/docs/agentidentitycredentials_v1beta/auth_provider_credentials_service.rst
@@ -1,0 +1,6 @@
+AuthProviderCredentialsService
+------------------------------------------------
+
+.. automodule:: google.cloud.agentidentitycredentials_v1beta.services.auth_provider_credentials_service
+    :members:
+    :inherited-members:

--- a/packages/google-cloud-agentidentitycredentials/docs/agentidentitycredentials_v1beta/services_.rst
+++ b/packages/google-cloud-agentidentitycredentials/docs/agentidentitycredentials_v1beta/services_.rst
@@ -1,0 +1,6 @@
+Services for Google Cloud Agentidentitycredentials v1beta API
+=============================================================
+.. toctree::
+    :maxdepth: 2
+
+    auth_provider_credentials_service

--- a/packages/google-cloud-agentidentitycredentials/docs/agentidentitycredentials_v1beta/types_.rst
+++ b/packages/google-cloud-agentidentitycredentials/docs/agentidentitycredentials_v1beta/types_.rst
@@ -1,0 +1,6 @@
+Types for Google Cloud Agentidentitycredentials v1beta API
+==========================================================
+
+.. automodule:: google.cloud.agentidentitycredentials_v1beta.types
+    :members:
+    :show-inheritance:

--- a/packages/google-cloud-agentidentitycredentials/docs/index.rst
+++ b/packages/google-cloud-agentidentitycredentials/docs/index.rst
@@ -2,6 +2,9 @@
 
 .. include:: multiprocessing.rst
 
+This package includes clients for multiple versions of agentidentitycredentials.googleapis.com.
+By default, you will get version ``agentidentitycredentials_v1``.
+
 
 API Reference
 -------------
@@ -10,6 +13,14 @@ API Reference
 
     agentidentitycredentials_v1/services_
     agentidentitycredentials_v1/types_
+
+API Reference
+-------------
+.. toctree::
+    :maxdepth: 2
+
+    agentidentitycredentials_v1beta/services_
+    agentidentitycredentials_v1beta/types_
 
 
 Changelog

--- a/packages/google-cloud-agentidentitycredentials/google/cloud/agentidentitycredentials_v1beta/__init__.py
+++ b/packages/google-cloud-agentidentitycredentials/google/cloud/agentidentitycredentials_v1beta/__init__.py
@@ -1,0 +1,129 @@
+# -*- coding: utf-8 -*-
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+import sys
+
+import google.api_core as api_core
+
+from google.cloud.agentidentitycredentials_v1beta import (
+    gapic_version as package_version,
+)
+
+__version__ = package_version.__version__
+
+from importlib import metadata
+
+from .services.auth_provider_credentials_service import (
+    AuthProviderCredentialsServiceAsyncClient,
+    AuthProviderCredentialsServiceClient,
+)
+from .types.auth_provider_credentials_service import (
+    FinalizeCredentialsRequest,
+    FinalizeCredentialsResponse,
+    RetrieveCredentialsRequest,
+    RetrieveCredentialsResponse,
+)
+
+if hasattr(api_core, "check_python_version") and hasattr(
+    api_core, "check_dependency_versions"
+):  # pragma: NO COVER
+    api_core.check_python_version("google.cloud.agentidentitycredentials_v1beta")  # type: ignore
+    api_core.check_dependency_versions("google.cloud.agentidentitycredentials_v1beta")  # type: ignore
+else:  # pragma: NO COVER
+    # An older version of api_core is installed which does not define the
+    # functions above. We do equivalent checks manually.
+    try:
+        import warnings
+
+        _py_version_str = sys.version.split()[0]
+        _package_label = "google.cloud.agentidentitycredentials_v1beta"
+        if sys.version_info < (3, 10):
+            warnings.warn(
+                "You are using a non-supported Python version "
+                + f"({_py_version_str}).  Google will not post any further "
+                + f"updates to {_package_label} supporting this Python version. "
+                + "Please upgrade to the latest Python version, or at "
+                + f"least to Python 3.10, and then update {_package_label}.",
+                FutureWarning,
+            )
+
+        def parse_version_to_tuple(version_string: str):
+            """Safely converts a semantic version string to a comparable tuple of integers.
+            Example: "6.33.5" -> (6, 33, 5)
+            Ignores non-numeric parts and handles common version formats.
+            Args:
+                version_string: Version string in the format "x.y.z" or "x.y.z<suffix>"
+            Returns:
+                Tuple of integers for the parsed version string.
+            """
+            parts = []
+            for part in version_string.split("."):
+                try:
+                    parts.append(int(part))
+                except ValueError:
+                    # If it's a non-numeric part (e.g., '1.0.0b1' -> 'b1'), stop here.
+                    # This is a simplification compared to 'packaging.parse_version', but sufficient
+                    # for comparing strictly numeric semantic versions.
+                    break
+            return tuple(parts)
+
+        def _get_version(dependency_name):
+            try:
+                version_string: str = metadata.version(dependency_name)
+                parsed_version = parse_version_to_tuple(version_string)
+                return (parsed_version, version_string)
+            except Exception:
+                # Catch exceptions from metadata.version() (e.g., PackageNotFoundError)
+                # or errors during parse_version_to_tuple
+                return (None, "--")
+
+        _dependency_package = "google.protobuf"
+        _next_supported_version = "6.33.5"
+        _next_supported_version_tuple = (6, 33, 5)
+        _recommendation = " (we recommend 7.x)"
+        (_version_used, _version_used_string) = _get_version(_dependency_package)
+        if _version_used and _version_used < _next_supported_version_tuple:
+            warnings.warn(
+                f"Package {_package_label} depends on "
+                + f"{_dependency_package}, currently installed at version "
+                + f"{_version_used_string}. Future updates to "
+                + f"{_package_label} will require {_dependency_package} at "
+                + f"version {_next_supported_version} or higher{_recommendation}."
+                + " Please ensure "
+                + "that either (a) your Python environment doesn't pin the "
+                + f"version of {_dependency_package}, so that updates to "
+                + f"{_package_label} can require the higher version, or "
+                + "(b) you manually update your Python environment to use at "
+                + f"least version {_next_supported_version} of "
+                + f"{_dependency_package}.",
+                FutureWarning,
+            )
+    except Exception:
+        warnings.warn(
+            "Could not determine the version of Python "
+            + "currently being used. To continue receiving "
+            + "updates for {_package_label}, ensure you are "
+            + "using a supported version of Python; see "
+            + "https://devguide.python.org/versions/"
+        )
+
+__all__ = (
+    "AuthProviderCredentialsServiceAsyncClient",
+    "AuthProviderCredentialsServiceClient",
+    "FinalizeCredentialsRequest",
+    "FinalizeCredentialsResponse",
+    "RetrieveCredentialsRequest",
+    "RetrieveCredentialsResponse",
+)

--- a/packages/google-cloud-agentidentitycredentials/google/cloud/agentidentitycredentials_v1beta/gapic_metadata.json
+++ b/packages/google-cloud-agentidentitycredentials/google/cloud/agentidentitycredentials_v1beta/gapic_metadata.json
@@ -1,0 +1,58 @@
+ {
+  "comment": "This file maps proto services/RPCs to the corresponding library clients/methods",
+  "language": "python",
+  "libraryPackage": "google.cloud.agentidentitycredentials_v1beta",
+  "protoPackage": "google.cloud.agentidentitycredentials.v1beta",
+  "schema": "1.0",
+  "services": {
+    "AuthProviderCredentialsService": {
+      "clients": {
+        "grpc": {
+          "libraryClient": "AuthProviderCredentialsServiceClient",
+          "rpcs": {
+            "FinalizeCredentials": {
+              "methods": [
+                "finalize_credentials"
+              ]
+            },
+            "RetrieveCredentials": {
+              "methods": [
+                "retrieve_credentials"
+              ]
+            }
+          }
+        },
+        "grpc-async": {
+          "libraryClient": "AuthProviderCredentialsServiceAsyncClient",
+          "rpcs": {
+            "FinalizeCredentials": {
+              "methods": [
+                "finalize_credentials"
+              ]
+            },
+            "RetrieveCredentials": {
+              "methods": [
+                "retrieve_credentials"
+              ]
+            }
+          }
+        },
+        "rest": {
+          "libraryClient": "AuthProviderCredentialsServiceClient",
+          "rpcs": {
+            "FinalizeCredentials": {
+              "methods": [
+                "finalize_credentials"
+              ]
+            },
+            "RetrieveCredentials": {
+              "methods": [
+                "retrieve_credentials"
+              ]
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/packages/google-cloud-agentidentitycredentials/google/cloud/agentidentitycredentials_v1beta/gapic_version.py
+++ b/packages/google-cloud-agentidentitycredentials/google/cloud/agentidentitycredentials_v1beta/gapic_version.py
@@ -1,0 +1,16 @@
+# -*- coding: utf-8 -*-
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+__version__ = "0.1.0"  # {x-release-please-version}

--- a/packages/google-cloud-agentidentitycredentials/google/cloud/agentidentitycredentials_v1beta/py.typed
+++ b/packages/google-cloud-agentidentitycredentials/google/cloud/agentidentitycredentials_v1beta/py.typed
@@ -1,0 +1,2 @@
+# Marker file for PEP 561.
+# The google-cloud-agentidentitycredentials package uses inline types.

--- a/packages/google-cloud-agentidentitycredentials/google/cloud/agentidentitycredentials_v1beta/services/__init__.py
+++ b/packages/google-cloud-agentidentitycredentials/google/cloud/agentidentitycredentials_v1beta/services/__init__.py
@@ -1,0 +1,15 @@
+# -*- coding: utf-8 -*-
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#

--- a/packages/google-cloud-agentidentitycredentials/google/cloud/agentidentitycredentials_v1beta/services/auth_provider_credentials_service/__init__.py
+++ b/packages/google-cloud-agentidentitycredentials/google/cloud/agentidentitycredentials_v1beta/services/auth_provider_credentials_service/__init__.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+from .async_client import AuthProviderCredentialsServiceAsyncClient
+from .client import AuthProviderCredentialsServiceClient
+
+__all__ = (
+    "AuthProviderCredentialsServiceClient",
+    "AuthProviderCredentialsServiceAsyncClient",
+)

--- a/packages/google-cloud-agentidentitycredentials/google/cloud/agentidentitycredentials_v1beta/services/auth_provider_credentials_service/async_client.py
+++ b/packages/google-cloud-agentidentitycredentials/google/cloud/agentidentitycredentials_v1beta/services/auth_provider_credentials_service/async_client.py
@@ -1,0 +1,576 @@
+# -*- coding: utf-8 -*-
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+import logging as std_logging
+import re
+from collections import OrderedDict
+from typing import (
+    Callable,
+    Dict,
+    Mapping,
+    MutableMapping,
+    MutableSequence,
+    Optional,
+    Sequence,
+    Tuple,
+    Type,
+    Union,
+)
+
+import google.protobuf
+from google.api_core import exceptions as core_exceptions
+from google.api_core import gapic_v1
+from google.api_core import retry_async as retries
+from google.api_core.client_options import ClientOptions
+from google.auth import credentials as ga_credentials  # type: ignore
+from google.oauth2 import service_account  # type: ignore
+
+from google.cloud.agentidentitycredentials_v1beta import (
+    gapic_version as package_version,
+)
+
+try:
+    OptionalRetry = Union[retries.AsyncRetry, gapic_v1.method._MethodDefault, None]
+except AttributeError:  # pragma: NO COVER
+    OptionalRetry = Union[retries.AsyncRetry, object, None]  # type: ignore
+
+from google.cloud.agentidentitycredentials_v1beta.types import (
+    auth_provider_credentials_service,
+)
+
+from .client import AuthProviderCredentialsServiceClient
+from .transports.base import (
+    DEFAULT_CLIENT_INFO,
+    AuthProviderCredentialsServiceTransport,
+)
+from .transports.grpc_asyncio import AuthProviderCredentialsServiceGrpcAsyncIOTransport
+
+try:
+    from google.api_core import client_logging  # type: ignore
+
+    CLIENT_LOGGING_SUPPORTED = True  # pragma: NO COVER
+except ImportError:  # pragma: NO COVER
+    CLIENT_LOGGING_SUPPORTED = False
+
+_LOGGER = std_logging.getLogger(__name__)
+
+
+class AuthProviderCredentialsServiceAsyncClient:
+    """Service for managing AuthProvider Credentials."""
+
+    _client: AuthProviderCredentialsServiceClient
+
+    # Copy defaults from the synchronous client for use here.
+    # Note: DEFAULT_ENDPOINT is deprecated. Use _DEFAULT_ENDPOINT_TEMPLATE instead.
+    DEFAULT_ENDPOINT = AuthProviderCredentialsServiceClient.DEFAULT_ENDPOINT
+    DEFAULT_MTLS_ENDPOINT = AuthProviderCredentialsServiceClient.DEFAULT_MTLS_ENDPOINT
+    _DEFAULT_ENDPOINT_TEMPLATE = (
+        AuthProviderCredentialsServiceClient._DEFAULT_ENDPOINT_TEMPLATE
+    )
+    _DEFAULT_UNIVERSE = AuthProviderCredentialsServiceClient._DEFAULT_UNIVERSE
+
+    auth_provider_path = staticmethod(
+        AuthProviderCredentialsServiceClient.auth_provider_path
+    )
+    parse_auth_provider_path = staticmethod(
+        AuthProviderCredentialsServiceClient.parse_auth_provider_path
+    )
+    common_billing_account_path = staticmethod(
+        AuthProviderCredentialsServiceClient.common_billing_account_path
+    )
+    parse_common_billing_account_path = staticmethod(
+        AuthProviderCredentialsServiceClient.parse_common_billing_account_path
+    )
+    common_folder_path = staticmethod(
+        AuthProviderCredentialsServiceClient.common_folder_path
+    )
+    parse_common_folder_path = staticmethod(
+        AuthProviderCredentialsServiceClient.parse_common_folder_path
+    )
+    common_organization_path = staticmethod(
+        AuthProviderCredentialsServiceClient.common_organization_path
+    )
+    parse_common_organization_path = staticmethod(
+        AuthProviderCredentialsServiceClient.parse_common_organization_path
+    )
+    common_project_path = staticmethod(
+        AuthProviderCredentialsServiceClient.common_project_path
+    )
+    parse_common_project_path = staticmethod(
+        AuthProviderCredentialsServiceClient.parse_common_project_path
+    )
+    common_location_path = staticmethod(
+        AuthProviderCredentialsServiceClient.common_location_path
+    )
+    parse_common_location_path = staticmethod(
+        AuthProviderCredentialsServiceClient.parse_common_location_path
+    )
+
+    @classmethod
+    def from_service_account_info(cls, info: dict, *args, **kwargs):
+        """Creates an instance of this client using the provided credentials
+            info.
+
+        Args:
+            info (dict): The service account private key info.
+            args: Additional arguments to pass to the constructor.
+            kwargs: Additional arguments to pass to the constructor.
+
+        Returns:
+            AuthProviderCredentialsServiceAsyncClient: The constructed client.
+        """
+        sa_info_func = (
+            AuthProviderCredentialsServiceClient.from_service_account_info.__func__  # type: ignore
+        )
+        return sa_info_func(
+            AuthProviderCredentialsServiceAsyncClient, info, *args, **kwargs
+        )
+
+    @classmethod
+    def from_service_account_file(cls, filename: str, *args, **kwargs):
+        """Creates an instance of this client using the provided credentials
+            file.
+
+        Args:
+            filename (str): The path to the service account private key json
+                file.
+            args: Additional arguments to pass to the constructor.
+            kwargs: Additional arguments to pass to the constructor.
+
+        Returns:
+            AuthProviderCredentialsServiceAsyncClient: The constructed client.
+        """
+        sa_file_func = (
+            AuthProviderCredentialsServiceClient.from_service_account_file.__func__  # type: ignore
+        )
+        return sa_file_func(
+            AuthProviderCredentialsServiceAsyncClient, filename, *args, **kwargs
+        )
+
+    from_service_account_json = from_service_account_file
+
+    @classmethod
+    def get_mtls_endpoint_and_cert_source(
+        cls, client_options: Optional[ClientOptions] = None
+    ):
+        """Return the API endpoint and client cert source for mutual TLS.
+
+        The client cert source is determined in the following order:
+        (1) if `GOOGLE_API_USE_CLIENT_CERTIFICATE` environment variable is not "true", the
+        client cert source is None.
+        (2) if `client_options.client_cert_source` is provided, use the provided one; if the
+        default client cert source exists, use the default one; otherwise the client cert
+        source is None.
+
+        The API endpoint is determined in the following order:
+        (1) if `client_options.api_endpoint` if provided, use the provided one.
+        (2) if `GOOGLE_API_USE_CLIENT_CERTIFICATE` environment variable is "always", use the
+        default mTLS endpoint; if the environment variable is "never", use the default API
+        endpoint; otherwise if client cert source exists, use the default mTLS endpoint, otherwise
+        use the default API endpoint.
+
+        More details can be found at https://google.aip.dev/auth/4114.
+
+        Args:
+            client_options (google.api_core.client_options.ClientOptions): Custom options for the
+                client. Only the `api_endpoint` and `client_cert_source` properties may be used
+                in this method.
+
+        Returns:
+            Tuple[str, Callable[[], Tuple[bytes, bytes]]]: returns the API endpoint and the
+                client cert source to use.
+
+        Raises:
+            google.auth.exceptions.MutualTLSChannelError: If any errors happen.
+        """
+        return AuthProviderCredentialsServiceClient.get_mtls_endpoint_and_cert_source(
+            client_options
+        )  # type: ignore
+
+    @property
+    def transport(self) -> AuthProviderCredentialsServiceTransport:
+        """Returns the transport used by the client instance.
+
+        Returns:
+            AuthProviderCredentialsServiceTransport: The transport used by the client instance.
+        """
+        return self._client.transport
+
+    @property
+    def api_endpoint(self) -> str:
+        """Return the API endpoint used by the client instance.
+
+        Returns:
+            str: The API endpoint used by the client instance.
+        """
+        return self._client._api_endpoint
+
+    @property
+    def universe_domain(self) -> str:
+        """Return the universe domain used by the client instance.
+
+        Returns:
+            str: The universe domain used
+                by the client instance.
+        """
+        return self._client._universe_domain
+
+    get_transport_class = AuthProviderCredentialsServiceClient.get_transport_class
+
+    def __init__(
+        self,
+        *,
+        credentials: Optional[ga_credentials.Credentials] = None,
+        transport: Optional[
+            Union[
+                str,
+                AuthProviderCredentialsServiceTransport,
+                Callable[..., AuthProviderCredentialsServiceTransport],
+            ]
+        ] = "grpc_asyncio",
+        client_options: Optional[ClientOptions] = None,
+        client_info: gapic_v1.client_info.ClientInfo = DEFAULT_CLIENT_INFO,
+    ) -> None:
+        """Instantiates the auth provider credentials service async client.
+
+        Args:
+            credentials (Optional[google.auth.credentials.Credentials]): The
+                authorization credentials to attach to requests. These
+                credentials identify the application to the service; if none
+                are specified, the client will attempt to ascertain the
+                credentials from the environment.
+            transport (Optional[Union[str,AuthProviderCredentialsServiceTransport,Callable[..., AuthProviderCredentialsServiceTransport]]]):
+                The transport to use, or a Callable that constructs and returns a new transport to use.
+                If a Callable is given, it will be called with the same set of initialization
+                arguments as used in the AuthProviderCredentialsServiceTransport constructor.
+                If set to None, a transport is chosen automatically.
+            client_options (Optional[Union[google.api_core.client_options.ClientOptions, dict]]):
+                Custom options for the client.
+
+                1. The ``api_endpoint`` property can be used to override the
+                default endpoint provided by the client when ``transport`` is
+                not explicitly provided. Only if this property is not set and
+                ``transport`` was not explicitly provided, the endpoint is
+                determined by the GOOGLE_API_USE_MTLS_ENDPOINT environment
+                variable, which have one of the following values:
+                "always" (always use the default mTLS endpoint), "never" (always
+                use the default regular endpoint) and "auto" (auto-switch to the
+                default mTLS endpoint if client certificate is present; this is
+                the default value).
+
+                2. If the GOOGLE_API_USE_CLIENT_CERTIFICATE environment variable
+                is "true", then the ``client_cert_source`` property can be used
+                to provide a client certificate for mTLS transport. If
+                not provided, the default SSL client certificate will be used if
+                present. If GOOGLE_API_USE_CLIENT_CERTIFICATE is "false" or not
+                set, no client certificate will be used.
+
+                3. The ``universe_domain`` property can be used to override the
+                default "googleapis.com" universe. Note that ``api_endpoint``
+                property still takes precedence; and ``universe_domain`` is
+                currently not supported for mTLS.
+
+            client_info (google.api_core.gapic_v1.client_info.ClientInfo):
+                The client info used to send a user-agent string along with
+                API requests. If ``None``, then default info will be used.
+                Generally, you only need to set this if you're developing
+                your own client library.
+
+        Raises:
+            google.auth.exceptions.MutualTlsChannelError: If mutual TLS transport
+                creation failed for any reason.
+        """
+        self._client = AuthProviderCredentialsServiceClient(
+            credentials=credentials,
+            transport=transport,
+            client_options=client_options,
+            client_info=client_info,
+        )
+
+        if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(
+            std_logging.DEBUG
+        ):  # pragma: NO COVER
+            _LOGGER.debug(
+                "Created client `google.cloud.agentidentitycredentials_v1beta.AuthProviderCredentialsServiceAsyncClient`.",
+                extra={
+                    "serviceName": "google.cloud.agentidentitycredentials.v1beta.AuthProviderCredentialsService",
+                    "universeDomain": getattr(
+                        self._client._transport._credentials, "universe_domain", ""
+                    ),
+                    "credentialsType": f"{type(self._client._transport._credentials).__module__}.{type(self._client._transport._credentials).__qualname__}",
+                    "credentialsInfo": getattr(
+                        self.transport._credentials, "get_cred_info", lambda: None
+                    )(),
+                }
+                if hasattr(self._client._transport, "_credentials")
+                else {
+                    "serviceName": "google.cloud.agentidentitycredentials.v1beta.AuthProviderCredentialsService",
+                    "credentialsType": None,
+                },
+            )
+
+    async def retrieve_credentials(
+        self,
+        request: Optional[
+            Union[auth_provider_credentials_service.RetrieveCredentialsRequest, dict]
+        ] = None,
+        *,
+        auth_provider: Optional[str] = None,
+        user_id: Optional[str] = None,
+        retry: OptionalRetry = gapic_v1.method.DEFAULT,
+        timeout: Union[float, object] = gapic_v1.method.DEFAULT,
+        metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
+    ) -> auth_provider_credentials_service.RetrieveCredentialsResponse:
+        r"""Retrieves authorization credentials for an authprovider, or
+        indicates what action needs to be taken to obtain credentials.
+        If the ``token`` field in the response is populated, credential
+        retrieval was successful. If one of the fields in the ``status``
+        oneof is populated, further action is required to obtain
+        credentials, such as redirecting the user for consent. View
+        comments on ``RetrieveCredentialsResponse`` for more
+        information.
+
+        .. code-block:: python
+
+            # This snippet has been automatically generated and should be regarded as a
+            # code template only.
+            # It will require modifications to work:
+            # - It may require correct/in-range values for request initialization.
+            # - It may require specifying regional endpoints when creating the service
+            #   client as shown in:
+            #   https://googleapis.dev/python/google-api-core/latest/client_options.html
+            from google.cloud import agentidentitycredentials_v1beta
+
+            async def sample_retrieve_credentials():
+                # Create a client
+                client = agentidentitycredentials_v1beta.AuthProviderCredentialsServiceAsyncClient()
+
+                # Initialize request argument(s)
+                request = agentidentitycredentials_v1beta.RetrieveCredentialsRequest(
+                    auth_provider="auth_provider_value",
+                    user_id="user_id_value",
+                )
+
+                # Make the request
+                response = await client.retrieve_credentials(request=request)
+
+                # Handle the response
+                print(response)
+
+        Args:
+            request (Optional[Union[google.cloud.agentidentitycredentials_v1beta.types.RetrieveCredentialsRequest, dict]]):
+                The request object. Request message for
+                RetrieveCredentials.
+            auth_provider (:class:`str`):
+                Required. The parent resource name of the AuthProvider.
+                Format:
+                ``projects/{project}/locations/{location}/authProviders/{auth_provider}``
+
+                This corresponds to the ``auth_provider`` field
+                on the ``request`` instance; if ``request`` is provided, this
+                should not be set.
+            user_id (:class:`str`):
+                Required. The identity of the end
+                user.
+
+                This corresponds to the ``user_id`` field
+                on the ``request`` instance; if ``request`` is provided, this
+                should not be set.
+            retry (google.api_core.retry_async.AsyncRetry): Designation of what errors, if any,
+                should be retried.
+            timeout (float): The timeout for this request.
+            metadata (Sequence[Tuple[str, Union[str, bytes]]]): Key/value pairs which should be
+                sent along with the request as metadata. Normally, each value must be of type `str`,
+                but for metadata keys ending with the suffix `-bin`, the corresponding values must
+                be of type `bytes`.
+
+        Returns:
+            google.cloud.agentidentitycredentials_v1beta.types.RetrieveCredentialsResponse:
+                Response message for
+                RetrieveCredentials. Contains the access
+                tokens and related artifacts.
+
+        """
+        # Create or coerce a protobuf request object.
+        # - Quick check: If we got a request object, we should *not* have
+        #   gotten any keyword arguments that map to the request.
+        flattened_params = [auth_provider, user_id]
+        has_flattened_params = (
+            len([param for param in flattened_params if param is not None]) > 0
+        )
+        if request is not None and has_flattened_params:
+            raise ValueError(
+                "If the `request` argument is set, then none of "
+                "the individual field arguments should be set."
+            )
+
+        # - Use the request object if provided (there's no risk of modifying the input as
+        #   there are no flattened fields), or create one.
+        if not isinstance(
+            request, auth_provider_credentials_service.RetrieveCredentialsRequest
+        ):
+            request = auth_provider_credentials_service.RetrieveCredentialsRequest(
+                request
+            )
+
+        # If we have keyword arguments corresponding to fields on the
+        # request, apply these.
+        if auth_provider is not None:
+            request.auth_provider = auth_provider
+        if user_id is not None:
+            request.user_id = user_id
+
+        # Wrap the RPC method; this adds retry and timeout information,
+        # and friendly error handling.
+        rpc = self._client._transport._wrapped_methods[
+            self._client._transport.retrieve_credentials
+        ]
+
+        # Certain fields should be provided within the metadata header;
+        # add these here.
+        metadata = tuple(metadata) + (
+            gapic_v1.routing_header.to_grpc_metadata(
+                (("auth_provider", request.auth_provider),)
+            ),
+        )
+
+        # Validate the universe domain.
+        self._client._validate_universe_domain()
+
+        # Send the request.
+        response = await rpc(
+            request,
+            retry=retry,
+            timeout=timeout,
+            metadata=metadata,
+        )
+
+        # Done; return the response.
+        return response
+
+    async def finalize_credentials(
+        self,
+        request: Optional[
+            Union[auth_provider_credentials_service.FinalizeCredentialsRequest, dict]
+        ] = None,
+        *,
+        retry: OptionalRetry = gapic_v1.method.DEFAULT,
+        timeout: Union[float, object] = gapic_v1.method.DEFAULT,
+        metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
+    ) -> auth_provider_credentials_service.FinalizeCredentialsResponse:
+        r"""Finalizes the credentials after a successful consent
+        flow.
+
+        .. code-block:: python
+
+            # This snippet has been automatically generated and should be regarded as a
+            # code template only.
+            # It will require modifications to work:
+            # - It may require correct/in-range values for request initialization.
+            # - It may require specifying regional endpoints when creating the service
+            #   client as shown in:
+            #   https://googleapis.dev/python/google-api-core/latest/client_options.html
+            from google.cloud import agentidentitycredentials_v1beta
+
+            async def sample_finalize_credentials():
+                # Create a client
+                client = agentidentitycredentials_v1beta.AuthProviderCredentialsServiceAsyncClient()
+
+                # Initialize request argument(s)
+                request = agentidentitycredentials_v1beta.FinalizeCredentialsRequest(
+                    auth_provider="auth_provider_value",
+                    user_id="user_id_value",
+                    user_id_validation_state=b'user_id_validation_state_blob',
+                    consent_nonce="consent_nonce_value",
+                )
+
+                # Make the request
+                response = await client.finalize_credentials(request=request)
+
+                # Handle the response
+                print(response)
+
+        Args:
+            request (Optional[Union[google.cloud.agentidentitycredentials_v1beta.types.FinalizeCredentialsRequest, dict]]):
+                The request object. Request message for
+                FinalizeCredentials.
+            retry (google.api_core.retry_async.AsyncRetry): Designation of what errors, if any,
+                should be retried.
+            timeout (float): The timeout for this request.
+            metadata (Sequence[Tuple[str, Union[str, bytes]]]): Key/value pairs which should be
+                sent along with the request as metadata. Normally, each value must be of type `str`,
+                but for metadata keys ending with the suffix `-bin`, the corresponding values must
+                be of type `bytes`.
+
+        Returns:
+            google.cloud.agentidentitycredentials_v1beta.types.FinalizeCredentialsResponse:
+                Response message for
+                FinalizeCredentials. Intentionally empty
+
+        """
+        # Create or coerce a protobuf request object.
+        # - Use the request object if provided (there's no risk of modifying the input as
+        #   there are no flattened fields), or create one.
+        if not isinstance(
+            request, auth_provider_credentials_service.FinalizeCredentialsRequest
+        ):
+            request = auth_provider_credentials_service.FinalizeCredentialsRequest(
+                request
+            )
+
+        # Wrap the RPC method; this adds retry and timeout information,
+        # and friendly error handling.
+        rpc = self._client._transport._wrapped_methods[
+            self._client._transport.finalize_credentials
+        ]
+
+        # Certain fields should be provided within the metadata header;
+        # add these here.
+        metadata = tuple(metadata) + (
+            gapic_v1.routing_header.to_grpc_metadata(
+                (("auth_provider", request.auth_provider),)
+            ),
+        )
+
+        # Validate the universe domain.
+        self._client._validate_universe_domain()
+
+        # Send the request.
+        response = await rpc(
+            request,
+            retry=retry,
+            timeout=timeout,
+            metadata=metadata,
+        )
+
+        # Done; return the response.
+        return response
+
+    async def __aenter__(self) -> "AuthProviderCredentialsServiceAsyncClient":
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        await self.transport.close()
+
+
+DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
+    gapic_version=package_version.__version__
+)
+
+if hasattr(DEFAULT_CLIENT_INFO, "protobuf_runtime_version"):  # pragma: NO COVER
+    DEFAULT_CLIENT_INFO.protobuf_runtime_version = google.protobuf.__version__
+
+
+__all__ = ("AuthProviderCredentialsServiceAsyncClient",)

--- a/packages/google-cloud-agentidentitycredentials/google/cloud/agentidentitycredentials_v1beta/services/auth_provider_credentials_service/client.py
+++ b/packages/google-cloud-agentidentitycredentials/google/cloud/agentidentitycredentials_v1beta/services/auth_provider_credentials_service/client.py
@@ -1,0 +1,1012 @@
+# -*- coding: utf-8 -*-
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+import json
+import logging as std_logging
+import os
+import re
+import warnings
+from collections import OrderedDict
+from http import HTTPStatus
+from typing import (
+    Callable,
+    Dict,
+    Mapping,
+    MutableMapping,
+    MutableSequence,
+    Optional,
+    Sequence,
+    Tuple,
+    Type,
+    Union,
+    cast,
+)
+
+import google.protobuf
+from google.api_core import client_options as client_options_lib
+from google.api_core import exceptions as core_exceptions
+from google.api_core import gapic_v1
+from google.api_core import retry as retries
+from google.auth import credentials as ga_credentials  # type: ignore
+from google.auth.exceptions import MutualTLSChannelError  # type: ignore
+from google.auth.transport import mtls  # type: ignore
+from google.auth.transport.grpc import SslCredentials  # type: ignore
+from google.oauth2 import service_account  # type: ignore
+
+from google.cloud.agentidentitycredentials_v1beta import (
+    gapic_version as package_version,
+)
+
+try:
+    OptionalRetry = Union[retries.Retry, gapic_v1.method._MethodDefault, None]
+except AttributeError:  # pragma: NO COVER
+    OptionalRetry = Union[retries.Retry, object, None]  # type: ignore
+
+try:
+    from google.api_core import client_logging  # type: ignore
+
+    CLIENT_LOGGING_SUPPORTED = True  # pragma: NO COVER
+except ImportError:  # pragma: NO COVER
+    CLIENT_LOGGING_SUPPORTED = False
+
+_LOGGER = std_logging.getLogger(__name__)
+
+from google.cloud.agentidentitycredentials_v1beta.types import (
+    auth_provider_credentials_service,
+)
+
+from .transports.base import (
+    DEFAULT_CLIENT_INFO,
+    AuthProviderCredentialsServiceTransport,
+)
+from .transports.grpc import AuthProviderCredentialsServiceGrpcTransport
+from .transports.grpc_asyncio import AuthProviderCredentialsServiceGrpcAsyncIOTransport
+from .transports.rest import AuthProviderCredentialsServiceRestTransport
+
+
+class AuthProviderCredentialsServiceClientMeta(type):
+    """Metaclass for the AuthProviderCredentialsService client.
+
+    This provides class-level methods for building and retrieving
+    support objects (e.g. transport) without polluting the client instance
+    objects.
+    """
+
+    _transport_registry = OrderedDict()  # type: Dict[str, Type[AuthProviderCredentialsServiceTransport]]
+    _transport_registry["grpc"] = AuthProviderCredentialsServiceGrpcTransport
+    _transport_registry["grpc_asyncio"] = (
+        AuthProviderCredentialsServiceGrpcAsyncIOTransport
+    )
+    _transport_registry["rest"] = AuthProviderCredentialsServiceRestTransport
+
+    def get_transport_class(
+        cls,
+        label: Optional[str] = None,
+    ) -> Type[AuthProviderCredentialsServiceTransport]:
+        """Returns an appropriate transport class.
+
+        Args:
+            label: The name of the desired transport. If none is
+                provided, then the first transport in the registry is used.
+
+        Returns:
+            The transport class to use.
+        """
+        # If a specific transport is requested, return that one.
+        if label:
+            return cls._transport_registry[label]
+
+        # No transport is requested; return the default (that is, the first one
+        # in the dictionary).
+        return next(iter(cls._transport_registry.values()))
+
+
+class AuthProviderCredentialsServiceClient(
+    metaclass=AuthProviderCredentialsServiceClientMeta
+):
+    """Service for managing AuthProvider Credentials."""
+
+    @staticmethod
+    def _get_default_mtls_endpoint(api_endpoint) -> Optional[str]:
+        """Converts api endpoint to mTLS endpoint.
+
+        Convert "*.sandbox.googleapis.com" and "*.googleapis.com" to
+        "*.mtls.sandbox.googleapis.com" and "*.mtls.googleapis.com" respectively.
+        Args:
+            api_endpoint (Optional[str]): the api endpoint to convert.
+        Returns:
+            Optional[str]: converted mTLS api endpoint.
+        """
+        if not api_endpoint:
+            return api_endpoint
+
+        mtls_endpoint_re = re.compile(
+            r"(?P<name>[^.]+)(?P<mtls>\.mtls)?(?P<sandbox>\.sandbox)?(?P<googledomain>\.googleapis\.com)?"
+        )
+
+        m = mtls_endpoint_re.match(api_endpoint)
+        if m is None:
+            # Could not parse api_endpoint; return as-is.
+            return api_endpoint
+
+        name, mtls, sandbox, googledomain = m.groups()
+        if mtls or not googledomain:
+            return api_endpoint
+
+        if sandbox:
+            return api_endpoint.replace(
+                "sandbox.googleapis.com", "mtls.sandbox.googleapis.com"
+            )
+
+        return api_endpoint.replace(".googleapis.com", ".mtls.googleapis.com")
+
+    # Note: DEFAULT_ENDPOINT is deprecated. Use _DEFAULT_ENDPOINT_TEMPLATE instead.
+    DEFAULT_ENDPOINT = "agentidentitycredentials.googleapis.com"
+    DEFAULT_MTLS_ENDPOINT = _get_default_mtls_endpoint.__func__(  # type: ignore
+        DEFAULT_ENDPOINT
+    )
+
+    _DEFAULT_ENDPOINT_TEMPLATE = "agentidentitycredentials.{UNIVERSE_DOMAIN}"
+    _DEFAULT_UNIVERSE = "googleapis.com"
+
+    @staticmethod
+    def _use_client_cert_effective():
+        """Returns whether client certificate should be used for mTLS if the
+        google-auth version supports should_use_client_cert automatic mTLS enablement.
+
+        Alternatively, read from the GOOGLE_API_USE_CLIENT_CERTIFICATE env var.
+
+        Returns:
+            bool: whether client certificate should be used for mTLS
+        Raises:
+            ValueError: (If using a version of google-auth without should_use_client_cert and
+            GOOGLE_API_USE_CLIENT_CERTIFICATE is set to an unexpected value.)
+        """
+        # check if google-auth version supports should_use_client_cert for automatic mTLS enablement
+        if hasattr(mtls, "should_use_client_cert"):  # pragma: NO COVER
+            return mtls.should_use_client_cert()
+        else:  # pragma: NO COVER
+            # if unsupported, fallback to reading from env var
+            use_client_cert_str = os.getenv(
+                "GOOGLE_API_USE_CLIENT_CERTIFICATE", "false"
+            ).lower()
+            if use_client_cert_str not in ("true", "false"):
+                raise ValueError(
+                    "Environment variable `GOOGLE_API_USE_CLIENT_CERTIFICATE` must be"
+                    " either `true` or `false`"
+                )
+            return use_client_cert_str == "true"
+
+    @classmethod
+    def from_service_account_info(cls, info: dict, *args, **kwargs):
+        """Creates an instance of this client using the provided credentials
+            info.
+
+        Args:
+            info (dict): The service account private key info.
+            args: Additional arguments to pass to the constructor.
+            kwargs: Additional arguments to pass to the constructor.
+
+        Returns:
+            AuthProviderCredentialsServiceClient: The constructed client.
+        """
+        credentials = service_account.Credentials.from_service_account_info(info)
+        kwargs["credentials"] = credentials
+        return cls(*args, **kwargs)
+
+    @classmethod
+    def from_service_account_file(cls, filename: str, *args, **kwargs):
+        """Creates an instance of this client using the provided credentials
+            file.
+
+        Args:
+            filename (str): The path to the service account private key json
+                file.
+            args: Additional arguments to pass to the constructor.
+            kwargs: Additional arguments to pass to the constructor.
+
+        Returns:
+            AuthProviderCredentialsServiceClient: The constructed client.
+        """
+        credentials = service_account.Credentials.from_service_account_file(filename)
+        kwargs["credentials"] = credentials
+        return cls(*args, **kwargs)
+
+    from_service_account_json = from_service_account_file
+
+    @property
+    def transport(self) -> AuthProviderCredentialsServiceTransport:
+        """Returns the transport used by the client instance.
+
+        Returns:
+            AuthProviderCredentialsServiceTransport: The transport used by the client
+                instance.
+        """
+        return self._transport
+
+    @staticmethod
+    def auth_provider_path(
+        project: str,
+        location: str,
+        auth_provider: str,
+    ) -> str:
+        """Returns a fully-qualified auth_provider string."""
+        return "projects/{project}/locations/{location}/authProviders/{auth_provider}".format(
+            project=project,
+            location=location,
+            auth_provider=auth_provider,
+        )
+
+    @staticmethod
+    def parse_auth_provider_path(path: str) -> Dict[str, str]:
+        """Parses a auth_provider path into its component segments."""
+        m = re.match(
+            r"^projects/(?P<project>.+?)/locations/(?P<location>.+?)/authProviders/(?P<auth_provider>.+?)$",
+            path,
+        )
+        return m.groupdict() if m else {}
+
+    @staticmethod
+    def common_billing_account_path(
+        billing_account: str,
+    ) -> str:
+        """Returns a fully-qualified billing_account string."""
+        return "billingAccounts/{billing_account}".format(
+            billing_account=billing_account,
+        )
+
+    @staticmethod
+    def parse_common_billing_account_path(path: str) -> Dict[str, str]:
+        """Parse a billing_account path into its component segments."""
+        m = re.match(r"^billingAccounts/(?P<billing_account>.+?)$", path)
+        return m.groupdict() if m else {}
+
+    @staticmethod
+    def common_folder_path(
+        folder: str,
+    ) -> str:
+        """Returns a fully-qualified folder string."""
+        return "folders/{folder}".format(
+            folder=folder,
+        )
+
+    @staticmethod
+    def parse_common_folder_path(path: str) -> Dict[str, str]:
+        """Parse a folder path into its component segments."""
+        m = re.match(r"^folders/(?P<folder>.+?)$", path)
+        return m.groupdict() if m else {}
+
+    @staticmethod
+    def common_organization_path(
+        organization: str,
+    ) -> str:
+        """Returns a fully-qualified organization string."""
+        return "organizations/{organization}".format(
+            organization=organization,
+        )
+
+    @staticmethod
+    def parse_common_organization_path(path: str) -> Dict[str, str]:
+        """Parse a organization path into its component segments."""
+        m = re.match(r"^organizations/(?P<organization>.+?)$", path)
+        return m.groupdict() if m else {}
+
+    @staticmethod
+    def common_project_path(
+        project: str,
+    ) -> str:
+        """Returns a fully-qualified project string."""
+        return "projects/{project}".format(
+            project=project,
+        )
+
+    @staticmethod
+    def parse_common_project_path(path: str) -> Dict[str, str]:
+        """Parse a project path into its component segments."""
+        m = re.match(r"^projects/(?P<project>.+?)$", path)
+        return m.groupdict() if m else {}
+
+    @staticmethod
+    def common_location_path(
+        project: str,
+        location: str,
+    ) -> str:
+        """Returns a fully-qualified location string."""
+        return "projects/{project}/locations/{location}".format(
+            project=project,
+            location=location,
+        )
+
+    @staticmethod
+    def parse_common_location_path(path: str) -> Dict[str, str]:
+        """Parse a location path into its component segments."""
+        m = re.match(r"^projects/(?P<project>.+?)/locations/(?P<location>.+?)$", path)
+        return m.groupdict() if m else {}
+
+    @classmethod
+    def get_mtls_endpoint_and_cert_source(
+        cls, client_options: Optional[client_options_lib.ClientOptions] = None
+    ):
+        """Deprecated. Return the API endpoint and client cert source for mutual TLS.
+
+        The client cert source is determined in the following order:
+        (1) if `GOOGLE_API_USE_CLIENT_CERTIFICATE` environment variable is not "true", the
+        client cert source is None.
+        (2) if `client_options.client_cert_source` is provided, use the provided one; if the
+        default client cert source exists, use the default one; otherwise the client cert
+        source is None.
+
+        The API endpoint is determined in the following order:
+        (1) if `client_options.api_endpoint` if provided, use the provided one.
+        (2) if `GOOGLE_API_USE_CLIENT_CERTIFICATE` environment variable is "always", use the
+        default mTLS endpoint; if the environment variable is "never", use the default API
+        endpoint; otherwise if client cert source exists, use the default mTLS endpoint, otherwise
+        use the default API endpoint.
+
+        More details can be found at https://google.aip.dev/auth/4114.
+
+        Args:
+            client_options (google.api_core.client_options.ClientOptions): Custom options for the
+                client. Only the `api_endpoint` and `client_cert_source` properties may be used
+                in this method.
+
+        Returns:
+            Tuple[str, Callable[[], Tuple[bytes, bytes]]]: returns the API endpoint and the
+                client cert source to use.
+
+        Raises:
+            google.auth.exceptions.MutualTLSChannelError: If any errors happen.
+        """
+
+        warnings.warn(
+            "get_mtls_endpoint_and_cert_source is deprecated. Use the api_endpoint property instead.",
+            DeprecationWarning,
+        )
+        if client_options is None:
+            client_options = client_options_lib.ClientOptions()
+        use_client_cert = (
+            AuthProviderCredentialsServiceClient._use_client_cert_effective()
+        )
+        use_mtls_endpoint = os.getenv("GOOGLE_API_USE_MTLS_ENDPOINT", "auto")
+        if use_mtls_endpoint not in ("auto", "never", "always"):
+            raise MutualTLSChannelError(
+                "Environment variable `GOOGLE_API_USE_MTLS_ENDPOINT` must be `never`, `auto` or `always`"
+            )
+
+        # Figure out the client cert source to use.
+        client_cert_source = None
+        if use_client_cert:
+            if client_options.client_cert_source:
+                client_cert_source = client_options.client_cert_source
+            elif mtls.has_default_client_cert_source():
+                client_cert_source = mtls.default_client_cert_source()
+
+        # Figure out which api endpoint to use.
+        if client_options.api_endpoint is not None:
+            api_endpoint = client_options.api_endpoint
+        elif use_mtls_endpoint == "always" or (
+            use_mtls_endpoint == "auto" and client_cert_source
+        ):
+            api_endpoint = cls.DEFAULT_MTLS_ENDPOINT
+        else:
+            api_endpoint = cls.DEFAULT_ENDPOINT
+
+        return api_endpoint, client_cert_source
+
+    @staticmethod
+    def _read_environment_variables():
+        """Returns the environment variables used by the client.
+
+        Returns:
+            Tuple[bool, str, str]: returns the GOOGLE_API_USE_CLIENT_CERTIFICATE,
+            GOOGLE_API_USE_MTLS_ENDPOINT, and GOOGLE_CLOUD_UNIVERSE_DOMAIN environment variables.
+
+        Raises:
+            ValueError: If GOOGLE_API_USE_CLIENT_CERTIFICATE is not
+                any of ["true", "false"].
+            google.auth.exceptions.MutualTLSChannelError: If GOOGLE_API_USE_MTLS_ENDPOINT
+                is not any of ["auto", "never", "always"].
+        """
+        use_client_cert = (
+            AuthProviderCredentialsServiceClient._use_client_cert_effective()
+        )
+        use_mtls_endpoint = os.getenv("GOOGLE_API_USE_MTLS_ENDPOINT", "auto").lower()
+        universe_domain_env = os.getenv("GOOGLE_CLOUD_UNIVERSE_DOMAIN")
+        if use_mtls_endpoint not in ("auto", "never", "always"):
+            raise MutualTLSChannelError(
+                "Environment variable `GOOGLE_API_USE_MTLS_ENDPOINT` must be `never`, `auto` or `always`"
+            )
+        return use_client_cert, use_mtls_endpoint, universe_domain_env
+
+    @staticmethod
+    def _get_client_cert_source(provided_cert_source, use_cert_flag):
+        """Return the client cert source to be used by the client.
+
+        Args:
+            provided_cert_source (bytes): The client certificate source provided.
+            use_cert_flag (bool): A flag indicating whether to use the client certificate.
+
+        Returns:
+            bytes or None: The client cert source to be used by the client.
+        """
+        client_cert_source = None
+        if use_cert_flag:
+            if provided_cert_source:
+                client_cert_source = provided_cert_source
+            elif mtls.has_default_client_cert_source():
+                client_cert_source = mtls.default_client_cert_source()
+        return client_cert_source
+
+    @staticmethod
+    def _get_api_endpoint(
+        api_override, client_cert_source, universe_domain, use_mtls_endpoint
+    ) -> str:
+        """Return the API endpoint used by the client.
+
+        Args:
+            api_override (str): The API endpoint override. If specified, this is always
+                the return value of this function and the other arguments are not used.
+            client_cert_source (bytes): The client certificate source used by the client.
+            universe_domain (str): The universe domain used by the client.
+            use_mtls_endpoint (str): How to use the mTLS endpoint, which depends also on the other parameters.
+                Possible values are "always", "auto", or "never".
+
+        Returns:
+            str: The API endpoint to be used by the client.
+        """
+        if api_override is not None:
+            api_endpoint = api_override
+        elif use_mtls_endpoint == "always" or (
+            use_mtls_endpoint == "auto" and client_cert_source
+        ):
+            _default_universe = AuthProviderCredentialsServiceClient._DEFAULT_UNIVERSE
+            if universe_domain != _default_universe:
+                raise MutualTLSChannelError(
+                    f"mTLS is not supported in any universe other than {_default_universe}."
+                )
+            api_endpoint = AuthProviderCredentialsServiceClient.DEFAULT_MTLS_ENDPOINT
+        else:
+            api_endpoint = (
+                AuthProviderCredentialsServiceClient._DEFAULT_ENDPOINT_TEMPLATE.format(
+                    UNIVERSE_DOMAIN=universe_domain
+                )
+            )
+        return api_endpoint
+
+    @staticmethod
+    def _get_universe_domain(
+        client_universe_domain: Optional[str], universe_domain_env: Optional[str]
+    ) -> str:
+        """Return the universe domain used by the client.
+
+        Args:
+            client_universe_domain (Optional[str]): The universe domain configured via the client options.
+            universe_domain_env (Optional[str]): The universe domain configured via the "GOOGLE_CLOUD_UNIVERSE_DOMAIN" environment variable.
+
+        Returns:
+            str: The universe domain to be used by the client.
+
+        Raises:
+            ValueError: If the universe domain is an empty string.
+        """
+        universe_domain = AuthProviderCredentialsServiceClient._DEFAULT_UNIVERSE
+        if client_universe_domain is not None:
+            universe_domain = client_universe_domain
+        elif universe_domain_env is not None:
+            universe_domain = universe_domain_env
+        if len(universe_domain.strip()) == 0:
+            raise ValueError("Universe Domain cannot be an empty string.")
+        return universe_domain
+
+    def _validate_universe_domain(self):
+        """Validates client's and credentials' universe domains are consistent.
+
+        Returns:
+            bool: True iff the configured universe domain is valid.
+
+        Raises:
+            ValueError: If the configured universe domain is not valid.
+        """
+
+        # NOTE (b/349488459): universe validation is disabled until further notice.
+        return True
+
+    def _add_cred_info_for_auth_errors(
+        self, error: core_exceptions.GoogleAPICallError
+    ) -> None:
+        """Adds credential info string to error details for 401/403/404 errors.
+
+        Args:
+            error (google.api_core.exceptions.GoogleAPICallError): The error to add the cred info.
+        """
+        if error.code not in [
+            HTTPStatus.UNAUTHORIZED,
+            HTTPStatus.FORBIDDEN,
+            HTTPStatus.NOT_FOUND,
+        ]:
+            return
+
+        cred = self._transport._credentials
+
+        # get_cred_info is only available in google-auth>=2.35.0
+        if not hasattr(cred, "get_cred_info"):
+            return
+
+        # ignore the type check since pypy test fails when get_cred_info
+        # is not available
+        cred_info = cred.get_cred_info()  # type: ignore
+        if cred_info and hasattr(error._details, "append"):
+            error._details.append(json.dumps(cred_info))
+
+    @property
+    def api_endpoint(self) -> str:
+        """Return the API endpoint used by the client instance.
+
+        Returns:
+            str: The API endpoint used by the client instance.
+        """
+        return self._api_endpoint
+
+    @property
+    def universe_domain(self) -> str:
+        """Return the universe domain used by the client instance.
+
+        Returns:
+            str: The universe domain used by the client instance.
+        """
+        return self._universe_domain
+
+    def __init__(
+        self,
+        *,
+        credentials: Optional[ga_credentials.Credentials] = None,
+        transport: Optional[
+            Union[
+                str,
+                AuthProviderCredentialsServiceTransport,
+                Callable[..., AuthProviderCredentialsServiceTransport],
+            ]
+        ] = None,
+        client_options: Optional[Union[client_options_lib.ClientOptions, dict]] = None,
+        client_info: gapic_v1.client_info.ClientInfo = DEFAULT_CLIENT_INFO,
+    ) -> None:
+        """Instantiates the auth provider credentials service client.
+
+        Args:
+            credentials (Optional[google.auth.credentials.Credentials]): The
+                authorization credentials to attach to requests. These
+                credentials identify the application to the service; if none
+                are specified, the client will attempt to ascertain the
+                credentials from the environment.
+            transport (Optional[Union[str,AuthProviderCredentialsServiceTransport,Callable[..., AuthProviderCredentialsServiceTransport]]]):
+                The transport to use, or a Callable that constructs and returns a new transport.
+                If a Callable is given, it will be called with the same set of initialization
+                arguments as used in the AuthProviderCredentialsServiceTransport constructor.
+                If set to None, a transport is chosen automatically.
+            client_options (Optional[Union[google.api_core.client_options.ClientOptions, dict]]):
+                Custom options for the client.
+
+                1. The ``api_endpoint`` property can be used to override the
+                default endpoint provided by the client when ``transport`` is
+                not explicitly provided. Only if this property is not set and
+                ``transport`` was not explicitly provided, the endpoint is
+                determined by the GOOGLE_API_USE_MTLS_ENDPOINT environment
+                variable, which have one of the following values:
+                "always" (always use the default mTLS endpoint), "never" (always
+                use the default regular endpoint) and "auto" (auto-switch to the
+                default mTLS endpoint if client certificate is present; this is
+                the default value).
+
+                2. If the GOOGLE_API_USE_CLIENT_CERTIFICATE environment variable
+                is "true", then the ``client_cert_source`` property can be used
+                to provide a client certificate for mTLS transport. If
+                not provided, the default SSL client certificate will be used if
+                present. If GOOGLE_API_USE_CLIENT_CERTIFICATE is "false" or not
+                set, no client certificate will be used.
+
+                3. The ``universe_domain`` property can be used to override the
+                default "googleapis.com" universe. Note that the ``api_endpoint``
+                property still takes precedence; and ``universe_domain`` is
+                currently not supported for mTLS.
+
+            client_info (google.api_core.gapic_v1.client_info.ClientInfo):
+                The client info used to send a user-agent string along with
+                API requests. If ``None``, then default info will be used.
+                Generally, you only need to set this if you're developing
+                your own client library.
+
+        Raises:
+            google.auth.exceptions.MutualTLSChannelError: If mutual TLS transport
+                creation failed for any reason.
+        """
+        self._client_options = client_options
+        if isinstance(self._client_options, dict):
+            self._client_options = client_options_lib.from_dict(self._client_options)
+        if self._client_options is None:
+            self._client_options = client_options_lib.ClientOptions()
+        self._client_options = cast(
+            client_options_lib.ClientOptions, self._client_options
+        )
+
+        universe_domain_opt = getattr(self._client_options, "universe_domain", None)
+
+        self._use_client_cert, self._use_mtls_endpoint, self._universe_domain_env = (
+            AuthProviderCredentialsServiceClient._read_environment_variables()
+        )
+        self._client_cert_source = (
+            AuthProviderCredentialsServiceClient._get_client_cert_source(
+                self._client_options.client_cert_source, self._use_client_cert
+            )
+        )
+        self._universe_domain = (
+            AuthProviderCredentialsServiceClient._get_universe_domain(
+                universe_domain_opt, self._universe_domain_env
+            )
+        )
+        self._api_endpoint: str = ""  # updated below, depending on `transport`
+
+        # Initialize the universe domain validation.
+        self._is_universe_domain_valid = False
+
+        if CLIENT_LOGGING_SUPPORTED:  # pragma: NO COVER
+            # Setup logging.
+            client_logging.initialize_logging()
+
+        api_key_value = getattr(self._client_options, "api_key", None)
+        if api_key_value and credentials:
+            raise ValueError(
+                "client_options.api_key and credentials are mutually exclusive"
+            )
+
+        # Save or instantiate the transport.
+        # Ordinarily, we provide the transport, but allowing a custom transport
+        # instance provides an extensibility point for unusual situations.
+        transport_provided = isinstance(
+            transport, AuthProviderCredentialsServiceTransport
+        )
+        if transport_provided:
+            # transport is a AuthProviderCredentialsServiceTransport instance.
+            if credentials or self._client_options.credentials_file or api_key_value:
+                raise ValueError(
+                    "When providing a transport instance, "
+                    "provide its credentials directly."
+                )
+            if self._client_options.scopes:
+                raise ValueError(
+                    "When providing a transport instance, provide its scopes directly."
+                )
+            self._transport = cast(AuthProviderCredentialsServiceTransport, transport)
+            self._api_endpoint = self._transport.host
+
+        self._api_endpoint = (
+            self._api_endpoint
+            or AuthProviderCredentialsServiceClient._get_api_endpoint(
+                self._client_options.api_endpoint,
+                self._client_cert_source,
+                self._universe_domain,
+                self._use_mtls_endpoint,
+            )
+        )
+
+        if not transport_provided:
+            import google.auth._default  # type: ignore
+
+            if api_key_value and hasattr(
+                google.auth._default, "get_api_key_credentials"
+            ):
+                credentials = google.auth._default.get_api_key_credentials(
+                    api_key_value
+                )
+
+            transport_init: Union[
+                Type[AuthProviderCredentialsServiceTransport],
+                Callable[..., AuthProviderCredentialsServiceTransport],
+            ] = (
+                AuthProviderCredentialsServiceClient.get_transport_class(transport)
+                if isinstance(transport, str) or transport is None
+                else cast(
+                    Callable[..., AuthProviderCredentialsServiceTransport], transport
+                )
+            )
+            # initialize with the provided callable or the passed in class
+            self._transport = transport_init(
+                credentials=credentials,
+                credentials_file=self._client_options.credentials_file,
+                host=self._api_endpoint,
+                scopes=self._client_options.scopes,
+                client_cert_source_for_mtls=self._client_cert_source,
+                quota_project_id=self._client_options.quota_project_id,
+                client_info=client_info,
+                always_use_jwt_access=True,
+                api_audience=self._client_options.api_audience,
+            )
+
+        if "async" not in str(self._transport):
+            if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(
+                std_logging.DEBUG
+            ):  # pragma: NO COVER
+                _LOGGER.debug(
+                    "Created client `google.cloud.agentidentitycredentials_v1beta.AuthProviderCredentialsServiceClient`.",
+                    extra={
+                        "serviceName": "google.cloud.agentidentitycredentials.v1beta.AuthProviderCredentialsService",
+                        "universeDomain": getattr(
+                            self._transport._credentials, "universe_domain", ""
+                        ),
+                        "credentialsType": f"{type(self._transport._credentials).__module__}.{type(self._transport._credentials).__qualname__}",
+                        "credentialsInfo": getattr(
+                            self.transport._credentials, "get_cred_info", lambda: None
+                        )(),
+                    }
+                    if hasattr(self._transport, "_credentials")
+                    else {
+                        "serviceName": "google.cloud.agentidentitycredentials.v1beta.AuthProviderCredentialsService",
+                        "credentialsType": None,
+                    },
+                )
+
+    def retrieve_credentials(
+        self,
+        request: Optional[
+            Union[auth_provider_credentials_service.RetrieveCredentialsRequest, dict]
+        ] = None,
+        *,
+        auth_provider: Optional[str] = None,
+        user_id: Optional[str] = None,
+        retry: OptionalRetry = gapic_v1.method.DEFAULT,
+        timeout: Union[float, object] = gapic_v1.method.DEFAULT,
+        metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
+    ) -> auth_provider_credentials_service.RetrieveCredentialsResponse:
+        r"""Retrieves authorization credentials for an authprovider, or
+        indicates what action needs to be taken to obtain credentials.
+        If the ``token`` field in the response is populated, credential
+        retrieval was successful. If one of the fields in the ``status``
+        oneof is populated, further action is required to obtain
+        credentials, such as redirecting the user for consent. View
+        comments on ``RetrieveCredentialsResponse`` for more
+        information.
+
+        .. code-block:: python
+
+            # This snippet has been automatically generated and should be regarded as a
+            # code template only.
+            # It will require modifications to work:
+            # - It may require correct/in-range values for request initialization.
+            # - It may require specifying regional endpoints when creating the service
+            #   client as shown in:
+            #   https://googleapis.dev/python/google-api-core/latest/client_options.html
+            from google.cloud import agentidentitycredentials_v1beta
+
+            def sample_retrieve_credentials():
+                # Create a client
+                client = agentidentitycredentials_v1beta.AuthProviderCredentialsServiceClient()
+
+                # Initialize request argument(s)
+                request = agentidentitycredentials_v1beta.RetrieveCredentialsRequest(
+                    auth_provider="auth_provider_value",
+                    user_id="user_id_value",
+                )
+
+                # Make the request
+                response = client.retrieve_credentials(request=request)
+
+                # Handle the response
+                print(response)
+
+        Args:
+            request (Union[google.cloud.agentidentitycredentials_v1beta.types.RetrieveCredentialsRequest, dict]):
+                The request object. Request message for
+                RetrieveCredentials.
+            auth_provider (str):
+                Required. The parent resource name of the AuthProvider.
+                Format:
+                ``projects/{project}/locations/{location}/authProviders/{auth_provider}``
+
+                This corresponds to the ``auth_provider`` field
+                on the ``request`` instance; if ``request`` is provided, this
+                should not be set.
+            user_id (str):
+                Required. The identity of the end
+                user.
+
+                This corresponds to the ``user_id`` field
+                on the ``request`` instance; if ``request`` is provided, this
+                should not be set.
+            retry (google.api_core.retry.Retry): Designation of what errors, if any,
+                should be retried.
+            timeout (float): The timeout for this request.
+            metadata (Sequence[Tuple[str, Union[str, bytes]]]): Key/value pairs which should be
+                sent along with the request as metadata. Normally, each value must be of type `str`,
+                but for metadata keys ending with the suffix `-bin`, the corresponding values must
+                be of type `bytes`.
+
+        Returns:
+            google.cloud.agentidentitycredentials_v1beta.types.RetrieveCredentialsResponse:
+                Response message for
+                RetrieveCredentials. Contains the access
+                tokens and related artifacts.
+
+        """
+        # Create or coerce a protobuf request object.
+        # - Quick check: If we got a request object, we should *not* have
+        #   gotten any keyword arguments that map to the request.
+        flattened_params = [auth_provider, user_id]
+        has_flattened_params = (
+            len([param for param in flattened_params if param is not None]) > 0
+        )
+        if request is not None and has_flattened_params:
+            raise ValueError(
+                "If the `request` argument is set, then none of "
+                "the individual field arguments should be set."
+            )
+
+        # - Use the request object if provided (there's no risk of modifying the input as
+        #   there are no flattened fields), or create one.
+        if not isinstance(
+            request, auth_provider_credentials_service.RetrieveCredentialsRequest
+        ):
+            request = auth_provider_credentials_service.RetrieveCredentialsRequest(
+                request
+            )
+            # If we have keyword arguments corresponding to fields on the
+            # request, apply these.
+            if auth_provider is not None:
+                request.auth_provider = auth_provider
+            if user_id is not None:
+                request.user_id = user_id
+
+        # Wrap the RPC method; this adds retry and timeout information,
+        # and friendly error handling.
+        rpc = self._transport._wrapped_methods[self._transport.retrieve_credentials]
+
+        # Certain fields should be provided within the metadata header;
+        # add these here.
+        metadata = tuple(metadata) + (
+            gapic_v1.routing_header.to_grpc_metadata(
+                (("auth_provider", request.auth_provider),)
+            ),
+        )
+
+        # Validate the universe domain.
+        self._validate_universe_domain()
+
+        # Send the request.
+        response = rpc(
+            request,
+            retry=retry,
+            timeout=timeout,
+            metadata=metadata,
+        )
+
+        # Done; return the response.
+        return response
+
+    def finalize_credentials(
+        self,
+        request: Optional[
+            Union[auth_provider_credentials_service.FinalizeCredentialsRequest, dict]
+        ] = None,
+        *,
+        retry: OptionalRetry = gapic_v1.method.DEFAULT,
+        timeout: Union[float, object] = gapic_v1.method.DEFAULT,
+        metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
+    ) -> auth_provider_credentials_service.FinalizeCredentialsResponse:
+        r"""Finalizes the credentials after a successful consent
+        flow.
+
+        .. code-block:: python
+
+            # This snippet has been automatically generated and should be regarded as a
+            # code template only.
+            # It will require modifications to work:
+            # - It may require correct/in-range values for request initialization.
+            # - It may require specifying regional endpoints when creating the service
+            #   client as shown in:
+            #   https://googleapis.dev/python/google-api-core/latest/client_options.html
+            from google.cloud import agentidentitycredentials_v1beta
+
+            def sample_finalize_credentials():
+                # Create a client
+                client = agentidentitycredentials_v1beta.AuthProviderCredentialsServiceClient()
+
+                # Initialize request argument(s)
+                request = agentidentitycredentials_v1beta.FinalizeCredentialsRequest(
+                    auth_provider="auth_provider_value",
+                    user_id="user_id_value",
+                    user_id_validation_state=b'user_id_validation_state_blob',
+                    consent_nonce="consent_nonce_value",
+                )
+
+                # Make the request
+                response = client.finalize_credentials(request=request)
+
+                # Handle the response
+                print(response)
+
+        Args:
+            request (Union[google.cloud.agentidentitycredentials_v1beta.types.FinalizeCredentialsRequest, dict]):
+                The request object. Request message for
+                FinalizeCredentials.
+            retry (google.api_core.retry.Retry): Designation of what errors, if any,
+                should be retried.
+            timeout (float): The timeout for this request.
+            metadata (Sequence[Tuple[str, Union[str, bytes]]]): Key/value pairs which should be
+                sent along with the request as metadata. Normally, each value must be of type `str`,
+                but for metadata keys ending with the suffix `-bin`, the corresponding values must
+                be of type `bytes`.
+
+        Returns:
+            google.cloud.agentidentitycredentials_v1beta.types.FinalizeCredentialsResponse:
+                Response message for
+                FinalizeCredentials. Intentionally empty
+
+        """
+        # Create or coerce a protobuf request object.
+        # - Use the request object if provided (there's no risk of modifying the input as
+        #   there are no flattened fields), or create one.
+        if not isinstance(
+            request, auth_provider_credentials_service.FinalizeCredentialsRequest
+        ):
+            request = auth_provider_credentials_service.FinalizeCredentialsRequest(
+                request
+            )
+
+        # Wrap the RPC method; this adds retry and timeout information,
+        # and friendly error handling.
+        rpc = self._transport._wrapped_methods[self._transport.finalize_credentials]
+
+        # Certain fields should be provided within the metadata header;
+        # add these here.
+        metadata = tuple(metadata) + (
+            gapic_v1.routing_header.to_grpc_metadata(
+                (("auth_provider", request.auth_provider),)
+            ),
+        )
+
+        # Validate the universe domain.
+        self._validate_universe_domain()
+
+        # Send the request.
+        response = rpc(
+            request,
+            retry=retry,
+            timeout=timeout,
+            metadata=metadata,
+        )
+
+        # Done; return the response.
+        return response
+
+    def __enter__(self) -> "AuthProviderCredentialsServiceClient":
+        return self
+
+    def __exit__(self, type, value, traceback):
+        """Releases underlying transport's resources.
+
+        .. warning::
+            ONLY use as a context manager if the transport is NOT shared
+            with other clients! Exiting the with block will CLOSE the transport
+            and may cause errors in other clients!
+        """
+        self.transport.close()
+
+
+DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
+    gapic_version=package_version.__version__
+)
+
+if hasattr(DEFAULT_CLIENT_INFO, "protobuf_runtime_version"):  # pragma: NO COVER
+    DEFAULT_CLIENT_INFO.protobuf_runtime_version = google.protobuf.__version__
+
+__all__ = ("AuthProviderCredentialsServiceClient",)

--- a/packages/google-cloud-agentidentitycredentials/google/cloud/agentidentitycredentials_v1beta/services/auth_provider_credentials_service/transports/README.rst
+++ b/packages/google-cloud-agentidentitycredentials/google/cloud/agentidentitycredentials_v1beta/services/auth_provider_credentials_service/transports/README.rst
@@ -1,0 +1,10 @@
+
+transport inheritance structure
+_______________________________
+
+``AuthProviderCredentialsServiceTransport`` is the ABC for all transports.
+
+- public child ``AuthProviderCredentialsServiceGrpcTransport`` for sync gRPC transport (defined in ``grpc.py``).
+- public child ``AuthProviderCredentialsServiceGrpcAsyncIOTransport`` for async gRPC transport (defined in ``grpc_asyncio.py``).
+- private child ``_BaseAuthProviderCredentialsServiceRestTransport`` for base REST transport with inner classes ``_BaseMETHOD`` (defined in ``rest_base.py``).
+- public child ``AuthProviderCredentialsServiceRestTransport`` for sync REST transport with inner classes ``METHOD`` derived from the parent's corresponding ``_BaseMETHOD`` classes (defined in ``rest.py``).

--- a/packages/google-cloud-agentidentitycredentials/google/cloud/agentidentitycredentials_v1beta/services/auth_provider_credentials_service/transports/__init__.py
+++ b/packages/google-cloud-agentidentitycredentials/google/cloud/agentidentitycredentials_v1beta/services/auth_provider_credentials_service/transports/__init__.py
@@ -1,0 +1,39 @@
+# -*- coding: utf-8 -*-
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+from collections import OrderedDict
+from typing import Dict, Type
+
+from .base import AuthProviderCredentialsServiceTransport
+from .grpc import AuthProviderCredentialsServiceGrpcTransport
+from .grpc_asyncio import AuthProviderCredentialsServiceGrpcAsyncIOTransport
+from .rest import (
+    AuthProviderCredentialsServiceRestInterceptor,
+    AuthProviderCredentialsServiceRestTransport,
+)
+
+# Compile a registry of transports.
+_transport_registry = OrderedDict()  # type: Dict[str, Type[AuthProviderCredentialsServiceTransport]]
+_transport_registry["grpc"] = AuthProviderCredentialsServiceGrpcTransport
+_transport_registry["grpc_asyncio"] = AuthProviderCredentialsServiceGrpcAsyncIOTransport
+_transport_registry["rest"] = AuthProviderCredentialsServiceRestTransport
+
+__all__ = (
+    "AuthProviderCredentialsServiceTransport",
+    "AuthProviderCredentialsServiceGrpcTransport",
+    "AuthProviderCredentialsServiceGrpcAsyncIOTransport",
+    "AuthProviderCredentialsServiceRestTransport",
+    "AuthProviderCredentialsServiceRestInterceptor",
+)

--- a/packages/google-cloud-agentidentitycredentials/google/cloud/agentidentitycredentials_v1beta/services/auth_provider_credentials_service/transports/base.py
+++ b/packages/google-cloud-agentidentitycredentials/google/cloud/agentidentitycredentials_v1beta/services/auth_provider_credentials_service/transports/base.py
@@ -1,0 +1,199 @@
+# -*- coding: utf-8 -*-
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+import abc
+from typing import Awaitable, Callable, Dict, Optional, Sequence, Union
+
+import google.api_core
+import google.auth  # type: ignore
+import google.protobuf
+from google.api_core import exceptions as core_exceptions
+from google.api_core import gapic_v1
+from google.api_core import retry as retries
+from google.auth import credentials as ga_credentials  # type: ignore
+from google.oauth2 import service_account  # type: ignore
+
+from google.cloud.agentidentitycredentials_v1beta import (
+    gapic_version as package_version,
+)
+from google.cloud.agentidentitycredentials_v1beta.types import (
+    auth_provider_credentials_service,
+)
+
+DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
+    gapic_version=package_version.__version__
+)
+
+if hasattr(DEFAULT_CLIENT_INFO, "protobuf_runtime_version"):  # pragma: NO COVER
+    DEFAULT_CLIENT_INFO.protobuf_runtime_version = google.protobuf.__version__
+
+
+class AuthProviderCredentialsServiceTransport(abc.ABC):
+    """Abstract transport class for AuthProviderCredentialsService."""
+
+    AUTH_SCOPES = ("https://www.googleapis.com/auth/cloud-platform",)
+
+    DEFAULT_HOST: str = "agentidentitycredentials.googleapis.com"
+
+    def __init__(
+        self,
+        *,
+        host: str = DEFAULT_HOST,
+        credentials: Optional[ga_credentials.Credentials] = None,
+        credentials_file: Optional[str] = None,
+        scopes: Optional[Sequence[str]] = None,
+        quota_project_id: Optional[str] = None,
+        client_info: gapic_v1.client_info.ClientInfo = DEFAULT_CLIENT_INFO,
+        always_use_jwt_access: Optional[bool] = False,
+        api_audience: Optional[str] = None,
+        **kwargs,
+    ) -> None:
+        """Instantiate the transport.
+
+        Args:
+            host (Optional[str]):
+                 The hostname to connect to (default: 'agentidentitycredentials.googleapis.com').
+            credentials (Optional[google.auth.credentials.Credentials]): The
+                authorization credentials to attach to requests. These
+                credentials identify the application to the service; if none
+                are specified, the client will attempt to ascertain the
+                credentials from the environment.
+            credentials_file (Optional[str]): Deprecated. A file with credentials that can
+                be loaded with :func:`google.auth.load_credentials_from_file`.
+                This argument is mutually exclusive with credentials. This argument will be
+                removed in the next major version of this library.
+            scopes (Optional[Sequence[str]]): A list of scopes.
+            quota_project_id (Optional[str]): An optional project to use for billing
+                and quota.
+            client_info (google.api_core.gapic_v1.client_info.ClientInfo):
+                The client info used to send a user-agent string along with
+                API requests. If ``None``, then default info will be used.
+                Generally, you only need to set this if you're developing
+                your own client library.
+            always_use_jwt_access (Optional[bool]): Whether self signed JWT should
+                be used for service account credentials.
+            api_audience (Optional[str]): The intended audience for the API calls
+                to the service that will be set when using certain 3rd party
+                authentication flows. Audience is typically a resource identifier.
+                If not set, the host value will be used as a default.
+        """
+
+        # Save the scopes.
+        self._scopes = scopes
+        if not hasattr(self, "_ignore_credentials"):
+            self._ignore_credentials: bool = False
+
+        # If no credentials are provided, then determine the appropriate
+        # defaults.
+        if credentials and credentials_file:
+            raise core_exceptions.DuplicateCredentialArgs(
+                "'credentials_file' and 'credentials' are mutually exclusive"
+            )
+
+        if credentials_file is not None:
+            credentials, _ = google.auth.load_credentials_from_file(
+                credentials_file,
+                scopes=scopes,
+                quota_project_id=quota_project_id,
+                default_scopes=self.AUTH_SCOPES,
+            )
+        elif credentials is None and not self._ignore_credentials:
+            credentials, _ = google.auth.default(
+                scopes=scopes,
+                quota_project_id=quota_project_id,
+                default_scopes=self.AUTH_SCOPES,
+            )
+            # Don't apply audience if the credentials file passed from user.
+            if hasattr(credentials, "with_gdch_audience"):
+                credentials = credentials.with_gdch_audience(
+                    api_audience if api_audience else host
+                )
+
+        # If the credentials are service account credentials, then always try to use self signed JWT.
+        if (
+            always_use_jwt_access
+            and isinstance(credentials, service_account.Credentials)
+            and hasattr(service_account.Credentials, "with_always_use_jwt_access")
+        ):
+            credentials = credentials.with_always_use_jwt_access(True)
+
+        # Save the credentials.
+        self._credentials = credentials
+
+        # Save the hostname. Default to port 443 (HTTPS) if none is specified.
+        if ":" not in host:
+            host += ":443"
+        self._host = host
+
+        self._wrapped_methods: Dict[Callable, Callable] = {}
+
+    @property
+    def host(self):
+        return self._host
+
+    def _prep_wrapped_messages(self, client_info):
+        # Precompute the wrapped methods.
+        self._wrapped_methods = {
+            self.retrieve_credentials: gapic_v1.method.wrap_method(
+                self.retrieve_credentials,
+                default_timeout=None,
+                client_info=client_info,
+            ),
+            self.finalize_credentials: gapic_v1.method.wrap_method(
+                self.finalize_credentials,
+                default_timeout=None,
+                client_info=client_info,
+            ),
+        }
+
+    def close(self):
+        """Closes resources associated with the transport.
+
+        .. warning::
+             Only call this method if the transport is NOT shared
+             with other clients - this may cause errors in other clients!
+        """
+        raise NotImplementedError()
+
+    @property
+    def retrieve_credentials(
+        self,
+    ) -> Callable[
+        [auth_provider_credentials_service.RetrieveCredentialsRequest],
+        Union[
+            auth_provider_credentials_service.RetrieveCredentialsResponse,
+            Awaitable[auth_provider_credentials_service.RetrieveCredentialsResponse],
+        ],
+    ]:
+        raise NotImplementedError()
+
+    @property
+    def finalize_credentials(
+        self,
+    ) -> Callable[
+        [auth_provider_credentials_service.FinalizeCredentialsRequest],
+        Union[
+            auth_provider_credentials_service.FinalizeCredentialsResponse,
+            Awaitable[auth_provider_credentials_service.FinalizeCredentialsResponse],
+        ],
+    ]:
+        raise NotImplementedError()
+
+    @property
+    def kind(self) -> str:
+        raise NotImplementedError()
+
+
+__all__ = ("AuthProviderCredentialsServiceTransport",)

--- a/packages/google-cloud-agentidentitycredentials/google/cloud/agentidentitycredentials_v1beta/services/auth_provider_credentials_service/transports/grpc.py
+++ b/packages/google-cloud-agentidentitycredentials/google/cloud/agentidentitycredentials_v1beta/services/auth_provider_credentials_service/transports/grpc.py
@@ -1,0 +1,406 @@
+# -*- coding: utf-8 -*-
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+import json
+import logging as std_logging
+import pickle
+import warnings
+from typing import Callable, Dict, Optional, Sequence, Tuple, Union
+
+import google.auth  # type: ignore
+import google.protobuf.message
+import grpc  # type: ignore
+import proto  # type: ignore
+from google.api_core import gapic_v1, grpc_helpers
+from google.auth import credentials as ga_credentials  # type: ignore
+from google.auth.transport.grpc import SslCredentials  # type: ignore
+from google.protobuf.json_format import MessageToJson
+
+from google.cloud.agentidentitycredentials_v1beta.types import (
+    auth_provider_credentials_service,
+)
+
+from .base import DEFAULT_CLIENT_INFO, AuthProviderCredentialsServiceTransport
+
+try:
+    from google.api_core import client_logging  # type: ignore
+
+    CLIENT_LOGGING_SUPPORTED = True  # pragma: NO COVER
+except ImportError:  # pragma: NO COVER
+    CLIENT_LOGGING_SUPPORTED = False
+
+_LOGGER = std_logging.getLogger(__name__)
+
+
+class _LoggingClientInterceptor(grpc.UnaryUnaryClientInterceptor):  # pragma: NO COVER
+    def intercept_unary_unary(self, continuation, client_call_details, request):
+        logging_enabled = CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(
+            std_logging.DEBUG
+        )
+        if logging_enabled:  # pragma: NO COVER
+            request_metadata = client_call_details.metadata
+            if isinstance(request, proto.Message):
+                request_payload = type(request).to_json(request)
+            elif isinstance(request, google.protobuf.message.Message):
+                request_payload = MessageToJson(request)
+            else:
+                request_payload = f"{type(request).__name__}: {pickle.dumps(request)!r}"
+
+            request_metadata = {
+                key: value.decode("utf-8") if isinstance(value, bytes) else value
+                for key, value in request_metadata
+            }
+            grpc_request = {
+                "payload": request_payload,
+                "requestMethod": "grpc",
+                "metadata": dict(request_metadata),
+            }
+            _LOGGER.debug(
+                f"Sending request for {client_call_details.method}",
+                extra={
+                    "serviceName": "google.cloud.agentidentitycredentials.v1beta.AuthProviderCredentialsService",
+                    "rpcName": str(client_call_details.method),
+                    "request": grpc_request,
+                    "metadata": grpc_request["metadata"],
+                },
+            )
+        response = continuation(client_call_details, request)
+        if logging_enabled:  # pragma: NO COVER
+            response_metadata = response.trailing_metadata()
+            # Convert gRPC metadata `<class 'grpc.aio._metadata.Metadata'>` to list of tuples
+            metadata = (
+                dict([(k, str(v)) for k, v in response_metadata])
+                if response_metadata
+                else None
+            )
+            result = response.result()
+            if isinstance(result, proto.Message):
+                response_payload = type(result).to_json(result)
+            elif isinstance(result, google.protobuf.message.Message):
+                response_payload = MessageToJson(result)
+            else:
+                response_payload = f"{type(result).__name__}: {pickle.dumps(result)!r}"
+            grpc_response = {
+                "payload": response_payload,
+                "metadata": metadata,
+                "status": "OK",
+            }
+            _LOGGER.debug(
+                f"Received response for {client_call_details.method}.",
+                extra={
+                    "serviceName": "google.cloud.agentidentitycredentials.v1beta.AuthProviderCredentialsService",
+                    "rpcName": client_call_details.method,
+                    "response": grpc_response,
+                    "metadata": grpc_response["metadata"],
+                },
+            )
+        return response
+
+
+class AuthProviderCredentialsServiceGrpcTransport(
+    AuthProviderCredentialsServiceTransport
+):
+    """gRPC backend transport for AuthProviderCredentialsService.
+
+    Service for managing AuthProvider Credentials.
+
+    This class defines the same methods as the primary client, so the
+    primary client can load the underlying transport implementation
+    and call it.
+
+    It sends protocol buffers over the wire using gRPC (which is built on
+    top of HTTP/2); the ``grpcio`` package must be installed.
+    """
+
+    _stubs: Dict[str, Callable]
+
+    def __init__(
+        self,
+        *,
+        host: str = "agentidentitycredentials.googleapis.com",
+        credentials: Optional[ga_credentials.Credentials] = None,
+        credentials_file: Optional[str] = None,
+        scopes: Optional[Sequence[str]] = None,
+        channel: Optional[Union[grpc.Channel, Callable[..., grpc.Channel]]] = None,
+        api_mtls_endpoint: Optional[str] = None,
+        client_cert_source: Optional[Callable[[], Tuple[bytes, bytes]]] = None,
+        ssl_channel_credentials: Optional[grpc.ChannelCredentials] = None,
+        client_cert_source_for_mtls: Optional[Callable[[], Tuple[bytes, bytes]]] = None,
+        quota_project_id: Optional[str] = None,
+        client_info: gapic_v1.client_info.ClientInfo = DEFAULT_CLIENT_INFO,
+        always_use_jwt_access: Optional[bool] = False,
+        api_audience: Optional[str] = None,
+    ) -> None:
+        """Instantiate the transport.
+
+        Args:
+            host (Optional[str]):
+                 The hostname to connect to (default: 'agentidentitycredentials.googleapis.com').
+            credentials (Optional[google.auth.credentials.Credentials]): The
+                authorization credentials to attach to requests. These
+                credentials identify the application to the service; if none
+                are specified, the client will attempt to ascertain the
+                credentials from the environment.
+                This argument is ignored if a ``channel`` instance is provided.
+            credentials_file (Optional[str]): Deprecated. A file with credentials that can
+                be loaded with :func:`google.auth.load_credentials_from_file`.
+                This argument is ignored if a ``channel`` instance is provided.
+                This argument will be removed in the next major version of this library.
+            scopes (Optional(Sequence[str])): A list of scopes. This argument is
+                ignored if a ``channel`` instance is provided.
+            channel (Optional[Union[grpc.Channel, Callable[..., grpc.Channel]]]):
+                A ``Channel`` instance through which to make calls, or a Callable
+                that constructs and returns one. If set to None, ``self.create_channel``
+                is used to create the channel. If a Callable is given, it will be called
+                with the same arguments as used in ``self.create_channel``.
+            api_mtls_endpoint (Optional[str]): Deprecated. The mutual TLS endpoint.
+                If provided, it overrides the ``host`` argument and tries to create
+                a mutual TLS channel with client SSL credentials from
+                ``client_cert_source`` or application default SSL credentials.
+            client_cert_source (Optional[Callable[[], Tuple[bytes, bytes]]]):
+                Deprecated. A callback to provide client SSL certificate bytes and
+                private key bytes, both in PEM format. It is ignored if
+                ``api_mtls_endpoint`` is None.
+            ssl_channel_credentials (grpc.ChannelCredentials): SSL credentials
+                for the grpc channel. It is ignored if a ``channel`` instance is provided.
+            client_cert_source_for_mtls (Optional[Callable[[], Tuple[bytes, bytes]]]):
+                A callback to provide client certificate bytes and private key bytes,
+                both in PEM format. It is used to configure a mutual TLS channel. It is
+                ignored if a ``channel`` instance or ``ssl_channel_credentials`` is provided.
+            quota_project_id (Optional[str]): An optional project to use for billing
+                and quota.
+            client_info (google.api_core.gapic_v1.client_info.ClientInfo):
+                The client info used to send a user-agent string along with
+                API requests. If ``None``, then default info will be used.
+                Generally, you only need to set this if you're developing
+                your own client library.
+            always_use_jwt_access (Optional[bool]): Whether self signed JWT should
+                be used for service account credentials.
+            api_audience (Optional[str]): The intended audience for the API calls
+                to the service that will be set when using certain 3rd party
+                authentication flows. Audience is typically a resource identifier.
+                If not set, the host value will be used as a default.
+
+        Raises:
+          google.auth.exceptions.MutualTLSChannelError: If mutual TLS transport
+              creation failed for any reason.
+          google.api_core.exceptions.DuplicateCredentialArgs: If both ``credentials``
+              and ``credentials_file`` are passed.
+        """
+        self._grpc_channel = None
+        self._ssl_channel_credentials = ssl_channel_credentials
+        self._stubs: Dict[str, Callable] = {}
+
+        if api_mtls_endpoint:
+            warnings.warn("api_mtls_endpoint is deprecated", DeprecationWarning)
+        if client_cert_source:
+            warnings.warn("client_cert_source is deprecated", DeprecationWarning)
+
+        if isinstance(channel, grpc.Channel):
+            # Ignore credentials if a channel was passed.
+            credentials = None
+            self._ignore_credentials = True
+            # If a channel was explicitly provided, set it.
+            self._grpc_channel = channel
+            self._ssl_channel_credentials = None
+
+        else:
+            if api_mtls_endpoint:
+                host = api_mtls_endpoint
+
+                # Create SSL credentials with client_cert_source or application
+                # default SSL credentials.
+                if client_cert_source:
+                    cert, key = client_cert_source()
+                    self._ssl_channel_credentials = grpc.ssl_channel_credentials(
+                        certificate_chain=cert, private_key=key
+                    )
+                else:
+                    self._ssl_channel_credentials = SslCredentials().ssl_credentials
+
+            else:
+                if client_cert_source_for_mtls and not ssl_channel_credentials:
+                    cert, key = client_cert_source_for_mtls()
+                    self._ssl_channel_credentials = grpc.ssl_channel_credentials(
+                        certificate_chain=cert, private_key=key
+                    )
+
+        # The base transport sets the host, credentials and scopes
+        super().__init__(
+            host=host,
+            credentials=credentials,
+            credentials_file=credentials_file,
+            scopes=scopes,
+            quota_project_id=quota_project_id,
+            client_info=client_info,
+            always_use_jwt_access=always_use_jwt_access,
+            api_audience=api_audience,
+        )
+
+        if not self._grpc_channel:
+            # initialize with the provided callable or the default channel
+            channel_init = channel or type(self).create_channel
+            self._grpc_channel = channel_init(
+                self._host,
+                # use the credentials which are saved
+                credentials=self._credentials,
+                # Set ``credentials_file`` to ``None`` here as
+                # the credentials that we saved earlier should be used.
+                credentials_file=None,
+                scopes=self._scopes,
+                ssl_credentials=self._ssl_channel_credentials,
+                quota_project_id=quota_project_id,
+                options=[
+                    ("grpc.max_send_message_length", -1),
+                    ("grpc.max_receive_message_length", -1),
+                ],
+            )
+
+        self._interceptor = _LoggingClientInterceptor()
+        self._logged_channel = grpc.intercept_channel(
+            self._grpc_channel, self._interceptor
+        )
+
+        # Wrap messages. This must be done after self._logged_channel exists
+        self._prep_wrapped_messages(client_info)
+
+    @classmethod
+    def create_channel(
+        cls,
+        host: str = "agentidentitycredentials.googleapis.com",
+        credentials: Optional[ga_credentials.Credentials] = None,
+        credentials_file: Optional[str] = None,
+        scopes: Optional[Sequence[str]] = None,
+        quota_project_id: Optional[str] = None,
+        **kwargs,
+    ) -> grpc.Channel:
+        """Create and return a gRPC channel object.
+        Args:
+            host (Optional[str]): The host for the channel to use.
+            credentials (Optional[~.Credentials]): The
+                authorization credentials to attach to requests. These
+                credentials identify this application to the service. If
+                none are specified, the client will attempt to ascertain
+                the credentials from the environment.
+            credentials_file (Optional[str]): Deprecated. A file with credentials that can
+                be loaded with :func:`google.auth.load_credentials_from_file`.
+                This argument is mutually exclusive with credentials.  This argument will be
+                removed in the next major version of this library.
+            scopes (Optional[Sequence[str]]): A optional list of scopes needed for this
+                service. These are only used when credentials are not specified and
+                are passed to :func:`google.auth.default`.
+            quota_project_id (Optional[str]): An optional project to use for billing
+                and quota.
+            kwargs (Optional[dict]): Keyword arguments, which are passed to the
+                channel creation.
+        Returns:
+            grpc.Channel: A gRPC channel object.
+
+        Raises:
+            google.api_core.exceptions.DuplicateCredentialArgs: If both ``credentials``
+              and ``credentials_file`` are passed.
+        """
+
+        return grpc_helpers.create_channel(
+            host,
+            credentials=credentials,
+            credentials_file=credentials_file,
+            quota_project_id=quota_project_id,
+            default_scopes=cls.AUTH_SCOPES,
+            scopes=scopes,
+            default_host=cls.DEFAULT_HOST,
+            **kwargs,
+        )
+
+    @property
+    def grpc_channel(self) -> grpc.Channel:
+        """Return the channel designed to connect to this service."""
+        return self._grpc_channel
+
+    @property
+    def retrieve_credentials(
+        self,
+    ) -> Callable[
+        [auth_provider_credentials_service.RetrieveCredentialsRequest],
+        auth_provider_credentials_service.RetrieveCredentialsResponse,
+    ]:
+        r"""Return a callable for the retrieve credentials method over gRPC.
+
+        Retrieves authorization credentials for an authprovider, or
+        indicates what action needs to be taken to obtain credentials.
+        If the ``token`` field in the response is populated, credential
+        retrieval was successful. If one of the fields in the ``status``
+        oneof is populated, further action is required to obtain
+        credentials, such as redirecting the user for consent. View
+        comments on ``RetrieveCredentialsResponse`` for more
+        information.
+
+        Returns:
+            Callable[[~.RetrieveCredentialsRequest],
+                    ~.RetrieveCredentialsResponse]:
+                A function that, when called, will call the underlying RPC
+                on the server.
+        """
+        # Generate a "stub function" on-the-fly which will actually make
+        # the request.
+        # gRPC handles serialization and deserialization, so we just need
+        # to pass in the functions for each.
+        if "retrieve_credentials" not in self._stubs:
+            self._stubs["retrieve_credentials"] = self._logged_channel.unary_unary(
+                "/google.cloud.agentidentitycredentials.v1beta.AuthProviderCredentialsService/RetrieveCredentials",
+                request_serializer=auth_provider_credentials_service.RetrieveCredentialsRequest.serialize,
+                response_deserializer=auth_provider_credentials_service.RetrieveCredentialsResponse.deserialize,
+            )
+        return self._stubs["retrieve_credentials"]
+
+    @property
+    def finalize_credentials(
+        self,
+    ) -> Callable[
+        [auth_provider_credentials_service.FinalizeCredentialsRequest],
+        auth_provider_credentials_service.FinalizeCredentialsResponse,
+    ]:
+        r"""Return a callable for the finalize credentials method over gRPC.
+
+        Finalizes the credentials after a successful consent
+        flow.
+
+        Returns:
+            Callable[[~.FinalizeCredentialsRequest],
+                    ~.FinalizeCredentialsResponse]:
+                A function that, when called, will call the underlying RPC
+                on the server.
+        """
+        # Generate a "stub function" on-the-fly which will actually make
+        # the request.
+        # gRPC handles serialization and deserialization, so we just need
+        # to pass in the functions for each.
+        if "finalize_credentials" not in self._stubs:
+            self._stubs["finalize_credentials"] = self._logged_channel.unary_unary(
+                "/google.cloud.agentidentitycredentials.v1beta.AuthProviderCredentialsService/FinalizeCredentials",
+                request_serializer=auth_provider_credentials_service.FinalizeCredentialsRequest.serialize,
+                response_deserializer=auth_provider_credentials_service.FinalizeCredentialsResponse.deserialize,
+            )
+        return self._stubs["finalize_credentials"]
+
+    def close(self):
+        self._logged_channel.close()
+
+    @property
+    def kind(self) -> str:
+        return "grpc"
+
+
+__all__ = ("AuthProviderCredentialsServiceGrpcTransport",)

--- a/packages/google-cloud-agentidentitycredentials/google/cloud/agentidentitycredentials_v1beta/services/auth_provider_credentials_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-agentidentitycredentials/google/cloud/agentidentitycredentials_v1beta/services/auth_provider_credentials_service/transports/grpc_asyncio.py
@@ -1,0 +1,434 @@
+# -*- coding: utf-8 -*-
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+import inspect
+import json
+import logging as std_logging
+import pickle
+import warnings
+from typing import Awaitable, Callable, Dict, Optional, Sequence, Tuple, Union
+
+import google.protobuf.message
+import grpc  # type: ignore
+import proto  # type: ignore
+from google.api_core import exceptions as core_exceptions
+from google.api_core import gapic_v1, grpc_helpers_async
+from google.api_core import retry_async as retries
+from google.auth import credentials as ga_credentials  # type: ignore
+from google.auth.transport.grpc import SslCredentials  # type: ignore
+from google.protobuf.json_format import MessageToJson
+from grpc.experimental import aio  # type: ignore
+
+from google.cloud.agentidentitycredentials_v1beta.types import (
+    auth_provider_credentials_service,
+)
+
+from .base import DEFAULT_CLIENT_INFO, AuthProviderCredentialsServiceTransport
+from .grpc import AuthProviderCredentialsServiceGrpcTransport
+
+try:
+    from google.api_core import client_logging  # type: ignore
+
+    CLIENT_LOGGING_SUPPORTED = True  # pragma: NO COVER
+except ImportError:  # pragma: NO COVER
+    CLIENT_LOGGING_SUPPORTED = False
+
+_LOGGER = std_logging.getLogger(__name__)
+
+
+class _LoggingClientAIOInterceptor(
+    grpc.aio.UnaryUnaryClientInterceptor
+):  # pragma: NO COVER
+    async def intercept_unary_unary(self, continuation, client_call_details, request):
+        logging_enabled = CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(
+            std_logging.DEBUG
+        )
+        if logging_enabled:  # pragma: NO COVER
+            request_metadata = client_call_details.metadata
+            if isinstance(request, proto.Message):
+                request_payload = type(request).to_json(request)
+            elif isinstance(request, google.protobuf.message.Message):
+                request_payload = MessageToJson(request)
+            else:
+                request_payload = f"{type(request).__name__}: {pickle.dumps(request)!r}"
+
+            request_metadata = {
+                key: value.decode("utf-8") if isinstance(value, bytes) else value
+                for key, value in request_metadata
+            }
+            grpc_request = {
+                "payload": request_payload,
+                "requestMethod": "grpc",
+                "metadata": dict(request_metadata),
+            }
+            _LOGGER.debug(
+                f"Sending request for {client_call_details.method}",
+                extra={
+                    "serviceName": "google.cloud.agentidentitycredentials.v1beta.AuthProviderCredentialsService",
+                    "rpcName": str(client_call_details.method),
+                    "request": grpc_request,
+                    "metadata": grpc_request["metadata"],
+                },
+            )
+        response = await continuation(client_call_details, request)
+        if logging_enabled:  # pragma: NO COVER
+            response_metadata = await response.trailing_metadata()
+            # Convert gRPC metadata `<class 'grpc.aio._metadata.Metadata'>` to list of tuples
+            metadata = (
+                dict([(k, str(v)) for k, v in response_metadata])
+                if response_metadata
+                else None
+            )
+            result = await response
+            if isinstance(result, proto.Message):
+                response_payload = type(result).to_json(result)
+            elif isinstance(result, google.protobuf.message.Message):
+                response_payload = MessageToJson(result)
+            else:
+                response_payload = f"{type(result).__name__}: {pickle.dumps(result)!r}"
+            grpc_response = {
+                "payload": response_payload,
+                "metadata": metadata,
+                "status": "OK",
+            }
+            _LOGGER.debug(
+                f"Received response to rpc {client_call_details.method}.",
+                extra={
+                    "serviceName": "google.cloud.agentidentitycredentials.v1beta.AuthProviderCredentialsService",
+                    "rpcName": str(client_call_details.method),
+                    "response": grpc_response,
+                    "metadata": grpc_response["metadata"],
+                },
+            )
+        return response
+
+
+class AuthProviderCredentialsServiceGrpcAsyncIOTransport(
+    AuthProviderCredentialsServiceTransport
+):
+    """gRPC AsyncIO backend transport for AuthProviderCredentialsService.
+
+    Service for managing AuthProvider Credentials.
+
+    This class defines the same methods as the primary client, so the
+    primary client can load the underlying transport implementation
+    and call it.
+
+    It sends protocol buffers over the wire using gRPC (which is built on
+    top of HTTP/2); the ``grpcio`` package must be installed.
+    """
+
+    _grpc_channel: aio.Channel
+    _stubs: Dict[str, Callable] = {}
+
+    @classmethod
+    def create_channel(
+        cls,
+        host: str = "agentidentitycredentials.googleapis.com",
+        credentials: Optional[ga_credentials.Credentials] = None,
+        credentials_file: Optional[str] = None,
+        scopes: Optional[Sequence[str]] = None,
+        quota_project_id: Optional[str] = None,
+        **kwargs,
+    ) -> aio.Channel:
+        """Create and return a gRPC AsyncIO channel object.
+        Args:
+            host (Optional[str]): The host for the channel to use.
+            credentials (Optional[~.Credentials]): The
+                authorization credentials to attach to requests. These
+                credentials identify this application to the service. If
+                none are specified, the client will attempt to ascertain
+                the credentials from the environment.
+            credentials_file (Optional[str]): Deprecated. A file with credentials that can
+                be loaded with :func:`google.auth.load_credentials_from_file`. This argument will be
+                removed in the next major version of this library.
+            scopes (Optional[Sequence[str]]): A optional list of scopes needed for this
+                service. These are only used when credentials are not specified and
+                are passed to :func:`google.auth.default`.
+            quota_project_id (Optional[str]): An optional project to use for billing
+                and quota.
+            kwargs (Optional[dict]): Keyword arguments, which are passed to the
+                channel creation.
+        Returns:
+            aio.Channel: A gRPC AsyncIO channel object.
+        """
+
+        return grpc_helpers_async.create_channel(
+            host,
+            credentials=credentials,
+            credentials_file=credentials_file,
+            quota_project_id=quota_project_id,
+            default_scopes=cls.AUTH_SCOPES,
+            scopes=scopes,
+            default_host=cls.DEFAULT_HOST,
+            **kwargs,
+        )
+
+    def __init__(
+        self,
+        *,
+        host: str = "agentidentitycredentials.googleapis.com",
+        credentials: Optional[ga_credentials.Credentials] = None,
+        credentials_file: Optional[str] = None,
+        scopes: Optional[Sequence[str]] = None,
+        channel: Optional[Union[aio.Channel, Callable[..., aio.Channel]]] = None,
+        api_mtls_endpoint: Optional[str] = None,
+        client_cert_source: Optional[Callable[[], Tuple[bytes, bytes]]] = None,
+        ssl_channel_credentials: Optional[grpc.ChannelCredentials] = None,
+        client_cert_source_for_mtls: Optional[Callable[[], Tuple[bytes, bytes]]] = None,
+        quota_project_id: Optional[str] = None,
+        client_info: gapic_v1.client_info.ClientInfo = DEFAULT_CLIENT_INFO,
+        always_use_jwt_access: Optional[bool] = False,
+        api_audience: Optional[str] = None,
+    ) -> None:
+        """Instantiate the transport.
+
+        Args:
+            host (Optional[str]):
+                 The hostname to connect to (default: 'agentidentitycredentials.googleapis.com').
+            credentials (Optional[google.auth.credentials.Credentials]): The
+                authorization credentials to attach to requests. These
+                credentials identify the application to the service; if none
+                are specified, the client will attempt to ascertain the
+                credentials from the environment.
+                This argument is ignored if a ``channel`` instance is provided.
+            credentials_file (Optional[str]): Deprecated. A file with credentials that can
+                be loaded with :func:`google.auth.load_credentials_from_file`.
+                This argument is ignored if a ``channel`` instance is provided.
+                This argument will be removed in the next major version of this library.
+            scopes (Optional[Sequence[str]]): A optional list of scopes needed for this
+                service. These are only used when credentials are not specified and
+                are passed to :func:`google.auth.default`.
+            channel (Optional[Union[aio.Channel, Callable[..., aio.Channel]]]):
+                A ``Channel`` instance through which to make calls, or a Callable
+                that constructs and returns one. If set to None, ``self.create_channel``
+                is used to create the channel. If a Callable is given, it will be called
+                with the same arguments as used in ``self.create_channel``.
+            api_mtls_endpoint (Optional[str]): Deprecated. The mutual TLS endpoint.
+                If provided, it overrides the ``host`` argument and tries to create
+                a mutual TLS channel with client SSL credentials from
+                ``client_cert_source`` or application default SSL credentials.
+            client_cert_source (Optional[Callable[[], Tuple[bytes, bytes]]]):
+                Deprecated. A callback to provide client SSL certificate bytes and
+                private key bytes, both in PEM format. It is ignored if
+                ``api_mtls_endpoint`` is None.
+            ssl_channel_credentials (grpc.ChannelCredentials): SSL credentials
+                for the grpc channel. It is ignored if a ``channel`` instance is provided.
+            client_cert_source_for_mtls (Optional[Callable[[], Tuple[bytes, bytes]]]):
+                A callback to provide client certificate bytes and private key bytes,
+                both in PEM format. It is used to configure a mutual TLS channel. It is
+                ignored if a ``channel`` instance or ``ssl_channel_credentials`` is provided.
+            quota_project_id (Optional[str]): An optional project to use for billing
+                and quota.
+            client_info (google.api_core.gapic_v1.client_info.ClientInfo):
+                The client info used to send a user-agent string along with
+                API requests. If ``None``, then default info will be used.
+                Generally, you only need to set this if you're developing
+                your own client library.
+            always_use_jwt_access (Optional[bool]): Whether self signed JWT should
+                be used for service account credentials.
+            api_audience (Optional[str]): The intended audience for the API calls
+                to the service that will be set when using certain 3rd party
+                authentication flows. Audience is typically a resource identifier.
+                If not set, the host value will be used as a default.
+
+        Raises:
+            google.auth.exceptions.MutualTlsChannelError: If mutual TLS transport
+              creation failed for any reason.
+          google.api_core.exceptions.DuplicateCredentialArgs: If both ``credentials``
+              and ``credentials_file`` are passed.
+        """
+        self._grpc_channel = None
+        self._ssl_channel_credentials = ssl_channel_credentials
+        self._stubs: Dict[str, Callable] = {}
+
+        if api_mtls_endpoint:
+            warnings.warn("api_mtls_endpoint is deprecated", DeprecationWarning)
+        if client_cert_source:
+            warnings.warn("client_cert_source is deprecated", DeprecationWarning)
+
+        if isinstance(channel, aio.Channel):
+            # Ignore credentials if a channel was passed.
+            credentials = None
+            self._ignore_credentials = True
+            # If a channel was explicitly provided, set it.
+            self._grpc_channel = channel
+            self._ssl_channel_credentials = None
+        else:
+            if api_mtls_endpoint:
+                host = api_mtls_endpoint
+
+                # Create SSL credentials with client_cert_source or application
+                # default SSL credentials.
+                if client_cert_source:
+                    cert, key = client_cert_source()
+                    self._ssl_channel_credentials = grpc.ssl_channel_credentials(
+                        certificate_chain=cert, private_key=key
+                    )
+                else:
+                    self._ssl_channel_credentials = SslCredentials().ssl_credentials
+
+            else:
+                if client_cert_source_for_mtls and not ssl_channel_credentials:
+                    cert, key = client_cert_source_for_mtls()
+                    self._ssl_channel_credentials = grpc.ssl_channel_credentials(
+                        certificate_chain=cert, private_key=key
+                    )
+
+        # The base transport sets the host, credentials and scopes
+        super().__init__(
+            host=host,
+            credentials=credentials,
+            credentials_file=credentials_file,
+            scopes=scopes,
+            quota_project_id=quota_project_id,
+            client_info=client_info,
+            always_use_jwt_access=always_use_jwt_access,
+            api_audience=api_audience,
+        )
+
+        if not self._grpc_channel:
+            # initialize with the provided callable or the default channel
+            channel_init = channel or type(self).create_channel
+            self._grpc_channel = channel_init(
+                self._host,
+                # use the credentials which are saved
+                credentials=self._credentials,
+                # Set ``credentials_file`` to ``None`` here as
+                # the credentials that we saved earlier should be used.
+                credentials_file=None,
+                scopes=self._scopes,
+                ssl_credentials=self._ssl_channel_credentials,
+                quota_project_id=quota_project_id,
+                options=[
+                    ("grpc.max_send_message_length", -1),
+                    ("grpc.max_receive_message_length", -1),
+                ],
+            )
+
+        self._interceptor = _LoggingClientAIOInterceptor()
+        self._grpc_channel._unary_unary_interceptors.append(self._interceptor)
+        self._logged_channel = self._grpc_channel
+        self._wrap_with_kind = (
+            "kind" in inspect.signature(gapic_v1.method_async.wrap_method).parameters
+        )
+        # Wrap messages. This must be done after self._logged_channel exists
+        self._prep_wrapped_messages(client_info)
+
+    @property
+    def grpc_channel(self) -> aio.Channel:
+        """Create the channel designed to connect to this service.
+
+        This property caches on the instance; repeated calls return
+        the same channel.
+        """
+        # Return the channel from cache.
+        return self._grpc_channel
+
+    @property
+    def retrieve_credentials(
+        self,
+    ) -> Callable[
+        [auth_provider_credentials_service.RetrieveCredentialsRequest],
+        Awaitable[auth_provider_credentials_service.RetrieveCredentialsResponse],
+    ]:
+        r"""Return a callable for the retrieve credentials method over gRPC.
+
+        Retrieves authorization credentials for an authprovider, or
+        indicates what action needs to be taken to obtain credentials.
+        If the ``token`` field in the response is populated, credential
+        retrieval was successful. If one of the fields in the ``status``
+        oneof is populated, further action is required to obtain
+        credentials, such as redirecting the user for consent. View
+        comments on ``RetrieveCredentialsResponse`` for more
+        information.
+
+        Returns:
+            Callable[[~.RetrieveCredentialsRequest],
+                    Awaitable[~.RetrieveCredentialsResponse]]:
+                A function that, when called, will call the underlying RPC
+                on the server.
+        """
+        # Generate a "stub function" on-the-fly which will actually make
+        # the request.
+        # gRPC handles serialization and deserialization, so we just need
+        # to pass in the functions for each.
+        if "retrieve_credentials" not in self._stubs:
+            self._stubs["retrieve_credentials"] = self._logged_channel.unary_unary(
+                "/google.cloud.agentidentitycredentials.v1beta.AuthProviderCredentialsService/RetrieveCredentials",
+                request_serializer=auth_provider_credentials_service.RetrieveCredentialsRequest.serialize,
+                response_deserializer=auth_provider_credentials_service.RetrieveCredentialsResponse.deserialize,
+            )
+        return self._stubs["retrieve_credentials"]
+
+    @property
+    def finalize_credentials(
+        self,
+    ) -> Callable[
+        [auth_provider_credentials_service.FinalizeCredentialsRequest],
+        Awaitable[auth_provider_credentials_service.FinalizeCredentialsResponse],
+    ]:
+        r"""Return a callable for the finalize credentials method over gRPC.
+
+        Finalizes the credentials after a successful consent
+        flow.
+
+        Returns:
+            Callable[[~.FinalizeCredentialsRequest],
+                    Awaitable[~.FinalizeCredentialsResponse]]:
+                A function that, when called, will call the underlying RPC
+                on the server.
+        """
+        # Generate a "stub function" on-the-fly which will actually make
+        # the request.
+        # gRPC handles serialization and deserialization, so we just need
+        # to pass in the functions for each.
+        if "finalize_credentials" not in self._stubs:
+            self._stubs["finalize_credentials"] = self._logged_channel.unary_unary(
+                "/google.cloud.agentidentitycredentials.v1beta.AuthProviderCredentialsService/FinalizeCredentials",
+                request_serializer=auth_provider_credentials_service.FinalizeCredentialsRequest.serialize,
+                response_deserializer=auth_provider_credentials_service.FinalizeCredentialsResponse.deserialize,
+            )
+        return self._stubs["finalize_credentials"]
+
+    def _prep_wrapped_messages(self, client_info):
+        """Precompute the wrapped methods, overriding the base class method to use async wrappers."""
+        self._wrapped_methods = {
+            self.retrieve_credentials: self._wrap_method(
+                self.retrieve_credentials,
+                default_timeout=None,
+                client_info=client_info,
+            ),
+            self.finalize_credentials: self._wrap_method(
+                self.finalize_credentials,
+                default_timeout=None,
+                client_info=client_info,
+            ),
+        }
+
+    def _wrap_method(self, func, *args, **kwargs):
+        if self._wrap_with_kind:  # pragma: NO COVER
+            kwargs["kind"] = self.kind
+        return gapic_v1.method_async.wrap_method(func, *args, **kwargs)
+
+    def close(self):
+        return self._logged_channel.close()
+
+    @property
+    def kind(self) -> str:
+        return "grpc_asyncio"
+
+
+__all__ = ("AuthProviderCredentialsServiceGrpcAsyncIOTransport",)

--- a/packages/google-cloud-agentidentitycredentials/google/cloud/agentidentitycredentials_v1beta/services/auth_provider_credentials_service/transports/rest.py
+++ b/packages/google-cloud-agentidentitycredentials/google/cloud/agentidentitycredentials_v1beta/services/auth_provider_credentials_service/transports/rest.py
@@ -1,0 +1,652 @@
+# -*- coding: utf-8 -*-
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+import dataclasses
+import json  # type: ignore
+import logging
+import warnings
+from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple, Union
+
+import google.protobuf
+from google.api_core import exceptions as core_exceptions
+from google.api_core import gapic_v1, rest_helpers, rest_streaming
+from google.api_core import retry as retries
+from google.auth import credentials as ga_credentials  # type: ignore
+from google.auth.transport.requests import AuthorizedSession  # type: ignore
+from google.protobuf import json_format
+from requests import __version__ as requests_version
+
+from google.cloud.agentidentitycredentials_v1beta.types import (
+    auth_provider_credentials_service,
+)
+
+from .base import DEFAULT_CLIENT_INFO as BASE_DEFAULT_CLIENT_INFO
+from .rest_base import _BaseAuthProviderCredentialsServiceRestTransport
+
+try:
+    OptionalRetry = Union[retries.Retry, gapic_v1.method._MethodDefault, None]
+except AttributeError:  # pragma: NO COVER
+    OptionalRetry = Union[retries.Retry, object, None]  # type: ignore
+
+try:
+    from google.api_core import client_logging  # type: ignore
+
+    CLIENT_LOGGING_SUPPORTED = True  # pragma: NO COVER
+except ImportError:  # pragma: NO COVER
+    CLIENT_LOGGING_SUPPORTED = False
+
+_LOGGER = logging.getLogger(__name__)
+
+DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
+    gapic_version=BASE_DEFAULT_CLIENT_INFO.gapic_version,
+    grpc_version=None,
+    rest_version=f"requests@{requests_version}",
+)
+
+if hasattr(DEFAULT_CLIENT_INFO, "protobuf_runtime_version"):  # pragma: NO COVER
+    DEFAULT_CLIENT_INFO.protobuf_runtime_version = google.protobuf.__version__
+
+
+class AuthProviderCredentialsServiceRestInterceptor:
+    """Interceptor for AuthProviderCredentialsService.
+
+    Interceptors are used to manipulate requests, request metadata, and responses
+    in arbitrary ways.
+    Example use cases include:
+    * Logging
+    * Verifying requests according to service or custom semantics
+    * Stripping extraneous information from responses
+
+    These use cases and more can be enabled by injecting an
+    instance of a custom subclass when constructing the AuthProviderCredentialsServiceRestTransport.
+
+    .. code-block:: python
+        class MyCustomAuthProviderCredentialsServiceInterceptor(AuthProviderCredentialsServiceRestInterceptor):
+            def pre_finalize_credentials(self, request, metadata):
+                logging.log(f"Received request: {request}")
+                return request, metadata
+
+            def post_finalize_credentials(self, response):
+                logging.log(f"Received response: {response}")
+                return response
+
+            def pre_retrieve_credentials(self, request, metadata):
+                logging.log(f"Received request: {request}")
+                return request, metadata
+
+            def post_retrieve_credentials(self, response):
+                logging.log(f"Received response: {response}")
+                return response
+
+        transport = AuthProviderCredentialsServiceRestTransport(interceptor=MyCustomAuthProviderCredentialsServiceInterceptor())
+        client = AuthProviderCredentialsServiceClient(transport=transport)
+
+
+    """
+
+    def pre_finalize_credentials(
+        self,
+        request: auth_provider_credentials_service.FinalizeCredentialsRequest,
+        metadata: Sequence[Tuple[str, Union[str, bytes]]],
+    ) -> Tuple[
+        auth_provider_credentials_service.FinalizeCredentialsRequest,
+        Sequence[Tuple[str, Union[str, bytes]]],
+    ]:
+        """Pre-rpc interceptor for finalize_credentials
+
+        Override in a subclass to manipulate the request or metadata
+        before they are sent to the AuthProviderCredentialsService server.
+        """
+        return request, metadata
+
+    def post_finalize_credentials(
+        self, response: auth_provider_credentials_service.FinalizeCredentialsResponse
+    ) -> auth_provider_credentials_service.FinalizeCredentialsResponse:
+        """Post-rpc interceptor for finalize_credentials
+
+        DEPRECATED. Please use the `post_finalize_credentials_with_metadata`
+        interceptor instead.
+
+        Override in a subclass to read or manipulate the response
+        after it is returned by the AuthProviderCredentialsService server but before
+        it is returned to user code. This `post_finalize_credentials` interceptor runs
+        before the `post_finalize_credentials_with_metadata` interceptor.
+        """
+        return response
+
+    def post_finalize_credentials_with_metadata(
+        self,
+        response: auth_provider_credentials_service.FinalizeCredentialsResponse,
+        metadata: Sequence[Tuple[str, Union[str, bytes]]],
+    ) -> Tuple[
+        auth_provider_credentials_service.FinalizeCredentialsResponse,
+        Sequence[Tuple[str, Union[str, bytes]]],
+    ]:
+        """Post-rpc interceptor for finalize_credentials
+
+        Override in a subclass to read or manipulate the response or metadata after it
+        is returned by the AuthProviderCredentialsService server but before it is returned to user code.
+
+        We recommend only using this `post_finalize_credentials_with_metadata`
+        interceptor in new development instead of the `post_finalize_credentials` interceptor.
+        When both interceptors are used, this `post_finalize_credentials_with_metadata` interceptor runs after the
+        `post_finalize_credentials` interceptor. The (possibly modified) response returned by
+        `post_finalize_credentials` will be passed to
+        `post_finalize_credentials_with_metadata`.
+        """
+        return response, metadata
+
+    def pre_retrieve_credentials(
+        self,
+        request: auth_provider_credentials_service.RetrieveCredentialsRequest,
+        metadata: Sequence[Tuple[str, Union[str, bytes]]],
+    ) -> Tuple[
+        auth_provider_credentials_service.RetrieveCredentialsRequest,
+        Sequence[Tuple[str, Union[str, bytes]]],
+    ]:
+        """Pre-rpc interceptor for retrieve_credentials
+
+        Override in a subclass to manipulate the request or metadata
+        before they are sent to the AuthProviderCredentialsService server.
+        """
+        return request, metadata
+
+    def post_retrieve_credentials(
+        self, response: auth_provider_credentials_service.RetrieveCredentialsResponse
+    ) -> auth_provider_credentials_service.RetrieveCredentialsResponse:
+        """Post-rpc interceptor for retrieve_credentials
+
+        DEPRECATED. Please use the `post_retrieve_credentials_with_metadata`
+        interceptor instead.
+
+        Override in a subclass to read or manipulate the response
+        after it is returned by the AuthProviderCredentialsService server but before
+        it is returned to user code. This `post_retrieve_credentials` interceptor runs
+        before the `post_retrieve_credentials_with_metadata` interceptor.
+        """
+        return response
+
+    def post_retrieve_credentials_with_metadata(
+        self,
+        response: auth_provider_credentials_service.RetrieveCredentialsResponse,
+        metadata: Sequence[Tuple[str, Union[str, bytes]]],
+    ) -> Tuple[
+        auth_provider_credentials_service.RetrieveCredentialsResponse,
+        Sequence[Tuple[str, Union[str, bytes]]],
+    ]:
+        """Post-rpc interceptor for retrieve_credentials
+
+        Override in a subclass to read or manipulate the response or metadata after it
+        is returned by the AuthProviderCredentialsService server but before it is returned to user code.
+
+        We recommend only using this `post_retrieve_credentials_with_metadata`
+        interceptor in new development instead of the `post_retrieve_credentials` interceptor.
+        When both interceptors are used, this `post_retrieve_credentials_with_metadata` interceptor runs after the
+        `post_retrieve_credentials` interceptor. The (possibly modified) response returned by
+        `post_retrieve_credentials` will be passed to
+        `post_retrieve_credentials_with_metadata`.
+        """
+        return response, metadata
+
+
+@dataclasses.dataclass
+class AuthProviderCredentialsServiceRestStub:
+    _session: AuthorizedSession
+    _host: str
+    _interceptor: AuthProviderCredentialsServiceRestInterceptor
+
+
+class AuthProviderCredentialsServiceRestTransport(
+    _BaseAuthProviderCredentialsServiceRestTransport
+):
+    """REST backend synchronous transport for AuthProviderCredentialsService.
+
+    Service for managing AuthProvider Credentials.
+
+    This class defines the same methods as the primary client, so the
+    primary client can load the underlying transport implementation
+    and call it.
+
+    It sends JSON representations of protocol buffers over HTTP/1.1
+    """
+
+    def __init__(
+        self,
+        *,
+        host: str = "agentidentitycredentials.googleapis.com",
+        credentials: Optional[ga_credentials.Credentials] = None,
+        credentials_file: Optional[str] = None,
+        scopes: Optional[Sequence[str]] = None,
+        client_cert_source_for_mtls: Optional[Callable[[], Tuple[bytes, bytes]]] = None,
+        quota_project_id: Optional[str] = None,
+        client_info: gapic_v1.client_info.ClientInfo = DEFAULT_CLIENT_INFO,
+        always_use_jwt_access: Optional[bool] = False,
+        url_scheme: str = "https",
+        interceptor: Optional[AuthProviderCredentialsServiceRestInterceptor] = None,
+        api_audience: Optional[str] = None,
+    ) -> None:
+        """Instantiate the transport.
+
+        Args:
+            host (Optional[str]):
+                 The hostname to connect to (default: 'agentidentitycredentials.googleapis.com').
+            credentials (Optional[google.auth.credentials.Credentials]): The
+                authorization credentials to attach to requests. These
+                credentials identify the application to the service; if none
+                are specified, the client will attempt to ascertain the
+                credentials from the environment.
+
+            credentials_file (Optional[str]): Deprecated. A file with credentials that can
+                be loaded with :func:`google.auth.load_credentials_from_file`.
+                This argument is ignored if ``channel`` is provided. This argument will be
+                removed in the next major version of this library.
+            scopes (Optional(Sequence[str])): A list of scopes. This argument is
+                ignored if ``channel`` is provided.
+            client_cert_source_for_mtls (Callable[[], Tuple[bytes, bytes]]): Client
+                certificate to configure mutual TLS HTTP channel. It is ignored
+                if ``channel`` is provided.
+            quota_project_id (Optional[str]): An optional project to use for billing
+                and quota.
+            client_info (google.api_core.gapic_v1.client_info.ClientInfo):
+                The client info used to send a user-agent string along with
+                API requests. If ``None``, then default info will be used.
+                Generally, you only need to set this if you are developing
+                your own client library.
+            always_use_jwt_access (Optional[bool]): Whether self signed JWT should
+                be used for service account credentials.
+            url_scheme: the protocol scheme for the API endpoint.  Normally
+                "https", but for testing or local servers,
+                "http" can be specified.
+            interceptor (Optional[AuthProviderCredentialsServiceRestInterceptor]): Interceptor used
+                to manipulate requests, request metadata, and responses.
+            api_audience (Optional[str]): The intended audience for the API calls
+                to the service that will be set when using certain 3rd party
+                authentication flows. Audience is typically a resource identifier.
+                If not set, the host value will be used as a default.
+        """
+        # Run the base constructor
+        # TODO(yon-mg): resolve other ctor params i.e. scopes, quota, etc.
+        # TODO: When custom host (api_endpoint) is set, `scopes` must *also* be set on the
+        # credentials object
+        super().__init__(
+            host=host,
+            credentials=credentials,
+            client_info=client_info,
+            always_use_jwt_access=always_use_jwt_access,
+            url_scheme=url_scheme,
+            api_audience=api_audience,
+        )
+        self._session = AuthorizedSession(
+            self._credentials, default_host=self.DEFAULT_HOST
+        )
+        if client_cert_source_for_mtls:
+            self._session.configure_mtls_channel(client_cert_source_for_mtls)
+        self._interceptor = (
+            interceptor or AuthProviderCredentialsServiceRestInterceptor()
+        )
+        self._prep_wrapped_messages(client_info)
+
+    class _FinalizeCredentials(
+        _BaseAuthProviderCredentialsServiceRestTransport._BaseFinalizeCredentials,
+        AuthProviderCredentialsServiceRestStub,
+    ):
+        def __hash__(self):
+            return hash(
+                "AuthProviderCredentialsServiceRestTransport.FinalizeCredentials"
+            )
+
+        @staticmethod
+        def _get_response(
+            host,
+            metadata,
+            query_params,
+            session,
+            timeout,
+            transcoded_request,
+            body=None,
+        ):
+            uri = transcoded_request["uri"]
+            method = transcoded_request["method"]
+            headers = dict(metadata)
+            headers["Content-Type"] = "application/json"
+            response = getattr(session, method)(
+                "{host}{uri}".format(host=host, uri=uri),
+                timeout=timeout,
+                headers=headers,
+                params=rest_helpers.flatten_query_params(query_params, strict=True),
+                data=body,
+            )
+            return response
+
+        def __call__(
+            self,
+            request: auth_provider_credentials_service.FinalizeCredentialsRequest,
+            *,
+            retry: OptionalRetry = gapic_v1.method.DEFAULT,
+            timeout: Optional[float] = None,
+            metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
+        ) -> auth_provider_credentials_service.FinalizeCredentialsResponse:
+            r"""Call the finalize credentials method over HTTP.
+
+            Args:
+                request (~.auth_provider_credentials_service.FinalizeCredentialsRequest):
+                    The request object. Request message for
+                FinalizeCredentials.
+                retry (google.api_core.retry.Retry): Designation of what errors, if any,
+                    should be retried.
+                timeout (float): The timeout for this request.
+                metadata (Sequence[Tuple[str, Union[str, bytes]]]): Key/value pairs which should be
+                    sent along with the request as metadata. Normally, each value must be of type `str`,
+                    but for metadata keys ending with the suffix `-bin`, the corresponding values must
+                    be of type `bytes`.
+
+            Returns:
+                ~.auth_provider_credentials_service.FinalizeCredentialsResponse:
+                    Response message for
+                FinalizeCredentials. Intentionally empty
+
+            """
+
+            http_options = _BaseAuthProviderCredentialsServiceRestTransport._BaseFinalizeCredentials._get_http_options()
+
+            request, metadata = self._interceptor.pre_finalize_credentials(
+                request, metadata
+            )
+            transcoded_request = _BaseAuthProviderCredentialsServiceRestTransport._BaseFinalizeCredentials._get_transcoded_request(
+                http_options, request
+            )
+
+            body = _BaseAuthProviderCredentialsServiceRestTransport._BaseFinalizeCredentials._get_request_body_json(
+                transcoded_request
+            )
+
+            # Jsonify the query params
+            query_params = _BaseAuthProviderCredentialsServiceRestTransport._BaseFinalizeCredentials._get_query_params_json(
+                transcoded_request
+            )
+
+            if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(
+                logging.DEBUG
+            ):  # pragma: NO COVER
+                request_url = "{host}{uri}".format(
+                    host=self._host, uri=transcoded_request["uri"]
+                )
+                method = transcoded_request["method"]
+                try:
+                    request_payload = type(request).to_json(request)
+                except:
+                    request_payload = None
+                http_request = {
+                    "payload": request_payload,
+                    "requestMethod": method,
+                    "requestUrl": request_url,
+                    "headers": dict(metadata),
+                }
+                _LOGGER.debug(
+                    f"Sending request for google.cloud.agentidentitycredentials_v1beta.AuthProviderCredentialsServiceClient.FinalizeCredentials",
+                    extra={
+                        "serviceName": "google.cloud.agentidentitycredentials.v1beta.AuthProviderCredentialsService",
+                        "rpcName": "FinalizeCredentials",
+                        "httpRequest": http_request,
+                        "metadata": http_request["headers"],
+                    },
+                )
+
+            # Send the request
+            response = AuthProviderCredentialsServiceRestTransport._FinalizeCredentials._get_response(
+                self._host,
+                metadata,
+                query_params,
+                self._session,
+                timeout,
+                transcoded_request,
+                body,
+            )
+
+            # In case of error, raise the appropriate core_exceptions.GoogleAPICallError exception
+            # subclass.
+            if response.status_code >= 400:
+                raise core_exceptions.from_http_response(response)
+
+            # Return the response
+            resp = auth_provider_credentials_service.FinalizeCredentialsResponse()
+            pb_resp = auth_provider_credentials_service.FinalizeCredentialsResponse.pb(
+                resp
+            )
+
+            json_format.Parse(response.content, pb_resp, ignore_unknown_fields=True)
+
+            resp = self._interceptor.post_finalize_credentials(resp)
+            response_metadata = [(k, str(v)) for k, v in response.headers.items()]
+            resp, _ = self._interceptor.post_finalize_credentials_with_metadata(
+                resp, response_metadata
+            )
+            if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(
+                logging.DEBUG
+            ):  # pragma: NO COVER
+                try:
+                    response_payload = auth_provider_credentials_service.FinalizeCredentialsResponse.to_json(
+                        response
+                    )
+                except:
+                    response_payload = None
+                http_response = {
+                    "payload": response_payload,
+                    "headers": dict(response.headers),
+                    "status": response.status_code,
+                }
+                _LOGGER.debug(
+                    "Received response for google.cloud.agentidentitycredentials_v1beta.AuthProviderCredentialsServiceClient.finalize_credentials",
+                    extra={
+                        "serviceName": "google.cloud.agentidentitycredentials.v1beta.AuthProviderCredentialsService",
+                        "rpcName": "FinalizeCredentials",
+                        "metadata": http_response["headers"],
+                        "httpResponse": http_response,
+                    },
+                )
+            return resp
+
+    class _RetrieveCredentials(
+        _BaseAuthProviderCredentialsServiceRestTransport._BaseRetrieveCredentials,
+        AuthProviderCredentialsServiceRestStub,
+    ):
+        def __hash__(self):
+            return hash(
+                "AuthProviderCredentialsServiceRestTransport.RetrieveCredentials"
+            )
+
+        @staticmethod
+        def _get_response(
+            host,
+            metadata,
+            query_params,
+            session,
+            timeout,
+            transcoded_request,
+            body=None,
+        ):
+            uri = transcoded_request["uri"]
+            method = transcoded_request["method"]
+            headers = dict(metadata)
+            headers["Content-Type"] = "application/json"
+            response = getattr(session, method)(
+                "{host}{uri}".format(host=host, uri=uri),
+                timeout=timeout,
+                headers=headers,
+                params=rest_helpers.flatten_query_params(query_params, strict=True),
+                data=body,
+            )
+            return response
+
+        def __call__(
+            self,
+            request: auth_provider_credentials_service.RetrieveCredentialsRequest,
+            *,
+            retry: OptionalRetry = gapic_v1.method.DEFAULT,
+            timeout: Optional[float] = None,
+            metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
+        ) -> auth_provider_credentials_service.RetrieveCredentialsResponse:
+            r"""Call the retrieve credentials method over HTTP.
+
+            Args:
+                request (~.auth_provider_credentials_service.RetrieveCredentialsRequest):
+                    The request object. Request message for
+                RetrieveCredentials.
+                retry (google.api_core.retry.Retry): Designation of what errors, if any,
+                    should be retried.
+                timeout (float): The timeout for this request.
+                metadata (Sequence[Tuple[str, Union[str, bytes]]]): Key/value pairs which should be
+                    sent along with the request as metadata. Normally, each value must be of type `str`,
+                    but for metadata keys ending with the suffix `-bin`, the corresponding values must
+                    be of type `bytes`.
+
+            Returns:
+                ~.auth_provider_credentials_service.RetrieveCredentialsResponse:
+                    Response message for
+                RetrieveCredentials. Contains the access
+                tokens and related artifacts.
+
+            """
+
+            http_options = _BaseAuthProviderCredentialsServiceRestTransport._BaseRetrieveCredentials._get_http_options()
+
+            request, metadata = self._interceptor.pre_retrieve_credentials(
+                request, metadata
+            )
+            transcoded_request = _BaseAuthProviderCredentialsServiceRestTransport._BaseRetrieveCredentials._get_transcoded_request(
+                http_options, request
+            )
+
+            body = _BaseAuthProviderCredentialsServiceRestTransport._BaseRetrieveCredentials._get_request_body_json(
+                transcoded_request
+            )
+
+            # Jsonify the query params
+            query_params = _BaseAuthProviderCredentialsServiceRestTransport._BaseRetrieveCredentials._get_query_params_json(
+                transcoded_request
+            )
+
+            if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(
+                logging.DEBUG
+            ):  # pragma: NO COVER
+                request_url = "{host}{uri}".format(
+                    host=self._host, uri=transcoded_request["uri"]
+                )
+                method = transcoded_request["method"]
+                try:
+                    request_payload = type(request).to_json(request)
+                except:
+                    request_payload = None
+                http_request = {
+                    "payload": request_payload,
+                    "requestMethod": method,
+                    "requestUrl": request_url,
+                    "headers": dict(metadata),
+                }
+                _LOGGER.debug(
+                    f"Sending request for google.cloud.agentidentitycredentials_v1beta.AuthProviderCredentialsServiceClient.RetrieveCredentials",
+                    extra={
+                        "serviceName": "google.cloud.agentidentitycredentials.v1beta.AuthProviderCredentialsService",
+                        "rpcName": "RetrieveCredentials",
+                        "httpRequest": http_request,
+                        "metadata": http_request["headers"],
+                    },
+                )
+
+            # Send the request
+            response = AuthProviderCredentialsServiceRestTransport._RetrieveCredentials._get_response(
+                self._host,
+                metadata,
+                query_params,
+                self._session,
+                timeout,
+                transcoded_request,
+                body,
+            )
+
+            # In case of error, raise the appropriate core_exceptions.GoogleAPICallError exception
+            # subclass.
+            if response.status_code >= 400:
+                raise core_exceptions.from_http_response(response)
+
+            # Return the response
+            resp = auth_provider_credentials_service.RetrieveCredentialsResponse()
+            pb_resp = auth_provider_credentials_service.RetrieveCredentialsResponse.pb(
+                resp
+            )
+
+            json_format.Parse(response.content, pb_resp, ignore_unknown_fields=True)
+
+            resp = self._interceptor.post_retrieve_credentials(resp)
+            response_metadata = [(k, str(v)) for k, v in response.headers.items()]
+            resp, _ = self._interceptor.post_retrieve_credentials_with_metadata(
+                resp, response_metadata
+            )
+            if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(
+                logging.DEBUG
+            ):  # pragma: NO COVER
+                try:
+                    response_payload = auth_provider_credentials_service.RetrieveCredentialsResponse.to_json(
+                        response
+                    )
+                except:
+                    response_payload = None
+                http_response = {
+                    "payload": response_payload,
+                    "headers": dict(response.headers),
+                    "status": response.status_code,
+                }
+                _LOGGER.debug(
+                    "Received response for google.cloud.agentidentitycredentials_v1beta.AuthProviderCredentialsServiceClient.retrieve_credentials",
+                    extra={
+                        "serviceName": "google.cloud.agentidentitycredentials.v1beta.AuthProviderCredentialsService",
+                        "rpcName": "RetrieveCredentials",
+                        "metadata": http_response["headers"],
+                        "httpResponse": http_response,
+                    },
+                )
+            return resp
+
+    @property
+    def finalize_credentials(
+        self,
+    ) -> Callable[
+        [auth_provider_credentials_service.FinalizeCredentialsRequest],
+        auth_provider_credentials_service.FinalizeCredentialsResponse,
+    ]:
+        # The return type is fine, but mypy isn't sophisticated enough to determine what's going on here.
+        # In C++ this would require a dynamic_cast
+        return self._FinalizeCredentials(self._session, self._host, self._interceptor)  # type: ignore
+
+    @property
+    def retrieve_credentials(
+        self,
+    ) -> Callable[
+        [auth_provider_credentials_service.RetrieveCredentialsRequest],
+        auth_provider_credentials_service.RetrieveCredentialsResponse,
+    ]:
+        # The return type is fine, but mypy isn't sophisticated enough to determine what's going on here.
+        # In C++ this would require a dynamic_cast
+        return self._RetrieveCredentials(self._session, self._host, self._interceptor)  # type: ignore
+
+    @property
+    def kind(self) -> str:
+        return "rest"
+
+    def close(self):
+        self._session.close()
+
+
+__all__ = ("AuthProviderCredentialsServiceRestTransport",)

--- a/packages/google-cloud-agentidentitycredentials/google/cloud/agentidentitycredentials_v1beta/services/auth_provider_credentials_service/transports/rest_base.py
+++ b/packages/google-cloud-agentidentitycredentials/google/cloud/agentidentitycredentials_v1beta/services/auth_provider_credentials_service/transports/rest_base.py
@@ -1,0 +1,213 @@
+# -*- coding: utf-8 -*-
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+import json  # type: ignore
+import re
+from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple, Union
+
+from google.api_core import gapic_v1, path_template
+from google.protobuf import json_format
+
+from google.cloud.agentidentitycredentials_v1beta.types import (
+    auth_provider_credentials_service,
+)
+
+from .base import DEFAULT_CLIENT_INFO, AuthProviderCredentialsServiceTransport
+
+
+class _BaseAuthProviderCredentialsServiceRestTransport(
+    AuthProviderCredentialsServiceTransport
+):
+    """Base REST backend transport for AuthProviderCredentialsService.
+
+    Note: This class is not meant to be used directly. Use its sync and
+    async sub-classes instead.
+
+    This class defines the same methods as the primary client, so the
+    primary client can load the underlying transport implementation
+    and call it.
+
+    It sends JSON representations of protocol buffers over HTTP/1.1
+    """
+
+    def __init__(
+        self,
+        *,
+        host: str = "agentidentitycredentials.googleapis.com",
+        credentials: Optional[Any] = None,
+        client_info: gapic_v1.client_info.ClientInfo = DEFAULT_CLIENT_INFO,
+        always_use_jwt_access: Optional[bool] = False,
+        url_scheme: str = "https",
+        api_audience: Optional[str] = None,
+    ) -> None:
+        """Instantiate the transport.
+        Args:
+            host (Optional[str]):
+                 The hostname to connect to (default: 'agentidentitycredentials.googleapis.com').
+            credentials (Optional[Any]): The
+                authorization credentials to attach to requests. These
+                credentials identify the application to the service; if none
+                are specified, the client will attempt to ascertain the
+                credentials from the environment.
+            client_info (google.api_core.gapic_v1.client_info.ClientInfo):
+                The client info used to send a user-agent string along with
+                API requests. If ``None``, then default info will be used.
+                Generally, you only need to set this if you are developing
+                your own client library.
+            always_use_jwt_access (Optional[bool]): Whether self signed JWT should
+                be used for service account credentials.
+            url_scheme: the protocol scheme for the API endpoint.  Normally
+                "https", but for testing or local servers,
+                "http" can be specified.
+        """
+        # Run the base constructor
+        maybe_url_match = re.match("^(?P<scheme>http(?:s)?://)?(?P<host>.*)$", host)
+        if maybe_url_match is None:
+            raise ValueError(
+                f"Unexpected hostname structure: {host}"
+            )  # pragma: NO COVER
+
+        url_match_items = maybe_url_match.groupdict()
+
+        host = f"{url_scheme}://{host}" if not url_match_items["scheme"] else host
+
+        super().__init__(
+            host=host,
+            credentials=credentials,
+            client_info=client_info,
+            always_use_jwt_access=always_use_jwt_access,
+            api_audience=api_audience,
+        )
+
+    class _BaseFinalizeCredentials:
+        def __hash__(self):  # pragma: NO COVER
+            return NotImplementedError("__hash__ must be implemented.")
+
+        __REQUIRED_FIELDS_DEFAULT_VALUES: Dict[str, Any] = {}
+
+        @classmethod
+        def _get_unset_required_fields(cls, message_dict):
+            return {
+                k: v
+                for k, v in cls.__REQUIRED_FIELDS_DEFAULT_VALUES.items()
+                if k not in message_dict
+            }
+
+        @staticmethod
+        def _get_http_options():
+            http_options: List[Dict[str, str]] = [
+                {
+                    "method": "post",
+                    "uri": "/v1beta/{auth_provider=projects/*/locations/*/authProviders/*}/credentials:finalize",
+                    "body": "*",
+                },
+            ]
+            return http_options
+
+        @staticmethod
+        def _get_transcoded_request(http_options, request):
+            pb_request = (
+                auth_provider_credentials_service.FinalizeCredentialsRequest.pb(request)
+            )
+            transcoded_request = path_template.transcode(http_options, pb_request)
+            return transcoded_request
+
+        @staticmethod
+        def _get_request_body_json(transcoded_request):
+            # Jsonify the request body
+
+            body = json_format.MessageToJson(
+                transcoded_request["body"], use_integers_for_enums=True
+            )
+            return body
+
+        @staticmethod
+        def _get_query_params_json(transcoded_request):
+            query_params = json.loads(
+                json_format.MessageToJson(
+                    transcoded_request["query_params"],
+                    use_integers_for_enums=True,
+                )
+            )
+            query_params.update(
+                _BaseAuthProviderCredentialsServiceRestTransport._BaseFinalizeCredentials._get_unset_required_fields(
+                    query_params
+                )
+            )
+
+            query_params["$alt"] = "json;enum-encoding=int"
+            return query_params
+
+    class _BaseRetrieveCredentials:
+        def __hash__(self):  # pragma: NO COVER
+            return NotImplementedError("__hash__ must be implemented.")
+
+        __REQUIRED_FIELDS_DEFAULT_VALUES: Dict[str, Any] = {}
+
+        @classmethod
+        def _get_unset_required_fields(cls, message_dict):
+            return {
+                k: v
+                for k, v in cls.__REQUIRED_FIELDS_DEFAULT_VALUES.items()
+                if k not in message_dict
+            }
+
+        @staticmethod
+        def _get_http_options():
+            http_options: List[Dict[str, str]] = [
+                {
+                    "method": "post",
+                    "uri": "/v1beta/{auth_provider=projects/*/locations/*/authProviders/*}/credentials:retrieve",
+                    "body": "*",
+                },
+            ]
+            return http_options
+
+        @staticmethod
+        def _get_transcoded_request(http_options, request):
+            pb_request = (
+                auth_provider_credentials_service.RetrieveCredentialsRequest.pb(request)
+            )
+            transcoded_request = path_template.transcode(http_options, pb_request)
+            return transcoded_request
+
+        @staticmethod
+        def _get_request_body_json(transcoded_request):
+            # Jsonify the request body
+
+            body = json_format.MessageToJson(
+                transcoded_request["body"], use_integers_for_enums=True
+            )
+            return body
+
+        @staticmethod
+        def _get_query_params_json(transcoded_request):
+            query_params = json.loads(
+                json_format.MessageToJson(
+                    transcoded_request["query_params"],
+                    use_integers_for_enums=True,
+                )
+            )
+            query_params.update(
+                _BaseAuthProviderCredentialsServiceRestTransport._BaseRetrieveCredentials._get_unset_required_fields(
+                    query_params
+                )
+            )
+
+            query_params["$alt"] = "json;enum-encoding=int"
+            return query_params
+
+
+__all__ = ("_BaseAuthProviderCredentialsServiceRestTransport",)

--- a/packages/google-cloud-agentidentitycredentials/google/cloud/agentidentitycredentials_v1beta/types/__init__.py
+++ b/packages/google-cloud-agentidentitycredentials/google/cloud/agentidentitycredentials_v1beta/types/__init__.py
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+from .auth_provider_credentials_service import (
+    FinalizeCredentialsRequest,
+    FinalizeCredentialsResponse,
+    RetrieveCredentialsRequest,
+    RetrieveCredentialsResponse,
+)
+
+__all__ = (
+    "FinalizeCredentialsRequest",
+    "FinalizeCredentialsResponse",
+    "RetrieveCredentialsRequest",
+    "RetrieveCredentialsResponse",
+)

--- a/packages/google-cloud-agentidentitycredentials/google/cloud/agentidentitycredentials_v1beta/types/auth_provider_credentials_service.py
+++ b/packages/google-cloud-agentidentitycredentials/google/cloud/agentidentitycredentials_v1beta/types/auth_provider_credentials_service.py
@@ -1,0 +1,290 @@
+# -*- coding: utf-8 -*-
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+from __future__ import annotations
+
+from typing import MutableMapping, MutableSequence
+
+import google.protobuf.timestamp_pb2 as timestamp_pb2  # type: ignore
+import proto  # type: ignore
+
+__protobuf__ = proto.module(
+    package="google.cloud.agentidentitycredentials.v1beta",
+    manifest={
+        "RetrieveCredentialsRequest",
+        "RetrieveCredentialsResponse",
+        "FinalizeCredentialsRequest",
+        "FinalizeCredentialsResponse",
+    },
+)
+
+
+class RetrieveCredentialsRequest(proto.Message):
+    r"""Request message for RetrieveCredentials.
+
+    Attributes:
+        auth_provider (str):
+            Required. The parent resource name of the AuthProvider.
+            Format:
+            ``projects/{project}/locations/{location}/authProviders/{auth_provider}``
+        user_id (str):
+            Required. The identity of the end user.
+        scopes (MutableSequence[str]):
+            Optional. The OAuth scopes required for this
+            access.
+        continue_uri (str):
+            Optional. The URI to redirect the user to
+            after consent is completed. This field is
+            required for authproviders using the 3-legged
+            OAuth flow. For other authprovider types, this
+            field is unused but not rejected.
+        force_refresh_token (str):
+            Optional. Input only. Set this field only if
+            the previous token was expired or invalid. This
+            value must be the full, previously returned
+            token string. Will trigger a refresh of the
+            access token with a stored refresh token, if
+            possible, or a new consent flow.
+    """
+
+    auth_provider: str = proto.Field(
+        proto.STRING,
+        number=1,
+    )
+    user_id: str = proto.Field(
+        proto.STRING,
+        number=2,
+    )
+    scopes: MutableSequence[str] = proto.RepeatedField(
+        proto.STRING,
+        number=3,
+    )
+    continue_uri: str = proto.Field(
+        proto.STRING,
+        number=4,
+    )
+    force_refresh_token: str = proto.Field(
+        proto.STRING,
+        number=7,
+    )
+
+
+class RetrieveCredentialsResponse(proto.Message):
+    r"""Response message for RetrieveCredentials.
+    Contains the access tokens and related artifacts.
+
+    This message has `oneof`_ fields (mutually exclusive fields).
+    For each oneof, at most one member field can be set at the same time.
+    Setting any member of the oneof automatically clears all other
+    members.
+
+    .. _oneof: https://proto-plus-python.readthedocs.io/en/stable/fields.html#oneofs-mutually-exclusive-fields
+
+    Attributes:
+        success (google.cloud.agentidentitycredentials_v1beta.types.RetrieveCredentialsResponse.Success):
+            Message indicating credentials were
+            successfully retrieved.
+
+            This field is a member of `oneof`_ ``result``.
+        pending (google.cloud.agentidentitycredentials_v1beta.types.RetrieveCredentialsResponse.Pending):
+            Message indicating credential retrieval is
+            pending.
+
+            This field is a member of `oneof`_ ``result``.
+        uri_consent_required (google.cloud.agentidentitycredentials_v1beta.types.RetrieveCredentialsResponse.UriConsentRequired):
+            Message indicating uri based consent is
+            required.
+
+            This field is a member of `oneof`_ ``result``.
+        consent_rejected (google.cloud.agentidentitycredentials_v1beta.types.RetrieveCredentialsResponse.ConsentRejected):
+            Message indicating consent was rejected.
+
+            This field is a member of `oneof`_ ``result``.
+    """
+
+    class Success(proto.Message):
+        r"""Message indicating successful retrieval of credentials.
+
+        Attributes:
+            token (str):
+                The retrieved access token or credential for the end user.
+
+                On MCPTool call, for an invalid token OAuth spec says this
+                should return 401 or 403, but MCPServers may implement this
+                differently. If you get any flavor of ``PERMISSION_DENIED``,
+                retry your original request to RetrieveCredentials with
+                [force_refresh_token][google.cloud.agentidentitycredentials.v1beta.RetrieveCredentialsRequest.force_refresh_token]
+                set to the expired/invalid token string, which will fetch a
+                new token or initiate a new consent flow.
+            header (str):
+                The HTTP header name where the token should
+                be placed.
+            expire_time (google.protobuf.timestamp_pb2.Timestamp):
+                The expiration time of the token.
+
+                This does not guarantee that the token will be
+                valid until this time, since the token could be
+                revoked earlier. There could also be clock skew
+                between the auth provider and the client so it
+                may expire slightly earlier. If not set, the
+                token might be permanent or it may be that the
+                service does not (or cannot) know when it will
+                expire.
+            scopes (MutableSequence[str]):
+                The scopes actually associated with the
+                retrieved token.
+                End users may have rejected some requested
+                scopes, or the third-party authorization servers
+                can return a different set of scopes than what
+                was asked for. Callers should verify that all
+                required scopes for their intended use are
+                included in this list.
+        """
+
+        token: str = proto.Field(
+            proto.STRING,
+            number=1,
+        )
+        header: str = proto.Field(
+            proto.STRING,
+            number=2,
+        )
+        expire_time: timestamp_pb2.Timestamp = proto.Field(
+            proto.MESSAGE,
+            number=3,
+            message=timestamp_pb2.Timestamp,
+        )
+        scopes: MutableSequence[str] = proto.RepeatedField(
+            proto.STRING,
+            number=4,
+        )
+
+    class UriConsentRequired(proto.Message):
+        r"""Indicates that the user must visit the provided URI to
+        consent to delegate permission to the agent to act on their
+        behalf. The caller can either poll the provided operation, or
+        await the user ID validation callback
+
+        Attributes:
+            authorization_uri (str):
+                Output only. The URL where the user should be
+                redirected to grant consent. This will always be
+                present.
+            consent_nonce (str):
+                Output only. A one-time, randomly generated
+                value that validates the entire consent flow is
+                handled by a single user, avoiding CSRF attacks.
+                It must be submitted with the
+                FinalizeCredentials request to complete the
+                OAuth exchange. This will always be present.
+                Implemented per
+                https://www.rfc-editor.org/rfc/rfc6819#section-5.3.5
+            uid (str):
+                Output only. The unique ID of the credentials
+                retrieval operation.
+        """
+
+        authorization_uri: str = proto.Field(
+            proto.STRING,
+            number=1,
+        )
+        consent_nonce: str = proto.Field(
+            proto.STRING,
+            number=2,
+        )
+        uid: str = proto.Field(
+            proto.STRING,
+            number=3,
+        )
+
+    class Pending(proto.Message):
+        r"""Indicates that the credential retrieval is pending. The
+        caller should retry the RetrieveCredentials request after some
+        time.
+
+        """
+
+    class ConsentRejected(proto.Message):
+        r"""Indicates the user has rejected the permission delegation or
+        cancelled the request.
+
+        """
+
+    success: Success = proto.Field(
+        proto.MESSAGE,
+        number=1,
+        oneof="result",
+        message=Success,
+    )
+    pending: Pending = proto.Field(
+        proto.MESSAGE,
+        number=2,
+        oneof="result",
+        message=Pending,
+    )
+    uri_consent_required: UriConsentRequired = proto.Field(
+        proto.MESSAGE,
+        number=3,
+        oneof="result",
+        message=UriConsentRequired,
+    )
+    consent_rejected: ConsentRejected = proto.Field(
+        proto.MESSAGE,
+        number=4,
+        oneof="result",
+        message=ConsentRejected,
+    )
+
+
+class FinalizeCredentialsRequest(proto.Message):
+    r"""Request message for FinalizeCredentials.
+
+    Attributes:
+        auth_provider (str):
+            Required. The resource name of the AuthProvider. Format:
+            ``projects/{project}/locations/{location}/authProviders/{auth_provider}``
+        user_id (str):
+            Required. The identity of the end user.
+        user_id_validation_state (bytes):
+            Required. The encrypted state passed back
+            from the consent flow.
+        consent_nonce (str):
+            Required. The same consent_nonce value that was provided
+            during redirect in the UriConsentRequired metadata.
+    """
+
+    auth_provider: str = proto.Field(
+        proto.STRING,
+        number=1,
+    )
+    user_id: str = proto.Field(
+        proto.STRING,
+        number=2,
+    )
+    user_id_validation_state: bytes = proto.Field(
+        proto.BYTES,
+        number=3,
+    )
+    consent_nonce: str = proto.Field(
+        proto.STRING,
+        number=4,
+    )
+
+
+class FinalizeCredentialsResponse(proto.Message):
+    r"""Response message for FinalizeCredentials. Intentionally empty"""
+
+
+__all__ = tuple(sorted(__protobuf__.manifest))

--- a/packages/google-cloud-agentidentitycredentials/samples/generated_samples/agentidentitycredentials_v1beta_generated_auth_provider_credentials_service_finalize_credentials_async.py
+++ b/packages/google-cloud-agentidentitycredentials/samples/generated_samples/agentidentitycredentials_v1beta_generated_auth_provider_credentials_service_finalize_credentials_async.py
@@ -1,0 +1,56 @@
+# -*- coding: utf-8 -*-
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Generated code. DO NOT EDIT!
+#
+# Snippet for FinalizeCredentials
+# NOTE: This snippet has been automatically generated for illustrative purposes only.
+# It may require modifications to work in your environment.
+
+# To install the latest published package dependency, execute the following:
+#   python3 -m pip install google-cloud-agentidentitycredentials
+
+
+# [START agentidentitycredentials_v1beta_generated_AuthProviderCredentialsService_FinalizeCredentials_async]
+# This snippet has been automatically generated and should be regarded as a
+# code template only.
+# It will require modifications to work:
+# - It may require correct/in-range values for request initialization.
+# - It may require specifying regional endpoints when creating the service
+#   client as shown in:
+#   https://googleapis.dev/python/google-api-core/latest/client_options.html
+from google.cloud import agentidentitycredentials_v1beta
+
+
+async def sample_finalize_credentials():
+    # Create a client
+    client = agentidentitycredentials_v1beta.AuthProviderCredentialsServiceAsyncClient()
+
+    # Initialize request argument(s)
+    request = agentidentitycredentials_v1beta.FinalizeCredentialsRequest(
+        auth_provider="auth_provider_value",
+        user_id="user_id_value",
+        user_id_validation_state=b"user_id_validation_state_blob",
+        consent_nonce="consent_nonce_value",
+    )
+
+    # Make the request
+    response = await client.finalize_credentials(request=request)
+
+    # Handle the response
+    print(response)
+
+
+# [END agentidentitycredentials_v1beta_generated_AuthProviderCredentialsService_FinalizeCredentials_async]

--- a/packages/google-cloud-agentidentitycredentials/samples/generated_samples/agentidentitycredentials_v1beta_generated_auth_provider_credentials_service_finalize_credentials_sync.py
+++ b/packages/google-cloud-agentidentitycredentials/samples/generated_samples/agentidentitycredentials_v1beta_generated_auth_provider_credentials_service_finalize_credentials_sync.py
@@ -1,0 +1,56 @@
+# -*- coding: utf-8 -*-
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Generated code. DO NOT EDIT!
+#
+# Snippet for FinalizeCredentials
+# NOTE: This snippet has been automatically generated for illustrative purposes only.
+# It may require modifications to work in your environment.
+
+# To install the latest published package dependency, execute the following:
+#   python3 -m pip install google-cloud-agentidentitycredentials
+
+
+# [START agentidentitycredentials_v1beta_generated_AuthProviderCredentialsService_FinalizeCredentials_sync]
+# This snippet has been automatically generated and should be regarded as a
+# code template only.
+# It will require modifications to work:
+# - It may require correct/in-range values for request initialization.
+# - It may require specifying regional endpoints when creating the service
+#   client as shown in:
+#   https://googleapis.dev/python/google-api-core/latest/client_options.html
+from google.cloud import agentidentitycredentials_v1beta
+
+
+def sample_finalize_credentials():
+    # Create a client
+    client = agentidentitycredentials_v1beta.AuthProviderCredentialsServiceClient()
+
+    # Initialize request argument(s)
+    request = agentidentitycredentials_v1beta.FinalizeCredentialsRequest(
+        auth_provider="auth_provider_value",
+        user_id="user_id_value",
+        user_id_validation_state=b"user_id_validation_state_blob",
+        consent_nonce="consent_nonce_value",
+    )
+
+    # Make the request
+    response = client.finalize_credentials(request=request)
+
+    # Handle the response
+    print(response)
+
+
+# [END agentidentitycredentials_v1beta_generated_AuthProviderCredentialsService_FinalizeCredentials_sync]

--- a/packages/google-cloud-agentidentitycredentials/samples/generated_samples/agentidentitycredentials_v1beta_generated_auth_provider_credentials_service_retrieve_credentials_async.py
+++ b/packages/google-cloud-agentidentitycredentials/samples/generated_samples/agentidentitycredentials_v1beta_generated_auth_provider_credentials_service_retrieve_credentials_async.py
@@ -1,0 +1,54 @@
+# -*- coding: utf-8 -*-
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Generated code. DO NOT EDIT!
+#
+# Snippet for RetrieveCredentials
+# NOTE: This snippet has been automatically generated for illustrative purposes only.
+# It may require modifications to work in your environment.
+
+# To install the latest published package dependency, execute the following:
+#   python3 -m pip install google-cloud-agentidentitycredentials
+
+
+# [START agentidentitycredentials_v1beta_generated_AuthProviderCredentialsService_RetrieveCredentials_async]
+# This snippet has been automatically generated and should be regarded as a
+# code template only.
+# It will require modifications to work:
+# - It may require correct/in-range values for request initialization.
+# - It may require specifying regional endpoints when creating the service
+#   client as shown in:
+#   https://googleapis.dev/python/google-api-core/latest/client_options.html
+from google.cloud import agentidentitycredentials_v1beta
+
+
+async def sample_retrieve_credentials():
+    # Create a client
+    client = agentidentitycredentials_v1beta.AuthProviderCredentialsServiceAsyncClient()
+
+    # Initialize request argument(s)
+    request = agentidentitycredentials_v1beta.RetrieveCredentialsRequest(
+        auth_provider="auth_provider_value",
+        user_id="user_id_value",
+    )
+
+    # Make the request
+    response = await client.retrieve_credentials(request=request)
+
+    # Handle the response
+    print(response)
+
+
+# [END agentidentitycredentials_v1beta_generated_AuthProviderCredentialsService_RetrieveCredentials_async]

--- a/packages/google-cloud-agentidentitycredentials/samples/generated_samples/agentidentitycredentials_v1beta_generated_auth_provider_credentials_service_retrieve_credentials_sync.py
+++ b/packages/google-cloud-agentidentitycredentials/samples/generated_samples/agentidentitycredentials_v1beta_generated_auth_provider_credentials_service_retrieve_credentials_sync.py
@@ -1,0 +1,54 @@
+# -*- coding: utf-8 -*-
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Generated code. DO NOT EDIT!
+#
+# Snippet for RetrieveCredentials
+# NOTE: This snippet has been automatically generated for illustrative purposes only.
+# It may require modifications to work in your environment.
+
+# To install the latest published package dependency, execute the following:
+#   python3 -m pip install google-cloud-agentidentitycredentials
+
+
+# [START agentidentitycredentials_v1beta_generated_AuthProviderCredentialsService_RetrieveCredentials_sync]
+# This snippet has been automatically generated and should be regarded as a
+# code template only.
+# It will require modifications to work:
+# - It may require correct/in-range values for request initialization.
+# - It may require specifying regional endpoints when creating the service
+#   client as shown in:
+#   https://googleapis.dev/python/google-api-core/latest/client_options.html
+from google.cloud import agentidentitycredentials_v1beta
+
+
+def sample_retrieve_credentials():
+    # Create a client
+    client = agentidentitycredentials_v1beta.AuthProviderCredentialsServiceClient()
+
+    # Initialize request argument(s)
+    request = agentidentitycredentials_v1beta.RetrieveCredentialsRequest(
+        auth_provider="auth_provider_value",
+        user_id="user_id_value",
+    )
+
+    # Make the request
+    response = client.retrieve_credentials(request=request)
+
+    # Handle the response
+    print(response)
+
+
+# [END agentidentitycredentials_v1beta_generated_AuthProviderCredentialsService_RetrieveCredentials_sync]

--- a/packages/google-cloud-agentidentitycredentials/samples/generated_samples/snippet_metadata_google.cloud.agentidentitycredentials.v1beta.json
+++ b/packages/google-cloud-agentidentitycredentials/samples/generated_samples/snippet_metadata_google.cloud.agentidentitycredentials.v1beta.json
@@ -1,0 +1,337 @@
+{
+  "clientLibrary": {
+    "apis": [
+      {
+        "id": "google.cloud.agentidentitycredentials.v1beta",
+        "version": "v1beta"
+      }
+    ],
+    "language": "PYTHON",
+    "name": "google-cloud-agentidentitycredentials",
+    "version": "0.1.0"
+  },
+  "snippets": [
+    {
+      "canonical": true,
+      "clientMethod": {
+        "async": true,
+        "client": {
+          "fullName": "google.cloud.agentidentitycredentials_v1beta.AuthProviderCredentialsServiceAsyncClient",
+          "shortName": "AuthProviderCredentialsServiceAsyncClient"
+        },
+        "fullName": "google.cloud.agentidentitycredentials_v1beta.AuthProviderCredentialsServiceAsyncClient.finalize_credentials",
+        "method": {
+          "fullName": "google.cloud.agentidentitycredentials.v1beta.AuthProviderCredentialsService.FinalizeCredentials",
+          "service": {
+            "fullName": "google.cloud.agentidentitycredentials.v1beta.AuthProviderCredentialsService",
+            "shortName": "AuthProviderCredentialsService"
+          },
+          "shortName": "FinalizeCredentials"
+        },
+        "parameters": [
+          {
+            "name": "request",
+            "type": "google.cloud.agentidentitycredentials_v1beta.types.FinalizeCredentialsRequest"
+          },
+          {
+            "name": "retry",
+            "type": "google.api_core.retry.Retry"
+          },
+          {
+            "name": "timeout",
+            "type": "float"
+          },
+          {
+            "name": "metadata",
+            "type": "Sequence[Tuple[str, Union[str, bytes]]]"
+          }
+        ],
+        "resultType": "google.cloud.agentidentitycredentials_v1beta.types.FinalizeCredentialsResponse",
+        "shortName": "finalize_credentials"
+      },
+      "description": "Sample for FinalizeCredentials",
+      "file": "agentidentitycredentials_v1beta_generated_auth_provider_credentials_service_finalize_credentials_async.py",
+      "language": "PYTHON",
+      "origin": "API_DEFINITION",
+      "regionTag": "agentidentitycredentials_v1beta_generated_AuthProviderCredentialsService_FinalizeCredentials_async",
+      "segments": [
+        {
+          "end": 54,
+          "start": 27,
+          "type": "FULL"
+        },
+        {
+          "end": 54,
+          "start": 27,
+          "type": "SHORT"
+        },
+        {
+          "end": 40,
+          "start": 38,
+          "type": "CLIENT_INITIALIZATION"
+        },
+        {
+          "end": 48,
+          "start": 41,
+          "type": "REQUEST_INITIALIZATION"
+        },
+        {
+          "end": 51,
+          "start": 49,
+          "type": "REQUEST_EXECUTION"
+        },
+        {
+          "end": 55,
+          "start": 52,
+          "type": "RESPONSE_HANDLING"
+        }
+      ],
+      "title": "agentidentitycredentials_v1beta_generated_auth_provider_credentials_service_finalize_credentials_async.py"
+    },
+    {
+      "canonical": true,
+      "clientMethod": {
+        "client": {
+          "fullName": "google.cloud.agentidentitycredentials_v1beta.AuthProviderCredentialsServiceClient",
+          "shortName": "AuthProviderCredentialsServiceClient"
+        },
+        "fullName": "google.cloud.agentidentitycredentials_v1beta.AuthProviderCredentialsServiceClient.finalize_credentials",
+        "method": {
+          "fullName": "google.cloud.agentidentitycredentials.v1beta.AuthProviderCredentialsService.FinalizeCredentials",
+          "service": {
+            "fullName": "google.cloud.agentidentitycredentials.v1beta.AuthProviderCredentialsService",
+            "shortName": "AuthProviderCredentialsService"
+          },
+          "shortName": "FinalizeCredentials"
+        },
+        "parameters": [
+          {
+            "name": "request",
+            "type": "google.cloud.agentidentitycredentials_v1beta.types.FinalizeCredentialsRequest"
+          },
+          {
+            "name": "retry",
+            "type": "google.api_core.retry.Retry"
+          },
+          {
+            "name": "timeout",
+            "type": "float"
+          },
+          {
+            "name": "metadata",
+            "type": "Sequence[Tuple[str, Union[str, bytes]]]"
+          }
+        ],
+        "resultType": "google.cloud.agentidentitycredentials_v1beta.types.FinalizeCredentialsResponse",
+        "shortName": "finalize_credentials"
+      },
+      "description": "Sample for FinalizeCredentials",
+      "file": "agentidentitycredentials_v1beta_generated_auth_provider_credentials_service_finalize_credentials_sync.py",
+      "language": "PYTHON",
+      "origin": "API_DEFINITION",
+      "regionTag": "agentidentitycredentials_v1beta_generated_AuthProviderCredentialsService_FinalizeCredentials_sync",
+      "segments": [
+        {
+          "end": 54,
+          "start": 27,
+          "type": "FULL"
+        },
+        {
+          "end": 54,
+          "start": 27,
+          "type": "SHORT"
+        },
+        {
+          "end": 40,
+          "start": 38,
+          "type": "CLIENT_INITIALIZATION"
+        },
+        {
+          "end": 48,
+          "start": 41,
+          "type": "REQUEST_INITIALIZATION"
+        },
+        {
+          "end": 51,
+          "start": 49,
+          "type": "REQUEST_EXECUTION"
+        },
+        {
+          "end": 55,
+          "start": 52,
+          "type": "RESPONSE_HANDLING"
+        }
+      ],
+      "title": "agentidentitycredentials_v1beta_generated_auth_provider_credentials_service_finalize_credentials_sync.py"
+    },
+    {
+      "canonical": true,
+      "clientMethod": {
+        "async": true,
+        "client": {
+          "fullName": "google.cloud.agentidentitycredentials_v1beta.AuthProviderCredentialsServiceAsyncClient",
+          "shortName": "AuthProviderCredentialsServiceAsyncClient"
+        },
+        "fullName": "google.cloud.agentidentitycredentials_v1beta.AuthProviderCredentialsServiceAsyncClient.retrieve_credentials",
+        "method": {
+          "fullName": "google.cloud.agentidentitycredentials.v1beta.AuthProviderCredentialsService.RetrieveCredentials",
+          "service": {
+            "fullName": "google.cloud.agentidentitycredentials.v1beta.AuthProviderCredentialsService",
+            "shortName": "AuthProviderCredentialsService"
+          },
+          "shortName": "RetrieveCredentials"
+        },
+        "parameters": [
+          {
+            "name": "request",
+            "type": "google.cloud.agentidentitycredentials_v1beta.types.RetrieveCredentialsRequest"
+          },
+          {
+            "name": "auth_provider",
+            "type": "str"
+          },
+          {
+            "name": "user_id",
+            "type": "str"
+          },
+          {
+            "name": "retry",
+            "type": "google.api_core.retry.Retry"
+          },
+          {
+            "name": "timeout",
+            "type": "float"
+          },
+          {
+            "name": "metadata",
+            "type": "Sequence[Tuple[str, Union[str, bytes]]]"
+          }
+        ],
+        "resultType": "google.cloud.agentidentitycredentials_v1beta.types.RetrieveCredentialsResponse",
+        "shortName": "retrieve_credentials"
+      },
+      "description": "Sample for RetrieveCredentials",
+      "file": "agentidentitycredentials_v1beta_generated_auth_provider_credentials_service_retrieve_credentials_async.py",
+      "language": "PYTHON",
+      "origin": "API_DEFINITION",
+      "regionTag": "agentidentitycredentials_v1beta_generated_AuthProviderCredentialsService_RetrieveCredentials_async",
+      "segments": [
+        {
+          "end": 52,
+          "start": 27,
+          "type": "FULL"
+        },
+        {
+          "end": 52,
+          "start": 27,
+          "type": "SHORT"
+        },
+        {
+          "end": 40,
+          "start": 38,
+          "type": "CLIENT_INITIALIZATION"
+        },
+        {
+          "end": 46,
+          "start": 41,
+          "type": "REQUEST_INITIALIZATION"
+        },
+        {
+          "end": 49,
+          "start": 47,
+          "type": "REQUEST_EXECUTION"
+        },
+        {
+          "end": 53,
+          "start": 50,
+          "type": "RESPONSE_HANDLING"
+        }
+      ],
+      "title": "agentidentitycredentials_v1beta_generated_auth_provider_credentials_service_retrieve_credentials_async.py"
+    },
+    {
+      "canonical": true,
+      "clientMethod": {
+        "client": {
+          "fullName": "google.cloud.agentidentitycredentials_v1beta.AuthProviderCredentialsServiceClient",
+          "shortName": "AuthProviderCredentialsServiceClient"
+        },
+        "fullName": "google.cloud.agentidentitycredentials_v1beta.AuthProviderCredentialsServiceClient.retrieve_credentials",
+        "method": {
+          "fullName": "google.cloud.agentidentitycredentials.v1beta.AuthProviderCredentialsService.RetrieveCredentials",
+          "service": {
+            "fullName": "google.cloud.agentidentitycredentials.v1beta.AuthProviderCredentialsService",
+            "shortName": "AuthProviderCredentialsService"
+          },
+          "shortName": "RetrieveCredentials"
+        },
+        "parameters": [
+          {
+            "name": "request",
+            "type": "google.cloud.agentidentitycredentials_v1beta.types.RetrieveCredentialsRequest"
+          },
+          {
+            "name": "auth_provider",
+            "type": "str"
+          },
+          {
+            "name": "user_id",
+            "type": "str"
+          },
+          {
+            "name": "retry",
+            "type": "google.api_core.retry.Retry"
+          },
+          {
+            "name": "timeout",
+            "type": "float"
+          },
+          {
+            "name": "metadata",
+            "type": "Sequence[Tuple[str, Union[str, bytes]]]"
+          }
+        ],
+        "resultType": "google.cloud.agentidentitycredentials_v1beta.types.RetrieveCredentialsResponse",
+        "shortName": "retrieve_credentials"
+      },
+      "description": "Sample for RetrieveCredentials",
+      "file": "agentidentitycredentials_v1beta_generated_auth_provider_credentials_service_retrieve_credentials_sync.py",
+      "language": "PYTHON",
+      "origin": "API_DEFINITION",
+      "regionTag": "agentidentitycredentials_v1beta_generated_AuthProviderCredentialsService_RetrieveCredentials_sync",
+      "segments": [
+        {
+          "end": 52,
+          "start": 27,
+          "type": "FULL"
+        },
+        {
+          "end": 52,
+          "start": 27,
+          "type": "SHORT"
+        },
+        {
+          "end": 40,
+          "start": 38,
+          "type": "CLIENT_INITIALIZATION"
+        },
+        {
+          "end": 46,
+          "start": 41,
+          "type": "REQUEST_INITIALIZATION"
+        },
+        {
+          "end": 49,
+          "start": 47,
+          "type": "REQUEST_EXECUTION"
+        },
+        {
+          "end": 53,
+          "start": 50,
+          "type": "RESPONSE_HANDLING"
+        }
+      ],
+      "title": "agentidentitycredentials_v1beta_generated_auth_provider_credentials_service_retrieve_credentials_sync.py"
+    }
+  ]
+}

--- a/packages/google-cloud-agentidentitycredentials/tests/unit/gapic/agentidentitycredentials_v1beta/__init__.py
+++ b/packages/google-cloud-agentidentitycredentials/tests/unit/gapic/agentidentitycredentials_v1beta/__init__.py
@@ -1,0 +1,15 @@
+# -*- coding: utf-8 -*-
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#

--- a/packages/google-cloud-agentidentitycredentials/tests/unit/gapic/agentidentitycredentials_v1beta/test_auth_provider_credentials_service.py
+++ b/packages/google-cloud-agentidentitycredentials/tests/unit/gapic/agentidentitycredentials_v1beta/test_auth_provider_credentials_service.py
@@ -1,0 +1,3710 @@
+# -*- coding: utf-8 -*-
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+import asyncio
+import json
+import math
+import os
+from collections.abc import AsyncIterable, Iterable, Mapping, Sequence
+from unittest import mock
+from unittest.mock import AsyncMock
+
+import grpc
+import pytest
+from google.api_core import api_core_version
+from google.protobuf import json_format
+from grpc.experimental import aio
+from proto.marshal.rules import wrappers
+from proto.marshal.rules.dates import DurationRule, TimestampRule
+from requests import PreparedRequest, Request, Response
+from requests.sessions import Session
+
+try:
+    from google.auth.aio import credentials as ga_credentials_async
+
+    HAS_GOOGLE_AUTH_AIO = True
+except ImportError:  # pragma: NO COVER
+    HAS_GOOGLE_AUTH_AIO = False
+
+import google.auth
+from google.api_core import (
+    client_options,
+    gapic_v1,
+    grpc_helpers,
+    grpc_helpers_async,
+    path_template,
+)
+from google.api_core import exceptions as core_exceptions
+from google.api_core import retry as retries
+from google.auth import credentials as ga_credentials
+from google.auth.exceptions import MutualTLSChannelError
+from google.oauth2 import service_account
+
+from google.cloud.agentidentitycredentials_v1beta.services.auth_provider_credentials_service import (
+    AuthProviderCredentialsServiceAsyncClient,
+    AuthProviderCredentialsServiceClient,
+    transports,
+)
+from google.cloud.agentidentitycredentials_v1beta.types import (
+    auth_provider_credentials_service,
+)
+
+CRED_INFO_JSON = {
+    "credential_source": "/path/to/file",
+    "credential_type": "service account credentials",
+    "principal": "service-account@example.com",
+}
+CRED_INFO_STRING = json.dumps(CRED_INFO_JSON)
+
+
+async def mock_async_gen(data, chunk_size=1):
+    for i in range(0, len(data)):  # pragma: NO COVER
+        chunk = data[i : i + chunk_size]
+        yield chunk.encode("utf-8")
+
+
+def client_cert_source_callback():
+    return b"cert bytes", b"key bytes"
+
+
+# TODO: use async auth anon credentials by default once the minimum version of google-auth is upgraded.
+# See related issue: https://github.com/googleapis/gapic-generator-python/issues/2107.
+def async_anonymous_credentials():
+    if HAS_GOOGLE_AUTH_AIO:
+        return ga_credentials_async.AnonymousCredentials()
+    return ga_credentials.AnonymousCredentials()
+
+
+# If default endpoint is localhost, then default mtls endpoint will be the same.
+# This method modifies the default endpoint so the client can produce a different
+# mtls endpoint for endpoint testing purposes.
+def modify_default_endpoint(client):
+    return (
+        "foo.googleapis.com"
+        if ("localhost" in client.DEFAULT_ENDPOINT)
+        else client.DEFAULT_ENDPOINT
+    )
+
+
+# If default endpoint template is localhost, then default mtls endpoint will be the same.
+# This method modifies the default endpoint template so the client can produce a different
+# mtls endpoint for endpoint testing purposes.
+def modify_default_endpoint_template(client):
+    return (
+        "test.{UNIVERSE_DOMAIN}"
+        if ("localhost" in client._DEFAULT_ENDPOINT_TEMPLATE)
+        else client._DEFAULT_ENDPOINT_TEMPLATE
+    )
+
+
+@pytest.fixture(autouse=True)
+def set_event_loop():
+    try:
+        asyncio.get_running_loop()
+        yield
+    except RuntimeError:
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+        try:
+            yield
+        finally:
+            loop.close()
+            asyncio.set_event_loop(None)
+
+
+def test__get_default_mtls_endpoint():
+    api_endpoint = "example.googleapis.com"
+    api_mtls_endpoint = "example.mtls.googleapis.com"
+    sandbox_endpoint = "example.sandbox.googleapis.com"
+    sandbox_mtls_endpoint = "example.mtls.sandbox.googleapis.com"
+    non_googleapi = "api.example.com"
+    custom_endpoint = ".custom"
+
+    assert AuthProviderCredentialsServiceClient._get_default_mtls_endpoint(None) is None
+    assert (
+        AuthProviderCredentialsServiceClient._get_default_mtls_endpoint(api_endpoint)
+        == api_mtls_endpoint
+    )
+    assert (
+        AuthProviderCredentialsServiceClient._get_default_mtls_endpoint(
+            api_mtls_endpoint
+        )
+        == api_mtls_endpoint
+    )
+    assert (
+        AuthProviderCredentialsServiceClient._get_default_mtls_endpoint(
+            sandbox_endpoint
+        )
+        == sandbox_mtls_endpoint
+    )
+    assert (
+        AuthProviderCredentialsServiceClient._get_default_mtls_endpoint(
+            sandbox_mtls_endpoint
+        )
+        == sandbox_mtls_endpoint
+    )
+    assert (
+        AuthProviderCredentialsServiceClient._get_default_mtls_endpoint(non_googleapi)
+        == non_googleapi
+    )
+    assert (
+        AuthProviderCredentialsServiceClient._get_default_mtls_endpoint(custom_endpoint)
+        == custom_endpoint
+    )
+
+
+def test__read_environment_variables():
+    assert AuthProviderCredentialsServiceClient._read_environment_variables() == (
+        False,
+        "auto",
+        None,
+    )
+
+    with mock.patch.dict(os.environ, {"GOOGLE_API_USE_CLIENT_CERTIFICATE": "true"}):
+        assert AuthProviderCredentialsServiceClient._read_environment_variables() == (
+            True,
+            "auto",
+            None,
+        )
+
+    with mock.patch.dict(os.environ, {"GOOGLE_API_USE_CLIENT_CERTIFICATE": "false"}):
+        assert AuthProviderCredentialsServiceClient._read_environment_variables() == (
+            False,
+            "auto",
+            None,
+        )
+
+    with mock.patch.dict(
+        os.environ, {"GOOGLE_API_USE_CLIENT_CERTIFICATE": "Unsupported"}
+    ):
+        if not hasattr(google.auth.transport.mtls, "should_use_client_cert"):
+            with pytest.raises(ValueError) as excinfo:
+                AuthProviderCredentialsServiceClient._read_environment_variables()
+            assert (
+                str(excinfo.value)
+                == "Environment variable `GOOGLE_API_USE_CLIENT_CERTIFICATE` must be either `true` or `false`"
+            )
+        else:
+            assert (
+                AuthProviderCredentialsServiceClient._read_environment_variables()
+                == (
+                    False,
+                    "auto",
+                    None,
+                )
+            )
+
+    with mock.patch.dict(os.environ, {"GOOGLE_API_USE_MTLS_ENDPOINT": "never"}):
+        assert AuthProviderCredentialsServiceClient._read_environment_variables() == (
+            False,
+            "never",
+            None,
+        )
+
+    with mock.patch.dict(os.environ, {"GOOGLE_API_USE_MTLS_ENDPOINT": "always"}):
+        assert AuthProviderCredentialsServiceClient._read_environment_variables() == (
+            False,
+            "always",
+            None,
+        )
+
+    with mock.patch.dict(os.environ, {"GOOGLE_API_USE_MTLS_ENDPOINT": "auto"}):
+        assert AuthProviderCredentialsServiceClient._read_environment_variables() == (
+            False,
+            "auto",
+            None,
+        )
+
+    with mock.patch.dict(os.environ, {"GOOGLE_API_USE_MTLS_ENDPOINT": "Unsupported"}):
+        with pytest.raises(MutualTLSChannelError) as excinfo:
+            AuthProviderCredentialsServiceClient._read_environment_variables()
+    assert (
+        str(excinfo.value)
+        == "Environment variable `GOOGLE_API_USE_MTLS_ENDPOINT` must be `never`, `auto` or `always`"
+    )
+
+    with mock.patch.dict(os.environ, {"GOOGLE_CLOUD_UNIVERSE_DOMAIN": "foo.com"}):
+        assert AuthProviderCredentialsServiceClient._read_environment_variables() == (
+            False,
+            "auto",
+            "foo.com",
+        )
+
+
+def test_use_client_cert_effective():
+    # Test case 1: Test when `should_use_client_cert` returns True.
+    # We mock the `should_use_client_cert` function to simulate a scenario where
+    # the google-auth library supports automatic mTLS and determines that a
+    # client certificate should be used.
+    if hasattr(google.auth.transport.mtls, "should_use_client_cert"):
+        with mock.patch(
+            "google.auth.transport.mtls.should_use_client_cert", return_value=True
+        ):
+            assert (
+                AuthProviderCredentialsServiceClient._use_client_cert_effective()
+                is True
+            )
+
+    # Test case 2: Test when `should_use_client_cert` returns False.
+    # We mock the `should_use_client_cert` function to simulate a scenario where
+    # the google-auth library supports automatic mTLS and determines that a
+    # client certificate should NOT be used.
+    if hasattr(google.auth.transport.mtls, "should_use_client_cert"):
+        with mock.patch(
+            "google.auth.transport.mtls.should_use_client_cert", return_value=False
+        ):
+            assert (
+                AuthProviderCredentialsServiceClient._use_client_cert_effective()
+                is False
+            )
+
+    # Test case 3: Test when `should_use_client_cert` is unavailable and the
+    # `GOOGLE_API_USE_CLIENT_CERTIFICATE` environment variable is set to "true".
+    if not hasattr(google.auth.transport.mtls, "should_use_client_cert"):
+        with mock.patch.dict(os.environ, {"GOOGLE_API_USE_CLIENT_CERTIFICATE": "true"}):
+            assert (
+                AuthProviderCredentialsServiceClient._use_client_cert_effective()
+                is True
+            )
+
+    # Test case 4: Test when `should_use_client_cert` is unavailable and the
+    # `GOOGLE_API_USE_CLIENT_CERTIFICATE` environment variable is set to "false".
+    if not hasattr(google.auth.transport.mtls, "should_use_client_cert"):
+        with mock.patch.dict(
+            os.environ, {"GOOGLE_API_USE_CLIENT_CERTIFICATE": "false"}
+        ):
+            assert (
+                AuthProviderCredentialsServiceClient._use_client_cert_effective()
+                is False
+            )
+
+    # Test case 5: Test when `should_use_client_cert` is unavailable and the
+    # `GOOGLE_API_USE_CLIENT_CERTIFICATE` environment variable is set to "True".
+    if not hasattr(google.auth.transport.mtls, "should_use_client_cert"):
+        with mock.patch.dict(os.environ, {"GOOGLE_API_USE_CLIENT_CERTIFICATE": "True"}):
+            assert (
+                AuthProviderCredentialsServiceClient._use_client_cert_effective()
+                is True
+            )
+
+    # Test case 6: Test when `should_use_client_cert` is unavailable and the
+    # `GOOGLE_API_USE_CLIENT_CERTIFICATE` environment variable is set to "False".
+    if not hasattr(google.auth.transport.mtls, "should_use_client_cert"):
+        with mock.patch.dict(
+            os.environ, {"GOOGLE_API_USE_CLIENT_CERTIFICATE": "False"}
+        ):
+            assert (
+                AuthProviderCredentialsServiceClient._use_client_cert_effective()
+                is False
+            )
+
+    # Test case 7: Test when `should_use_client_cert` is unavailable and the
+    # `GOOGLE_API_USE_CLIENT_CERTIFICATE` environment variable is set to "TRUE".
+    if not hasattr(google.auth.transport.mtls, "should_use_client_cert"):
+        with mock.patch.dict(os.environ, {"GOOGLE_API_USE_CLIENT_CERTIFICATE": "TRUE"}):
+            assert (
+                AuthProviderCredentialsServiceClient._use_client_cert_effective()
+                is True
+            )
+
+    # Test case 8: Test when `should_use_client_cert` is unavailable and the
+    # `GOOGLE_API_USE_CLIENT_CERTIFICATE` environment variable is set to "FALSE".
+    if not hasattr(google.auth.transport.mtls, "should_use_client_cert"):
+        with mock.patch.dict(
+            os.environ, {"GOOGLE_API_USE_CLIENT_CERTIFICATE": "FALSE"}
+        ):
+            assert (
+                AuthProviderCredentialsServiceClient._use_client_cert_effective()
+                is False
+            )
+
+    # Test case 9: Test when `should_use_client_cert` is unavailable and the
+    # `GOOGLE_API_USE_CLIENT_CERTIFICATE` environment variable is not set.
+    # In this case, the method should return False, which is the default value.
+    if not hasattr(google.auth.transport.mtls, "should_use_client_cert"):
+        with mock.patch.dict(os.environ, clear=True):
+            assert (
+                AuthProviderCredentialsServiceClient._use_client_cert_effective()
+                is False
+            )
+
+    # Test case 10: Test when `should_use_client_cert` is unavailable and the
+    # `GOOGLE_API_USE_CLIENT_CERTIFICATE` environment variable is set to an invalid value.
+    # The method should raise a ValueError as the environment variable must be either
+    # "true" or "false".
+    if not hasattr(google.auth.transport.mtls, "should_use_client_cert"):
+        with mock.patch.dict(
+            os.environ, {"GOOGLE_API_USE_CLIENT_CERTIFICATE": "unsupported"}
+        ):
+            with pytest.raises(ValueError):
+                AuthProviderCredentialsServiceClient._use_client_cert_effective()
+
+    # Test case 11: Test when `should_use_client_cert` is available and the
+    # `GOOGLE_API_USE_CLIENT_CERTIFICATE` environment variable is set to an invalid value.
+    # The method should return False as the environment variable is set to an invalid value.
+    if hasattr(google.auth.transport.mtls, "should_use_client_cert"):
+        with mock.patch.dict(
+            os.environ, {"GOOGLE_API_USE_CLIENT_CERTIFICATE": "unsupported"}
+        ):
+            assert (
+                AuthProviderCredentialsServiceClient._use_client_cert_effective()
+                is False
+            )
+
+    # Test case 12: Test when `should_use_client_cert` is available and the
+    # `GOOGLE_API_USE_CLIENT_CERTIFICATE` environment variable is unset. Also,
+    # the GOOGLE_API_CONFIG environment variable is unset.
+    if hasattr(google.auth.transport.mtls, "should_use_client_cert"):
+        with mock.patch.dict(os.environ, {"GOOGLE_API_USE_CLIENT_CERTIFICATE": ""}):
+            with mock.patch.dict(os.environ, {"GOOGLE_API_CERTIFICATE_CONFIG": ""}):
+                assert (
+                    AuthProviderCredentialsServiceClient._use_client_cert_effective()
+                    is False
+                )
+
+
+def test__get_client_cert_source():
+    mock_provided_cert_source = mock.Mock()
+    mock_default_cert_source = mock.Mock()
+
+    assert (
+        AuthProviderCredentialsServiceClient._get_client_cert_source(None, False)
+        is None
+    )
+    assert (
+        AuthProviderCredentialsServiceClient._get_client_cert_source(
+            mock_provided_cert_source, False
+        )
+        is None
+    )
+    assert (
+        AuthProviderCredentialsServiceClient._get_client_cert_source(
+            mock_provided_cert_source, True
+        )
+        == mock_provided_cert_source
+    )
+
+    with mock.patch(
+        "google.auth.transport.mtls.has_default_client_cert_source", return_value=True
+    ):
+        with mock.patch(
+            "google.auth.transport.mtls.default_client_cert_source",
+            return_value=mock_default_cert_source,
+        ):
+            assert (
+                AuthProviderCredentialsServiceClient._get_client_cert_source(None, True)
+                is mock_default_cert_source
+            )
+            assert (
+                AuthProviderCredentialsServiceClient._get_client_cert_source(
+                    mock_provided_cert_source, "true"
+                )
+                is mock_provided_cert_source
+            )
+
+
+@mock.patch.object(
+    AuthProviderCredentialsServiceClient,
+    "_DEFAULT_ENDPOINT_TEMPLATE",
+    modify_default_endpoint_template(AuthProviderCredentialsServiceClient),
+)
+@mock.patch.object(
+    AuthProviderCredentialsServiceAsyncClient,
+    "_DEFAULT_ENDPOINT_TEMPLATE",
+    modify_default_endpoint_template(AuthProviderCredentialsServiceAsyncClient),
+)
+def test__get_api_endpoint():
+    api_override = "foo.com"
+    mock_client_cert_source = mock.Mock()
+    default_universe = AuthProviderCredentialsServiceClient._DEFAULT_UNIVERSE
+    default_endpoint = (
+        AuthProviderCredentialsServiceClient._DEFAULT_ENDPOINT_TEMPLATE.format(
+            UNIVERSE_DOMAIN=default_universe
+        )
+    )
+    mock_universe = "bar.com"
+    mock_endpoint = (
+        AuthProviderCredentialsServiceClient._DEFAULT_ENDPOINT_TEMPLATE.format(
+            UNIVERSE_DOMAIN=mock_universe
+        )
+    )
+
+    assert (
+        AuthProviderCredentialsServiceClient._get_api_endpoint(
+            api_override, mock_client_cert_source, default_universe, "always"
+        )
+        == api_override
+    )
+    assert (
+        AuthProviderCredentialsServiceClient._get_api_endpoint(
+            None, mock_client_cert_source, default_universe, "auto"
+        )
+        == AuthProviderCredentialsServiceClient.DEFAULT_MTLS_ENDPOINT
+    )
+    assert (
+        AuthProviderCredentialsServiceClient._get_api_endpoint(
+            None, None, default_universe, "auto"
+        )
+        == default_endpoint
+    )
+    assert (
+        AuthProviderCredentialsServiceClient._get_api_endpoint(
+            None, None, default_universe, "always"
+        )
+        == AuthProviderCredentialsServiceClient.DEFAULT_MTLS_ENDPOINT
+    )
+    assert (
+        AuthProviderCredentialsServiceClient._get_api_endpoint(
+            None, mock_client_cert_source, default_universe, "always"
+        )
+        == AuthProviderCredentialsServiceClient.DEFAULT_MTLS_ENDPOINT
+    )
+    assert (
+        AuthProviderCredentialsServiceClient._get_api_endpoint(
+            None, None, mock_universe, "never"
+        )
+        == mock_endpoint
+    )
+    assert (
+        AuthProviderCredentialsServiceClient._get_api_endpoint(
+            None, None, default_universe, "never"
+        )
+        == default_endpoint
+    )
+
+    with pytest.raises(MutualTLSChannelError) as excinfo:
+        AuthProviderCredentialsServiceClient._get_api_endpoint(
+            None, mock_client_cert_source, mock_universe, "auto"
+        )
+    assert (
+        str(excinfo.value)
+        == "mTLS is not supported in any universe other than googleapis.com."
+    )
+
+
+def test__get_universe_domain():
+    client_universe_domain = "foo.com"
+    universe_domain_env = "bar.com"
+
+    assert (
+        AuthProviderCredentialsServiceClient._get_universe_domain(
+            client_universe_domain, universe_domain_env
+        )
+        == client_universe_domain
+    )
+    assert (
+        AuthProviderCredentialsServiceClient._get_universe_domain(
+            None, universe_domain_env
+        )
+        == universe_domain_env
+    )
+    assert (
+        AuthProviderCredentialsServiceClient._get_universe_domain(None, None)
+        == AuthProviderCredentialsServiceClient._DEFAULT_UNIVERSE
+    )
+
+    with pytest.raises(ValueError) as excinfo:
+        AuthProviderCredentialsServiceClient._get_universe_domain("", None)
+    assert str(excinfo.value) == "Universe Domain cannot be an empty string."
+
+
+@pytest.mark.parametrize(
+    "error_code,cred_info_json,show_cred_info",
+    [
+        (401, CRED_INFO_JSON, True),
+        (403, CRED_INFO_JSON, True),
+        (404, CRED_INFO_JSON, True),
+        (500, CRED_INFO_JSON, False),
+        (401, None, False),
+        (403, None, False),
+        (404, None, False),
+        (500, None, False),
+    ],
+)
+def test__add_cred_info_for_auth_errors(error_code, cred_info_json, show_cred_info):
+    cred = mock.Mock(["get_cred_info"])
+    cred.get_cred_info = mock.Mock(return_value=cred_info_json)
+    client = AuthProviderCredentialsServiceClient(credentials=cred)
+    client._transport._credentials = cred
+
+    error = core_exceptions.GoogleAPICallError("message", details=["foo"])
+    error.code = error_code
+
+    client._add_cred_info_for_auth_errors(error)
+    if show_cred_info:
+        assert error.details == ["foo", CRED_INFO_STRING]
+    else:
+        assert error.details == ["foo"]
+
+
+@pytest.mark.parametrize("error_code", [401, 403, 404, 500])
+def test__add_cred_info_for_auth_errors_no_get_cred_info(error_code):
+    cred = mock.Mock([])
+    assert not hasattr(cred, "get_cred_info")
+    client = AuthProviderCredentialsServiceClient(credentials=cred)
+    client._transport._credentials = cred
+
+    error = core_exceptions.GoogleAPICallError("message", details=[])
+    error.code = error_code
+
+    client._add_cred_info_for_auth_errors(error)
+    assert error.details == []
+
+
+@pytest.mark.parametrize(
+    "client_class,transport_name",
+    [
+        (AuthProviderCredentialsServiceClient, "grpc"),
+        (AuthProviderCredentialsServiceAsyncClient, "grpc_asyncio"),
+        (AuthProviderCredentialsServiceClient, "rest"),
+    ],
+)
+def test_auth_provider_credentials_service_client_from_service_account_info(
+    client_class, transport_name
+):
+    creds = ga_credentials.AnonymousCredentials()
+    with mock.patch.object(
+        service_account.Credentials, "from_service_account_info"
+    ) as factory:
+        factory.return_value = creds
+        info = {"valid": True}
+        client = client_class.from_service_account_info(info, transport=transport_name)
+        assert client.transport._credentials == creds
+        assert isinstance(client, client_class)
+
+        assert client.transport._host == (
+            "agentidentitycredentials.googleapis.com:443"
+            if transport_name in ["grpc", "grpc_asyncio"]
+            else "https://agentidentitycredentials.googleapis.com"
+        )
+
+
+@pytest.mark.parametrize(
+    "transport_class,transport_name",
+    [
+        (transports.AuthProviderCredentialsServiceGrpcTransport, "grpc"),
+        (transports.AuthProviderCredentialsServiceGrpcAsyncIOTransport, "grpc_asyncio"),
+        (transports.AuthProviderCredentialsServiceRestTransport, "rest"),
+    ],
+)
+def test_auth_provider_credentials_service_client_service_account_always_use_jwt(
+    transport_class, transport_name
+):
+    with mock.patch.object(
+        service_account.Credentials, "with_always_use_jwt_access", create=True
+    ) as use_jwt:
+        creds = service_account.Credentials(None, None, None)
+        transport = transport_class(credentials=creds, always_use_jwt_access=True)
+        use_jwt.assert_called_once_with(True)
+
+    with mock.patch.object(
+        service_account.Credentials, "with_always_use_jwt_access", create=True
+    ) as use_jwt:
+        creds = service_account.Credentials(None, None, None)
+        transport = transport_class(credentials=creds, always_use_jwt_access=False)
+        use_jwt.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "client_class,transport_name",
+    [
+        (AuthProviderCredentialsServiceClient, "grpc"),
+        (AuthProviderCredentialsServiceAsyncClient, "grpc_asyncio"),
+        (AuthProviderCredentialsServiceClient, "rest"),
+    ],
+)
+def test_auth_provider_credentials_service_client_from_service_account_file(
+    client_class, transport_name
+):
+    creds = ga_credentials.AnonymousCredentials()
+    with mock.patch.object(
+        service_account.Credentials, "from_service_account_file"
+    ) as factory:
+        factory.return_value = creds
+        client = client_class.from_service_account_file(
+            "dummy/file/path.json", transport=transport_name
+        )
+        assert client.transport._credentials == creds
+        assert isinstance(client, client_class)
+
+        client = client_class.from_service_account_json(
+            "dummy/file/path.json", transport=transport_name
+        )
+        assert client.transport._credentials == creds
+        assert isinstance(client, client_class)
+
+        assert client.transport._host == (
+            "agentidentitycredentials.googleapis.com:443"
+            if transport_name in ["grpc", "grpc_asyncio"]
+            else "https://agentidentitycredentials.googleapis.com"
+        )
+
+
+def test_auth_provider_credentials_service_client_get_transport_class():
+    transport = AuthProviderCredentialsServiceClient.get_transport_class()
+    available_transports = [
+        transports.AuthProviderCredentialsServiceGrpcTransport,
+        transports.AuthProviderCredentialsServiceRestTransport,
+    ]
+    assert transport in available_transports
+
+    transport = AuthProviderCredentialsServiceClient.get_transport_class("grpc")
+    assert transport == transports.AuthProviderCredentialsServiceGrpcTransport
+
+
+@pytest.mark.parametrize(
+    "client_class,transport_class,transport_name",
+    [
+        (
+            AuthProviderCredentialsServiceClient,
+            transports.AuthProviderCredentialsServiceGrpcTransport,
+            "grpc",
+        ),
+        (
+            AuthProviderCredentialsServiceAsyncClient,
+            transports.AuthProviderCredentialsServiceGrpcAsyncIOTransport,
+            "grpc_asyncio",
+        ),
+        (
+            AuthProviderCredentialsServiceClient,
+            transports.AuthProviderCredentialsServiceRestTransport,
+            "rest",
+        ),
+    ],
+)
+@mock.patch.object(
+    AuthProviderCredentialsServiceClient,
+    "_DEFAULT_ENDPOINT_TEMPLATE",
+    modify_default_endpoint_template(AuthProviderCredentialsServiceClient),
+)
+@mock.patch.object(
+    AuthProviderCredentialsServiceAsyncClient,
+    "_DEFAULT_ENDPOINT_TEMPLATE",
+    modify_default_endpoint_template(AuthProviderCredentialsServiceAsyncClient),
+)
+def test_auth_provider_credentials_service_client_client_options(
+    client_class, transport_class, transport_name
+):
+    # Check that if channel is provided we won't create a new one.
+    with mock.patch.object(
+        AuthProviderCredentialsServiceClient, "get_transport_class"
+    ) as gtc:
+        transport = transport_class(credentials=ga_credentials.AnonymousCredentials())
+        client = client_class(transport=transport)
+        gtc.assert_not_called()
+
+    # Check that if channel is provided via str we will create a new one.
+    with mock.patch.object(
+        AuthProviderCredentialsServiceClient, "get_transport_class"
+    ) as gtc:
+        client = client_class(transport=transport_name)
+        gtc.assert_called()
+
+    # Check the case api_endpoint is provided.
+    options = client_options.ClientOptions(api_endpoint="squid.clam.whelk")
+    with mock.patch.object(transport_class, "__init__") as patched:
+        patched.return_value = None
+        client = client_class(transport=transport_name, client_options=options)
+        patched.assert_called_once_with(
+            credentials=None,
+            credentials_file=None,
+            host="squid.clam.whelk",
+            scopes=None,
+            client_cert_source_for_mtls=None,
+            quota_project_id=None,
+            client_info=transports.base.DEFAULT_CLIENT_INFO,
+            always_use_jwt_access=True,
+            api_audience=None,
+        )
+
+    # Check the case api_endpoint is not provided and GOOGLE_API_USE_MTLS_ENDPOINT is
+    # "never".
+    with mock.patch.dict(os.environ, {"GOOGLE_API_USE_MTLS_ENDPOINT": "never"}):
+        with mock.patch.object(transport_class, "__init__") as patched:
+            patched.return_value = None
+            client = client_class(transport=transport_name)
+            patched.assert_called_once_with(
+                credentials=None,
+                credentials_file=None,
+                host=client._DEFAULT_ENDPOINT_TEMPLATE.format(
+                    UNIVERSE_DOMAIN=client._DEFAULT_UNIVERSE
+                ),
+                scopes=None,
+                client_cert_source_for_mtls=None,
+                quota_project_id=None,
+                client_info=transports.base.DEFAULT_CLIENT_INFO,
+                always_use_jwt_access=True,
+                api_audience=None,
+            )
+
+    # Check the case api_endpoint is not provided and GOOGLE_API_USE_MTLS_ENDPOINT is
+    # "always".
+    with mock.patch.dict(os.environ, {"GOOGLE_API_USE_MTLS_ENDPOINT": "always"}):
+        with mock.patch.object(transport_class, "__init__") as patched:
+            patched.return_value = None
+            client = client_class(transport=transport_name)
+            patched.assert_called_once_with(
+                credentials=None,
+                credentials_file=None,
+                host=client.DEFAULT_MTLS_ENDPOINT,
+                scopes=None,
+                client_cert_source_for_mtls=None,
+                quota_project_id=None,
+                client_info=transports.base.DEFAULT_CLIENT_INFO,
+                always_use_jwt_access=True,
+                api_audience=None,
+            )
+
+    # Check the case api_endpoint is not provided and GOOGLE_API_USE_MTLS_ENDPOINT has
+    # unsupported value.
+    with mock.patch.dict(os.environ, {"GOOGLE_API_USE_MTLS_ENDPOINT": "Unsupported"}):
+        with pytest.raises(MutualTLSChannelError) as excinfo:
+            client = client_class(transport=transport_name)
+    assert (
+        str(excinfo.value)
+        == "Environment variable `GOOGLE_API_USE_MTLS_ENDPOINT` must be `never`, `auto` or `always`"
+    )
+
+    # Check the case quota_project_id is provided
+    options = client_options.ClientOptions(quota_project_id="octopus")
+    with mock.patch.object(transport_class, "__init__") as patched:
+        patched.return_value = None
+        client = client_class(client_options=options, transport=transport_name)
+        patched.assert_called_once_with(
+            credentials=None,
+            credentials_file=None,
+            host=client._DEFAULT_ENDPOINT_TEMPLATE.format(
+                UNIVERSE_DOMAIN=client._DEFAULT_UNIVERSE
+            ),
+            scopes=None,
+            client_cert_source_for_mtls=None,
+            quota_project_id="octopus",
+            client_info=transports.base.DEFAULT_CLIENT_INFO,
+            always_use_jwt_access=True,
+            api_audience=None,
+        )
+    # Check the case api_endpoint is provided
+    options = client_options.ClientOptions(
+        api_audience="https://language.googleapis.com"
+    )
+    with mock.patch.object(transport_class, "__init__") as patched:
+        patched.return_value = None
+        client = client_class(client_options=options, transport=transport_name)
+        patched.assert_called_once_with(
+            credentials=None,
+            credentials_file=None,
+            host=client._DEFAULT_ENDPOINT_TEMPLATE.format(
+                UNIVERSE_DOMAIN=client._DEFAULT_UNIVERSE
+            ),
+            scopes=None,
+            client_cert_source_for_mtls=None,
+            quota_project_id=None,
+            client_info=transports.base.DEFAULT_CLIENT_INFO,
+            always_use_jwt_access=True,
+            api_audience="https://language.googleapis.com",
+        )
+
+
+@pytest.mark.parametrize(
+    "client_class,transport_class,transport_name,use_client_cert_env",
+    [
+        (
+            AuthProviderCredentialsServiceClient,
+            transports.AuthProviderCredentialsServiceGrpcTransport,
+            "grpc",
+            "true",
+        ),
+        (
+            AuthProviderCredentialsServiceAsyncClient,
+            transports.AuthProviderCredentialsServiceGrpcAsyncIOTransport,
+            "grpc_asyncio",
+            "true",
+        ),
+        (
+            AuthProviderCredentialsServiceClient,
+            transports.AuthProviderCredentialsServiceGrpcTransport,
+            "grpc",
+            "false",
+        ),
+        (
+            AuthProviderCredentialsServiceAsyncClient,
+            transports.AuthProviderCredentialsServiceGrpcAsyncIOTransport,
+            "grpc_asyncio",
+            "false",
+        ),
+        (
+            AuthProviderCredentialsServiceClient,
+            transports.AuthProviderCredentialsServiceRestTransport,
+            "rest",
+            "true",
+        ),
+        (
+            AuthProviderCredentialsServiceClient,
+            transports.AuthProviderCredentialsServiceRestTransport,
+            "rest",
+            "false",
+        ),
+    ],
+)
+@mock.patch.object(
+    AuthProviderCredentialsServiceClient,
+    "_DEFAULT_ENDPOINT_TEMPLATE",
+    modify_default_endpoint_template(AuthProviderCredentialsServiceClient),
+)
+@mock.patch.object(
+    AuthProviderCredentialsServiceAsyncClient,
+    "_DEFAULT_ENDPOINT_TEMPLATE",
+    modify_default_endpoint_template(AuthProviderCredentialsServiceAsyncClient),
+)
+@mock.patch.dict(os.environ, {"GOOGLE_API_USE_MTLS_ENDPOINT": "auto"})
+def test_auth_provider_credentials_service_client_mtls_env_auto(
+    client_class, transport_class, transport_name, use_client_cert_env
+):
+    # This tests the endpoint autoswitch behavior. Endpoint is autoswitched to the default
+    # mtls endpoint, if GOOGLE_API_USE_CLIENT_CERTIFICATE is "true" and client cert exists.
+
+    # Check the case client_cert_source is provided. Whether client cert is used depends on
+    # GOOGLE_API_USE_CLIENT_CERTIFICATE value.
+    with mock.patch.dict(
+        os.environ, {"GOOGLE_API_USE_CLIENT_CERTIFICATE": use_client_cert_env}
+    ):
+        options = client_options.ClientOptions(
+            client_cert_source=client_cert_source_callback
+        )
+        with mock.patch.object(transport_class, "__init__") as patched:
+            patched.return_value = None
+            client = client_class(client_options=options, transport=transport_name)
+
+            if use_client_cert_env == "false":
+                expected_client_cert_source = None
+                expected_host = client._DEFAULT_ENDPOINT_TEMPLATE.format(
+                    UNIVERSE_DOMAIN=client._DEFAULT_UNIVERSE
+                )
+            else:
+                expected_client_cert_source = client_cert_source_callback
+                expected_host = client.DEFAULT_MTLS_ENDPOINT
+
+            patched.assert_called_once_with(
+                credentials=None,
+                credentials_file=None,
+                host=expected_host,
+                scopes=None,
+                client_cert_source_for_mtls=expected_client_cert_source,
+                quota_project_id=None,
+                client_info=transports.base.DEFAULT_CLIENT_INFO,
+                always_use_jwt_access=True,
+                api_audience=None,
+            )
+
+    # Check the case ADC client cert is provided. Whether client cert is used depends on
+    # GOOGLE_API_USE_CLIENT_CERTIFICATE value.
+    with mock.patch.dict(
+        os.environ, {"GOOGLE_API_USE_CLIENT_CERTIFICATE": use_client_cert_env}
+    ):
+        with mock.patch.object(transport_class, "__init__") as patched:
+            with mock.patch(
+                "google.auth.transport.mtls.has_default_client_cert_source",
+                return_value=True,
+            ):
+                with mock.patch(
+                    "google.auth.transport.mtls.default_client_cert_source",
+                    return_value=client_cert_source_callback,
+                ):
+                    if use_client_cert_env == "false":
+                        expected_host = client._DEFAULT_ENDPOINT_TEMPLATE.format(
+                            UNIVERSE_DOMAIN=client._DEFAULT_UNIVERSE
+                        )
+                        expected_client_cert_source = None
+                    else:
+                        expected_host = client.DEFAULT_MTLS_ENDPOINT
+                        expected_client_cert_source = client_cert_source_callback
+
+                    patched.return_value = None
+                    client = client_class(transport=transport_name)
+                    patched.assert_called_once_with(
+                        credentials=None,
+                        credentials_file=None,
+                        host=expected_host,
+                        scopes=None,
+                        client_cert_source_for_mtls=expected_client_cert_source,
+                        quota_project_id=None,
+                        client_info=transports.base.DEFAULT_CLIENT_INFO,
+                        always_use_jwt_access=True,
+                        api_audience=None,
+                    )
+
+    # Check the case client_cert_source and ADC client cert are not provided.
+    with mock.patch.dict(
+        os.environ, {"GOOGLE_API_USE_CLIENT_CERTIFICATE": use_client_cert_env}
+    ):
+        with mock.patch.object(transport_class, "__init__") as patched:
+            with mock.patch(
+                "google.auth.transport.mtls.has_default_client_cert_source",
+                return_value=False,
+            ):
+                patched.return_value = None
+                client = client_class(transport=transport_name)
+                patched.assert_called_once_with(
+                    credentials=None,
+                    credentials_file=None,
+                    host=client._DEFAULT_ENDPOINT_TEMPLATE.format(
+                        UNIVERSE_DOMAIN=client._DEFAULT_UNIVERSE
+                    ),
+                    scopes=None,
+                    client_cert_source_for_mtls=None,
+                    quota_project_id=None,
+                    client_info=transports.base.DEFAULT_CLIENT_INFO,
+                    always_use_jwt_access=True,
+                    api_audience=None,
+                )
+
+
+@pytest.mark.parametrize(
+    "client_class",
+    [AuthProviderCredentialsServiceClient, AuthProviderCredentialsServiceAsyncClient],
+)
+@mock.patch.object(
+    AuthProviderCredentialsServiceClient,
+    "DEFAULT_ENDPOINT",
+    modify_default_endpoint(AuthProviderCredentialsServiceClient),
+)
+@mock.patch.object(
+    AuthProviderCredentialsServiceAsyncClient,
+    "DEFAULT_ENDPOINT",
+    modify_default_endpoint(AuthProviderCredentialsServiceAsyncClient),
+)
+def test_auth_provider_credentials_service_client_get_mtls_endpoint_and_cert_source(
+    client_class,
+):
+    mock_client_cert_source = mock.Mock()
+
+    # Test the case GOOGLE_API_USE_CLIENT_CERTIFICATE is "true".
+    with mock.patch.dict(os.environ, {"GOOGLE_API_USE_CLIENT_CERTIFICATE": "true"}):
+        mock_api_endpoint = "foo"
+        options = client_options.ClientOptions(
+            client_cert_source=mock_client_cert_source, api_endpoint=mock_api_endpoint
+        )
+        api_endpoint, cert_source = client_class.get_mtls_endpoint_and_cert_source(
+            options
+        )
+        assert api_endpoint == mock_api_endpoint
+        assert cert_source == mock_client_cert_source
+
+    # Test the case GOOGLE_API_USE_CLIENT_CERTIFICATE is "false".
+    with mock.patch.dict(os.environ, {"GOOGLE_API_USE_CLIENT_CERTIFICATE": "false"}):
+        mock_client_cert_source = mock.Mock()
+        mock_api_endpoint = "foo"
+        options = client_options.ClientOptions(
+            client_cert_source=mock_client_cert_source, api_endpoint=mock_api_endpoint
+        )
+        api_endpoint, cert_source = client_class.get_mtls_endpoint_and_cert_source(
+            options
+        )
+        assert api_endpoint == mock_api_endpoint
+        assert cert_source is None
+
+    # Test the case GOOGLE_API_USE_CLIENT_CERTIFICATE is "Unsupported".
+    with mock.patch.dict(
+        os.environ, {"GOOGLE_API_USE_CLIENT_CERTIFICATE": "Unsupported"}
+    ):
+        if hasattr(google.auth.transport.mtls, "should_use_client_cert"):
+            mock_client_cert_source = mock.Mock()
+            mock_api_endpoint = "foo"
+            options = client_options.ClientOptions(
+                client_cert_source=mock_client_cert_source,
+                api_endpoint=mock_api_endpoint,
+            )
+            api_endpoint, cert_source = client_class.get_mtls_endpoint_and_cert_source(
+                options
+            )
+            assert api_endpoint == mock_api_endpoint
+            assert cert_source is None
+
+    # Test cases for mTLS enablement when GOOGLE_API_USE_CLIENT_CERTIFICATE is unset.
+    test_cases = [
+        (
+            # With workloads present in config, mTLS is enabled.
+            {
+                "version": 1,
+                "cert_configs": {
+                    "workload": {
+                        "cert_path": "path/to/cert/file",
+                        "key_path": "path/to/key/file",
+                    }
+                },
+            },
+            mock_client_cert_source,
+        ),
+        (
+            # With workloads not present in config, mTLS is disabled.
+            {
+                "version": 1,
+                "cert_configs": {},
+            },
+            None,
+        ),
+    ]
+    if hasattr(google.auth.transport.mtls, "should_use_client_cert"):
+        for config_data, expected_cert_source in test_cases:
+            env = os.environ.copy()
+            env.pop("GOOGLE_API_USE_CLIENT_CERTIFICATE", None)
+            with mock.patch.dict(os.environ, env, clear=True):
+                config_filename = "mock_certificate_config.json"
+                config_file_content = json.dumps(config_data)
+                m = mock.mock_open(read_data=config_file_content)
+                with mock.patch("builtins.open", m):
+                    with mock.patch.dict(
+                        os.environ, {"GOOGLE_API_CERTIFICATE_CONFIG": config_filename}
+                    ):
+                        mock_api_endpoint = "foo"
+                        options = client_options.ClientOptions(
+                            client_cert_source=mock_client_cert_source,
+                            api_endpoint=mock_api_endpoint,
+                        )
+                        api_endpoint, cert_source = (
+                            client_class.get_mtls_endpoint_and_cert_source(options)
+                        )
+                        assert api_endpoint == mock_api_endpoint
+                        assert cert_source is expected_cert_source
+
+    # Test cases for mTLS enablement when GOOGLE_API_USE_CLIENT_CERTIFICATE is unset(empty).
+    test_cases = [
+        (
+            # With workloads present in config, mTLS is enabled.
+            {
+                "version": 1,
+                "cert_configs": {
+                    "workload": {
+                        "cert_path": "path/to/cert/file",
+                        "key_path": "path/to/key/file",
+                    }
+                },
+            },
+            mock_client_cert_source,
+        ),
+        (
+            # With workloads not present in config, mTLS is disabled.
+            {
+                "version": 1,
+                "cert_configs": {},
+            },
+            None,
+        ),
+    ]
+    if hasattr(google.auth.transport.mtls, "should_use_client_cert"):
+        for config_data, expected_cert_source in test_cases:
+            env = os.environ.copy()
+            env.pop("GOOGLE_API_USE_CLIENT_CERTIFICATE", "")
+            with mock.patch.dict(os.environ, env, clear=True):
+                config_filename = "mock_certificate_config.json"
+                config_file_content = json.dumps(config_data)
+                m = mock.mock_open(read_data=config_file_content)
+                with mock.patch("builtins.open", m):
+                    with mock.patch.dict(
+                        os.environ, {"GOOGLE_API_CERTIFICATE_CONFIG": config_filename}
+                    ):
+                        mock_api_endpoint = "foo"
+                        options = client_options.ClientOptions(
+                            client_cert_source=mock_client_cert_source,
+                            api_endpoint=mock_api_endpoint,
+                        )
+                        api_endpoint, cert_source = (
+                            client_class.get_mtls_endpoint_and_cert_source(options)
+                        )
+                        assert api_endpoint == mock_api_endpoint
+                        assert cert_source is expected_cert_source
+
+    # Test the case GOOGLE_API_USE_MTLS_ENDPOINT is "never".
+    with mock.patch.dict(os.environ, {"GOOGLE_API_USE_MTLS_ENDPOINT": "never"}):
+        api_endpoint, cert_source = client_class.get_mtls_endpoint_and_cert_source()
+        assert api_endpoint == client_class.DEFAULT_ENDPOINT
+        assert cert_source is None
+
+    # Test the case GOOGLE_API_USE_MTLS_ENDPOINT is "always".
+    with mock.patch.dict(os.environ, {"GOOGLE_API_USE_MTLS_ENDPOINT": "always"}):
+        api_endpoint, cert_source = client_class.get_mtls_endpoint_and_cert_source()
+        assert api_endpoint == client_class.DEFAULT_MTLS_ENDPOINT
+        assert cert_source is None
+
+    # Test the case GOOGLE_API_USE_MTLS_ENDPOINT is "auto" and default cert doesn't exist.
+    with mock.patch.dict(os.environ, {"GOOGLE_API_USE_CLIENT_CERTIFICATE": "true"}):
+        with mock.patch(
+            "google.auth.transport.mtls.has_default_client_cert_source",
+            return_value=False,
+        ):
+            api_endpoint, cert_source = client_class.get_mtls_endpoint_and_cert_source()
+            assert api_endpoint == client_class.DEFAULT_ENDPOINT
+            assert cert_source is None
+
+    # Test the case GOOGLE_API_USE_MTLS_ENDPOINT is "auto" and default cert exists.
+    with mock.patch.dict(os.environ, {"GOOGLE_API_USE_CLIENT_CERTIFICATE": "true"}):
+        with mock.patch(
+            "google.auth.transport.mtls.has_default_client_cert_source",
+            return_value=True,
+        ):
+            with mock.patch(
+                "google.auth.transport.mtls.default_client_cert_source",
+                return_value=mock_client_cert_source,
+            ):
+                api_endpoint, cert_source = (
+                    client_class.get_mtls_endpoint_and_cert_source()
+                )
+                assert api_endpoint == client_class.DEFAULT_MTLS_ENDPOINT
+                assert cert_source == mock_client_cert_source
+
+    # Check the case api_endpoint is not provided and GOOGLE_API_USE_MTLS_ENDPOINT has
+    # unsupported value.
+    with mock.patch.dict(os.environ, {"GOOGLE_API_USE_MTLS_ENDPOINT": "Unsupported"}):
+        with pytest.raises(MutualTLSChannelError) as excinfo:
+            client_class.get_mtls_endpoint_and_cert_source()
+
+        assert (
+            str(excinfo.value)
+            == "Environment variable `GOOGLE_API_USE_MTLS_ENDPOINT` must be `never`, `auto` or `always`"
+        )
+
+
+@pytest.mark.parametrize(
+    "client_class",
+    [AuthProviderCredentialsServiceClient, AuthProviderCredentialsServiceAsyncClient],
+)
+@mock.patch.object(
+    AuthProviderCredentialsServiceClient,
+    "_DEFAULT_ENDPOINT_TEMPLATE",
+    modify_default_endpoint_template(AuthProviderCredentialsServiceClient),
+)
+@mock.patch.object(
+    AuthProviderCredentialsServiceAsyncClient,
+    "_DEFAULT_ENDPOINT_TEMPLATE",
+    modify_default_endpoint_template(AuthProviderCredentialsServiceAsyncClient),
+)
+def test_auth_provider_credentials_service_client_client_api_endpoint(client_class):
+    mock_client_cert_source = client_cert_source_callback
+    api_override = "foo.com"
+    default_universe = AuthProviderCredentialsServiceClient._DEFAULT_UNIVERSE
+    default_endpoint = (
+        AuthProviderCredentialsServiceClient._DEFAULT_ENDPOINT_TEMPLATE.format(
+            UNIVERSE_DOMAIN=default_universe
+        )
+    )
+    mock_universe = "bar.com"
+    mock_endpoint = (
+        AuthProviderCredentialsServiceClient._DEFAULT_ENDPOINT_TEMPLATE.format(
+            UNIVERSE_DOMAIN=mock_universe
+        )
+    )
+
+    # If ClientOptions.api_endpoint is set and GOOGLE_API_USE_CLIENT_CERTIFICATE="true",
+    # use ClientOptions.api_endpoint as the api endpoint regardless.
+    with mock.patch.dict(os.environ, {"GOOGLE_API_USE_CLIENT_CERTIFICATE": "true"}):
+        with mock.patch(
+            "google.auth.transport.requests.AuthorizedSession.configure_mtls_channel"
+        ):
+            options = client_options.ClientOptions(
+                client_cert_source=mock_client_cert_source, api_endpoint=api_override
+            )
+            client = client_class(
+                client_options=options,
+                credentials=ga_credentials.AnonymousCredentials(),
+            )
+            assert client.api_endpoint == api_override
+
+    # If ClientOptions.api_endpoint is not set and GOOGLE_API_USE_MTLS_ENDPOINT="never",
+    # use the _DEFAULT_ENDPOINT_TEMPLATE populated with GDU as the api endpoint.
+    with mock.patch.dict(os.environ, {"GOOGLE_API_USE_MTLS_ENDPOINT": "never"}):
+        client = client_class(credentials=ga_credentials.AnonymousCredentials())
+        assert client.api_endpoint == default_endpoint
+
+    # If ClientOptions.api_endpoint is not set and GOOGLE_API_USE_MTLS_ENDPOINT="always",
+    # use the DEFAULT_MTLS_ENDPOINT as the api endpoint.
+    with mock.patch.dict(os.environ, {"GOOGLE_API_USE_MTLS_ENDPOINT": "always"}):
+        client = client_class(credentials=ga_credentials.AnonymousCredentials())
+        assert client.api_endpoint == client_class.DEFAULT_MTLS_ENDPOINT
+
+    # If ClientOptions.api_endpoint is not set, GOOGLE_API_USE_MTLS_ENDPOINT="auto" (default),
+    # GOOGLE_API_USE_CLIENT_CERTIFICATE="false" (default), default cert source doesn't exist,
+    # and ClientOptions.universe_domain="bar.com",
+    # use the _DEFAULT_ENDPOINT_TEMPLATE populated with universe domain as the api endpoint.
+    options = client_options.ClientOptions()
+    universe_exists = hasattr(options, "universe_domain")
+    if universe_exists:
+        options = client_options.ClientOptions(universe_domain=mock_universe)
+        client = client_class(
+            client_options=options, credentials=ga_credentials.AnonymousCredentials()
+        )
+    else:
+        client = client_class(
+            client_options=options, credentials=ga_credentials.AnonymousCredentials()
+        )
+    assert client.api_endpoint == (
+        mock_endpoint if universe_exists else default_endpoint
+    )
+    assert client.universe_domain == (
+        mock_universe if universe_exists else default_universe
+    )
+
+    # If ClientOptions does not have a universe domain attribute and GOOGLE_API_USE_MTLS_ENDPOINT="never",
+    # use the _DEFAULT_ENDPOINT_TEMPLATE populated with GDU as the api endpoint.
+    options = client_options.ClientOptions()
+    if hasattr(options, "universe_domain"):
+        delattr(options, "universe_domain")
+    with mock.patch.dict(os.environ, {"GOOGLE_API_USE_MTLS_ENDPOINT": "never"}):
+        client = client_class(
+            client_options=options, credentials=ga_credentials.AnonymousCredentials()
+        )
+        assert client.api_endpoint == default_endpoint
+
+
+@pytest.mark.parametrize(
+    "client_class,transport_class,transport_name",
+    [
+        (
+            AuthProviderCredentialsServiceClient,
+            transports.AuthProviderCredentialsServiceGrpcTransport,
+            "grpc",
+        ),
+        (
+            AuthProviderCredentialsServiceAsyncClient,
+            transports.AuthProviderCredentialsServiceGrpcAsyncIOTransport,
+            "grpc_asyncio",
+        ),
+        (
+            AuthProviderCredentialsServiceClient,
+            transports.AuthProviderCredentialsServiceRestTransport,
+            "rest",
+        ),
+    ],
+)
+def test_auth_provider_credentials_service_client_client_options_scopes(
+    client_class, transport_class, transport_name
+):
+    # Check the case scopes are provided.
+    options = client_options.ClientOptions(
+        scopes=["1", "2"],
+    )
+    with mock.patch.object(transport_class, "__init__") as patched:
+        patched.return_value = None
+        client = client_class(client_options=options, transport=transport_name)
+        patched.assert_called_once_with(
+            credentials=None,
+            credentials_file=None,
+            host=client._DEFAULT_ENDPOINT_TEMPLATE.format(
+                UNIVERSE_DOMAIN=client._DEFAULT_UNIVERSE
+            ),
+            scopes=["1", "2"],
+            client_cert_source_for_mtls=None,
+            quota_project_id=None,
+            client_info=transports.base.DEFAULT_CLIENT_INFO,
+            always_use_jwt_access=True,
+            api_audience=None,
+        )
+
+
+@pytest.mark.parametrize(
+    "client_class,transport_class,transport_name,grpc_helpers",
+    [
+        (
+            AuthProviderCredentialsServiceClient,
+            transports.AuthProviderCredentialsServiceGrpcTransport,
+            "grpc",
+            grpc_helpers,
+        ),
+        (
+            AuthProviderCredentialsServiceAsyncClient,
+            transports.AuthProviderCredentialsServiceGrpcAsyncIOTransport,
+            "grpc_asyncio",
+            grpc_helpers_async,
+        ),
+        (
+            AuthProviderCredentialsServiceClient,
+            transports.AuthProviderCredentialsServiceRestTransport,
+            "rest",
+            None,
+        ),
+    ],
+)
+def test_auth_provider_credentials_service_client_client_options_credentials_file(
+    client_class, transport_class, transport_name, grpc_helpers
+):
+    # Check the case credentials file is provided.
+    options = client_options.ClientOptions(credentials_file="credentials.json")
+
+    with mock.patch.object(transport_class, "__init__") as patched:
+        patched.return_value = None
+        client = client_class(client_options=options, transport=transport_name)
+        patched.assert_called_once_with(
+            credentials=None,
+            credentials_file="credentials.json",
+            host=client._DEFAULT_ENDPOINT_TEMPLATE.format(
+                UNIVERSE_DOMAIN=client._DEFAULT_UNIVERSE
+            ),
+            scopes=None,
+            client_cert_source_for_mtls=None,
+            quota_project_id=None,
+            client_info=transports.base.DEFAULT_CLIENT_INFO,
+            always_use_jwt_access=True,
+            api_audience=None,
+        )
+
+
+def test_auth_provider_credentials_service_client_client_options_from_dict():
+    with mock.patch(
+        "google.cloud.agentidentitycredentials_v1beta.services.auth_provider_credentials_service.transports.AuthProviderCredentialsServiceGrpcTransport.__init__"
+    ) as grpc_transport:
+        grpc_transport.return_value = None
+        client = AuthProviderCredentialsServiceClient(
+            client_options={"api_endpoint": "squid.clam.whelk"}
+        )
+        grpc_transport.assert_called_once_with(
+            credentials=None,
+            credentials_file=None,
+            host="squid.clam.whelk",
+            scopes=None,
+            client_cert_source_for_mtls=None,
+            quota_project_id=None,
+            client_info=transports.base.DEFAULT_CLIENT_INFO,
+            always_use_jwt_access=True,
+            api_audience=None,
+        )
+
+
+@pytest.mark.parametrize(
+    "client_class,transport_class,transport_name,grpc_helpers",
+    [
+        (
+            AuthProviderCredentialsServiceClient,
+            transports.AuthProviderCredentialsServiceGrpcTransport,
+            "grpc",
+            grpc_helpers,
+        ),
+        (
+            AuthProviderCredentialsServiceAsyncClient,
+            transports.AuthProviderCredentialsServiceGrpcAsyncIOTransport,
+            "grpc_asyncio",
+            grpc_helpers_async,
+        ),
+    ],
+)
+def test_auth_provider_credentials_service_client_create_channel_credentials_file(
+    client_class, transport_class, transport_name, grpc_helpers
+):
+    # Check the case credentials file is provided.
+    options = client_options.ClientOptions(credentials_file="credentials.json")
+
+    with mock.patch.object(transport_class, "__init__") as patched:
+        patched.return_value = None
+        client = client_class(client_options=options, transport=transport_name)
+        patched.assert_called_once_with(
+            credentials=None,
+            credentials_file="credentials.json",
+            host=client._DEFAULT_ENDPOINT_TEMPLATE.format(
+                UNIVERSE_DOMAIN=client._DEFAULT_UNIVERSE
+            ),
+            scopes=None,
+            client_cert_source_for_mtls=None,
+            quota_project_id=None,
+            client_info=transports.base.DEFAULT_CLIENT_INFO,
+            always_use_jwt_access=True,
+            api_audience=None,
+        )
+
+    # test that the credentials from file are saved and used as the credentials.
+    with (
+        mock.patch.object(
+            google.auth, "load_credentials_from_file", autospec=True
+        ) as load_creds,
+        mock.patch.object(google.auth, "default", autospec=True) as adc,
+        mock.patch.object(grpc_helpers, "create_channel") as create_channel,
+    ):
+        creds = ga_credentials.AnonymousCredentials()
+        file_creds = ga_credentials.AnonymousCredentials()
+        load_creds.return_value = (file_creds, None)
+        adc.return_value = (creds, None)
+        client = client_class(client_options=options, transport=transport_name)
+        create_channel.assert_called_with(
+            "agentidentitycredentials.googleapis.com:443",
+            credentials=file_creds,
+            credentials_file=None,
+            quota_project_id=None,
+            default_scopes=("https://www.googleapis.com/auth/cloud-platform",),
+            scopes=None,
+            default_host="agentidentitycredentials.googleapis.com",
+            ssl_credentials=None,
+            options=[
+                ("grpc.max_send_message_length", -1),
+                ("grpc.max_receive_message_length", -1),
+            ],
+        )
+
+
+@pytest.mark.parametrize(
+    "request_type",
+    [
+        auth_provider_credentials_service.RetrieveCredentialsRequest(),
+        {},
+    ],
+)
+def test_retrieve_credentials(request_type, transport: str = "grpc"):
+    client = AuthProviderCredentialsServiceClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport=transport,
+    )
+
+    # Everything is optional in proto3 as far as the runtime is concerned,
+    # and we are mocking out the actual API, so just send an empty request.
+    request = request_type
+
+    # Mock the actual call within the gRPC stub, and fake the request.
+    with mock.patch.object(
+        type(client.transport.retrieve_credentials), "__call__"
+    ) as call:
+        # Designate an appropriate return value for the call.
+        call.return_value = (
+            auth_provider_credentials_service.RetrieveCredentialsResponse()
+        )
+        response = client.retrieve_credentials(request)
+
+        # Establish that the underlying gRPC stub method was called.
+        assert len(call.mock_calls) == 1
+        _, args, _ = call.mock_calls[0]
+        request = auth_provider_credentials_service.RetrieveCredentialsRequest()
+        assert args[0] == request
+
+    # Establish that the response is the type that we expect.
+    assert isinstance(
+        response, auth_provider_credentials_service.RetrieveCredentialsResponse
+    )
+
+
+def test_retrieve_credentials_non_empty_request_with_auto_populated_field():
+    # This test is a coverage failsafe to make sure that UUID4 fields are
+    # automatically populated, according to AIP-4235, with non-empty requests.
+    client = AuthProviderCredentialsServiceClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
+    )
+
+    # Populate all string fields in the request which are not UUID4
+    # since we want to check that UUID4 are populated automatically
+    # if they meet the requirements of AIP 4235.
+    request = auth_provider_credentials_service.RetrieveCredentialsRequest(
+        auth_provider="auth_provider_value",
+        user_id="user_id_value",
+        continue_uri="continue_uri_value",
+        force_refresh_token="force_refresh_token_value",
+    )
+
+    # Mock the actual call within the gRPC stub, and fake the request.
+    with mock.patch.object(
+        type(client.transport.retrieve_credentials), "__call__"
+    ) as call:
+        call.return_value.name = (
+            "foo"  # operation_request.operation in compute client(s) expect a string.
+        )
+        client.retrieve_credentials(request=request)
+        call.assert_called()
+        _, args, _ = call.mock_calls[0]
+        request_msg = auth_provider_credentials_service.RetrieveCredentialsRequest(
+            auth_provider="auth_provider_value",
+            user_id="user_id_value",
+            continue_uri="continue_uri_value",
+            force_refresh_token="force_refresh_token_value",
+        )
+        assert args[0] == request_msg
+
+
+def test_retrieve_credentials_use_cached_wrapped_rpc():
+    # Clients should use _prep_wrapped_messages to create cached wrapped rpcs,
+    # instead of constructing them on each call
+    with mock.patch("google.api_core.gapic_v1.method.wrap_method") as wrapper_fn:
+        client = AuthProviderCredentialsServiceClient(
+            credentials=ga_credentials.AnonymousCredentials(),
+            transport="grpc",
+        )
+
+        # Should wrap all calls on client creation
+        assert wrapper_fn.call_count > 0
+        wrapper_fn.reset_mock()
+
+        # Ensure method has been cached
+        assert (
+            client._transport.retrieve_credentials in client._transport._wrapped_methods
+        )
+
+        # Replace cached wrapped function with mock
+        mock_rpc = mock.Mock()
+        mock_rpc.return_value.name = (
+            "foo"  # operation_request.operation in compute client(s) expect a string.
+        )
+        client._transport._wrapped_methods[client._transport.retrieve_credentials] = (
+            mock_rpc
+        )
+        request = {}
+        client.retrieve_credentials(request)
+
+        # Establish that the underlying gRPC stub method was called.
+        assert mock_rpc.call_count == 1
+
+        client.retrieve_credentials(request)
+
+        # Establish that a new wrapper was not created for this call
+        assert wrapper_fn.call_count == 0
+        assert mock_rpc.call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_retrieve_credentials_async_use_cached_wrapped_rpc(
+    transport: str = "grpc_asyncio",
+):
+    # Clients should use _prep_wrapped_messages to create cached wrapped rpcs,
+    # instead of constructing them on each call
+    with mock.patch("google.api_core.gapic_v1.method_async.wrap_method") as wrapper_fn:
+        client = AuthProviderCredentialsServiceAsyncClient(
+            credentials=async_anonymous_credentials(),
+            transport=transport,
+        )
+
+        # Should wrap all calls on client creation
+        assert wrapper_fn.call_count > 0
+        wrapper_fn.reset_mock()
+
+        # Ensure method has been cached
+        assert (
+            client._client._transport.retrieve_credentials
+            in client._client._transport._wrapped_methods
+        )
+
+        # Replace cached wrapped function with mock
+        mock_rpc = mock.AsyncMock()
+        mock_rpc.return_value = mock.Mock()
+        client._client._transport._wrapped_methods[
+            client._client._transport.retrieve_credentials
+        ] = mock_rpc
+
+        request = {}
+        await client.retrieve_credentials(request)
+
+        # Establish that the underlying gRPC stub method was called.
+        assert mock_rpc.call_count == 1
+
+        await client.retrieve_credentials(request)
+
+        # Establish that a new wrapper was not created for this call
+        assert wrapper_fn.call_count == 0
+        assert mock_rpc.call_count == 2
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "request_type",
+    [
+        auth_provider_credentials_service.RetrieveCredentialsRequest(),
+        {},
+    ],
+)
+async def test_retrieve_credentials_async(
+    request_type, transport: str = "grpc_asyncio"
+):
+    client = AuthProviderCredentialsServiceAsyncClient(
+        credentials=async_anonymous_credentials(),
+        transport=transport,
+    )
+
+    # Everything is optional in proto3 as far as the runtime is concerned,
+    # and we are mocking out the actual API, so just send an empty request.
+    request = request_type
+
+    # Mock the actual call within the gRPC stub, and fake the request.
+    with mock.patch.object(
+        type(client.transport.retrieve_credentials), "__call__"
+    ) as call:
+        # Designate an appropriate return value for the call.
+        call.return_value = grpc_helpers_async.FakeUnaryUnaryCall(
+            auth_provider_credentials_service.RetrieveCredentialsResponse()
+        )
+        response = await client.retrieve_credentials(request)
+
+        # Establish that the underlying gRPC stub method was called.
+        assert len(call.mock_calls)
+        _, args, _ = call.mock_calls[0]
+        request = auth_provider_credentials_service.RetrieveCredentialsRequest()
+        assert args[0] == request
+
+    # Establish that the response is the type that we expect.
+    assert isinstance(
+        response, auth_provider_credentials_service.RetrieveCredentialsResponse
+    )
+
+
+def test_retrieve_credentials_field_headers():
+    client = AuthProviderCredentialsServiceClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+    )
+
+    # Any value that is part of the HTTP/1.1 URI should be sent as
+    # a field header. Set these to a non-empty value.
+    request = auth_provider_credentials_service.RetrieveCredentialsRequest()
+
+    request.auth_provider = "auth_provider_value"
+
+    # Mock the actual call within the gRPC stub, and fake the request.
+    with mock.patch.object(
+        type(client.transport.retrieve_credentials), "__call__"
+    ) as call:
+        call.return_value = (
+            auth_provider_credentials_service.RetrieveCredentialsResponse()
+        )
+        client.retrieve_credentials(request)
+
+        # Establish that the underlying gRPC stub method was called.
+        assert len(call.mock_calls) == 1
+        _, args, _ = call.mock_calls[0]
+        assert args[0] == request
+
+    # Establish that the field header was sent.
+    _, _, kw = call.mock_calls[0]
+    assert (
+        "x-goog-request-params",
+        "auth_provider=auth_provider_value",
+    ) in kw["metadata"]
+
+
+@pytest.mark.asyncio
+async def test_retrieve_credentials_field_headers_async():
+    client = AuthProviderCredentialsServiceAsyncClient(
+        credentials=async_anonymous_credentials(),
+    )
+
+    # Any value that is part of the HTTP/1.1 URI should be sent as
+    # a field header. Set these to a non-empty value.
+    request = auth_provider_credentials_service.RetrieveCredentialsRequest()
+
+    request.auth_provider = "auth_provider_value"
+
+    # Mock the actual call within the gRPC stub, and fake the request.
+    with mock.patch.object(
+        type(client.transport.retrieve_credentials), "__call__"
+    ) as call:
+        call.return_value = grpc_helpers_async.FakeUnaryUnaryCall(
+            auth_provider_credentials_service.RetrieveCredentialsResponse()
+        )
+        await client.retrieve_credentials(request)
+
+        # Establish that the underlying gRPC stub method was called.
+        assert len(call.mock_calls)
+        _, args, _ = call.mock_calls[0]
+        assert args[0] == request
+
+    # Establish that the field header was sent.
+    _, _, kw = call.mock_calls[0]
+    assert (
+        "x-goog-request-params",
+        "auth_provider=auth_provider_value",
+    ) in kw["metadata"]
+
+
+def test_retrieve_credentials_flattened():
+    client = AuthProviderCredentialsServiceClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+    )
+
+    # Mock the actual call within the gRPC stub, and fake the request.
+    with mock.patch.object(
+        type(client.transport.retrieve_credentials), "__call__"
+    ) as call:
+        # Designate an appropriate return value for the call.
+        call.return_value = (
+            auth_provider_credentials_service.RetrieveCredentialsResponse()
+        )
+        # Call the method with a truthy value for each flattened field,
+        # using the keyword arguments to the method.
+        client.retrieve_credentials(
+            auth_provider="auth_provider_value",
+            user_id="user_id_value",
+        )
+
+        # Establish that the underlying call was made with the expected
+        # request object values.
+        assert len(call.mock_calls) == 1
+        _, args, _ = call.mock_calls[0]
+        arg = args[0].auth_provider
+        mock_val = "auth_provider_value"
+        assert arg == mock_val
+        arg = args[0].user_id
+        mock_val = "user_id_value"
+        assert arg == mock_val
+
+
+def test_retrieve_credentials_flattened_error():
+    client = AuthProviderCredentialsServiceClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+    )
+
+    # Attempting to call a method with both a request object and flattened
+    # fields is an error.
+    with pytest.raises(ValueError):
+        client.retrieve_credentials(
+            auth_provider_credentials_service.RetrieveCredentialsRequest(),
+            auth_provider="auth_provider_value",
+            user_id="user_id_value",
+        )
+
+
+@pytest.mark.asyncio
+async def test_retrieve_credentials_flattened_async():
+    client = AuthProviderCredentialsServiceAsyncClient(
+        credentials=async_anonymous_credentials(),
+    )
+
+    # Mock the actual call within the gRPC stub, and fake the request.
+    with mock.patch.object(
+        type(client.transport.retrieve_credentials), "__call__"
+    ) as call:
+        # Designate an appropriate return value for the call.
+        call.return_value = (
+            auth_provider_credentials_service.RetrieveCredentialsResponse()
+        )
+
+        call.return_value = grpc_helpers_async.FakeUnaryUnaryCall(
+            auth_provider_credentials_service.RetrieveCredentialsResponse()
+        )
+        # Call the method with a truthy value for each flattened field,
+        # using the keyword arguments to the method.
+        response = await client.retrieve_credentials(
+            auth_provider="auth_provider_value",
+            user_id="user_id_value",
+        )
+
+        # Establish that the underlying call was made with the expected
+        # request object values.
+        assert len(call.mock_calls)
+        _, args, _ = call.mock_calls[0]
+        arg = args[0].auth_provider
+        mock_val = "auth_provider_value"
+        assert arg == mock_val
+        arg = args[0].user_id
+        mock_val = "user_id_value"
+        assert arg == mock_val
+
+
+@pytest.mark.asyncio
+async def test_retrieve_credentials_flattened_error_async():
+    client = AuthProviderCredentialsServiceAsyncClient(
+        credentials=async_anonymous_credentials(),
+    )
+
+    # Attempting to call a method with both a request object and flattened
+    # fields is an error.
+    with pytest.raises(ValueError):
+        await client.retrieve_credentials(
+            auth_provider_credentials_service.RetrieveCredentialsRequest(),
+            auth_provider="auth_provider_value",
+            user_id="user_id_value",
+        )
+
+
+@pytest.mark.parametrize(
+    "request_type",
+    [
+        auth_provider_credentials_service.FinalizeCredentialsRequest(),
+        {},
+    ],
+)
+def test_finalize_credentials(request_type, transport: str = "grpc"):
+    client = AuthProviderCredentialsServiceClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport=transport,
+    )
+
+    # Everything is optional in proto3 as far as the runtime is concerned,
+    # and we are mocking out the actual API, so just send an empty request.
+    request = request_type
+
+    # Mock the actual call within the gRPC stub, and fake the request.
+    with mock.patch.object(
+        type(client.transport.finalize_credentials), "__call__"
+    ) as call:
+        # Designate an appropriate return value for the call.
+        call.return_value = (
+            auth_provider_credentials_service.FinalizeCredentialsResponse()
+        )
+        response = client.finalize_credentials(request)
+
+        # Establish that the underlying gRPC stub method was called.
+        assert len(call.mock_calls) == 1
+        _, args, _ = call.mock_calls[0]
+        request = auth_provider_credentials_service.FinalizeCredentialsRequest()
+        assert args[0] == request
+
+    # Establish that the response is the type that we expect.
+    assert isinstance(
+        response, auth_provider_credentials_service.FinalizeCredentialsResponse
+    )
+
+
+def test_finalize_credentials_non_empty_request_with_auto_populated_field():
+    # This test is a coverage failsafe to make sure that UUID4 fields are
+    # automatically populated, according to AIP-4235, with non-empty requests.
+    client = AuthProviderCredentialsServiceClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
+    )
+
+    # Populate all string fields in the request which are not UUID4
+    # since we want to check that UUID4 are populated automatically
+    # if they meet the requirements of AIP 4235.
+    request = auth_provider_credentials_service.FinalizeCredentialsRequest(
+        auth_provider="auth_provider_value",
+        user_id="user_id_value",
+        consent_nonce="consent_nonce_value",
+    )
+
+    # Mock the actual call within the gRPC stub, and fake the request.
+    with mock.patch.object(
+        type(client.transport.finalize_credentials), "__call__"
+    ) as call:
+        call.return_value.name = (
+            "foo"  # operation_request.operation in compute client(s) expect a string.
+        )
+        client.finalize_credentials(request=request)
+        call.assert_called()
+        _, args, _ = call.mock_calls[0]
+        request_msg = auth_provider_credentials_service.FinalizeCredentialsRequest(
+            auth_provider="auth_provider_value",
+            user_id="user_id_value",
+            consent_nonce="consent_nonce_value",
+        )
+        assert args[0] == request_msg
+
+
+def test_finalize_credentials_use_cached_wrapped_rpc():
+    # Clients should use _prep_wrapped_messages to create cached wrapped rpcs,
+    # instead of constructing them on each call
+    with mock.patch("google.api_core.gapic_v1.method.wrap_method") as wrapper_fn:
+        client = AuthProviderCredentialsServiceClient(
+            credentials=ga_credentials.AnonymousCredentials(),
+            transport="grpc",
+        )
+
+        # Should wrap all calls on client creation
+        assert wrapper_fn.call_count > 0
+        wrapper_fn.reset_mock()
+
+        # Ensure method has been cached
+        assert (
+            client._transport.finalize_credentials in client._transport._wrapped_methods
+        )
+
+        # Replace cached wrapped function with mock
+        mock_rpc = mock.Mock()
+        mock_rpc.return_value.name = (
+            "foo"  # operation_request.operation in compute client(s) expect a string.
+        )
+        client._transport._wrapped_methods[client._transport.finalize_credentials] = (
+            mock_rpc
+        )
+        request = {}
+        client.finalize_credentials(request)
+
+        # Establish that the underlying gRPC stub method was called.
+        assert mock_rpc.call_count == 1
+
+        client.finalize_credentials(request)
+
+        # Establish that a new wrapper was not created for this call
+        assert wrapper_fn.call_count == 0
+        assert mock_rpc.call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_finalize_credentials_async_use_cached_wrapped_rpc(
+    transport: str = "grpc_asyncio",
+):
+    # Clients should use _prep_wrapped_messages to create cached wrapped rpcs,
+    # instead of constructing them on each call
+    with mock.patch("google.api_core.gapic_v1.method_async.wrap_method") as wrapper_fn:
+        client = AuthProviderCredentialsServiceAsyncClient(
+            credentials=async_anonymous_credentials(),
+            transport=transport,
+        )
+
+        # Should wrap all calls on client creation
+        assert wrapper_fn.call_count > 0
+        wrapper_fn.reset_mock()
+
+        # Ensure method has been cached
+        assert (
+            client._client._transport.finalize_credentials
+            in client._client._transport._wrapped_methods
+        )
+
+        # Replace cached wrapped function with mock
+        mock_rpc = mock.AsyncMock()
+        mock_rpc.return_value = mock.Mock()
+        client._client._transport._wrapped_methods[
+            client._client._transport.finalize_credentials
+        ] = mock_rpc
+
+        request = {}
+        await client.finalize_credentials(request)
+
+        # Establish that the underlying gRPC stub method was called.
+        assert mock_rpc.call_count == 1
+
+        await client.finalize_credentials(request)
+
+        # Establish that a new wrapper was not created for this call
+        assert wrapper_fn.call_count == 0
+        assert mock_rpc.call_count == 2
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "request_type",
+    [
+        auth_provider_credentials_service.FinalizeCredentialsRequest(),
+        {},
+    ],
+)
+async def test_finalize_credentials_async(
+    request_type, transport: str = "grpc_asyncio"
+):
+    client = AuthProviderCredentialsServiceAsyncClient(
+        credentials=async_anonymous_credentials(),
+        transport=transport,
+    )
+
+    # Everything is optional in proto3 as far as the runtime is concerned,
+    # and we are mocking out the actual API, so just send an empty request.
+    request = request_type
+
+    # Mock the actual call within the gRPC stub, and fake the request.
+    with mock.patch.object(
+        type(client.transport.finalize_credentials), "__call__"
+    ) as call:
+        # Designate an appropriate return value for the call.
+        call.return_value = grpc_helpers_async.FakeUnaryUnaryCall(
+            auth_provider_credentials_service.FinalizeCredentialsResponse()
+        )
+        response = await client.finalize_credentials(request)
+
+        # Establish that the underlying gRPC stub method was called.
+        assert len(call.mock_calls)
+        _, args, _ = call.mock_calls[0]
+        request = auth_provider_credentials_service.FinalizeCredentialsRequest()
+        assert args[0] == request
+
+    # Establish that the response is the type that we expect.
+    assert isinstance(
+        response, auth_provider_credentials_service.FinalizeCredentialsResponse
+    )
+
+
+def test_finalize_credentials_field_headers():
+    client = AuthProviderCredentialsServiceClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+    )
+
+    # Any value that is part of the HTTP/1.1 URI should be sent as
+    # a field header. Set these to a non-empty value.
+    request = auth_provider_credentials_service.FinalizeCredentialsRequest()
+
+    request.auth_provider = "auth_provider_value"
+
+    # Mock the actual call within the gRPC stub, and fake the request.
+    with mock.patch.object(
+        type(client.transport.finalize_credentials), "__call__"
+    ) as call:
+        call.return_value = (
+            auth_provider_credentials_service.FinalizeCredentialsResponse()
+        )
+        client.finalize_credentials(request)
+
+        # Establish that the underlying gRPC stub method was called.
+        assert len(call.mock_calls) == 1
+        _, args, _ = call.mock_calls[0]
+        assert args[0] == request
+
+    # Establish that the field header was sent.
+    _, _, kw = call.mock_calls[0]
+    assert (
+        "x-goog-request-params",
+        "auth_provider=auth_provider_value",
+    ) in kw["metadata"]
+
+
+@pytest.mark.asyncio
+async def test_finalize_credentials_field_headers_async():
+    client = AuthProviderCredentialsServiceAsyncClient(
+        credentials=async_anonymous_credentials(),
+    )
+
+    # Any value that is part of the HTTP/1.1 URI should be sent as
+    # a field header. Set these to a non-empty value.
+    request = auth_provider_credentials_service.FinalizeCredentialsRequest()
+
+    request.auth_provider = "auth_provider_value"
+
+    # Mock the actual call within the gRPC stub, and fake the request.
+    with mock.patch.object(
+        type(client.transport.finalize_credentials), "__call__"
+    ) as call:
+        call.return_value = grpc_helpers_async.FakeUnaryUnaryCall(
+            auth_provider_credentials_service.FinalizeCredentialsResponse()
+        )
+        await client.finalize_credentials(request)
+
+        # Establish that the underlying gRPC stub method was called.
+        assert len(call.mock_calls)
+        _, args, _ = call.mock_calls[0]
+        assert args[0] == request
+
+    # Establish that the field header was sent.
+    _, _, kw = call.mock_calls[0]
+    assert (
+        "x-goog-request-params",
+        "auth_provider=auth_provider_value",
+    ) in kw["metadata"]
+
+
+def test_retrieve_credentials_rest_use_cached_wrapped_rpc():
+    # Clients should use _prep_wrapped_messages to create cached wrapped rpcs,
+    # instead of constructing them on each call
+    with mock.patch("google.api_core.gapic_v1.method.wrap_method") as wrapper_fn:
+        client = AuthProviderCredentialsServiceClient(
+            credentials=ga_credentials.AnonymousCredentials(),
+            transport="rest",
+        )
+
+        # Should wrap all calls on client creation
+        assert wrapper_fn.call_count > 0
+        wrapper_fn.reset_mock()
+
+        # Ensure method has been cached
+        assert (
+            client._transport.retrieve_credentials in client._transport._wrapped_methods
+        )
+
+        # Replace cached wrapped function with mock
+        mock_rpc = mock.Mock()
+        mock_rpc.return_value.name = (
+            "foo"  # operation_request.operation in compute client(s) expect a string.
+        )
+        client._transport._wrapped_methods[client._transport.retrieve_credentials] = (
+            mock_rpc
+        )
+
+        request = {}
+        client.retrieve_credentials(request)
+
+        # Establish that the underlying gRPC stub method was called.
+        assert mock_rpc.call_count == 1
+
+        client.retrieve_credentials(request)
+
+        # Establish that a new wrapper was not created for this call
+        assert wrapper_fn.call_count == 0
+        assert mock_rpc.call_count == 2
+
+
+def test_retrieve_credentials_rest_required_fields(
+    request_type=auth_provider_credentials_service.RetrieveCredentialsRequest,
+):
+    transport_class = transports.AuthProviderCredentialsServiceRestTransport
+
+    request_init = {}
+    request_init["auth_provider"] = ""
+    request_init["user_id"] = ""
+    request = request_type(**request_init)
+    pb_request = request_type.pb(request)
+    jsonified_request = json.loads(
+        json_format.MessageToJson(pb_request, use_integers_for_enums=False)
+    )
+
+    # verify fields with default values are dropped
+
+    unset_fields = transport_class(
+        credentials=ga_credentials.AnonymousCredentials()
+    ).retrieve_credentials._get_unset_required_fields(jsonified_request)
+    jsonified_request.update(unset_fields)
+
+    # verify required fields with default values are now present
+
+    jsonified_request["authProvider"] = "auth_provider_value"
+    jsonified_request["userId"] = "user_id_value"
+
+    unset_fields = transport_class(
+        credentials=ga_credentials.AnonymousCredentials()
+    ).retrieve_credentials._get_unset_required_fields(jsonified_request)
+    jsonified_request.update(unset_fields)
+
+    # verify required fields with non-default values are left alone
+    assert "authProvider" in jsonified_request
+    assert jsonified_request["authProvider"] == "auth_provider_value"
+    assert "userId" in jsonified_request
+    assert jsonified_request["userId"] == "user_id_value"
+
+    client = AuthProviderCredentialsServiceClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="rest",
+    )
+    request = request_type(**request_init)
+
+    # Designate an appropriate value for the returned response.
+    return_value = auth_provider_credentials_service.RetrieveCredentialsResponse()
+    # Mock the http request call within the method and fake a response.
+    with mock.patch.object(Session, "request") as req:
+        # We need to mock transcode() because providing default values
+        # for required fields will fail the real version if the http_options
+        # expect actual values for those fields.
+        with mock.patch.object(path_template, "transcode") as transcode:
+            # A uri without fields and an empty body will force all the
+            # request fields to show up in the query_params.
+            pb_request = request_type.pb(request)
+            transcode_result = {
+                "uri": "v1/sample_method",
+                "method": "post",
+                "query_params": pb_request,
+            }
+            transcode_result["body"] = pb_request
+            transcode.return_value = transcode_result
+
+            response_value = Response()
+            response_value.status_code = 200
+
+            # Convert return value to protobuf type
+            return_value = (
+                auth_provider_credentials_service.RetrieveCredentialsResponse.pb(
+                    return_value
+                )
+            )
+            json_return_value = json_format.MessageToJson(return_value)
+
+            response_value._content = json_return_value.encode("UTF-8")
+            req.return_value = response_value
+            req.return_value.headers = {"header-1": "value-1", "header-2": "value-2"}
+
+            response = client.retrieve_credentials(request)
+
+            expected_params = [("$alt", "json;enum-encoding=int")]
+            actual_params = req.call_args.kwargs["params"]
+            assert sorted(expected_params) == sorted(actual_params)
+
+
+def test_retrieve_credentials_rest_unset_required_fields():
+    transport = transports.AuthProviderCredentialsServiceRestTransport(
+        credentials=ga_credentials.AnonymousCredentials
+    )
+
+    unset_fields = transport.retrieve_credentials._get_unset_required_fields({})
+    assert set(unset_fields) == (
+        set(())
+        & set(
+            (
+                "authProvider",
+                "userId",
+            )
+        )
+    )
+
+
+def test_retrieve_credentials_rest_flattened():
+    client = AuthProviderCredentialsServiceClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="rest",
+    )
+
+    # Mock the http request call within the method and fake a response.
+    with mock.patch.object(type(client.transport._session), "request") as req:
+        # Designate an appropriate value for the returned response.
+        return_value = auth_provider_credentials_service.RetrieveCredentialsResponse()
+
+        # get arguments that satisfy an http rule for this method
+        sample_request = {
+            "auth_provider": "projects/sample1/locations/sample2/authProviders/sample3"
+        }
+
+        # get truthy value for each flattened field
+        mock_args = dict(
+            auth_provider="auth_provider_value",
+            user_id="user_id_value",
+        )
+        mock_args.update(sample_request)
+
+        # Wrap the value into a proper Response obj
+        response_value = Response()
+        response_value.status_code = 200
+        # Convert return value to protobuf type
+        return_value = auth_provider_credentials_service.RetrieveCredentialsResponse.pb(
+            return_value
+        )
+        json_return_value = json_format.MessageToJson(return_value)
+        response_value._content = json_return_value.encode("UTF-8")
+        req.return_value = response_value
+        req.return_value.headers = {"header-1": "value-1", "header-2": "value-2"}
+
+        client.retrieve_credentials(**mock_args)
+
+        # Establish that the underlying call was made with the expected
+        # request object values.
+        assert len(req.mock_calls) == 1
+        _, args, _ = req.mock_calls[0]
+        assert path_template.validate(
+            "%s/v1beta/{auth_provider=projects/*/locations/*/authProviders/*}/credentials:retrieve"
+            % client.transport._host,
+            args[1],
+        )
+
+
+def test_retrieve_credentials_rest_flattened_error(transport: str = "rest"):
+    client = AuthProviderCredentialsServiceClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport=transport,
+    )
+
+    # Attempting to call a method with both a request object and flattened
+    # fields is an error.
+    with pytest.raises(ValueError):
+        client.retrieve_credentials(
+            auth_provider_credentials_service.RetrieveCredentialsRequest(),
+            auth_provider="auth_provider_value",
+            user_id="user_id_value",
+        )
+
+
+def test_finalize_credentials_rest_use_cached_wrapped_rpc():
+    # Clients should use _prep_wrapped_messages to create cached wrapped rpcs,
+    # instead of constructing them on each call
+    with mock.patch("google.api_core.gapic_v1.method.wrap_method") as wrapper_fn:
+        client = AuthProviderCredentialsServiceClient(
+            credentials=ga_credentials.AnonymousCredentials(),
+            transport="rest",
+        )
+
+        # Should wrap all calls on client creation
+        assert wrapper_fn.call_count > 0
+        wrapper_fn.reset_mock()
+
+        # Ensure method has been cached
+        assert (
+            client._transport.finalize_credentials in client._transport._wrapped_methods
+        )
+
+        # Replace cached wrapped function with mock
+        mock_rpc = mock.Mock()
+        mock_rpc.return_value.name = (
+            "foo"  # operation_request.operation in compute client(s) expect a string.
+        )
+        client._transport._wrapped_methods[client._transport.finalize_credentials] = (
+            mock_rpc
+        )
+
+        request = {}
+        client.finalize_credentials(request)
+
+        # Establish that the underlying gRPC stub method was called.
+        assert mock_rpc.call_count == 1
+
+        client.finalize_credentials(request)
+
+        # Establish that a new wrapper was not created for this call
+        assert wrapper_fn.call_count == 0
+        assert mock_rpc.call_count == 2
+
+
+def test_finalize_credentials_rest_required_fields(
+    request_type=auth_provider_credentials_service.FinalizeCredentialsRequest,
+):
+    transport_class = transports.AuthProviderCredentialsServiceRestTransport
+
+    request_init = {}
+    request_init["auth_provider"] = ""
+    request_init["user_id"] = ""
+    request_init["user_id_validation_state"] = b""
+    request_init["consent_nonce"] = ""
+    request = request_type(**request_init)
+    pb_request = request_type.pb(request)
+    jsonified_request = json.loads(
+        json_format.MessageToJson(pb_request, use_integers_for_enums=False)
+    )
+
+    # verify fields with default values are dropped
+
+    unset_fields = transport_class(
+        credentials=ga_credentials.AnonymousCredentials()
+    ).finalize_credentials._get_unset_required_fields(jsonified_request)
+    jsonified_request.update(unset_fields)
+
+    # verify required fields with default values are now present
+
+    jsonified_request["authProvider"] = "auth_provider_value"
+    jsonified_request["userId"] = "user_id_value"
+    jsonified_request["userIdValidationState"] = b"user_id_validation_state_blob"
+    jsonified_request["consentNonce"] = "consent_nonce_value"
+
+    unset_fields = transport_class(
+        credentials=ga_credentials.AnonymousCredentials()
+    ).finalize_credentials._get_unset_required_fields(jsonified_request)
+    jsonified_request.update(unset_fields)
+
+    # verify required fields with non-default values are left alone
+    assert "authProvider" in jsonified_request
+    assert jsonified_request["authProvider"] == "auth_provider_value"
+    assert "userId" in jsonified_request
+    assert jsonified_request["userId"] == "user_id_value"
+    assert "userIdValidationState" in jsonified_request
+    assert (
+        jsonified_request["userIdValidationState"] == b"user_id_validation_state_blob"
+    )
+    assert "consentNonce" in jsonified_request
+    assert jsonified_request["consentNonce"] == "consent_nonce_value"
+
+    client = AuthProviderCredentialsServiceClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="rest",
+    )
+    request = request_type(**request_init)
+
+    # Designate an appropriate value for the returned response.
+    return_value = auth_provider_credentials_service.FinalizeCredentialsResponse()
+    # Mock the http request call within the method and fake a response.
+    with mock.patch.object(Session, "request") as req:
+        # We need to mock transcode() because providing default values
+        # for required fields will fail the real version if the http_options
+        # expect actual values for those fields.
+        with mock.patch.object(path_template, "transcode") as transcode:
+            # A uri without fields and an empty body will force all the
+            # request fields to show up in the query_params.
+            pb_request = request_type.pb(request)
+            transcode_result = {
+                "uri": "v1/sample_method",
+                "method": "post",
+                "query_params": pb_request,
+            }
+            transcode_result["body"] = pb_request
+            transcode.return_value = transcode_result
+
+            response_value = Response()
+            response_value.status_code = 200
+
+            # Convert return value to protobuf type
+            return_value = (
+                auth_provider_credentials_service.FinalizeCredentialsResponse.pb(
+                    return_value
+                )
+            )
+            json_return_value = json_format.MessageToJson(return_value)
+
+            response_value._content = json_return_value.encode("UTF-8")
+            req.return_value = response_value
+            req.return_value.headers = {"header-1": "value-1", "header-2": "value-2"}
+
+            response = client.finalize_credentials(request)
+
+            expected_params = [("$alt", "json;enum-encoding=int")]
+            actual_params = req.call_args.kwargs["params"]
+            assert sorted(expected_params) == sorted(actual_params)
+
+
+def test_finalize_credentials_rest_unset_required_fields():
+    transport = transports.AuthProviderCredentialsServiceRestTransport(
+        credentials=ga_credentials.AnonymousCredentials
+    )
+
+    unset_fields = transport.finalize_credentials._get_unset_required_fields({})
+    assert set(unset_fields) == (
+        set(())
+        & set(
+            (
+                "authProvider",
+                "userId",
+                "userIdValidationState",
+                "consentNonce",
+            )
+        )
+    )
+
+
+def test_credentials_transport_error():
+    # It is an error to provide credentials and a transport instance.
+    transport = transports.AuthProviderCredentialsServiceGrpcTransport(
+        credentials=ga_credentials.AnonymousCredentials(),
+    )
+    with pytest.raises(ValueError):
+        client = AuthProviderCredentialsServiceClient(
+            credentials=ga_credentials.AnonymousCredentials(),
+            transport=transport,
+        )
+
+    # It is an error to provide a credentials file and a transport instance.
+    transport = transports.AuthProviderCredentialsServiceGrpcTransport(
+        credentials=ga_credentials.AnonymousCredentials(),
+    )
+    with pytest.raises(ValueError):
+        client = AuthProviderCredentialsServiceClient(
+            client_options={"credentials_file": "credentials.json"},
+            transport=transport,
+        )
+
+    # It is an error to provide an api_key and a transport instance.
+    transport = transports.AuthProviderCredentialsServiceGrpcTransport(
+        credentials=ga_credentials.AnonymousCredentials(),
+    )
+    options = client_options.ClientOptions()
+    options.api_key = "api_key"
+    with pytest.raises(ValueError):
+        client = AuthProviderCredentialsServiceClient(
+            client_options=options,
+            transport=transport,
+        )
+
+    # It is an error to provide an api_key and a credential.
+    options = client_options.ClientOptions()
+    options.api_key = "api_key"
+    with pytest.raises(ValueError):
+        client = AuthProviderCredentialsServiceClient(
+            client_options=options, credentials=ga_credentials.AnonymousCredentials()
+        )
+
+    # It is an error to provide scopes and a transport instance.
+    transport = transports.AuthProviderCredentialsServiceGrpcTransport(
+        credentials=ga_credentials.AnonymousCredentials(),
+    )
+    with pytest.raises(ValueError):
+        client = AuthProviderCredentialsServiceClient(
+            client_options={"scopes": ["1", "2"]},
+            transport=transport,
+        )
+
+
+def test_transport_instance():
+    # A client may be instantiated with a custom transport instance.
+    transport = transports.AuthProviderCredentialsServiceGrpcTransport(
+        credentials=ga_credentials.AnonymousCredentials(),
+    )
+    client = AuthProviderCredentialsServiceClient(transport=transport)
+    assert client.transport is transport
+
+
+def test_transport_get_channel():
+    # A client may be instantiated with a custom transport instance.
+    transport = transports.AuthProviderCredentialsServiceGrpcTransport(
+        credentials=ga_credentials.AnonymousCredentials(),
+    )
+    channel = transport.grpc_channel
+    assert channel
+
+    transport = transports.AuthProviderCredentialsServiceGrpcAsyncIOTransport(
+        credentials=ga_credentials.AnonymousCredentials(),
+    )
+    channel = transport.grpc_channel
+    assert channel
+
+
+@pytest.mark.parametrize(
+    "transport_class",
+    [
+        transports.AuthProviderCredentialsServiceGrpcTransport,
+        transports.AuthProviderCredentialsServiceGrpcAsyncIOTransport,
+        transports.AuthProviderCredentialsServiceRestTransport,
+    ],
+)
+def test_transport_adc(transport_class):
+    # Test default credentials are used if not provided.
+    with mock.patch.object(google.auth, "default") as adc:
+        adc.return_value = (ga_credentials.AnonymousCredentials(), None)
+        transport_class()
+        adc.assert_called_once()
+
+
+def test_transport_kind_grpc():
+    transport = AuthProviderCredentialsServiceClient.get_transport_class("grpc")(
+        credentials=ga_credentials.AnonymousCredentials()
+    )
+    assert transport.kind == "grpc"
+
+
+def test_initialize_client_w_grpc():
+    client = AuthProviderCredentialsServiceClient(
+        credentials=ga_credentials.AnonymousCredentials(), transport="grpc"
+    )
+    assert client is not None
+
+
+# This test is a coverage failsafe to make sure that totally empty calls,
+# i.e. request == None and no flattened fields passed, work.
+def test_retrieve_credentials_empty_call_grpc():
+    client = AuthProviderCredentialsServiceClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
+    )
+
+    # Mock the actual call, and fake the request.
+    with mock.patch.object(
+        type(client.transport.retrieve_credentials), "__call__"
+    ) as call:
+        call.return_value = (
+            auth_provider_credentials_service.RetrieveCredentialsResponse()
+        )
+        client.retrieve_credentials(request=None)
+
+        # Establish that the underlying stub method was called.
+        call.assert_called()
+        _, args, _ = call.mock_calls[0]
+        request_msg = auth_provider_credentials_service.RetrieveCredentialsRequest()
+        assert args[0] == request_msg
+
+
+# This test is a coverage failsafe to make sure that totally empty calls,
+# i.e. request == None and no flattened fields passed, work.
+def test_finalize_credentials_empty_call_grpc():
+    client = AuthProviderCredentialsServiceClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
+    )
+
+    # Mock the actual call, and fake the request.
+    with mock.patch.object(
+        type(client.transport.finalize_credentials), "__call__"
+    ) as call:
+        call.return_value = (
+            auth_provider_credentials_service.FinalizeCredentialsResponse()
+        )
+        client.finalize_credentials(request=None)
+
+        # Establish that the underlying stub method was called.
+        call.assert_called()
+        _, args, _ = call.mock_calls[0]
+        request_msg = auth_provider_credentials_service.FinalizeCredentialsRequest()
+        assert args[0] == request_msg
+
+
+def test_transport_kind_grpc_asyncio():
+    transport = AuthProviderCredentialsServiceAsyncClient.get_transport_class(
+        "grpc_asyncio"
+    )(credentials=async_anonymous_credentials())
+    assert transport.kind == "grpc_asyncio"
+
+
+def test_initialize_client_w_grpc_asyncio():
+    client = AuthProviderCredentialsServiceAsyncClient(
+        credentials=async_anonymous_credentials(), transport="grpc_asyncio"
+    )
+    assert client is not None
+
+
+# This test is a coverage failsafe to make sure that totally empty calls,
+# i.e. request == None and no flattened fields passed, work.
+@pytest.mark.asyncio
+async def test_retrieve_credentials_empty_call_grpc_asyncio():
+    client = AuthProviderCredentialsServiceAsyncClient(
+        credentials=async_anonymous_credentials(),
+        transport="grpc_asyncio",
+    )
+
+    # Mock the actual call, and fake the request.
+    with mock.patch.object(
+        type(client.transport.retrieve_credentials), "__call__"
+    ) as call:
+        # Designate an appropriate return value for the call.
+        call.return_value = grpc_helpers_async.FakeUnaryUnaryCall(
+            auth_provider_credentials_service.RetrieveCredentialsResponse()
+        )
+        await client.retrieve_credentials(request=None)
+
+        # Establish that the underlying stub method was called.
+        call.assert_called()
+        _, args, _ = call.mock_calls[0]
+        request_msg = auth_provider_credentials_service.RetrieveCredentialsRequest()
+        assert args[0] == request_msg
+
+
+# This test is a coverage failsafe to make sure that totally empty calls,
+# i.e. request == None and no flattened fields passed, work.
+@pytest.mark.asyncio
+async def test_finalize_credentials_empty_call_grpc_asyncio():
+    client = AuthProviderCredentialsServiceAsyncClient(
+        credentials=async_anonymous_credentials(),
+        transport="grpc_asyncio",
+    )
+
+    # Mock the actual call, and fake the request.
+    with mock.patch.object(
+        type(client.transport.finalize_credentials), "__call__"
+    ) as call:
+        # Designate an appropriate return value for the call.
+        call.return_value = grpc_helpers_async.FakeUnaryUnaryCall(
+            auth_provider_credentials_service.FinalizeCredentialsResponse()
+        )
+        await client.finalize_credentials(request=None)
+
+        # Establish that the underlying stub method was called.
+        call.assert_called()
+        _, args, _ = call.mock_calls[0]
+        request_msg = auth_provider_credentials_service.FinalizeCredentialsRequest()
+        assert args[0] == request_msg
+
+
+def test_transport_kind_rest():
+    transport = AuthProviderCredentialsServiceClient.get_transport_class("rest")(
+        credentials=ga_credentials.AnonymousCredentials()
+    )
+    assert transport.kind == "rest"
+
+
+def test_retrieve_credentials_rest_bad_request(
+    request_type=auth_provider_credentials_service.RetrieveCredentialsRequest,
+):
+    client = AuthProviderCredentialsServiceClient(
+        credentials=ga_credentials.AnonymousCredentials(), transport="rest"
+    )
+    # send a request that will satisfy transcoding
+    request_init = {
+        "auth_provider": "projects/sample1/locations/sample2/authProviders/sample3"
+    }
+    request = request_type(**request_init)
+
+    # Mock the http request call within the method and fake a BadRequest error.
+    with (
+        mock.patch.object(Session, "request") as req,
+        pytest.raises(core_exceptions.BadRequest),
+    ):
+        # Wrap the value into a proper Response obj
+        response_value = mock.Mock()
+        json_return_value = ""
+        response_value.json = mock.Mock(return_value={})
+        response_value.status_code = 400
+        response_value.request = mock.Mock()
+        req.return_value = response_value
+        req.return_value.headers = {"header-1": "value-1", "header-2": "value-2"}
+        client.retrieve_credentials(request)
+
+
+@pytest.mark.parametrize(
+    "request_type",
+    [
+        auth_provider_credentials_service.RetrieveCredentialsRequest,
+        dict,
+    ],
+)
+def test_retrieve_credentials_rest_call_success(request_type):
+    client = AuthProviderCredentialsServiceClient(
+        credentials=ga_credentials.AnonymousCredentials(), transport="rest"
+    )
+
+    # send a request that will satisfy transcoding
+    request_init = {
+        "auth_provider": "projects/sample1/locations/sample2/authProviders/sample3"
+    }
+    request = request_type(**request_init)
+
+    # Mock the http request call within the method and fake a response.
+    with mock.patch.object(type(client.transport._session), "request") as req:
+        # Designate an appropriate value for the returned response.
+        return_value = auth_provider_credentials_service.RetrieveCredentialsResponse()
+
+        # Wrap the value into a proper Response obj
+        response_value = mock.Mock()
+        response_value.status_code = 200
+
+        # Convert return value to protobuf type
+        return_value = auth_provider_credentials_service.RetrieveCredentialsResponse.pb(
+            return_value
+        )
+        json_return_value = json_format.MessageToJson(return_value)
+        response_value.content = json_return_value.encode("UTF-8")
+        req.return_value = response_value
+        req.return_value.headers = {"header-1": "value-1", "header-2": "value-2"}
+        response = client.retrieve_credentials(request)
+
+    # Establish that the response is the type that we expect.
+    assert isinstance(
+        response, auth_provider_credentials_service.RetrieveCredentialsResponse
+    )
+
+
+@pytest.mark.parametrize("null_interceptor", [True, False])
+def test_retrieve_credentials_rest_interceptors(null_interceptor):
+    transport = transports.AuthProviderCredentialsServiceRestTransport(
+        credentials=ga_credentials.AnonymousCredentials(),
+        interceptor=None
+        if null_interceptor
+        else transports.AuthProviderCredentialsServiceRestInterceptor(),
+    )
+    client = AuthProviderCredentialsServiceClient(transport=transport)
+
+    with (
+        mock.patch.object(type(client.transport._session), "request") as req,
+        mock.patch.object(path_template, "transcode") as transcode,
+        mock.patch.object(
+            transports.AuthProviderCredentialsServiceRestInterceptor,
+            "post_retrieve_credentials",
+        ) as post,
+        mock.patch.object(
+            transports.AuthProviderCredentialsServiceRestInterceptor,
+            "post_retrieve_credentials_with_metadata",
+        ) as post_with_metadata,
+        mock.patch.object(
+            transports.AuthProviderCredentialsServiceRestInterceptor,
+            "pre_retrieve_credentials",
+        ) as pre,
+    ):
+        pre.assert_not_called()
+        post.assert_not_called()
+        post_with_metadata.assert_not_called()
+        pb_message = auth_provider_credentials_service.RetrieveCredentialsRequest.pb(
+            auth_provider_credentials_service.RetrieveCredentialsRequest()
+        )
+        transcode.return_value = {
+            "method": "post",
+            "uri": "my_uri",
+            "body": pb_message,
+            "query_params": pb_message,
+        }
+
+        req.return_value = mock.Mock()
+        req.return_value.status_code = 200
+        req.return_value.headers = {"header-1": "value-1", "header-2": "value-2"}
+        return_value = (
+            auth_provider_credentials_service.RetrieveCredentialsResponse.to_json(
+                auth_provider_credentials_service.RetrieveCredentialsResponse()
+            )
+        )
+        req.return_value.content = return_value
+
+        request = auth_provider_credentials_service.RetrieveCredentialsRequest()
+        metadata = [
+            ("key", "val"),
+            ("cephalopod", "squid"),
+        ]
+        pre.return_value = request, metadata
+        post.return_value = (
+            auth_provider_credentials_service.RetrieveCredentialsResponse()
+        )
+        post_with_metadata.return_value = (
+            auth_provider_credentials_service.RetrieveCredentialsResponse(),
+            metadata,
+        )
+
+        client.retrieve_credentials(
+            request,
+            metadata=[
+                ("key", "val"),
+                ("cephalopod", "squid"),
+            ],
+        )
+
+        pre.assert_called_once()
+        post.assert_called_once()
+        post_with_metadata.assert_called_once()
+
+
+def test_finalize_credentials_rest_bad_request(
+    request_type=auth_provider_credentials_service.FinalizeCredentialsRequest,
+):
+    client = AuthProviderCredentialsServiceClient(
+        credentials=ga_credentials.AnonymousCredentials(), transport="rest"
+    )
+    # send a request that will satisfy transcoding
+    request_init = {
+        "auth_provider": "projects/sample1/locations/sample2/authProviders/sample3"
+    }
+    request = request_type(**request_init)
+
+    # Mock the http request call within the method and fake a BadRequest error.
+    with (
+        mock.patch.object(Session, "request") as req,
+        pytest.raises(core_exceptions.BadRequest),
+    ):
+        # Wrap the value into a proper Response obj
+        response_value = mock.Mock()
+        json_return_value = ""
+        response_value.json = mock.Mock(return_value={})
+        response_value.status_code = 400
+        response_value.request = mock.Mock()
+        req.return_value = response_value
+        req.return_value.headers = {"header-1": "value-1", "header-2": "value-2"}
+        client.finalize_credentials(request)
+
+
+@pytest.mark.parametrize(
+    "request_type",
+    [
+        auth_provider_credentials_service.FinalizeCredentialsRequest,
+        dict,
+    ],
+)
+def test_finalize_credentials_rest_call_success(request_type):
+    client = AuthProviderCredentialsServiceClient(
+        credentials=ga_credentials.AnonymousCredentials(), transport="rest"
+    )
+
+    # send a request that will satisfy transcoding
+    request_init = {
+        "auth_provider": "projects/sample1/locations/sample2/authProviders/sample3"
+    }
+    request = request_type(**request_init)
+
+    # Mock the http request call within the method and fake a response.
+    with mock.patch.object(type(client.transport._session), "request") as req:
+        # Designate an appropriate value for the returned response.
+        return_value = auth_provider_credentials_service.FinalizeCredentialsResponse()
+
+        # Wrap the value into a proper Response obj
+        response_value = mock.Mock()
+        response_value.status_code = 200
+
+        # Convert return value to protobuf type
+        return_value = auth_provider_credentials_service.FinalizeCredentialsResponse.pb(
+            return_value
+        )
+        json_return_value = json_format.MessageToJson(return_value)
+        response_value.content = json_return_value.encode("UTF-8")
+        req.return_value = response_value
+        req.return_value.headers = {"header-1": "value-1", "header-2": "value-2"}
+        response = client.finalize_credentials(request)
+
+    # Establish that the response is the type that we expect.
+    assert isinstance(
+        response, auth_provider_credentials_service.FinalizeCredentialsResponse
+    )
+
+
+@pytest.mark.parametrize("null_interceptor", [True, False])
+def test_finalize_credentials_rest_interceptors(null_interceptor):
+    transport = transports.AuthProviderCredentialsServiceRestTransport(
+        credentials=ga_credentials.AnonymousCredentials(),
+        interceptor=None
+        if null_interceptor
+        else transports.AuthProviderCredentialsServiceRestInterceptor(),
+    )
+    client = AuthProviderCredentialsServiceClient(transport=transport)
+
+    with (
+        mock.patch.object(type(client.transport._session), "request") as req,
+        mock.patch.object(path_template, "transcode") as transcode,
+        mock.patch.object(
+            transports.AuthProviderCredentialsServiceRestInterceptor,
+            "post_finalize_credentials",
+        ) as post,
+        mock.patch.object(
+            transports.AuthProviderCredentialsServiceRestInterceptor,
+            "post_finalize_credentials_with_metadata",
+        ) as post_with_metadata,
+        mock.patch.object(
+            transports.AuthProviderCredentialsServiceRestInterceptor,
+            "pre_finalize_credentials",
+        ) as pre,
+    ):
+        pre.assert_not_called()
+        post.assert_not_called()
+        post_with_metadata.assert_not_called()
+        pb_message = auth_provider_credentials_service.FinalizeCredentialsRequest.pb(
+            auth_provider_credentials_service.FinalizeCredentialsRequest()
+        )
+        transcode.return_value = {
+            "method": "post",
+            "uri": "my_uri",
+            "body": pb_message,
+            "query_params": pb_message,
+        }
+
+        req.return_value = mock.Mock()
+        req.return_value.status_code = 200
+        req.return_value.headers = {"header-1": "value-1", "header-2": "value-2"}
+        return_value = (
+            auth_provider_credentials_service.FinalizeCredentialsResponse.to_json(
+                auth_provider_credentials_service.FinalizeCredentialsResponse()
+            )
+        )
+        req.return_value.content = return_value
+
+        request = auth_provider_credentials_service.FinalizeCredentialsRequest()
+        metadata = [
+            ("key", "val"),
+            ("cephalopod", "squid"),
+        ]
+        pre.return_value = request, metadata
+        post.return_value = (
+            auth_provider_credentials_service.FinalizeCredentialsResponse()
+        )
+        post_with_metadata.return_value = (
+            auth_provider_credentials_service.FinalizeCredentialsResponse(),
+            metadata,
+        )
+
+        client.finalize_credentials(
+            request,
+            metadata=[
+                ("key", "val"),
+                ("cephalopod", "squid"),
+            ],
+        )
+
+        pre.assert_called_once()
+        post.assert_called_once()
+        post_with_metadata.assert_called_once()
+
+
+def test_initialize_client_w_rest():
+    client = AuthProviderCredentialsServiceClient(
+        credentials=ga_credentials.AnonymousCredentials(), transport="rest"
+    )
+    assert client is not None
+
+
+# This test is a coverage failsafe to make sure that totally empty calls,
+# i.e. request == None and no flattened fields passed, work.
+def test_retrieve_credentials_empty_call_rest():
+    client = AuthProviderCredentialsServiceClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="rest",
+    )
+
+    # Mock the actual call, and fake the request.
+    with mock.patch.object(
+        type(client.transport.retrieve_credentials), "__call__"
+    ) as call:
+        client.retrieve_credentials(request=None)
+
+        # Establish that the underlying stub method was called.
+        call.assert_called()
+        _, args, _ = call.mock_calls[0]
+        request_msg = auth_provider_credentials_service.RetrieveCredentialsRequest()
+        assert args[0] == request_msg
+
+
+# This test is a coverage failsafe to make sure that totally empty calls,
+# i.e. request == None and no flattened fields passed, work.
+def test_finalize_credentials_empty_call_rest():
+    client = AuthProviderCredentialsServiceClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="rest",
+    )
+
+    # Mock the actual call, and fake the request.
+    with mock.patch.object(
+        type(client.transport.finalize_credentials), "__call__"
+    ) as call:
+        client.finalize_credentials(request=None)
+
+        # Establish that the underlying stub method was called.
+        call.assert_called()
+        _, args, _ = call.mock_calls[0]
+        request_msg = auth_provider_credentials_service.FinalizeCredentialsRequest()
+        assert args[0] == request_msg
+
+
+def test_transport_grpc_default():
+    # A client should use the gRPC transport by default.
+    client = AuthProviderCredentialsServiceClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+    )
+    assert isinstance(
+        client.transport,
+        transports.AuthProviderCredentialsServiceGrpcTransport,
+    )
+
+
+def test_auth_provider_credentials_service_base_transport_error():
+    # Passing both a credentials object and credentials_file should raise an error
+    with pytest.raises(core_exceptions.DuplicateCredentialArgs):
+        transport = transports.AuthProviderCredentialsServiceTransport(
+            credentials=ga_credentials.AnonymousCredentials(),
+            credentials_file="credentials.json",
+        )
+
+
+def test_auth_provider_credentials_service_base_transport():
+    # Instantiate the base transport.
+    with mock.patch(
+        "google.cloud.agentidentitycredentials_v1beta.services.auth_provider_credentials_service.transports.AuthProviderCredentialsServiceTransport.__init__"
+    ) as Transport:
+        Transport.return_value = None
+        transport = transports.AuthProviderCredentialsServiceTransport(
+            credentials=ga_credentials.AnonymousCredentials(),
+        )
+
+    # Every method on the transport should just blindly
+    # raise NotImplementedError.
+    methods = (
+        "retrieve_credentials",
+        "finalize_credentials",
+    )
+    for method in methods:
+        with pytest.raises(NotImplementedError):
+            getattr(transport, method)(request=object())
+
+    with pytest.raises(NotImplementedError):
+        transport.close()
+
+    # Catch all for all remaining methods and properties
+    remainder = [
+        "kind",
+    ]
+    for r in remainder:
+        with pytest.raises(NotImplementedError):
+            getattr(transport, r)()
+
+
+def test_auth_provider_credentials_service_base_transport_with_credentials_file():
+    # Instantiate the base transport with a credentials file
+    with (
+        mock.patch.object(
+            google.auth, "load_credentials_from_file", autospec=True
+        ) as load_creds,
+        mock.patch(
+            "google.cloud.agentidentitycredentials_v1beta.services.auth_provider_credentials_service.transports.AuthProviderCredentialsServiceTransport._prep_wrapped_messages"
+        ) as Transport,
+    ):
+        Transport.return_value = None
+        load_creds.return_value = (ga_credentials.AnonymousCredentials(), None)
+        transport = transports.AuthProviderCredentialsServiceTransport(
+            credentials_file="credentials.json",
+            quota_project_id="octopus",
+        )
+        load_creds.assert_called_once_with(
+            "credentials.json",
+            scopes=None,
+            default_scopes=("https://www.googleapis.com/auth/cloud-platform",),
+            quota_project_id="octopus",
+        )
+
+
+def test_auth_provider_credentials_service_base_transport_with_adc():
+    # Test the default credentials are used if credentials and credentials_file are None.
+    with (
+        mock.patch.object(google.auth, "default", autospec=True) as adc,
+        mock.patch(
+            "google.cloud.agentidentitycredentials_v1beta.services.auth_provider_credentials_service.transports.AuthProviderCredentialsServiceTransport._prep_wrapped_messages"
+        ) as Transport,
+    ):
+        Transport.return_value = None
+        adc.return_value = (ga_credentials.AnonymousCredentials(), None)
+        transport = transports.AuthProviderCredentialsServiceTransport()
+        adc.assert_called_once()
+
+
+def test_auth_provider_credentials_service_auth_adc():
+    # If no credentials are provided, we should use ADC credentials.
+    with mock.patch.object(google.auth, "default", autospec=True) as adc:
+        adc.return_value = (ga_credentials.AnonymousCredentials(), None)
+        AuthProviderCredentialsServiceClient()
+        adc.assert_called_once_with(
+            scopes=None,
+            default_scopes=("https://www.googleapis.com/auth/cloud-platform",),
+            quota_project_id=None,
+        )
+
+
+@pytest.mark.parametrize(
+    "transport_class",
+    [
+        transports.AuthProviderCredentialsServiceGrpcTransport,
+        transports.AuthProviderCredentialsServiceGrpcAsyncIOTransport,
+    ],
+)
+def test_auth_provider_credentials_service_transport_auth_adc(transport_class):
+    # If credentials and host are not provided, the transport class should use
+    # ADC credentials.
+    with mock.patch.object(google.auth, "default", autospec=True) as adc:
+        adc.return_value = (ga_credentials.AnonymousCredentials(), None)
+        transport_class(quota_project_id="octopus", scopes=["1", "2"])
+        adc.assert_called_once_with(
+            scopes=["1", "2"],
+            default_scopes=("https://www.googleapis.com/auth/cloud-platform",),
+            quota_project_id="octopus",
+        )
+
+
+@pytest.mark.parametrize(
+    "transport_class",
+    [
+        transports.AuthProviderCredentialsServiceGrpcTransport,
+        transports.AuthProviderCredentialsServiceGrpcAsyncIOTransport,
+        transports.AuthProviderCredentialsServiceRestTransport,
+    ],
+)
+def test_auth_provider_credentials_service_transport_auth_gdch_credentials(
+    transport_class,
+):
+    host = "https://language.com"
+    api_audience_tests = [None, "https://language2.com"]
+    api_audience_expect = [host, "https://language2.com"]
+    for t, e in zip(api_audience_tests, api_audience_expect):
+        with mock.patch.object(google.auth, "default", autospec=True) as adc:
+            gdch_mock = mock.MagicMock()
+            type(gdch_mock).with_gdch_audience = mock.PropertyMock(
+                return_value=gdch_mock
+            )
+            adc.return_value = (gdch_mock, None)
+            transport_class(host=host, api_audience=t)
+            gdch_mock.with_gdch_audience.assert_called_once_with(e)
+
+
+@pytest.mark.parametrize(
+    "transport_class,grpc_helpers",
+    [
+        (transports.AuthProviderCredentialsServiceGrpcTransport, grpc_helpers),
+        (
+            transports.AuthProviderCredentialsServiceGrpcAsyncIOTransport,
+            grpc_helpers_async,
+        ),
+    ],
+)
+def test_auth_provider_credentials_service_transport_create_channel(
+    transport_class, grpc_helpers
+):
+    # If credentials and host are not provided, the transport class should use
+    # ADC credentials.
+    with (
+        mock.patch.object(google.auth, "default", autospec=True) as adc,
+        mock.patch.object(
+            grpc_helpers, "create_channel", autospec=True
+        ) as create_channel,
+    ):
+        creds = ga_credentials.AnonymousCredentials()
+        adc.return_value = (creds, None)
+        transport_class(quota_project_id="octopus", scopes=["1", "2"])
+
+        create_channel.assert_called_with(
+            "agentidentitycredentials.googleapis.com:443",
+            credentials=creds,
+            credentials_file=None,
+            quota_project_id="octopus",
+            default_scopes=("https://www.googleapis.com/auth/cloud-platform",),
+            scopes=["1", "2"],
+            default_host="agentidentitycredentials.googleapis.com",
+            ssl_credentials=None,
+            options=[
+                ("grpc.max_send_message_length", -1),
+                ("grpc.max_receive_message_length", -1),
+            ],
+        )
+
+
+@pytest.mark.parametrize(
+    "transport_class",
+    [
+        transports.AuthProviderCredentialsServiceGrpcTransport,
+        transports.AuthProviderCredentialsServiceGrpcAsyncIOTransport,
+    ],
+)
+def test_auth_provider_credentials_service_grpc_transport_client_cert_source_for_mtls(
+    transport_class,
+):
+    cred = ga_credentials.AnonymousCredentials()
+
+    # Check ssl_channel_credentials is used if provided.
+    with mock.patch.object(transport_class, "create_channel") as mock_create_channel:
+        mock_ssl_channel_creds = mock.Mock()
+        transport_class(
+            host="squid.clam.whelk",
+            credentials=cred,
+            ssl_channel_credentials=mock_ssl_channel_creds,
+        )
+        mock_create_channel.assert_called_once_with(
+            "squid.clam.whelk:443",
+            credentials=cred,
+            credentials_file=None,
+            scopes=None,
+            ssl_credentials=mock_ssl_channel_creds,
+            quota_project_id=None,
+            options=[
+                ("grpc.max_send_message_length", -1),
+                ("grpc.max_receive_message_length", -1),
+            ],
+        )
+
+    # Check if ssl_channel_credentials is not provided, then client_cert_source_for_mtls
+    # is used.
+    with mock.patch.object(transport_class, "create_channel", return_value=mock.Mock()):
+        with mock.patch("grpc.ssl_channel_credentials") as mock_ssl_cred:
+            transport_class(
+                credentials=cred,
+                client_cert_source_for_mtls=client_cert_source_callback,
+            )
+            expected_cert, expected_key = client_cert_source_callback()
+            mock_ssl_cred.assert_called_once_with(
+                certificate_chain=expected_cert, private_key=expected_key
+            )
+
+
+def test_auth_provider_credentials_service_http_transport_client_cert_source_for_mtls():
+    cred = ga_credentials.AnonymousCredentials()
+    with mock.patch(
+        "google.auth.transport.requests.AuthorizedSession.configure_mtls_channel"
+    ) as mock_configure_mtls_channel:
+        transports.AuthProviderCredentialsServiceRestTransport(
+            credentials=cred, client_cert_source_for_mtls=client_cert_source_callback
+        )
+        mock_configure_mtls_channel.assert_called_once_with(client_cert_source_callback)
+
+
+@pytest.mark.parametrize(
+    "transport_name",
+    [
+        "grpc",
+        "grpc_asyncio",
+        "rest",
+    ],
+)
+def test_auth_provider_credentials_service_host_no_port(transport_name):
+    client = AuthProviderCredentialsServiceClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        client_options=client_options.ClientOptions(
+            api_endpoint="agentidentitycredentials.googleapis.com"
+        ),
+        transport=transport_name,
+    )
+    assert client.transport._host == (
+        "agentidentitycredentials.googleapis.com:443"
+        if transport_name in ["grpc", "grpc_asyncio"]
+        else "https://agentidentitycredentials.googleapis.com"
+    )
+
+
+@pytest.mark.parametrize(
+    "transport_name",
+    [
+        "grpc",
+        "grpc_asyncio",
+        "rest",
+    ],
+)
+def test_auth_provider_credentials_service_host_with_port(transport_name):
+    client = AuthProviderCredentialsServiceClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        client_options=client_options.ClientOptions(
+            api_endpoint="agentidentitycredentials.googleapis.com:8000"
+        ),
+        transport=transport_name,
+    )
+    assert client.transport._host == (
+        "agentidentitycredentials.googleapis.com:8000"
+        if transport_name in ["grpc", "grpc_asyncio"]
+        else "https://agentidentitycredentials.googleapis.com:8000"
+    )
+
+
+@pytest.mark.parametrize(
+    "transport_name",
+    [
+        "rest",
+    ],
+)
+def test_auth_provider_credentials_service_client_transport_session_collision(
+    transport_name,
+):
+    creds1 = ga_credentials.AnonymousCredentials()
+    creds2 = ga_credentials.AnonymousCredentials()
+    client1 = AuthProviderCredentialsServiceClient(
+        credentials=creds1,
+        transport=transport_name,
+    )
+    client2 = AuthProviderCredentialsServiceClient(
+        credentials=creds2,
+        transport=transport_name,
+    )
+    session1 = client1.transport.retrieve_credentials._session
+    session2 = client2.transport.retrieve_credentials._session
+    assert session1 != session2
+    session1 = client1.transport.finalize_credentials._session
+    session2 = client2.transport.finalize_credentials._session
+    assert session1 != session2
+
+
+def test_auth_provider_credentials_service_grpc_transport_channel():
+    channel = grpc.secure_channel("http://localhost/", grpc.local_channel_credentials())
+
+    # Check that channel is used if provided.
+    transport = transports.AuthProviderCredentialsServiceGrpcTransport(
+        host="squid.clam.whelk",
+        channel=channel,
+    )
+    assert transport.grpc_channel == channel
+    assert transport._host == "squid.clam.whelk:443"
+    assert transport._ssl_channel_credentials == None
+
+
+def test_auth_provider_credentials_service_grpc_asyncio_transport_channel():
+    channel = aio.secure_channel("http://localhost/", grpc.local_channel_credentials())
+
+    # Check that channel is used if provided.
+    transport = transports.AuthProviderCredentialsServiceGrpcAsyncIOTransport(
+        host="squid.clam.whelk",
+        channel=channel,
+    )
+    assert transport.grpc_channel == channel
+    assert transport._host == "squid.clam.whelk:443"
+    assert transport._ssl_channel_credentials == None
+
+
+# Remove this test when deprecated arguments (api_mtls_endpoint, client_cert_source) are
+# removed from grpc/grpc_asyncio transport constructor.
+@pytest.mark.filterwarnings("ignore::FutureWarning")
+@pytest.mark.parametrize(
+    "transport_class",
+    [
+        transports.AuthProviderCredentialsServiceGrpcTransport,
+        transports.AuthProviderCredentialsServiceGrpcAsyncIOTransport,
+    ],
+)
+def test_auth_provider_credentials_service_transport_channel_mtls_with_client_cert_source(
+    transport_class,
+):
+    with mock.patch(
+        "grpc.ssl_channel_credentials", autospec=True
+    ) as grpc_ssl_channel_cred:
+        with mock.patch.object(
+            transport_class, "create_channel"
+        ) as grpc_create_channel:
+            mock_ssl_cred = mock.Mock()
+            grpc_ssl_channel_cred.return_value = mock_ssl_cred
+
+            mock_grpc_channel = mock.Mock()
+            grpc_create_channel.return_value = mock_grpc_channel
+
+            cred = ga_credentials.AnonymousCredentials()
+            with pytest.warns(DeprecationWarning):
+                with mock.patch.object(google.auth, "default") as adc:
+                    adc.return_value = (cred, None)
+                    transport = transport_class(
+                        host="squid.clam.whelk",
+                        api_mtls_endpoint="mtls.squid.clam.whelk",
+                        client_cert_source=client_cert_source_callback,
+                    )
+                    adc.assert_called_once()
+
+            grpc_ssl_channel_cred.assert_called_once_with(
+                certificate_chain=b"cert bytes", private_key=b"key bytes"
+            )
+            grpc_create_channel.assert_called_once_with(
+                "mtls.squid.clam.whelk:443",
+                credentials=cred,
+                credentials_file=None,
+                scopes=None,
+                ssl_credentials=mock_ssl_cred,
+                quota_project_id=None,
+                options=[
+                    ("grpc.max_send_message_length", -1),
+                    ("grpc.max_receive_message_length", -1),
+                ],
+            )
+            assert transport.grpc_channel == mock_grpc_channel
+            assert transport._ssl_channel_credentials == mock_ssl_cred
+
+
+# Remove this test when deprecated arguments (api_mtls_endpoint, client_cert_source) are
+# removed from grpc/grpc_asyncio transport constructor.
+@pytest.mark.parametrize(
+    "transport_class",
+    [
+        transports.AuthProviderCredentialsServiceGrpcTransport,
+        transports.AuthProviderCredentialsServiceGrpcAsyncIOTransport,
+    ],
+)
+def test_auth_provider_credentials_service_transport_channel_mtls_with_adc(
+    transport_class,
+):
+    mock_ssl_cred = mock.Mock()
+    with mock.patch.multiple(
+        "google.auth.transport.grpc.SslCredentials",
+        __init__=mock.Mock(return_value=None),
+        ssl_credentials=mock.PropertyMock(return_value=mock_ssl_cred),
+    ):
+        with mock.patch.object(
+            transport_class, "create_channel"
+        ) as grpc_create_channel:
+            mock_grpc_channel = mock.Mock()
+            grpc_create_channel.return_value = mock_grpc_channel
+            mock_cred = mock.Mock()
+
+            with pytest.warns(DeprecationWarning):
+                transport = transport_class(
+                    host="squid.clam.whelk",
+                    credentials=mock_cred,
+                    api_mtls_endpoint="mtls.squid.clam.whelk",
+                    client_cert_source=None,
+                )
+
+            grpc_create_channel.assert_called_once_with(
+                "mtls.squid.clam.whelk:443",
+                credentials=mock_cred,
+                credentials_file=None,
+                scopes=None,
+                ssl_credentials=mock_ssl_cred,
+                quota_project_id=None,
+                options=[
+                    ("grpc.max_send_message_length", -1),
+                    ("grpc.max_receive_message_length", -1),
+                ],
+            )
+            assert transport.grpc_channel == mock_grpc_channel
+
+
+def test_auth_provider_path():
+    project = "squid"
+    location = "clam"
+    auth_provider = "whelk"
+    expected = (
+        "projects/{project}/locations/{location}/authProviders/{auth_provider}".format(
+            project=project,
+            location=location,
+            auth_provider=auth_provider,
+        )
+    )
+    actual = AuthProviderCredentialsServiceClient.auth_provider_path(
+        project, location, auth_provider
+    )
+    assert expected == actual
+
+
+def test_parse_auth_provider_path():
+    expected = {
+        "project": "octopus",
+        "location": "oyster",
+        "auth_provider": "nudibranch",
+    }
+    path = AuthProviderCredentialsServiceClient.auth_provider_path(**expected)
+
+    # Check that the path construction is reversible.
+    actual = AuthProviderCredentialsServiceClient.parse_auth_provider_path(path)
+    assert expected == actual
+
+
+def test_common_billing_account_path():
+    billing_account = "cuttlefish"
+    expected = "billingAccounts/{billing_account}".format(
+        billing_account=billing_account,
+    )
+    actual = AuthProviderCredentialsServiceClient.common_billing_account_path(
+        billing_account
+    )
+    assert expected == actual
+
+
+def test_parse_common_billing_account_path():
+    expected = {
+        "billing_account": "mussel",
+    }
+    path = AuthProviderCredentialsServiceClient.common_billing_account_path(**expected)
+
+    # Check that the path construction is reversible.
+    actual = AuthProviderCredentialsServiceClient.parse_common_billing_account_path(
+        path
+    )
+    assert expected == actual
+
+
+def test_common_folder_path():
+    folder = "winkle"
+    expected = "folders/{folder}".format(
+        folder=folder,
+    )
+    actual = AuthProviderCredentialsServiceClient.common_folder_path(folder)
+    assert expected == actual
+
+
+def test_parse_common_folder_path():
+    expected = {
+        "folder": "nautilus",
+    }
+    path = AuthProviderCredentialsServiceClient.common_folder_path(**expected)
+
+    # Check that the path construction is reversible.
+    actual = AuthProviderCredentialsServiceClient.parse_common_folder_path(path)
+    assert expected == actual
+
+
+def test_common_organization_path():
+    organization = "scallop"
+    expected = "organizations/{organization}".format(
+        organization=organization,
+    )
+    actual = AuthProviderCredentialsServiceClient.common_organization_path(organization)
+    assert expected == actual
+
+
+def test_parse_common_organization_path():
+    expected = {
+        "organization": "abalone",
+    }
+    path = AuthProviderCredentialsServiceClient.common_organization_path(**expected)
+
+    # Check that the path construction is reversible.
+    actual = AuthProviderCredentialsServiceClient.parse_common_organization_path(path)
+    assert expected == actual
+
+
+def test_common_project_path():
+    project = "squid"
+    expected = "projects/{project}".format(
+        project=project,
+    )
+    actual = AuthProviderCredentialsServiceClient.common_project_path(project)
+    assert expected == actual
+
+
+def test_parse_common_project_path():
+    expected = {
+        "project": "clam",
+    }
+    path = AuthProviderCredentialsServiceClient.common_project_path(**expected)
+
+    # Check that the path construction is reversible.
+    actual = AuthProviderCredentialsServiceClient.parse_common_project_path(path)
+    assert expected == actual
+
+
+def test_common_location_path():
+    project = "whelk"
+    location = "octopus"
+    expected = "projects/{project}/locations/{location}".format(
+        project=project,
+        location=location,
+    )
+    actual = AuthProviderCredentialsServiceClient.common_location_path(
+        project, location
+    )
+    assert expected == actual
+
+
+def test_parse_common_location_path():
+    expected = {
+        "project": "oyster",
+        "location": "nudibranch",
+    }
+    path = AuthProviderCredentialsServiceClient.common_location_path(**expected)
+
+    # Check that the path construction is reversible.
+    actual = AuthProviderCredentialsServiceClient.parse_common_location_path(path)
+    assert expected == actual
+
+
+def test_client_with_default_client_info():
+    client_info = gapic_v1.client_info.ClientInfo()
+
+    with mock.patch.object(
+        transports.AuthProviderCredentialsServiceTransport, "_prep_wrapped_messages"
+    ) as prep:
+        client = AuthProviderCredentialsServiceClient(
+            credentials=ga_credentials.AnonymousCredentials(),
+            client_info=client_info,
+        )
+        prep.assert_called_once_with(client_info)
+
+    with mock.patch.object(
+        transports.AuthProviderCredentialsServiceTransport, "_prep_wrapped_messages"
+    ) as prep:
+        transport_class = AuthProviderCredentialsServiceClient.get_transport_class()
+        transport = transport_class(
+            credentials=ga_credentials.AnonymousCredentials(),
+            client_info=client_info,
+        )
+        prep.assert_called_once_with(client_info)
+
+
+def test_transport_close_grpc():
+    client = AuthProviderCredentialsServiceClient(
+        credentials=ga_credentials.AnonymousCredentials(), transport="grpc"
+    )
+    with mock.patch.object(
+        type(getattr(client.transport, "_grpc_channel")), "close"
+    ) as close:
+        with client:
+            close.assert_not_called()
+        close.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_transport_close_grpc_asyncio():
+    client = AuthProviderCredentialsServiceAsyncClient(
+        credentials=async_anonymous_credentials(), transport="grpc_asyncio"
+    )
+    with mock.patch.object(
+        type(getattr(client.transport, "_grpc_channel")), "close"
+    ) as close:
+        async with client:
+            close.assert_not_called()
+        close.assert_called_once()
+
+
+def test_transport_close_rest():
+    client = AuthProviderCredentialsServiceClient(
+        credentials=ga_credentials.AnonymousCredentials(), transport="rest"
+    )
+    with mock.patch.object(
+        type(getattr(client.transport, "_session")), "close"
+    ) as close:
+        with client:
+            close.assert_not_called()
+        close.assert_called_once()
+
+
+def test_client_ctx():
+    transports = [
+        "rest",
+        "grpc",
+    ]
+    for transport in transports:
+        client = AuthProviderCredentialsServiceClient(
+            credentials=ga_credentials.AnonymousCredentials(), transport=transport
+        )
+        # Test client calls underlying transport.
+        with mock.patch.object(type(client.transport), "close") as close:
+            close.assert_not_called()
+            with client:
+                pass
+            close.assert_called()
+
+
+@pytest.mark.parametrize(
+    "client_class,transport_class",
+    [
+        (
+            AuthProviderCredentialsServiceClient,
+            transports.AuthProviderCredentialsServiceGrpcTransport,
+        ),
+        (
+            AuthProviderCredentialsServiceAsyncClient,
+            transports.AuthProviderCredentialsServiceGrpcAsyncIOTransport,
+        ),
+    ],
+)
+def test_api_key_credentials(client_class, transport_class):
+    with mock.patch.object(
+        google.auth._default, "get_api_key_credentials", create=True
+    ) as get_api_key_credentials:
+        mock_cred = mock.Mock()
+        get_api_key_credentials.return_value = mock_cred
+        options = client_options.ClientOptions()
+        options.api_key = "api_key"
+        with mock.patch.object(transport_class, "__init__") as patched:
+            patched.return_value = None
+            client = client_class(client_options=options)
+            patched.assert_called_once_with(
+                credentials=mock_cred,
+                credentials_file=None,
+                host=client._DEFAULT_ENDPOINT_TEMPLATE.format(
+                    UNIVERSE_DOMAIN=client._DEFAULT_UNIVERSE
+                ),
+                scopes=None,
+                client_cert_source_for_mtls=None,
+                quota_project_id=None,
+                client_info=transports.base.DEFAULT_CLIENT_INFO,
+                always_use_jwt_access=True,
+                api_audience=None,
+            )

--- a/release-please-bulk-config.json
+++ b/release-please-bulk-config.json
@@ -267,9 +267,15 @@
       "extra-files": [
         "google/cloud/agentidentitycredentials/gapic_version.py",
         "google/cloud/agentidentitycredentials_v1/gapic_version.py",
+        "google/cloud/agentidentitycredentials_v1beta/gapic_version.py",
         {
           "jsonpath": "$.clientLibrary.version",
           "path": "samples/generated_samples/snippet_metadata_google.cloud.agentidentitycredentials.v1.json",
+          "type": "json"
+        },
+        {
+          "jsonpath": "$.clientLibrary.version",
+          "path": "samples/generated_samples/snippet_metadata_google.cloud.agentidentitycredentials.v1beta.json",
           "type": "json"
         }
       ]


### PR DESCRIPTION
Generated v1beta1 version for the existing google-cloud-agentidentitycredentials library.

```
suztomo@suztomo:~/librarian-2026/google-cloud-python$ go run github.com/googleapis/librarian/cmd/librarian@${V} add "${API_PATH}"
suztomo@suztomo:~/librarian-2026/google-cloud-python$ git diff
diff --git a/librarian.yaml b/librarian.yaml
index 58d7547d317..ec0609a6428 100644
--- a/librarian.yaml
+++ b/librarian.yaml
@@ -290,6 +290,7 @@ libraries:
     version: 0.1.0
     apis:
       - path: google/cloud/agentidentitycredentials/v1
+      - path: google/cloud/agentidentitycredentials/v1beta
     copyright_year: "2026"
     python:
       default_version: v1
diff --git a/release-please-bulk-config.json b/release-please-bulk-config.json
index 57ebae116c4..c5b6b2c0ee4 100644
--- a/release-please-bulk-config.json
+++ b/release-please-bulk-config.json
@@ -267,10 +267,16 @@
       "extra-files": [
         "google/cloud/agentidentitycredentials/gapic_version.py",
         "google/cloud/agentidentitycredentials_v1/gapic_version.py",
+        "google/cloud/agentidentitycredentials_v1beta/gapic_version.py",
         {
           "jsonpath": "$.clientLibrary.version",
           "path": "samples/generated_samples/snippet_metadata_google.cloud.agentidentitycredentials.v1.json",
           "type": "json"
+        },
+        {
+          "jsonpath": "$.clientLibrary.version",
+          "path": "samples/generated_samples/snippet_metadata_google.cloud.agentidentitycredentials.v1beta.json",
+          "type": "json"
         }
       ]
     },
suztomo@suztomo:~/librarian-2026/google-cloud-python$ docker run -u $(id -u):$(id -g) -v .:/repo -v ~/.cache:/.cache -w /repo \
  docker.io/library/librarian-python:${V}  generate -v google-cloud-agentidentitycredentials
...
```