### PR TITLE
chore: regenerate google-cloud-productregistry

### DIFF
--- a/librarian.yaml
+++ b/librarian.yaml
@@ -1712,6 +1712,12 @@ libraries:
       - path: google/cloud/privilegedaccessmanager/v1
     python:
       default_version: v1
+  - name: google-cloud-productregistry
+    version: 0.1.0
+    apis:
+      - path: google/cloud/productregistry/v1
+    python:
+      default_version: v1
   - name: google-cloud-pubsub
     version: 2.39.0
     apis:

--- a/packages/google-cloud-productregistry/google/cloud/productregistry_v1/__init__.py
+++ b/packages/google-cloud-productregistry/google/cloud/productregistry_v1/__init__.py
@@ -23,6 +23,22 @@ __version__ = package_version.__version__
 
 from importlib import metadata
 
+# PEP 0810: Explicit Lazy Imports
+# Python 3.15+ natively intercepts and defers these imports.
+# Developers can disable this behavior and force eager imports.
+# For more information, see:
+# https://docs.python.org/3.15/library/sys.html#sys.set_lazy_imports_filter
+# Older Python versions safely ignore this variable.
+__lazy_modules__ = {
+    "google.cloud.productregistry_v1.services.cloud_product_registry_read_service",
+    "google.cloud.productregistry_v1.types.cloud_product_registry_read_service",
+    "google.cloud.productregistry_v1.types.lifecycle_state",
+    "google.cloud.productregistry_v1.types.logical_product",
+    "google.cloud.productregistry_v1.types.logical_product_variant",
+    "google.cloud.productregistry_v1.types.product_suite",
+}
+
+
 from .services.cloud_product_registry_read_service import (
     CloudProductRegistryReadServiceAsyncClient,
     CloudProductRegistryReadServiceClient,

--- a/packages/google-cloud-productregistry/google/cloud/productregistry_v1/services/cloud_product_registry_read_service/async_client.py
+++ b/packages/google-cloud-productregistry/google/cloud/productregistry_v1/services/cloud_product_registry_read_service/async_client.py
@@ -1138,9 +1138,7 @@ class CloudProductRegistryReadServiceAsyncClient:
 DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
     gapic_version=package_version.__version__
 )
-
-if hasattr(DEFAULT_CLIENT_INFO, "protobuf_runtime_version"):  # pragma: NO COVER
-    DEFAULT_CLIENT_INFO.protobuf_runtime_version = google.protobuf.__version__
+DEFAULT_CLIENT_INFO.protobuf_runtime_version = google.protobuf.__version__
 
 
 __all__ = ("CloudProductRegistryReadServiceAsyncClient",)

--- a/packages/google-cloud-productregistry/google/cloud/productregistry_v1/services/cloud_product_registry_read_service/client.py
+++ b/packages/google-cloud-productregistry/google/cloud/productregistry_v1/services/cloud_product_registry_read_service/client.py
@@ -1582,8 +1582,6 @@ class CloudProductRegistryReadServiceClient(
 DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
     gapic_version=package_version.__version__
 )
-
-if hasattr(DEFAULT_CLIENT_INFO, "protobuf_runtime_version"):  # pragma: NO COVER
-    DEFAULT_CLIENT_INFO.protobuf_runtime_version = google.protobuf.__version__
+DEFAULT_CLIENT_INFO.protobuf_runtime_version = google.protobuf.__version__
 
 __all__ = ("CloudProductRegistryReadServiceClient",)

--- a/packages/google-cloud-productregistry/google/cloud/productregistry_v1/services/cloud_product_registry_read_service/transports/base.py
+++ b/packages/google-cloud-productregistry/google/cloud/productregistry_v1/services/cloud_product_registry_read_service/transports/base.py
@@ -36,9 +36,7 @@ from google.cloud.productregistry_v1.types import (
 DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
     gapic_version=package_version.__version__
 )
-
-if hasattr(DEFAULT_CLIENT_INFO, "protobuf_runtime_version"):  # pragma: NO COVER
-    DEFAULT_CLIENT_INFO.protobuf_runtime_version = google.protobuf.__version__
+DEFAULT_CLIENT_INFO.protobuf_runtime_version = google.protobuf.__version__
 
 
 class CloudProductRegistryReadServiceTransport(abc.ABC):

