### PR TITLE
fix(sqlalchemy-spanner): register TOKENLIST in _type_map for reflection

### DIFF
--- a/packages/sqlalchemy-spanner/google/cloud/sqlalchemy_spanner/sqlalchemy_spanner.py
+++ b/packages/sqlalchemy-spanner/google/cloud/sqlalchemy_spanner/sqlalchemy_spanner.py
@@ -120,6 +120,7 @@ _type_map = {
     "TIMESTAMP": types.TIMESTAMP,
     "ARRAY": types.ARRAY,
     "JSON": types.JSON,
+    "TOKENLIST": types.String,
 }
 
 

--- a/packages/sqlalchemy-spanner/tests/mockserver_tests/test_tokenlist.py
+++ b/packages/sqlalchemy-spanner/tests/mockserver_tests/test_tokenlist.py
@@ -1,0 +1,26 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from sqlalchemy import types
+from sqlalchemy.testing import eq_, fixtures
+from google.cloud.sqlalchemy_spanner.sqlalchemy_spanner import _type_map, SpannerDialect
+
+
+class TokenlistTest(fixtures.TestBase):
+    def test_tokenlist_reflection_type_mapping(self):
+        """Test mockserver reflection mapping for TOKENLIST columns."""
+        dialect = SpannerDialect()
+        eq_(_type_map.get("TOKENLIST"), types.String)
+        col_type = dialect._designate_type("TOKENLIST")
+        eq_(col_type, types.String)


### PR DESCRIPTION
Table reflection raises KeyError: 'TOKENLIST' whenever a table containing a TOKENLIST column is reflected.

Fixes this issue by registering "TOKENLIST": types.String in _type_map in google/cloud/sqlalchemy_spanner/sqlalchemy_spanner.py.

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/google-cloud-python/issues) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)

Fixes #<issue_number_goes_here> 🦕