### PR TITLE
chore(librarian): add tools section to librarian.yaml

### DIFF
--- a/librarian.yaml
+++ b/librarian.yaml
@@ -18,6 +18,22 @@ sources:
   googleapis:
     commit: ede8b2e652dc3716b544205ef772b39b86e3d2cb
     sha256: 8f7c17af87f6215012010dddaffec3aa5df5668bf0def727577bc0bc6b698193
+tools:
+  pip:
+    - name: gapic-generator
+      version: "1.37.1"
+    - name: nox
+      version: "2025.11.12"
+    - name: ruff
+      version: "0.14.14"
+    - name: isort
+      version: "5.11.0"
+    - name: black
+      version: "23.7.0"
+      package: "black[jupyter]==23.7.0"
+    - name: synthtool
+      version: "e643ce8e20f8fe237a31a1754524ba987de72875"
+      package: "gcp-synthtool@git+https://github.com/googleapis/synthtool@e643ce8e20f8fe237a31a1754524ba987de72875"
 default:
   output: packages
   tag_format: '{name}-v{version}'

--- a/librarian.yaml
+++ b/librarian.yaml
@@ -20,20 +20,20 @@ sources:
     sha256: 8f7c17af87f6215012010dddaffec3aa5df5668bf0def727577bc0bc6b698193
 tools:
   pip:
-    - name: gapic-generator
-      version: "1.37.1"
-    - name: nox
-      version: "2025.11.12"
-    - name: ruff
-      version: "0.14.14"
-    - name: isort
-      version: "5.11.0"
     - name: black
-      version: "23.7.0"
-      package: "black[jupyter]==23.7.0"
+      version: 23.7.0
+      package: black[jupyter]==23.7.0
+    - name: gapic-generator
+      version: 1.37.1
+    - name: isort
+      version: 5.11.0
+    - name: nox
+      version: 2025.11.12
+    - name: ruff
+      version: 0.14.14
     - name: synthtool
-      version: "e643ce8e20f8fe237a31a1754524ba987de72875"
-      package: "gcp-synthtool@git+https://github.com/googleapis/synthtool@e643ce8e20f8fe237a31a1754524ba987de72875"
+      version: e643ce8e20f8fe237a31a1754524ba987de72875
+      package: gcp-synthtool@git+https://github.com/googleapis/synthtool@e643ce8e20f8fe237a31a1754524ba987de72875
 default:
   output: packages
   tag_format: '{name}-v{version}'


### PR DESCRIPTION
Move Python tool installation list to librarian.yaml.

Note: this section is not consumed by Librarian yet, a follow up change to Librarian will be made to consume this setting.

For #6508