--- a/packages/google-cloud-productregistry/google/cloud/productregistry_v1/services/cloud_product_registry_read_service/transports/rest.py
+++ b/packages/google-cloud-productregistry/google/cloud/productregistry_v1/services/cloud_product_registry_read_service/transports/rest.py
@@ -58,8 +58,7 @@ DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
     rest_version=f"requests@{requests_version}",
 )
 
-if hasattr(DEFAULT_CLIENT_INFO, "protobuf_runtime_version"):  # pragma: NO COVER
-    DEFAULT_CLIENT_INFO.protobuf_runtime_version = google.protobuf.__version__
+DEFAULT_CLIENT_INFO.protobuf_runtime_version = google.protobuf.__version__
 
 
 class CloudProductRegistryReadServiceRestInterceptor:

--- a/packages/google-cloud-productregistry/setup.py
+++ b/packages/google-cloud-productregistry/setup.py
@@ -44,7 +44,7 @@ else:
     release_status = "Development Status :: 5 - Production/Stable"
 
 dependencies = [
-    "google-api-core[grpc] >= 2.24.2, <3.0.0",
+    "google-api-core[grpc] >= 2.25.0, <3.0.0",
     # Exclude incompatible versions of `google-auth`
     # See https://github.com/googleapis/google-cloud-python/issues/12364
     "google-auth >= 2.14.1, <3.0.0,!=2.24.0,!=2.25.0",

--- a/packages/google-cloud-productregistry/testing/constraints-3.10.txt
+++ b/packages/google-cloud-productregistry/testing/constraints-3.10.txt
@@ -4,7 +4,7 @@
 # pinning their versions to their lower bounds.
 # For example, if setup.py has "google-cloud-foo >= 1.14.0, < 2.0.0",
 # then this file should have google-cloud-foo==1.14.0
-google-api-core==2.24.2
+google-api-core==2.25.0
 google-auth==2.14.1
 grpcio==1.59.0
 proto-plus==1.26.1

--- a/packages/google-cloud-productregistry/tests/unit/gapic/productregistry_v1/test_cloud_product_registry_read_service.py
+++ b/packages/google-cloud-productregistry/tests/unit/gapic/productregistry_v1/test_cloud_product_registry_read_service.py
@@ -1078,7 +1078,14 @@ def test_cloud_product_registry_read_service_client_get_mtls_endpoint_and_cert_s
                 config_filename = "mock_certificate_config.json"
                 config_file_content = json.dumps(config_data)
                 m = mock.mock_open(read_data=config_file_content)
-                with mock.patch("builtins.open", m):
+                with (
+                    mock.patch("builtins.open", m),
+                    mock.patch(
+                        "os.path.exists",
+                        side_effect=lambda path: os.path.basename(path)
+                        == config_filename,
+                    ),
+                ):
                     with mock.patch.dict(
                         os.environ, {"GOOGLE_API_CERTIFICATE_CONFIG": config_filename}
                     ):
@@ -1125,7 +1132,14 @@ def test_cloud_product_registry_read_service_client_get_mtls_endpoint_and_cert_s
                 config_filename = "mock_certificate_config.json"
                 config_file_content = json.dumps(config_data)
                 m = mock.mock_open(read_data=config_file_content)
-                with mock.patch("builtins.open", m):
+                with (
+                    mock.patch("builtins.open", m),
+                    mock.patch(
+                        "os.path.exists",
+                        side_effect=lambda path: os.path.basename(path)
+                        == config_filename,
+                    ),
+                ):
                     with mock.patch.dict(
                         os.environ, {"GOOGLE_API_CERTIFICATE_CONFIG": config_filename}
                     ):


### PR DESCRIPTION
`google-cloud-productregistry` was recently added in https://github.com/googleapis/google-cloud-python/pull/17783 but was missing from `librarian.yaml`.  As a result, the library was out of date. This PR adds an entry to `librarian.yaml` and updates `google-cloud-productregistry` using librarian `0.30.0`.