### PR TITLE
chore: update librarian to v0.31.0

### DIFF
--- a/librarian.yaml
+++ b/librarian.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 language: python
-version: v0.30.0
+version: v0.31.0
 repo: googleapis/google-cloud-python
 sources:
   googleapis:


### PR DESCRIPTION
Update librarian version and re-generate.
Run with commands:
```
go run github.com/googleapis/librarian/cmd/librarian@latest update version
V=$(go run github.com/googleapis/librarian/cmd/librarian@latest config get version)
go run github.com/googleapis/librarian/cmd/librarian@${V} tidy
# Build a new Docker image
go run github.com/googleapis/librarian/tool/cmd/builddockerimages@latest --language python --version=${V}
# Regenerate all libraries in Docker. Around 2 minutes.
docker run -u $(id -u):$(id -g) -v .:/repo -v ~/.cache:/.cache -w /repo docker.io/library/librarian-python:${V}  generate -v --all
```