### PR TITLE
chore: regenerate google-cloud-bigtable

### DIFF
--- a/librarian.yaml
+++ b/librarian.yaml
@@ -660,7 +660,6 @@ libraries:
     apis:
       - path: google/bigtable/v2
       - path: google/bigtable/admin/v2
-    skip_generate: true
     python:
       library_type: GAPIC_COMBO
       opt_args_by_api:

--- a/packages/google-cloud-bigtable/google/cloud/bigtable_admin_v2/__init__.py
+++ b/packages/google-cloud-bigtable/google/cloud/bigtable_admin_v2/__init__.py
@@ -23,6 +23,24 @@ __version__ = package_version.__version__
 
 from importlib import metadata
 
+# PEP 0810: Explicit Lazy Imports
+# Python 3.15+ natively intercepts and defers these imports.
+# Developers can disable this behavior and force eager imports.
+# For more information, see:
+# https://docs.python.org/3.15/library/sys.html#sys.set_lazy_imports_filter
+# Older Python versions safely ignore this variable.
+__lazy_modules__ = {
+    "google.cloud.bigtable_admin_v2.services.bigtable_instance_admin",
+    "google.cloud.bigtable_admin_v2.services.bigtable_table_admin",
+    "google.cloud.bigtable_admin_v2.types.bigtable_instance_admin",
+    "google.cloud.bigtable_admin_v2.types.bigtable_table_admin",
+    "google.cloud.bigtable_admin_v2.types.common",
+    "google.cloud.bigtable_admin_v2.types.instance",
+    "google.cloud.bigtable_admin_v2.types.table",
+    "google.cloud.bigtable_admin_v2.types.types",
+}
+
+
 from .services.bigtable_instance_admin import (
     BigtableInstanceAdminAsyncClient,
     BigtableInstanceAdminClient,

--- a/packages/google-cloud-bigtable/google/cloud/bigtable_admin_v2/services/bigtable_instance_admin/async_client.py
+++ b/packages/google-cloud-bigtable/google/cloud/bigtable_admin_v2/services/bigtable_instance_admin/async_client.py
@@ -4343,9 +4343,7 @@ class BigtableInstanceAdminAsyncClient:
 DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
     gapic_version=package_version.__version__
 )
-
-if hasattr(DEFAULT_CLIENT_INFO, "protobuf_runtime_version"):  # pragma: NO COVER
-    DEFAULT_CLIENT_INFO.protobuf_runtime_version = google.protobuf.__version__
+DEFAULT_CLIENT_INFO.protobuf_runtime_version = google.protobuf.__version__
 
 
 __all__ = ("BigtableInstanceAdminAsyncClient",)

--- a/packages/google-cloud-bigtable/google/cloud/bigtable_admin_v2/services/bigtable_instance_admin/client.py
+++ b/packages/google-cloud-bigtable/google/cloud/bigtable_admin_v2/services/bigtable_instance_admin/client.py
@@ -4832,8 +4832,6 @@ class BigtableInstanceAdminClient(metaclass=BigtableInstanceAdminClientMeta):
 DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
     gapic_version=package_version.__version__
 )
-
-if hasattr(DEFAULT_CLIENT_INFO, "protobuf_runtime_version"):  # pragma: NO COVER
-    DEFAULT_CLIENT_INFO.protobuf_runtime_version = google.protobuf.__version__
+DEFAULT_CLIENT_INFO.protobuf_runtime_version = google.protobuf.__version__
 
 __all__ = ("BigtableInstanceAdminClient",)

--- a/packages/google-cloud-bigtable/google/cloud/bigtable_admin_v2/services/bigtable_instance_admin/transports/base.py
+++ b/packages/google-cloud-bigtable/google/cloud/bigtable_admin_v2/services/bigtable_instance_admin/transports/base.py
@@ -35,9 +35,7 @@ from google.cloud.bigtable_admin_v2.types import bigtable_instance_admin, instan
 DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
     gapic_version=package_version.__version__
 )
-
-if hasattr(DEFAULT_CLIENT_INFO, "protobuf_runtime_version"):  # pragma: NO COVER
-    DEFAULT_CLIENT_INFO.protobuf_runtime_version = google.protobuf.__version__
+DEFAULT_CLIENT_INFO.protobuf_runtime_version = google.protobuf.__version__
 
 
 class BigtableInstanceAdminTransport(abc.ABC):

