### PR TITLE
feat(sqlalchemy-spanner): export MAX_SIZE constant

### DIFF
--- a/packages/sqlalchemy-spanner/google/cloud/sqlalchemy_spanner/__init__.py
+++ b/packages/sqlalchemy-spanner/google/cloud/sqlalchemy_spanner/__init__.py
@@ -12,7 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from .sqlalchemy_spanner import SpannerDialect
+from .sqlalchemy_spanner import MAX_SIZE, SpannerDialect
 from .version import __version__
 
-__all__ = (SpannerDialect, __version__)
+__all__ = (
+    "MAX_SIZE",
+    "SpannerDialect",
+    "__version__",
+)

--- a/packages/sqlalchemy-spanner/google/cloud/sqlalchemy_spanner/sqlalchemy_spanner.py
+++ b/packages/sqlalchemy-spanner/google/cloud/sqlalchemy_spanner/sqlalchemy_spanner.py
@@ -150,6 +150,8 @@ _compound_keywords = {
     selectable.CompoundSelect.INTERSECT_ALL: "INTERSECT ALL",
 }
 
+#: Maximum allowable character/byte length for Cloud Spanner STRING(MAX) and
+#: BYTES(MAX) DDL data types (2.5 MiB = 2,621,440 bytes).
 MAX_SIZE = 2621440
 _max_size = MAX_SIZE
 

--- a/packages/sqlalchemy-spanner/google/cloud/sqlalchemy_spanner/sqlalchemy_spanner.py
+++ b/packages/sqlalchemy-spanner/google/cloud/sqlalchemy_spanner/sqlalchemy_spanner.py
@@ -150,7 +150,8 @@ _compound_keywords = {
     selectable.CompoundSelect.INTERSECT_ALL: "INTERSECT ALL",
 }
 
-_max_size = 2621440
+MAX_SIZE = 2621440
+_max_size = MAX_SIZE
 
 
 def int_from_size(size_str):
@@ -162,7 +163,7 @@ def int_from_size(size_str):
     Returns:
         int: The column length value.
     """
-    return _max_size if size_str == "MAX" else int(size_str)
+    return MAX_SIZE if size_str == "MAX" else int(size_str)
 
 
 def engine_to_connection(function):
@@ -833,6 +834,7 @@ class SpannerDialect(DefaultDialect):
     paramstyle = "format"
     encoding = "utf-8"
     max_identifier_length = 256
+    max_size = MAX_SIZE
     _legacy_binary_type_literal_encoding = "utf-8"
     _default_isolation_level = "SERIALIZABLE"
 

--- a/packages/sqlalchemy-spanner/tests/unit/test_dialect.py
+++ b/packages/sqlalchemy-spanner/tests/unit/test_dialect.py
@@ -84,3 +84,17 @@ class TestSpannerDialect(fixtures.TestBase):
         assert ("public", "my_table") in res
         index_info = res[("public", "my_table")][0]
         eq_(index_info["column_sorting"], {})
+
+    def test_max_size_exported(self):
+        """Test MAX_SIZE export and int_from_size helper behavior."""
+        from google.cloud.sqlalchemy_spanner import MAX_SIZE
+        from google.cloud.sqlalchemy_spanner.sqlalchemy_spanner import (
+            _max_size,
+            int_from_size,
+        )
+
+        eq_(MAX_SIZE, 2621440)
+        eq_(_max_size, MAX_SIZE)
+        eq_(SpannerDialect.max_size, MAX_SIZE)
+        eq_(int_from_size("MAX"), 2621440)
+        eq_(int_from_size("100"), 100)


### PR DESCRIPTION
Promoting _max_size to public MAX_SIZE (and dialect.max_size) allows cross-dialect applications to inspect Spanner's STRING(MAX) limit through the public API. It eliminates private symbol imports while preserving full backward compatibility for existing code.
