### PR TITLE
chore(generator): update pqc system tests to use grpcio 1.83.0

### DIFF
--- a/packages/gapic-generator/noxfile.py
+++ b/packages/gapic-generator/noxfile.py
@@ -498,9 +498,7 @@ def showcase_pqc(
     """Run the Showcase PQC verification test suite against grpcio 1.83+ over standard TLS."""
     with showcase_library(session, templates=templates, other_opts=other_opts):
         session.install("pytest", "pytest-asyncio")
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/17751):
-        # Update the version below to `1.83.0` once released, and remove `--pre`.
-        session.install("--pre", "--upgrade", "grpcio>=1.83.0rc0", "grpcio-status>=1.83.0rc0")
+        session.install("--pre", "--upgrade", "grpcio>=1.83.0", "grpcio-status>=1.83.0")
         session.run("py.test", "--quiet", "--tls", *(session.posargs or ["tests/system/test_pqc.py"]), env=env)
 
 

--- a/packages/gapic-generator/noxfile.py
+++ b/packages/gapic-generator/noxfile.py
@@ -498,7 +498,7 @@ def showcase_pqc(
     """Run the Showcase PQC verification test suite against grpcio 1.83+ over standard TLS."""
     with showcase_library(session, templates=templates, other_opts=other_opts):
         session.install("pytest", "pytest-asyncio")
-        session.install("--pre", "--upgrade", "grpcio>=1.83.0", "grpcio-status>=1.83.0")
+        session.install("--upgrade", "grpcio>=1.83.0", "grpcio-status>=1.83.0")
         session.run("py.test", "--quiet", "--tls", *(session.posargs or ["tests/system/test_pqc.py"]), env=env)
 
 

--- a/packages/gapic-generator/tests/system/test_pqc.py
+++ b/packages/gapic-generator/tests/system/test_pqc.py
@@ -45,7 +45,7 @@ def test_pqc_grpc(intercepted_echo_grpc):
     """Verifies that the gRPC client library negotiates post-quantum MLKEM with Showcase server."""
     # TODO(https://github.com/googleapis/google-cloud-python/issues/17752):
     # Remove this check once grpcio >= 1.83.0 is enforced across all client libraries.
-    if Version(grpc.__version__) < Version("1.83.0rc0"):
+    if Version(grpc.__version__) < Version("1.83.0"):
         # TODO(https://github.com/googleapis/google-cloud-python/issues/17751): 
         # Update the version in the check above to `1.83.0` once released.
         pytest.skip(f"gRPC PQC negotiation requires grpcio >= 1.83.0 (current: {grpc.__version__})")
@@ -69,7 +69,7 @@ async def test_pqc_grpc_async(intercepted_echo_grpc_async):
     """Verifies that the async gRPC client library negotiates post-quantum MLKEM with Showcase server."""
     # TODO(https://github.com/googleapis/google-cloud-python/issues/17752):
     # Remove this check once grpcio >= 1.83.0 is enforced across all client libraries.
-    if Version(grpc.__version__) < Version("1.83.0rc0"):
+    if Version(grpc.__version__) < Version("1.83.0"):
         # TODO(https://github.com/googleapis/google-cloud-python/issues/17751):
         # Update the version in the check above to `1.83.0` once released.
         pytest.skip(

--- a/packages/gapic-generator/tests/system/test_pqc.py
+++ b/packages/gapic-generator/tests/system/test_pqc.py
@@ -46,8 +46,6 @@ def test_pqc_grpc(intercepted_echo_grpc):
     # TODO(https://github.com/googleapis/google-cloud-python/issues/17752):
     # Remove this check once grpcio >= 1.83.0 is enforced across all client libraries.
     if Version(grpc.__version__) < Version("1.83.0"):
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/17751): 
-        # Update the version in the check above to `1.83.0` once released.
         pytest.skip(f"gRPC PQC negotiation requires grpcio >= 1.83.0 (current: {grpc.__version__})")
 
     client, interceptor = intercepted_echo_grpc
@@ -70,8 +68,6 @@ async def test_pqc_grpc_async(intercepted_echo_grpc_async):
     # TODO(https://github.com/googleapis/google-cloud-python/issues/17752):
     # Remove this check once grpcio >= 1.83.0 is enforced across all client libraries.
     if Version(grpc.__version__) < Version("1.83.0"):
-        # TODO(https://github.com/googleapis/google-cloud-python/issues/17751):
-        # Update the version in the check above to `1.83.0` once released.
         pytest.skip(
             f"gRPC PQC negotiation requires grpcio >= 1.83.0 (current: {grpc.__version__})"
         )


### PR DESCRIPTION
update pqc system tests to use grpcio 1.83.0

Fixes: https://github.com/googleapis/google-cloud-python/issues/17751