--- a/packages/google-cloud-bigtable/google/cloud/bigtable_admin_v2/services/bigtable_instance_admin/transports/rest.py
+++ b/packages/google-cloud-bigtable/google/cloud/bigtable_admin_v2/services/bigtable_instance_admin/transports/rest.py
@@ -57,8 +57,7 @@ DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
     rest_version=f"requests@{requests_version}",
 )
 
-if hasattr(DEFAULT_CLIENT_INFO, "protobuf_runtime_version"):  # pragma: NO COVER
-    DEFAULT_CLIENT_INFO.protobuf_runtime_version = google.protobuf.__version__
+DEFAULT_CLIENT_INFO.protobuf_runtime_version = google.protobuf.__version__
 
 
 class BigtableInstanceAdminRestInterceptor:

--- a/packages/google-cloud-bigtable/google/cloud/bigtable_admin_v2/services/bigtable_table_admin/async_client.py
+++ b/packages/google-cloud-bigtable/google/cloud/bigtable_admin_v2/services/bigtable_table_admin/async_client.py
@@ -4961,9 +4961,7 @@ class BaseBigtableTableAdminAsyncClient:
 DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
     gapic_version=package_version.__version__
 )
-
-if hasattr(DEFAULT_CLIENT_INFO, "protobuf_runtime_version"):  # pragma: NO COVER
-    DEFAULT_CLIENT_INFO.protobuf_runtime_version = google.protobuf.__version__
+DEFAULT_CLIENT_INFO.protobuf_runtime_version = google.protobuf.__version__
 
 
 __all__ = ("BaseBigtableTableAdminAsyncClient",)

--- a/packages/google-cloud-bigtable/google/cloud/bigtable_admin_v2/services/bigtable_table_admin/client.py
+++ b/packages/google-cloud-bigtable/google/cloud/bigtable_admin_v2/services/bigtable_table_admin/client.py
@@ -5449,8 +5449,6 @@ class BaseBigtableTableAdminClient(metaclass=BaseBigtableTableAdminClientMeta):
 DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
     gapic_version=package_version.__version__
 )
-
-if hasattr(DEFAULT_CLIENT_INFO, "protobuf_runtime_version"):  # pragma: NO COVER
-    DEFAULT_CLIENT_INFO.protobuf_runtime_version = google.protobuf.__version__
+DEFAULT_CLIENT_INFO.protobuf_runtime_version = google.protobuf.__version__
 
 __all__ = ("BaseBigtableTableAdminClient",)

--- a/packages/google-cloud-bigtable/google/cloud/bigtable_admin_v2/services/bigtable_table_admin/transports/base.py
+++ b/packages/google-cloud-bigtable/google/cloud/bigtable_admin_v2/services/bigtable_table_admin/transports/base.py
@@ -36,9 +36,7 @@ from google.cloud.bigtable_admin_v2.types import table as gba_table
 DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
     gapic_version=package_version.__version__
 )
-
-if hasattr(DEFAULT_CLIENT_INFO, "protobuf_runtime_version"):  # pragma: NO COVER
-    DEFAULT_CLIENT_INFO.protobuf_runtime_version = google.protobuf.__version__
+DEFAULT_CLIENT_INFO.protobuf_runtime_version = google.protobuf.__version__
 
 
 class BigtableTableAdminTransport(abc.ABC):

--- a/packages/google-cloud-bigtable/google/cloud/bigtable_admin_v2/services/bigtable_table_admin/transports/rest.py
+++ b/packages/google-cloud-bigtable/google/cloud/bigtable_admin_v2/services/bigtable_table_admin/transports/rest.py
@@ -58,8 +58,7 @@ DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
     rest_version=f"requests@{requests_version}",
 )
 
-if hasattr(DEFAULT_CLIENT_INFO, "protobuf_runtime_version"):  # pragma: NO COVER
-    DEFAULT_CLIENT_INFO.protobuf_runtime_version = google.protobuf.__version__
+DEFAULT_CLIENT_INFO.protobuf_runtime_version = google.protobuf.__version__
 
 
 class BigtableTableAdminRestInterceptor:

--- a/packages/google-cloud-bigtable/google/cloud/bigtable_v2/__init__.py
+++ b/packages/google-cloud-bigtable/google/cloud/bigtable_v2/__init__.py
@@ -23,6 +23,25 @@ __version__ = package_version.__version__
 
 from importlib import metadata
 
