### PR TITLE
chore(bigquery): fix timeout flakiness in job tests

### DIFF
--- a/packages/google-cloud-bigquery/tests/unit/job/test_async_job_retry.py
+++ b/packages/google-cloud-bigquery/tests/unit/job/test_async_job_retry.py
@@ -15,11 +15,10 @@
 from unittest import mock
 
 import google.api_core.retry
+import google.cloud.bigquery.job
 from google.api_core import exceptions
 
 from . import helpers
-import google.cloud.bigquery.job
-
 
 PROJECT = "test-project"
 JOB_ID = "test-job-id"
@@ -110,7 +109,7 @@ def test_result_w_retry_wo_state(global_time_lock):
         predicate=custom_predicate,
         initial=0.001,
         maximum=0.001,
-        deadline=0.1,
+        deadline=1.0,
     )
     assert job.result(retry=custom_retry) is job
 

--- a/packages/google-cloud-bigquery/tests/unit/job/test_query_job_retry.py
+++ b/packages/google-cloud-bigquery/tests/unit/job/test_query_job_retry.py
@@ -11,14 +11,13 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import concurrent.futures
 from unittest import mock
 
-import concurrent.futures
 import freezegun
-from google.api_core import exceptions
 import google.api_core.retry
 import pytest
-
+from google.api_core import exceptions
 from google.cloud.bigquery.client import _MIN_GET_QUERY_RESULTS_TIMEOUT
 from google.cloud.bigquery.job import QueryJob
 from google.cloud.bigquery.retry import DEFAULT_GET_JOB_TIMEOUT
@@ -26,7 +25,6 @@ from google.cloud.bigquery.table import RowIterator
 
 from ..helpers import make_connection
 from .helpers import _make_client
-
 
 PROJECT = "test-project"
 JOB_ID = "test-job-id"
@@ -105,7 +103,7 @@ def test_result_w_custom_retry(global_time_lock):
         initial=0.001,
         maximum=0.001,
         multiplier=1.0,
-        deadline=0.1,
+        deadline=1.0,
         predicate=custom_predicate,
     )
 


### PR DESCRIPTION
## The Problem
Two unit tests in `google-cloud-bigquery` (`test_result_w_retry_wo_state` and `test_result_w_custom_retry`) were failing intermittently with a `TimeoutError` or `RetryError`. This flakiness occurs because the tests use a very short inner retry deadline of 0.1 seconds. Under heavy load (such as during parallel testing or on constrained continuous integration runners), this deadline can be exceeded, causing the test to fail confusingly.

## The Solution
Increased the `deadline` parameter for the custom retry objects in both tests from 0.1 seconds to 1.0 seconds. This provides enough buffer for the test assertions to complete without timing out, aligning with other similar tests in the suite.

## Notes to Reviewers
- This change only affects unit tests and does not alter production code.
- This issue is blocking:
  - https://github.com/googleapis/google-cloud-python/pull/17642
  - https://github.com/googleapis/google-cloud-python/pull/17608

Here is a snippet of the failure:
```python
    def test_result_w_retry_wo_state(global_time_lock):
        from google.cloud.bigquery.retry import DEFAULT_GET_JOB_TIMEOUT
    
        begun_job_resource = helpers._make_job_resource(
            job_id=JOB_ID, project_id=PROJECT, location="EU", started=True
        )
        done_job_resource = helpers._make_job_resource(
            job_id=JOB_ID,
            project_id=PROJECT,
            location="EU",
            started=True,
            ended=True,
        )
        conn = helpers.make_connection(
            exceptions.NotFound("not normally retriable"),
            begun_job_resource,
            exceptions.NotFound("not normally retriable"),
            done_job_resource,
        )
        client = helpers._make_client(project=PROJECT, connection=conn)
        job = google.cloud.bigquery.job._AsyncJob(
            google.cloud.bigquery.job._JobReference(JOB_ID, PROJECT, "EU"), client
        )
        custom_predicate = mock.Mock()
        custom_predicate.return_value = True
        custom_retry = google.api_core.retry.Retry(
            predicate=custom_predicate,
            initial=0.001,
            maximum=0.001,
            deadline=0.1,
        )
>       assert job.result(retry=custom_retry) is job
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

tests/unit/job/test_async_job_retry.py:115: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
google/cloud/bigquery/job/base.py:1047: in result
    return super(_AsyncJob, self).result(timeout=timeout, retry=retry)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
.nox/unit-3-12-test_type-unit/lib/python3.12/site-packages/google/api_core/future/polling.py:256: in result
    self._blocking_poll(timeout=timeout, retry=retry, polling=polling)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = _AsyncJob<project=test-project, location=EU, id=test-job-id>
timeout = None
retry = <google.api_core.retry.retry_unary.Retry object at 0x7ff2beda32c0>
polling = <google.api_core.retry.retry_unary.Retry object at 0x7ff2beda01d0>

    def _blocking_poll(self, timeout=_DEFAULT_VALUE, retry=None, polling=None):
        """Poll and wait for the Future to be resolved."""
    
        if self._result_set:
            return
    
        polling = polling or self._polling
        if timeout is not PollingFuture._DEFAULT_VALUE:
            polling = polling.with_timeout(timeout)
    
        try:
            polling(self._done_or_raise)(retry=retry)
        except exceptions.RetryError:
>           raise concurrent.futures.TimeoutError(
                f"Operation did not complete within the designated timeout of "
                f"{polling.timeout} seconds."
            )
E           TimeoutError: Operation did not complete within the designated timeout of None seconds.
```