+# PEP 0810: Explicit Lazy Imports
+# Python 3.15+ natively intercepts and defers these imports.
+# Developers can disable this behavior and force eager imports.
+# For more information, see:
+# https://docs.python.org/3.15/library/sys.html#sys.set_lazy_imports_filter
+# Older Python versions safely ignore this variable.
+__lazy_modules__ = {
+    "google.cloud.bigtable_v2.services.bigtable",
+    "google.cloud.bigtable_v2.types.bigtable",
+    "google.cloud.bigtable_v2.types.data",
+    "google.cloud.bigtable_v2.types.feature_flags",
+    "google.cloud.bigtable_v2.types.peer_info",
+    "google.cloud.bigtable_v2.types.request_stats",
+    "google.cloud.bigtable_v2.types.response_params",
+    "google.cloud.bigtable_v2.types.session",
+    "google.cloud.bigtable_v2.types.types",
+}
+
+
 from .services.bigtable import BigtableAsyncClient, BigtableClient
 from .types.bigtable import (
     CheckAndMutateRowRequest,

--- a/packages/google-cloud-bigtable/google/cloud/bigtable_v2/services/bigtable/async_client.py
+++ b/packages/google-cloud-bigtable/google/cloud/bigtable_v2/services/bigtable/async_client.py
@@ -1750,9 +1750,7 @@ class BigtableAsyncClient:
 DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
     gapic_version=package_version.__version__
 )
-
-if hasattr(DEFAULT_CLIENT_INFO, "protobuf_runtime_version"):  # pragma: NO COVER
-    DEFAULT_CLIENT_INFO.protobuf_runtime_version = google.protobuf.__version__
+DEFAULT_CLIENT_INFO.protobuf_runtime_version = google.protobuf.__version__
 
 
 __all__ = ("BigtableAsyncClient",)

--- a/packages/google-cloud-bigtable/google/cloud/bigtable_v2/services/bigtable/client.py
+++ b/packages/google-cloud-bigtable/google/cloud/bigtable_v2/services/bigtable/client.py
@@ -2217,8 +2217,6 @@ class BigtableClient(metaclass=BigtableClientMeta):
 DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
     gapic_version=package_version.__version__
 )
-
-if hasattr(DEFAULT_CLIENT_INFO, "protobuf_runtime_version"):  # pragma: NO COVER
-    DEFAULT_CLIENT_INFO.protobuf_runtime_version = google.protobuf.__version__
+DEFAULT_CLIENT_INFO.protobuf_runtime_version = google.protobuf.__version__
 
 __all__ = ("BigtableClient",)

--- a/packages/google-cloud-bigtable/google/cloud/bigtable_v2/services/bigtable/transports/base.py
+++ b/packages/google-cloud-bigtable/google/cloud/bigtable_v2/services/bigtable/transports/base.py
@@ -31,9 +31,7 @@ from google.cloud.bigtable_v2.types import bigtable
 DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
     gapic_version=package_version.__version__
 )
-
-if hasattr(DEFAULT_CLIENT_INFO, "protobuf_runtime_version"):  # pragma: NO COVER
-    DEFAULT_CLIENT_INFO.protobuf_runtime_version = google.protobuf.__version__
+DEFAULT_CLIENT_INFO.protobuf_runtime_version = google.protobuf.__version__
 
 
 class BigtableTransport(abc.ABC):

--- a/packages/google-cloud-bigtable/google/cloud/bigtable_v2/services/bigtable/transports/rest.py
+++ b/packages/google-cloud-bigtable/google/cloud/bigtable_v2/services/bigtable/transports/rest.py
@@ -53,8 +53,7 @@ DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
     rest_version=f"requests@{requests_version}",
 )
 
-if hasattr(DEFAULT_CLIENT_INFO, "protobuf_runtime_version"):  # pragma: NO COVER
-    DEFAULT_CLIENT_INFO.protobuf_runtime_version = google.protobuf.__version__
+DEFAULT_CLIENT_INFO.protobuf_runtime_version = google.protobuf.__version__
 
 
 class BigtableRestInterceptor:

--- a/packages/google-cloud-bigtable/noxfile.py
+++ b/packages/google-cloud-bigtable/noxfile.py
@@ -78,7 +78,6 @@ MYPY_CONFIG_FILE = next(
     str(CURRENT_DIRECTORY.parent.parent / "mypy.ini"),
 )
 
-
 # 'docfx' is excluded since it only needs to run in 'docs-presubmit'
 nox.options.sessions = [
     "unit-3.10",
@@ -188,7 +187,10 @@ def mypy(session):
     )
     session.install("google-cloud-testutils")
     session.run(
-        "mypy", f"--config-file={MYPY_CONFIG_FILE}", "-p", "google.cloud.bigtable.data"
+        "mypy",
+        f"--config-file={MYPY_CONFIG_FILE}",
+        "-p",
+        "google.cloud.bigtable.data",
     )
 
 

--- a/packages/google-cloud-bigtable/setup.py
+++ b/packages/google-cloud-bigtable/setup.py
@@ -42,7 +42,7 @@ else:
     release_status = "Development Status :: 5 - Production/Stable"
 
 dependencies = [
-    "google-api-core[grpc] >= 2.24.2, <3.0.0",
+    "google-api-core[grpc] >= 2.25.0, <3.0.0",
     # Exclude incompatible versions of `google-auth`
     # See https://github.com/googleapis/google-cloud-python/issues/12364
     "google-auth >= 2.14.1, <3.0.0,!=2.24.0,!=2.25.0",

--- a/packages/google-cloud-bigtable/testing/constraints-3.10.txt
+++ b/packages/google-cloud-bigtable/testing/constraints-3.10.txt
@@ -4,7 +4,7 @@
 # pinning their versions to their lower bounds.
 # For example, if setup.py has "google-cloud-foo >= 1.14.0, < 2.0.0",
 # then this file should have google-cloud-foo==1.14.0
-google-api-core==2.24.2
+google-api-core==2.25.0
 google-cloud-core==2.0.0
 grpc-google-iam-v1==0.14.2
 google-crc32c==1.6.0

--- a/packages/google-cloud-bigtable/tests/unit/data/_async/test_mutations_batcher.py
+++ b/packages/google-cloud-bigtable/tests/unit/data/_async/test_mutations_batcher.py
@@ -923,8 +923,12 @@ class TestMutationsBatcherAsync:
                 for m in mutations:
                     await instance.append(m)
                 assert instance._entries_processed_since_last_raise == 0
-                # let flush trigger due to timer
-                await CrossSync.sleep(0.1)
+                # Poll in short intervals to wait for the background timer flush to finish,
+                # avoiding timing/scheduling flakiness on slower or heavily loaded environments.
+                for _ in range(50):
+                    if instance._entries_processed_since_last_raise == num_mutations:
+                        break
+                    await CrossSync.sleep(0.05)
                 assert instance._entries_processed_since_last_raise == num_mutations
 
     @CrossSync.pytest

--- a/packages/google-cloud-bigtable/tests/unit/data/_sync_autogen/test_mutations_batcher.py
+++ b/packages/google-cloud-bigtable/tests/unit/data/_sync_autogen/test_mutations_batcher.py
@@ -804,7 +804,10 @@ class TestMutationsBatcher:
                 for m in mutations:
                     instance.append(m)
                 assert instance._entries_processed_since_last_raise == 0
-                CrossSync._Sync_Impl.sleep(0.1)
+                for _ in range(50):
+                    if instance._entries_processed_since_last_raise == num_mutations:
+                        break
+                    CrossSync._Sync_Impl.sleep(0.05)
                 assert instance._entries_processed_since_last_raise == num_mutations
 
     def test__execute_mutate_rows(self):

--- a/packages/google-cloud-bigtable/tests/unit/gapic/bigtable_admin_v2/test_bigtable_instance_admin.py
+++ b/packages/google-cloud-bigtable/tests/unit/gapic/bigtable_admin_v2/test_bigtable_instance_admin.py
@@ -1021,7 +1021,14 @@ def test_bigtable_instance_admin_client_get_mtls_endpoint_and_cert_source(client
                 config_filename = "mock_certificate_config.json"
                 config_file_content = json.dumps(config_data)
                 m = mock.mock_open(read_data=config_file_content)
-                with mock.patch("builtins.open", m):
+                with (
+                    mock.patch("builtins.open", m),
+                    mock.patch(
+                        "os.path.exists",
+                        side_effect=lambda path: os.path.basename(path)
+                        == config_filename,
+                    ),
+                ):
                     with mock.patch.dict(
                         os.environ, {"GOOGLE_API_CERTIFICATE_CONFIG": config_filename}
                     ):
@@ -1068,7 +1075,14 @@ def test_bigtable_instance_admin_client_get_mtls_endpoint_and_cert_source(client
                 config_filename = "mock_certificate_config.json"
                 config_file_content = json.dumps(config_data)
                 m = mock.mock_open(read_data=config_file_content)
-                with mock.patch("builtins.open", m):
+                with (
+                    mock.patch("builtins.open", m),
+                    mock.patch(
+                        "os.path.exists",
+                        side_effect=lambda path: os.path.basename(path)
+                        == config_filename,
+                    ),
+                ):
                     with mock.patch.dict(
                         os.environ, {"GOOGLE_API_CERTIFICATE_CONFIG": config_filename}
                     ):

--- a/packages/google-cloud-bigtable/tests/unit/gapic/bigtable_admin_v2/test_bigtable_table_admin.py
+++ b/packages/google-cloud-bigtable/tests/unit/gapic/bigtable_admin_v2/test_bigtable_table_admin.py
@@ -1024,7 +1024,14 @@ def test_base_bigtable_table_admin_client_get_mtls_endpoint_and_cert_source(
                 config_filename = "mock_certificate_config.json"
                 config_file_content = json.dumps(config_data)
                 m = mock.mock_open(read_data=config_file_content)
-                with mock.patch("builtins.open", m):
+                with (
+                    mock.patch("builtins.open", m),
+                    mock.patch(
+                        "os.path.exists",
+                        side_effect=lambda path: os.path.basename(path)
+                        == config_filename,
+                    ),
+                ):
                     with mock.patch.dict(
                         os.environ, {"GOOGLE_API_CERTIFICATE_CONFIG": config_filename}
                     ):
@@ -1071,7 +1078,14 @@ def test_base_bigtable_table_admin_client_get_mtls_endpoint_and_cert_source(
                 config_filename = "mock_certificate_config.json"
                 config_file_content = json.dumps(config_data)
                 m = mock.mock_open(read_data=config_file_content)
-                with mock.patch("builtins.open", m):
+                with (
+                    mock.patch("builtins.open", m),
+                    mock.patch(
+                        "os.path.exists",
+                        side_effect=lambda path: os.path.basename(path)
+                        == config_filename,
+                    ),
+                ):
                     with mock.patch.dict(
                         os.environ, {"GOOGLE_API_CERTIFICATE_CONFIG": config_filename}
                     ):

--- a/packages/google-cloud-bigtable/tests/unit/gapic/bigtable_v2/test_bigtable.py
+++ b/packages/google-cloud-bigtable/tests/unit/gapic/bigtable_v2/test_bigtable.py
@@ -917,7 +917,14 @@ def test_bigtable_client_get_mtls_endpoint_and_cert_source(client_class):
                 config_filename = "mock_certificate_config.json"
                 config_file_content = json.dumps(config_data)
                 m = mock.mock_open(read_data=config_file_content)
-                with mock.patch("builtins.open", m):
+                with (
+                    mock.patch("builtins.open", m),
+                    mock.patch(
+                        "os.path.exists",
+                        side_effect=lambda path: os.path.basename(path)
+                        == config_filename,
+                    ),
+                ):
                     with mock.patch.dict(
                         os.environ, {"GOOGLE_API_CERTIFICATE_CONFIG": config_filename}
                     ):
@@ -964,7 +971,14 @@ def test_bigtable_client_get_mtls_endpoint_and_cert_source(client_class):
                 config_filename = "mock_certificate_config.json"
                 config_file_content = json.dumps(config_data)
                 m = mock.mock_open(read_data=config_file_content)
-                with mock.patch("builtins.open", m):
+                with (
+                    mock.patch("builtins.open", m),
+                    mock.patch(
+                        "os.path.exists",
+                        side_effect=lambda path: os.path.basename(path)
+                        == config_filename,
+                    ),
+                ):
                     with mock.patch.dict(
                         os.environ, {"GOOGLE_API_CERTIFICATE_CONFIG": config_filename}
                     ):


### PR DESCRIPTION
This PR is a follow up to https://github.com/googleapis/google-cloud-python/pull/17880 where `google-cloud-bigtable` was excluded due to failing tests.