### PR TITLE
feat: update googleapis and regenerate

### DIFF
--- a/librarian.yaml
+++ b/librarian.yaml
@@ -16,8 +16,8 @@ version: v0.31.0
 repo: googleapis/google-cloud-python
 sources:
   googleapis:
-    commit: ede8b2e652dc3716b544205ef772b39b86e3d2cb
-    sha256: 8f7c17af87f6215012010dddaffec3aa5df5668bf0def727577bc0bc6b698193
+    commit: b8486a2f44f15dc578a9dc1e17b144253079d5c1
+    sha256: 12411ca5cb6c70d7c873d7058c5182a8d23fa88af8d984b0e73b1c3ad1d83766
 tools:
   pip:
     - name: black

--- a/packages/google-cloud-network-services/google/cloud/network_services_v1/types/endpoint_policy.py
+++ b/packages/google-cloud-network-services/google/cloud/network_services_v1/types/endpoint_policy.py
@@ -86,7 +86,8 @@ class EndpointPolicy(proto.Message):
             authentication is disabled(open) for this
             endpoint.
         client_tls_policy (str):
-            Optional. A URL referring to a ClientTlsPolicy resource.
+            Optional. Deprecated: This field is not used and is a no-op.
+            A URL referring to a ClientTlsPolicy resource.
             ClientTlsPolicy can be set to specify the authentication for
             traffic from the proxy to the actual endpoints. More
             specifically, it is applied to the outgoing traffic from the

--- a/packages/google-cloud-spanner/google/cloud/spanner_v1/services/spanner/transports/grpc_asyncio.py
+++ b/packages/google-cloud-spanner/google/cloud/spanner_v1/services/spanner/transports/grpc_asyncio.py
@@ -32,7 +32,10 @@ from google.auth.transport.grpc import SslCredentials  # type: ignore
 from google.protobuf.json_format import MessageToJson
 from grpc.experimental import aio  # type: ignore
 
-from google.cloud.spanner_v1.metrics.metrics_interceptor import MetricsInterceptor
+from google.cloud.spanner_v1.metrics.metrics_interceptor import (
+    AsyncMetricsInterceptor,
+    MetricsInterceptor,
+)
 from google.cloud.spanner_v1.types import (
     commit_response,
     location,
@@ -326,6 +329,26 @@ class SpannerGrpcAsyncIOTransport(SpannerTransport):
                     ("grpc.keepalive_time_ms", 120000),
                 ],
             )
+
+        if metrics_interceptor is not None:
+            self._metrics_interceptor = AsyncMetricsInterceptor()
+            # Attach interceptor directly since grpc.aio does not provide intercept_channel.
+            if hasattr(self._grpc_channel, "_unary_unary_interceptors"):
+                self._grpc_channel._unary_unary_interceptors.append(
+                    self._metrics_interceptor
+                )
+            if hasattr(self._grpc_channel, "_unary_stream_interceptors"):
+                self._grpc_channel._unary_stream_interceptors.append(
+                    self._metrics_interceptor
+                )
+            if hasattr(self._grpc_channel, "_stream_unary_interceptors"):
+                self._grpc_channel._stream_unary_interceptors.append(
+                    self._metrics_interceptor
+                )
+            if hasattr(self._grpc_channel, "_stream_stream_interceptors"):
+                self._grpc_channel._stream_stream_interceptors.append(
+                    self._metrics_interceptor
+                )
 
         self._interceptor = _LoggingClientAIOInterceptor()
         self._grpc_channel._unary_unary_interceptors.append(self._interceptor)

--- a/packages/google-cloud-spanner/google/cloud/spanner_v1/services/spanner/transports/grpc_asyncio.py
+++ b/packages/google-cloud-spanner/google/cloud/spanner_v1/services/spanner/transports/grpc_asyncio.py
@@ -32,10 +32,7 @@ from google.auth.transport.grpc import SslCredentials  # type: ignore
 from google.protobuf.json_format import MessageToJson
 from grpc.experimental import aio  # type: ignore
 
-from google.cloud.spanner_v1.metrics.metrics_interceptor import (
-    AsyncMetricsInterceptor,
-    MetricsInterceptor,
-)
+from google.cloud.spanner_v1.metrics.metrics_interceptor import MetricsInterceptor
 from google.cloud.spanner_v1.types import (
     commit_response,
     location,
@@ -329,26 +326,6 @@ class SpannerGrpcAsyncIOTransport(SpannerTransport):
                     ("grpc.keepalive_time_ms", 120000),
                 ],
             )
-
-        if metrics_interceptor is not None:
-            self._metrics_interceptor = AsyncMetricsInterceptor()
-            # Attach interceptor directly since grpc.aio does not provide intercept_channel.
-            if hasattr(self._grpc_channel, "_unary_unary_interceptors"):
-                self._grpc_channel._unary_unary_interceptors.append(
-                    self._metrics_interceptor
-                )
-            if hasattr(self._grpc_channel, "_unary_stream_interceptors"):
-                self._grpc_channel._unary_stream_interceptors.append(
-                    self._metrics_interceptor
-                )
-            if hasattr(self._grpc_channel, "_stream_unary_interceptors"):
-                self._grpc_channel._stream_unary_interceptors.append(
-                    self._metrics_interceptor
-                )
-            if hasattr(self._grpc_channel, "_stream_stream_interceptors"):
-                self._grpc_channel._stream_stream_interceptors.append(
-                    self._metrics_interceptor
-                )
 
         self._interceptor = _LoggingClientAIOInterceptor()
         self._grpc_channel._unary_unary_interceptors.append(self._interceptor)

--- a/packages/google-cloud-support/google/cloud/support/__init__.py
+++ b/packages/google-cloud-support/google/cloud/support/__init__.py
@@ -73,6 +73,7 @@ from google.cloud.support_v2.types.support_event_subscription import (
 from google.cloud.support_v2.types.support_event_subscription_service import (
     CreateSupportEventSubscriptionRequest,
     DeleteSupportEventSubscriptionRequest,
+    ExpungeSupportEventSubscriptionRequest,
     GetSupportEventSubscriptionRequest,
     ListSupportEventSubscriptionsRequest,
     ListSupportEventSubscriptionsResponse,
@@ -116,6 +117,7 @@ __all__ = (
     "SupportEventSubscription",
     "CreateSupportEventSubscriptionRequest",
     "DeleteSupportEventSubscriptionRequest",
+    "ExpungeSupportEventSubscriptionRequest",
     "GetSupportEventSubscriptionRequest",
     "ListSupportEventSubscriptionsRequest",
     "ListSupportEventSubscriptionsResponse",

--- a/packages/google-cloud-support/google/cloud/support_v2/__init__.py
+++ b/packages/google-cloud-support/google/cloud/support_v2/__init__.py
@@ -90,6 +90,7 @@ from .types.support_event_subscription import SupportEventSubscription
 from .types.support_event_subscription_service import (
     CreateSupportEventSubscriptionRequest,
     DeleteSupportEventSubscriptionRequest,
+    ExpungeSupportEventSubscriptionRequest,
     GetSupportEventSubscriptionRequest,
     ListSupportEventSubscriptionsRequest,
     ListSupportEventSubscriptionsResponse,
@@ -200,6 +201,7 @@ __all__ = (
     "DeleteSupportEventSubscriptionRequest",
     "EscalateCaseRequest",
     "Escalation",
+    "ExpungeSupportEventSubscriptionRequest",
     "GetAttachmentRequest",
     "GetCaseRequest",
     "GetCommentRequest",

--- a/packages/google-cloud-support/google/cloud/support_v2/gapic_metadata.json
+++ b/packages/google-cloud-support/google/cloud/support_v2/gapic_metadata.json
@@ -272,6 +272,11 @@
                 "delete_support_event_subscription"
               ]
             },
+            "ExpungeSupportEventSubscription": {
+              "methods": [
+                "expunge_support_event_subscription"
+              ]
+            },
             "GetSupportEventSubscription": {
               "methods": [
                 "get_support_event_subscription"
@@ -307,6 +312,11 @@
                 "delete_support_event_subscription"
               ]
             },
+            "ExpungeSupportEventSubscription": {
+              "methods": [
+                "expunge_support_event_subscription"
+              ]
+            },
             "GetSupportEventSubscription": {
               "methods": [
                 "get_support_event_subscription"
@@ -340,6 +350,11 @@
             "DeleteSupportEventSubscription": {
               "methods": [
                 "delete_support_event_subscription"
+              ]
+            },
+            "ExpungeSupportEventSubscription": {
+              "methods": [
+                "expunge_support_event_subscription"
               ]
             },
             "GetSupportEventSubscription": {

--- a/packages/google-cloud-support/google/cloud/support_v2/services/support_event_subscription_service/async_client.py
+++ b/packages/google-cloud-support/google/cloud/support_v2/services/support_event_subscription_service/async_client.py
@@ -600,7 +600,8 @@ class SupportEventSubscriptionServiceAsyncClient:
         timeout: Union[float, object] = gapic_v1.method.DEFAULT,
         metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
     ) -> pagers.ListSupportEventSubscriptionsAsyncPager:
-        r"""Lists support event subscriptions.
+        r"""Lists support event subscriptions for an
+        organization.
 
         .. code-block:: python
 
@@ -1080,6 +1081,146 @@ class SupportEventSubscriptionServiceAsyncClient:
 
         # Done; return the response.
         return response
+
+    async def expunge_support_event_subscription(
+        self,
+        request: Optional[
+            Union[
+                support_event_subscription_service.ExpungeSupportEventSubscriptionRequest,
+                dict,
+            ]
+        ] = None,
+        *,
+        name: Optional[str] = None,
+        retry: OptionalRetry = gapic_v1.method.DEFAULT,
+        timeout: Union[float, object] = gapic_v1.method.DEFAULT,
+        metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
+    ) -> None:
+        r"""Expunges a support event subscription.
+
+        EXAMPLES:
+
+        cURL:
+
+        .. code:: shell
+
+           support_event_subscription="organizations/123456789/supportEventSubscriptions/abcdef123456"
+           curl \
+             --request POST \
+             --header "Authorization: Bearer $(gcloud auth print-access-token)" \
+             "https://cloudsupport.googleapis.com/v2/$support_event_subscription:expunge"
+
+        Python:
+
+        .. code:: python
+
+           import googleapiclient.discovery
+
+           api_version = "v2"
+           supportApiService = googleapiclient.discovery.build(
+               serviceName="cloudsupport",
+               version=api_version,
+               discoveryServiceUrl=f"https://cloudsupport.googleapis.com/$discovery/rest?version={api_version}",
+           )
+
+           request = supportApiService.supportEventSubscriptions().expunge(
+               name="organizations/123456789/supportEventSubscriptions/abcdef123456"
+           )
+           print(request.execute())
+
+        .. code-block:: python
+
+            # This snippet has been automatically generated and should be regarded as a
+            # code template only.
+            # It will require modifications to work:
+            # - It may require correct/in-range values for request initialization.
+            # - It may require specifying regional endpoints when creating the service
+            #   client as shown in:
+            #   https://googleapis.dev/python/google-api-core/latest/client_options.html
+            from google.cloud import support_v2
+
+            async def sample_expunge_support_event_subscription():
+                # Create a client
+                client = support_v2.SupportEventSubscriptionServiceAsyncClient()
+
+                # Initialize request argument(s)
+                request = support_v2.ExpungeSupportEventSubscriptionRequest(
+                    name="name_value",
+                )
+
+                # Make the request
+                await client.expunge_support_event_subscription(request=request)
+
+        Args:
+            request (Optional[Union[google.cloud.support_v2.types.ExpungeSupportEventSubscriptionRequest, dict]]):
+                The request object. Request message for
+                ExpungeSupportEventSubscription.
+            name (:class:`str`):
+                Required. The name of the support event subscription to
+                expunge. Format:
+                organizations/{organization_id}/supportEventSubscriptions/{subscription_id}
+
+                This corresponds to the ``name`` field
+                on the ``request`` instance; if ``request`` is provided, this
+                should not be set.
+            retry (google.api_core.retry_async.AsyncRetry): Designation of what errors, if any,
+                should be retried.
+            timeout (float): The timeout for this request.
+            metadata (Sequence[Tuple[str, Union[str, bytes]]]): Key/value pairs which should be
+                sent along with the request as metadata. Normally, each value must be of type `str`,
+                but for metadata keys ending with the suffix `-bin`, the corresponding values must
+                be of type `bytes`.
+        """
+        # Create or coerce a protobuf request object.
+        # - Quick check: If we got a request object, we should *not* have
+        #   gotten any keyword arguments that map to the request.
+        flattened_params = [name]
+        has_flattened_params = (
+            len([param for param in flattened_params if param is not None]) > 0
+        )
+        if request is not None and has_flattened_params:
+            raise ValueError(
+                "If the `request` argument is set, then none of "
+                "the individual field arguments should be set."
+            )
+
+        # - Use the request object if provided (there's no risk of modifying the input as
+        #   there are no flattened fields), or create one.
+        if not isinstance(
+            request,
+            support_event_subscription_service.ExpungeSupportEventSubscriptionRequest,
+        ):
+            request = support_event_subscription_service.ExpungeSupportEventSubscriptionRequest(
+                request
+            )
+
+        # If we have keyword arguments corresponding to fields on the
+        # request, apply these.
+        if name is not None:
+            request.name = name
+
+        # Wrap the RPC method; this adds retry and timeout information,
+        # and friendly error handling.
+        rpc = self._client._transport._wrapped_methods[
+            self._client._transport.expunge_support_event_subscription
+        ]
+
+        # Certain fields should be provided within the metadata header;
+        # add these here.
+        metadata = tuple(metadata) + (
+            gapic_v1.routing_header.to_grpc_metadata((("name", request.name),)),
+        )
+
+        # Validate the universe domain.
+        self._client._validate_universe_domain()
+
+        # Send the request.
+        await rpc(
+            request,
+            retry=retry,
+            timeout=timeout,
+            metadata=metadata,
+        )
 
     async def __aenter__(self) -> "SupportEventSubscriptionServiceAsyncClient":
         return self

--- a/packages/google-cloud-support/google/cloud/support_v2/services/support_event_subscription_service/client.py
+++ b/packages/google-cloud-support/google/cloud/support_v2/services/support_event_subscription_service/client.py
@@ -1031,7 +1031,8 @@ class SupportEventSubscriptionServiceClient(
         timeout: Union[float, object] = gapic_v1.method.DEFAULT,
         metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
     ) -> pagers.ListSupportEventSubscriptionsPager:
-        r"""Lists support event subscriptions.
+        r"""Lists support event subscriptions for an
+        organization.
 
         .. code-block:: python
 
@@ -1508,6 +1509,145 @@ class SupportEventSubscriptionServiceClient(
 
         # Done; return the response.
         return response
+
+    def expunge_support_event_subscription(
+        self,
+        request: Optional[
+            Union[
+                support_event_subscription_service.ExpungeSupportEventSubscriptionRequest,
+                dict,
+            ]
+        ] = None,
+        *,
+        name: Optional[str] = None,
+        retry: OptionalRetry = gapic_v1.method.DEFAULT,
+        timeout: Union[float, object] = gapic_v1.method.DEFAULT,
+        metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
+    ) -> None:
+        r"""Expunges a support event subscription.
+
+        EXAMPLES:
+
+        cURL:
+
+        .. code:: shell
+
+           support_event_subscription="organizations/123456789/supportEventSubscriptions/abcdef123456"
+           curl \
+             --request POST \
+             --header "Authorization: Bearer $(gcloud auth print-access-token)" \
+             "https://cloudsupport.googleapis.com/v2/$support_event_subscription:expunge"
+
+        Python:
+
+        .. code:: python
+
+           import googleapiclient.discovery
+
+           api_version = "v2"
+           supportApiService = googleapiclient.discovery.build(
+               serviceName="cloudsupport",
+               version=api_version,
+               discoveryServiceUrl=f"https://cloudsupport.googleapis.com/$discovery/rest?version={api_version}",
+           )
+
+           request = supportApiService.supportEventSubscriptions().expunge(
+               name="organizations/123456789/supportEventSubscriptions/abcdef123456"
+           )
+           print(request.execute())
+
+        .. code-block:: python
+
+            # This snippet has been automatically generated and should be regarded as a
+            # code template only.
+            # It will require modifications to work:
+            # - It may require correct/in-range values for request initialization.
+            # - It may require specifying regional endpoints when creating the service
+            #   client as shown in:
+            #   https://googleapis.dev/python/google-api-core/latest/client_options.html
+            from google.cloud import support_v2
+
+            def sample_expunge_support_event_subscription():
+                # Create a client
+                client = support_v2.SupportEventSubscriptionServiceClient()
+
+                # Initialize request argument(s)
+                request = support_v2.ExpungeSupportEventSubscriptionRequest(
+                    name="name_value",
+                )
+
+                # Make the request
+                client.expunge_support_event_subscription(request=request)
+
+        Args:
+            request (Union[google.cloud.support_v2.types.ExpungeSupportEventSubscriptionRequest, dict]):
+                The request object. Request message for
+                ExpungeSupportEventSubscription.
+            name (str):
+                Required. The name of the support event subscription to
+                expunge. Format:
+                organizations/{organization_id}/supportEventSubscriptions/{subscription_id}
+
+                This corresponds to the ``name`` field
+                on the ``request`` instance; if ``request`` is provided, this
+                should not be set.
+            retry (google.api_core.retry.Retry): Designation of what errors, if any,
+                should be retried.
+            timeout (float): The timeout for this request.
+            metadata (Sequence[Tuple[str, Union[str, bytes]]]): Key/value pairs which should be
+                sent along with the request as metadata. Normally, each value must be of type `str`,
+                but for metadata keys ending with the suffix `-bin`, the corresponding values must
+                be of type `bytes`.
+        """
+        # Create or coerce a protobuf request object.
+        # - Quick check: If we got a request object, we should *not* have
+        #   gotten any keyword arguments that map to the request.
+        flattened_params = [name]
+        has_flattened_params = (
+            len([param for param in flattened_params if param is not None]) > 0
+        )
+        if request is not None and has_flattened_params:
+            raise ValueError(
+                "If the `request` argument is set, then none of "
+                "the individual field arguments should be set."
+            )
+
+        # - Use the request object if provided (there's no risk of modifying the input as
+        #   there are no flattened fields), or create one.
+        if not isinstance(
+            request,
+            support_event_subscription_service.ExpungeSupportEventSubscriptionRequest,
+        ):
+            request = support_event_subscription_service.ExpungeSupportEventSubscriptionRequest(
+                request
+            )
+            # If we have keyword arguments corresponding to fields on the
+            # request, apply these.
+            if name is not None:
+                request.name = name
+
+        # Wrap the RPC method; this adds retry and timeout information,
+        # and friendly error handling.
+        rpc = self._transport._wrapped_methods[
+            self._transport.expunge_support_event_subscription
+        ]
+
+        # Certain fields should be provided within the metadata header;
+        # add these here.
+        metadata = tuple(metadata) + (
+            gapic_v1.routing_header.to_grpc_metadata((("name", request.name),)),
+        )
+
+        # Validate the universe domain.
+        self._validate_universe_domain()
+
+        # Send the request.
+        rpc(
+            request,
+            retry=retry,
+            timeout=timeout,
+            metadata=metadata,
+        )
 
     def __enter__(self) -> "SupportEventSubscriptionServiceClient":
         return self

--- a/packages/google-cloud-support/google/cloud/support_v2/services/support_event_subscription_service/transports/base.py
+++ b/packages/google-cloud-support/google/cloud/support_v2/services/support_event_subscription_service/transports/base.py
@@ -19,6 +19,7 @@ from typing import Awaitable, Callable, Dict, Optional, Sequence, Union
 import google.api_core
 import google.auth  # type: ignore
 import google.protobuf
+import google.protobuf.empty_pb2 as empty_pb2  # type: ignore
 from google.api_core import exceptions as core_exceptions
 from google.api_core import gapic_v1
 from google.api_core import retry as retries
@@ -176,6 +177,11 @@ class SupportEventSubscriptionServiceTransport(abc.ABC):
                 default_timeout=None,
                 client_info=client_info,
             ),
+            self.expunge_support_event_subscription: gapic_v1.method.wrap_method(
+                self.expunge_support_event_subscription,
+                default_timeout=None,
+                client_info=client_info,
+            ),
         }
 
     def close(self):
@@ -258,6 +264,15 @@ class SupportEventSubscriptionServiceTransport(abc.ABC):
             support_event_subscription.SupportEventSubscription,
             Awaitable[support_event_subscription.SupportEventSubscription],
         ],
+    ]:
+        raise NotImplementedError()
+
+    @property
+    def expunge_support_event_subscription(
+        self,
+    ) -> Callable[
+        [support_event_subscription_service.ExpungeSupportEventSubscriptionRequest],
+        Union[empty_pb2.Empty, Awaitable[empty_pb2.Empty]],
     ]:
         raise NotImplementedError()
 

--- a/packages/google-cloud-support/google/cloud/support_v2/services/support_event_subscription_service/transports/grpc.py
+++ b/packages/google-cloud-support/google/cloud/support_v2/services/support_event_subscription_service/transports/grpc.py
@@ -20,6 +20,7 @@ import warnings
 from typing import Callable, Dict, Optional, Sequence, Tuple, Union
 
 import google.auth  # type: ignore
+import google.protobuf.empty_pb2 as empty_pb2  # type: ignore
 import google.protobuf.message
 import grpc  # type: ignore
 import proto  # type: ignore
@@ -407,7 +408,8 @@ class SupportEventSubscriptionServiceGrpcTransport(
         r"""Return a callable for the list support event
         subscriptions method over gRPC.
 
-        Lists support event subscriptions.
+        Lists support event subscriptions for an
+        organization.
 
         Returns:
             Callable[[~.ListSupportEventSubscriptionsRequest],
@@ -524,6 +526,68 @@ class SupportEventSubscriptionServiceGrpcTransport(
                 )
             )
         return self._stubs["undelete_support_event_subscription"]
+
+    @property
+    def expunge_support_event_subscription(
+        self,
+    ) -> Callable[
+        [support_event_subscription_service.ExpungeSupportEventSubscriptionRequest],
+        empty_pb2.Empty,
+    ]:
+        r"""Return a callable for the expunge support event
+        subscription method over gRPC.
+
+        Expunges a support event subscription.
+
+        EXAMPLES:
+
+        cURL:
+
+        .. code:: shell
+
+           support_event_subscription="organizations/123456789/supportEventSubscriptions/abcdef123456"
+           curl \
+             --request POST \
+             --header "Authorization: Bearer $(gcloud auth print-access-token)" \
+             "https://cloudsupport.googleapis.com/v2/$support_event_subscription:expunge"
+
+        Python:
+
+        .. code:: python
+
+           import googleapiclient.discovery
+
+           api_version = "v2"
+           supportApiService = googleapiclient.discovery.build(
+               serviceName="cloudsupport",
+               version=api_version,
+               discoveryServiceUrl=f"https://cloudsupport.googleapis.com/$discovery/rest?version={api_version}",
+           )
+
+           request = supportApiService.supportEventSubscriptions().expunge(
+               name="organizations/123456789/supportEventSubscriptions/abcdef123456"
+           )
+           print(request.execute())
+
+        Returns:
+            Callable[[~.ExpungeSupportEventSubscriptionRequest],
+                    ~.Empty]:
+                A function that, when called, will call the underlying RPC
+                on the server.
+        """
+        # Generate a "stub function" on-the-fly which will actually make
+        # the request.
+        # gRPC handles serialization and deserialization, so we just need
+        # to pass in the functions for each.
+        if "expunge_support_event_subscription" not in self._stubs:
+            self._stubs["expunge_support_event_subscription"] = (
+                self._logged_channel.unary_unary(
+                    "/google.cloud.support.v2.SupportEventSubscriptionService/ExpungeSupportEventSubscription",
+                    request_serializer=support_event_subscription_service.ExpungeSupportEventSubscriptionRequest.serialize,
+                    response_deserializer=empty_pb2.Empty.FromString,
+                )
+            )
+        return self._stubs["expunge_support_event_subscription"]
 
     def close(self):
         self._logged_channel.close()

--- a/packages/google-cloud-support/google/cloud/support_v2/services/support_event_subscription_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-support/google/cloud/support_v2/services/support_event_subscription_service/transports/grpc_asyncio.py
@@ -20,6 +20,7 @@ import pickle
 import warnings
 from typing import Awaitable, Callable, Dict, Optional, Sequence, Tuple, Union
 
+import google.protobuf.empty_pb2 as empty_pb2  # type: ignore
 import google.protobuf.message
 import grpc  # type: ignore
 import proto  # type: ignore
@@ -417,7 +418,8 @@ class SupportEventSubscriptionServiceGrpcAsyncIOTransport(
         r"""Return a callable for the list support event
         subscriptions method over gRPC.
 
-        Lists support event subscriptions.
+        Lists support event subscriptions for an
+        organization.
 
         Returns:
             Callable[[~.ListSupportEventSubscriptionsRequest],
@@ -535,6 +537,68 @@ class SupportEventSubscriptionServiceGrpcAsyncIOTransport(
             )
         return self._stubs["undelete_support_event_subscription"]
 
+    @property
+    def expunge_support_event_subscription(
+        self,
+    ) -> Callable[
+        [support_event_subscription_service.ExpungeSupportEventSubscriptionRequest],
+        Awaitable[empty_pb2.Empty],
+    ]:
+        r"""Return a callable for the expunge support event
+        subscription method over gRPC.
+
+        Expunges a support event subscription.
+
+        EXAMPLES:
+
+        cURL:
+
+        .. code:: shell
+
+           support_event_subscription="organizations/123456789/supportEventSubscriptions/abcdef123456"
+           curl \
+             --request POST \
+             --header "Authorization: Bearer $(gcloud auth print-access-token)" \
+             "https://cloudsupport.googleapis.com/v2/$support_event_subscription:expunge"
+
+        Python:
+
+        .. code:: python
+
+           import googleapiclient.discovery
+
+           api_version = "v2"
+           supportApiService = googleapiclient.discovery.build(
+               serviceName="cloudsupport",
+               version=api_version,
+               discoveryServiceUrl=f"https://cloudsupport.googleapis.com/$discovery/rest?version={api_version}",
+           )
+
+           request = supportApiService.supportEventSubscriptions().expunge(
+               name="organizations/123456789/supportEventSubscriptions/abcdef123456"
+           )
+           print(request.execute())
+
+        Returns:
+            Callable[[~.ExpungeSupportEventSubscriptionRequest],
+                    Awaitable[~.Empty]]:
+                A function that, when called, will call the underlying RPC
+                on the server.
+        """
+        # Generate a "stub function" on-the-fly which will actually make
+        # the request.
+        # gRPC handles serialization and deserialization, so we just need
+        # to pass in the functions for each.
+        if "expunge_support_event_subscription" not in self._stubs:
+            self._stubs["expunge_support_event_subscription"] = (
+                self._logged_channel.unary_unary(
+                    "/google.cloud.support.v2.SupportEventSubscriptionService/ExpungeSupportEventSubscription",
+                    request_serializer=support_event_subscription_service.ExpungeSupportEventSubscriptionRequest.serialize,
+                    response_deserializer=empty_pb2.Empty.FromString,
+                )
+            )
+        return self._stubs["expunge_support_event_subscription"]
+
     def _prep_wrapped_messages(self, client_info):
         """Precompute the wrapped methods, overriding the base class method to use async wrappers."""
         self._wrapped_methods = {
@@ -565,6 +629,11 @@ class SupportEventSubscriptionServiceGrpcAsyncIOTransport(
             ),
             self.undelete_support_event_subscription: self._wrap_method(
                 self.undelete_support_event_subscription,
+                default_timeout=None,
+                client_info=client_info,
+            ),
+            self.expunge_support_event_subscription: self._wrap_method(
+                self.expunge_support_event_subscription,
                 default_timeout=None,
                 client_info=client_info,
             ),

--- a/packages/google-cloud-support/google/cloud/support_v2/services/support_event_subscription_service/transports/rest.py
+++ b/packages/google-cloud-support/google/cloud/support_v2/services/support_event_subscription_service/transports/rest.py
@@ -20,6 +20,7 @@ import warnings
 from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple, Union
 
 import google.protobuf
+import google.protobuf.empty_pb2 as empty_pb2  # type: ignore
 from google.api_core import exceptions as core_exceptions
 from google.api_core import gapic_v1, rest_helpers, rest_streaming
 from google.api_core import retry as retries
@@ -92,6 +93,10 @@ class SupportEventSubscriptionServiceRestInterceptor:
             def post_delete_support_event_subscription(self, response):
                 logging.log(f"Received response: {response}")
                 return response
+
+            def pre_expunge_support_event_subscription(self, request, metadata):
+                logging.log(f"Received request: {request}")
+                return request, metadata
 
             def pre_get_support_event_subscription(self, request, metadata):
                 logging.log(f"Received request: {request}")
@@ -234,6 +239,21 @@ class SupportEventSubscriptionServiceRestInterceptor:
         `post_delete_support_event_subscription_with_metadata`.
         """
         return response, metadata
+
+    def pre_expunge_support_event_subscription(
+        self,
+        request: support_event_subscription_service.ExpungeSupportEventSubscriptionRequest,
+        metadata: Sequence[Tuple[str, Union[str, bytes]]],
+    ) -> Tuple[
+        support_event_subscription_service.ExpungeSupportEventSubscriptionRequest,
+        Sequence[Tuple[str, Union[str, bytes]]],
+    ]:
+        """Pre-rpc interceptor for expunge_support_event_subscription
+
+        Override in a subclass to manipulate the request or metadata
+        before they are sent to the SupportEventSubscriptionService server.
+        """
+        return request, metadata
 
     def pre_get_support_event_subscription(
         self,
@@ -857,6 +877,125 @@ class SupportEventSubscriptionServiceRestTransport(
                     },
                 )
             return resp
+
+    class _ExpungeSupportEventSubscription(
+        _BaseSupportEventSubscriptionServiceRestTransport._BaseExpungeSupportEventSubscription,
+        SupportEventSubscriptionServiceRestStub,
+    ):
+        def __hash__(self):
+            return hash(
+                "SupportEventSubscriptionServiceRestTransport.ExpungeSupportEventSubscription"
+            )
+
+        @staticmethod
+        def _get_response(
+            host,
+            metadata,
+            query_params,
+            session,
+            timeout,
+            transcoded_request,
+            body=None,
+        ):
+            uri = transcoded_request["uri"]
+            method = transcoded_request["method"]
+            headers = dict(metadata)
+            headers["Content-Type"] = "application/json"
+            response = getattr(session, method)(
+                "{host}{uri}".format(host=host, uri=uri),
+                timeout=timeout,
+                headers=headers,
+                params=rest_helpers.flatten_query_params(query_params, strict=True),
+                data=body,
+            )
+            return response
+
+        def __call__(
+            self,
+            request: support_event_subscription_service.ExpungeSupportEventSubscriptionRequest,
+            *,
+            retry: OptionalRetry = gapic_v1.method.DEFAULT,
+            timeout: Optional[float] = None,
+            metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
+        ):
+            r"""Call the expunge support event
+            subscription method over HTTP.
+
+                Args:
+                    request (~.support_event_subscription_service.ExpungeSupportEventSubscriptionRequest):
+                        The request object. Request message for
+                    ExpungeSupportEventSubscription.
+                    retry (google.api_core.retry.Retry): Designation of what errors, if any,
+                        should be retried.
+                    timeout (float): The timeout for this request.
+                    metadata (Sequence[Tuple[str, Union[str, bytes]]]): Key/value pairs which should be
+                        sent along with the request as metadata. Normally, each value must be of type `str`,
+                        but for metadata keys ending with the suffix `-bin`, the corresponding values must
+                        be of type `bytes`.
+            """
+
+            http_options = _BaseSupportEventSubscriptionServiceRestTransport._BaseExpungeSupportEventSubscription._get_http_options()
+
+            request, metadata = (
+                self._interceptor.pre_expunge_support_event_subscription(
+                    request, metadata
+                )
+            )
+            transcoded_request = _BaseSupportEventSubscriptionServiceRestTransport._BaseExpungeSupportEventSubscription._get_transcoded_request(
+                http_options, request
+            )
+
+            body = _BaseSupportEventSubscriptionServiceRestTransport._BaseExpungeSupportEventSubscription._get_request_body_json(
+                transcoded_request
+            )
+
+            # Jsonify the query params
+            query_params = _BaseSupportEventSubscriptionServiceRestTransport._BaseExpungeSupportEventSubscription._get_query_params_json(
+                transcoded_request
+            )
+
+            if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(
+                logging.DEBUG
+            ):  # pragma: NO COVER
+                request_url = "{host}{uri}".format(
+                    host=self._host, uri=transcoded_request["uri"]
+                )
+                method = transcoded_request["method"]
+                try:
+                    request_payload = type(request).to_json(request)
+                except:
+                    request_payload = None
+                http_request = {
+                    "payload": request_payload,
+                    "requestMethod": method,
+                    "requestUrl": request_url,
+                    "headers": dict(metadata),
+                }
+                _LOGGER.debug(
+                    f"Sending request for google.cloud.support_v2.SupportEventSubscriptionServiceClient.ExpungeSupportEventSubscription",
+                    extra={
+                        "serviceName": "google.cloud.support.v2.SupportEventSubscriptionService",
+                        "rpcName": "ExpungeSupportEventSubscription",
+                        "httpRequest": http_request,
+                        "metadata": http_request["headers"],
+                    },
+                )
+
+            # Send the request
+            response = SupportEventSubscriptionServiceRestTransport._ExpungeSupportEventSubscription._get_response(
+                self._host,
+                metadata,
+                query_params,
+                self._session,
+                timeout,
+                transcoded_request,
+                body,
+            )
+
+            # In case of error, raise the appropriate core_exceptions.GoogleAPICallError exception
+            # subclass.
+            if response.status_code >= 400:
+                raise core_exceptions.from_http_response(response)
 
     class _GetSupportEventSubscription(
         _BaseSupportEventSubscriptionServiceRestTransport._BaseGetSupportEventSubscription,
@@ -1517,6 +1656,19 @@ class SupportEventSubscriptionServiceRestTransport(
         # The return type is fine, but mypy isn't sophisticated enough to determine what's going on here.
         # In C++ this would require a dynamic_cast
         return self._DeleteSupportEventSubscription(
+            self._session, self._host, self._interceptor
+        )  # type: ignore
+
+    @property
+    def expunge_support_event_subscription(
+        self,
+    ) -> Callable[
+        [support_event_subscription_service.ExpungeSupportEventSubscriptionRequest],
+        empty_pb2.Empty,
+    ]:
+        # The return type is fine, but mypy isn't sophisticated enough to determine what's going on here.
+        # In C++ this would require a dynamic_cast
+        return self._ExpungeSupportEventSubscription(
             self._session, self._host, self._interceptor
         )  # type: ignore
 

--- a/packages/google-cloud-support/google/cloud/support_v2/services/support_event_subscription_service/transports/rest_base.py
+++ b/packages/google-cloud-support/google/cloud/support_v2/services/support_event_subscription_service/transports/rest_base.py
@@ -17,6 +17,7 @@ import json  # type: ignore
 import re
 from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple, Union
 
+import google.protobuf.empty_pb2 as empty_pb2  # type: ignore
 from google.api_core import gapic_v1, path_template
 from google.protobuf import json_format
 
@@ -114,7 +115,7 @@ class _BaseSupportEventSubscriptionServiceRestTransport(
             http_options: List[Dict[str, str]] = [
                 {
                     "method": "post",
-                    "uri": "/v2/{parent=*/*}/supportEventSubscriptions",
+                    "uri": "/v2/{parent=organizations/*}/supportEventSubscriptions",
                     "body": "support_event_subscription",
                 },
             ]
@@ -173,7 +174,7 @@ class _BaseSupportEventSubscriptionServiceRestTransport(
             http_options: List[Dict[str, str]] = [
                 {
                     "method": "delete",
-                    "uri": "/v2/{name=*/*/supportEventSubscriptions/*}",
+                    "uri": "/v2/{name=organizations/*/supportEventSubscriptions/*}",
                 },
             ]
             return http_options
@@ -203,6 +204,65 @@ class _BaseSupportEventSubscriptionServiceRestTransport(
             query_params["$alt"] = "json;enum-encoding=int"
             return query_params
 
+    class _BaseExpungeSupportEventSubscription:
+        def __hash__(self):  # pragma: NO COVER
+            return NotImplementedError("__hash__ must be implemented.")
+
+        __REQUIRED_FIELDS_DEFAULT_VALUES: Dict[str, Any] = {}
+
+        @classmethod
+        def _get_unset_required_fields(cls, message_dict):
+            return {
+                k: v
+                for k, v in cls.__REQUIRED_FIELDS_DEFAULT_VALUES.items()
+                if k not in message_dict
+            }
+
+        @staticmethod
+        def _get_http_options():
+            http_options: List[Dict[str, str]] = [
+                {
+                    "method": "post",
+                    "uri": "/v2/{name=organizations/*/supportEventSubscriptions/*}:expunge",
+                    "body": "*",
+                },
+            ]
+            return http_options
+
+        @staticmethod
+        def _get_transcoded_request(http_options, request):
+            pb_request = support_event_subscription_service.ExpungeSupportEventSubscriptionRequest.pb(
+                request
+            )
+            transcoded_request = path_template.transcode(http_options, pb_request)
+            return transcoded_request
+
+        @staticmethod
+        def _get_request_body_json(transcoded_request):
+            # Jsonify the request body
+
+            body = json_format.MessageToJson(
+                transcoded_request["body"], use_integers_for_enums=True
+            )
+            return body
+
+        @staticmethod
+        def _get_query_params_json(transcoded_request):
+            query_params = json.loads(
+                json_format.MessageToJson(
+                    transcoded_request["query_params"],
+                    use_integers_for_enums=True,
+                )
+            )
+            query_params.update(
+                _BaseSupportEventSubscriptionServiceRestTransport._BaseExpungeSupportEventSubscription._get_unset_required_fields(
+                    query_params
+                )
+            )
+
+            query_params["$alt"] = "json;enum-encoding=int"
+            return query_params
+
     class _BaseGetSupportEventSubscription:
         def __hash__(self):  # pragma: NO COVER
             return NotImplementedError("__hash__ must be implemented.")
@@ -222,7 +282,7 @@ class _BaseSupportEventSubscriptionServiceRestTransport(
             http_options: List[Dict[str, str]] = [
                 {
                     "method": "get",
-                    "uri": "/v2/{name=*/*/supportEventSubscriptions/*}",
+                    "uri": "/v2/{name=organizations/*/supportEventSubscriptions/*}",
                 },
             ]
             return http_options
@@ -271,7 +331,7 @@ class _BaseSupportEventSubscriptionServiceRestTransport(
             http_options: List[Dict[str, str]] = [
                 {
                     "method": "get",
-                    "uri": "/v2/{parent=*/*}/supportEventSubscriptions",
+                    "uri": "/v2/{parent=organizations/*}/supportEventSubscriptions",
                 },
             ]
             return http_options
@@ -320,7 +380,7 @@ class _BaseSupportEventSubscriptionServiceRestTransport(
             http_options: List[Dict[str, str]] = [
                 {
                     "method": "post",
-                    "uri": "/v2/{name=*/*/supportEventSubscriptions/*}:undelete",
+                    "uri": "/v2/{name=organizations/*/supportEventSubscriptions/*}:undelete",
                     "body": "*",
                 },
             ]
@@ -379,7 +439,7 @@ class _BaseSupportEventSubscriptionServiceRestTransport(
             http_options: List[Dict[str, str]] = [
                 {
                     "method": "patch",
-                    "uri": "/v2/{support_event_subscription.name=*/*/supportEventSubscriptions/*}",
+                    "uri": "/v2/{support_event_subscription.name=organizations/*/supportEventSubscriptions/*}",
                     "body": "support_event_subscription",
                 },
             ]

--- a/packages/google-cloud-support/google/cloud/support_v2/types/__init__.py
+++ b/packages/google-cloud-support/google/cloud/support_v2/types/__init__.py
@@ -59,6 +59,7 @@ from .support_event_subscription import (
 from .support_event_subscription_service import (
     CreateSupportEventSubscriptionRequest,
     DeleteSupportEventSubscriptionRequest,
+    ExpungeSupportEventSubscriptionRequest,
     GetSupportEventSubscriptionRequest,
     ListSupportEventSubscriptionsRequest,
     ListSupportEventSubscriptionsResponse,
@@ -94,6 +95,7 @@ __all__ = (
     "SupportEventSubscription",
     "CreateSupportEventSubscriptionRequest",
     "DeleteSupportEventSubscriptionRequest",
+    "ExpungeSupportEventSubscriptionRequest",
     "GetSupportEventSubscriptionRequest",
     "ListSupportEventSubscriptionsRequest",
     "ListSupportEventSubscriptionsResponse",

--- a/packages/google-cloud-support/google/cloud/support_v2/types/support_event_subscription_service.py
+++ b/packages/google-cloud-support/google/cloud/support_v2/types/support_event_subscription_service.py
@@ -34,6 +34,7 @@ __protobuf__ = proto.module(
         "UpdateSupportEventSubscriptionRequest",
         "DeleteSupportEventSubscriptionRequest",
         "UndeleteSupportEventSubscriptionRequest",
+        "ExpungeSupportEventSubscriptionRequest",
     },
 )
 
@@ -213,6 +214,22 @@ class UndeleteSupportEventSubscriptionRequest(proto.Message):
         name (str):
             Required. The name of the support event subscription to
             undelete. Format:
+            organizations/{organization_id}/supportEventSubscriptions/{subscription_id}
+    """
+
+    name: str = proto.Field(
+        proto.STRING,
+        number=1,
+    )
+
+
+class ExpungeSupportEventSubscriptionRequest(proto.Message):
+    r"""Request message for ExpungeSupportEventSubscription.
+
+    Attributes:
+        name (str):
+            Required. The name of the support event subscription to
+            expunge. Format:
             organizations/{organization_id}/supportEventSubscriptions/{subscription_id}
     """
 

--- a/packages/google-cloud-support/google/cloud/support_v2beta/__init__.py
+++ b/packages/google-cloud-support/google/cloud/support_v2beta/__init__.py
@@ -100,6 +100,7 @@ from .types.support_event_subscription import SupportEventSubscription
 from .types.support_event_subscription_service import (
     CreateSupportEventSubscriptionRequest,
     DeleteSupportEventSubscriptionRequest,
+    ExpungeSupportEventSubscriptionRequest,
     GetSupportEventSubscriptionRequest,
     ListSupportEventSubscriptionsRequest,
     ListSupportEventSubscriptionsResponse,
@@ -212,6 +213,7 @@ __all__ = (
     "EmailMessage",
     "EscalateCaseRequest",
     "Escalation",
+    "ExpungeSupportEventSubscriptionRequest",
     "FeedItem",
     "FeedServiceClient",
     "GetAttachmentRequest",

--- a/packages/google-cloud-support/google/cloud/support_v2beta/gapic_metadata.json
+++ b/packages/google-cloud-support/google/cloud/support_v2beta/gapic_metadata.json
@@ -306,6 +306,11 @@
                 "delete_support_event_subscription"
               ]
             },
+            "ExpungeSupportEventSubscription": {
+              "methods": [
+                "expunge_support_event_subscription"
+              ]
+            },
             "GetSupportEventSubscription": {
               "methods": [
                 "get_support_event_subscription"
@@ -341,6 +346,11 @@
                 "delete_support_event_subscription"
               ]
             },
+            "ExpungeSupportEventSubscription": {
+              "methods": [
+                "expunge_support_event_subscription"
+              ]
+            },
             "GetSupportEventSubscription": {
               "methods": [
                 "get_support_event_subscription"
@@ -374,6 +384,11 @@
             "DeleteSupportEventSubscription": {
               "methods": [
                 "delete_support_event_subscription"
+              ]
+            },
+            "ExpungeSupportEventSubscription": {
+              "methods": [
+                "expunge_support_event_subscription"
               ]
             },
             "GetSupportEventSubscription": {

--- a/packages/google-cloud-support/google/cloud/support_v2beta/services/support_event_subscription_service/async_client.py
+++ b/packages/google-cloud-support/google/cloud/support_v2beta/services/support_event_subscription_service/async_client.py
@@ -602,7 +602,8 @@ class SupportEventSubscriptionServiceAsyncClient:
         timeout: Union[float, object] = gapic_v1.method.DEFAULT,
         metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
     ) -> pagers.ListSupportEventSubscriptionsAsyncPager:
-        r"""Lists support event subscriptions.
+        r"""Lists support event subscriptions for an
+        organization.
 
         .. code-block:: python
 
@@ -1082,6 +1083,146 @@ class SupportEventSubscriptionServiceAsyncClient:
 
         # Done; return the response.
         return response
+
+    async def expunge_support_event_subscription(
+        self,
+        request: Optional[
+            Union[
+                support_event_subscription_service.ExpungeSupportEventSubscriptionRequest,
+                dict,
+            ]
+        ] = None,
+        *,
+        name: Optional[str] = None,
+        retry: OptionalRetry = gapic_v1.method.DEFAULT,
+        timeout: Union[float, object] = gapic_v1.method.DEFAULT,
+        metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
+    ) -> None:
+        r"""Expunges a support event subscription.
+
+        EXAMPLES:
+
+        cURL:
+
+        .. code:: shell
+
+           support_event_subscription="organizations/123456789/supportEventSubscriptions/abcdef123456"
+           curl \
+             --request POST \
+             --header "Authorization: Bearer $(gcloud auth print-access-token)" \
+             "https://cloudsupport.googleapis.com/v2beta/$support_event_subscription:expunge"
+
+        Python:
+
+        .. code:: python
+
+           import googleapiclient.discovery
+
+           api_version = "v2beta"
+           supportApiService = googleapiclient.discovery.build(
+               serviceName="cloudsupport",
+               version=api_version,
+               discoveryServiceUrl=f"https://cloudsupport.googleapis.com/$discovery/rest?version={api_version}",
+           )
+
+           request = supportApiService.supportEventSubscriptions().expunge(
+               name="organizations/123456789/supportEventSubscriptions/abcdef123456"
+           )
+           print(request.execute())
+
+        .. code-block:: python
+
+            # This snippet has been automatically generated and should be regarded as a
+            # code template only.
+            # It will require modifications to work:
+            # - It may require correct/in-range values for request initialization.
+            # - It may require specifying regional endpoints when creating the service
+            #   client as shown in:
+            #   https://googleapis.dev/python/google-api-core/latest/client_options.html
+            from google.cloud import support_v2beta
+
+            async def sample_expunge_support_event_subscription():
+                # Create a client
+                client = support_v2beta.SupportEventSubscriptionServiceAsyncClient()
+
+                # Initialize request argument(s)
+                request = support_v2beta.ExpungeSupportEventSubscriptionRequest(
+                    name="name_value",
+                )
+
+                # Make the request
+                await client.expunge_support_event_subscription(request=request)
+
+        Args:
+            request (Optional[Union[google.cloud.support_v2beta.types.ExpungeSupportEventSubscriptionRequest, dict]]):
+                The request object. Request message for
+                ExpungeSupportEventSubscription.
+            name (:class:`str`):
+                Required. The name of the support event subscription to
+                expunge. Format:
+                organizations/{organization_id}/supportEventSubscriptions/{subscription_id}
+
+                This corresponds to the ``name`` field
+                on the ``request`` instance; if ``request`` is provided, this
+                should not be set.
+            retry (google.api_core.retry_async.AsyncRetry): Designation of what errors, if any,
+                should be retried.
+            timeout (float): The timeout for this request.
+            metadata (Sequence[Tuple[str, Union[str, bytes]]]): Key/value pairs which should be
+                sent along with the request as metadata. Normally, each value must be of type `str`,
+                but for metadata keys ending with the suffix `-bin`, the corresponding values must
+                be of type `bytes`.
+        """
+        # Create or coerce a protobuf request object.
+        # - Quick check: If we got a request object, we should *not* have
+        #   gotten any keyword arguments that map to the request.
+        flattened_params = [name]
+        has_flattened_params = (
+            len([param for param in flattened_params if param is not None]) > 0
+        )
+        if request is not None and has_flattened_params:
+            raise ValueError(
+                "If the `request` argument is set, then none of "
+                "the individual field arguments should be set."
+            )
+
+        # - Use the request object if provided (there's no risk of modifying the input as
+        #   there are no flattened fields), or create one.
+        if not isinstance(
+            request,
+            support_event_subscription_service.ExpungeSupportEventSubscriptionRequest,
+        ):
+            request = support_event_subscription_service.ExpungeSupportEventSubscriptionRequest(
+                request
+            )
+
+        # If we have keyword arguments corresponding to fields on the
+        # request, apply these.
+        if name is not None:
+            request.name = name
+
+        # Wrap the RPC method; this adds retry and timeout information,
+        # and friendly error handling.
+        rpc = self._client._transport._wrapped_methods[
+            self._client._transport.expunge_support_event_subscription
+        ]
+
+        # Certain fields should be provided within the metadata header;
+        # add these here.
+        metadata = tuple(metadata) + (
+            gapic_v1.routing_header.to_grpc_metadata((("name", request.name),)),
+        )
+
+        # Validate the universe domain.
+        self._client._validate_universe_domain()
+
+        # Send the request.
+        await rpc(
+            request,
+            retry=retry,
+            timeout=timeout,
+            metadata=metadata,
+        )
 
     async def __aenter__(self) -> "SupportEventSubscriptionServiceAsyncClient":
         return self

--- a/packages/google-cloud-support/google/cloud/support_v2beta/services/support_event_subscription_service/client.py
+++ b/packages/google-cloud-support/google/cloud/support_v2beta/services/support_event_subscription_service/client.py
@@ -1033,7 +1033,8 @@ class SupportEventSubscriptionServiceClient(
         timeout: Union[float, object] = gapic_v1.method.DEFAULT,
         metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
     ) -> pagers.ListSupportEventSubscriptionsPager:
-        r"""Lists support event subscriptions.
+        r"""Lists support event subscriptions for an
+        organization.
 
         .. code-block:: python
 
@@ -1510,6 +1511,145 @@ class SupportEventSubscriptionServiceClient(
 
         # Done; return the response.
         return response
+
+    def expunge_support_event_subscription(
+        self,
+        request: Optional[
+            Union[
+                support_event_subscription_service.ExpungeSupportEventSubscriptionRequest,
+                dict,
+            ]
+        ] = None,
+        *,
+        name: Optional[str] = None,
+        retry: OptionalRetry = gapic_v1.method.DEFAULT,
+        timeout: Union[float, object] = gapic_v1.method.DEFAULT,
+        metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
+    ) -> None:
+        r"""Expunges a support event subscription.
+
+        EXAMPLES:
+
+        cURL:
+
+        .. code:: shell
+
+           support_event_subscription="organizations/123456789/supportEventSubscriptions/abcdef123456"
+           curl \
+             --request POST \
+             --header "Authorization: Bearer $(gcloud auth print-access-token)" \
+             "https://cloudsupport.googleapis.com/v2beta/$support_event_subscription:expunge"
+
+        Python:
+
+        .. code:: python
+
+           import googleapiclient.discovery
+
+           api_version = "v2beta"
+           supportApiService = googleapiclient.discovery.build(
+               serviceName="cloudsupport",
+               version=api_version,
+               discoveryServiceUrl=f"https://cloudsupport.googleapis.com/$discovery/rest?version={api_version}",
+           )
+
+           request = supportApiService.supportEventSubscriptions().expunge(
+               name="organizations/123456789/supportEventSubscriptions/abcdef123456"
+           )
+           print(request.execute())
+
+        .. code-block:: python
+
+            # This snippet has been automatically generated and should be regarded as a
+            # code template only.
+            # It will require modifications to work:
+            # - It may require correct/in-range values for request initialization.
+            # - It may require specifying regional endpoints when creating the service
+            #   client as shown in:
+            #   https://googleapis.dev/python/google-api-core/latest/client_options.html
+            from google.cloud import support_v2beta
+
+            def sample_expunge_support_event_subscription():
+                # Create a client
+                client = support_v2beta.SupportEventSubscriptionServiceClient()
+
+                # Initialize request argument(s)
+                request = support_v2beta.ExpungeSupportEventSubscriptionRequest(
+                    name="name_value",
+                )
+
+                # Make the request
+                client.expunge_support_event_subscription(request=request)
+
+        Args:
+            request (Union[google.cloud.support_v2beta.types.ExpungeSupportEventSubscriptionRequest, dict]):
+                The request object. Request message for
+                ExpungeSupportEventSubscription.
+            name (str):
+                Required. The name of the support event subscription to
+                expunge. Format:
+                organizations/{organization_id}/supportEventSubscriptions/{subscription_id}
+
+                This corresponds to the ``name`` field
+                on the ``request`` instance; if ``request`` is provided, this
+                should not be set.
+            retry (google.api_core.retry.Retry): Designation of what errors, if any,
+                should be retried.
+            timeout (float): The timeout for this request.
+            metadata (Sequence[Tuple[str, Union[str, bytes]]]): Key/value pairs which should be
+                sent along with the request as metadata. Normally, each value must be of type `str`,
+                but for metadata keys ending with the suffix `-bin`, the corresponding values must
+                be of type `bytes`.
+        """
+        # Create or coerce a protobuf request object.
+        # - Quick check: If we got a request object, we should *not* have
+        #   gotten any keyword arguments that map to the request.
+        flattened_params = [name]
+        has_flattened_params = (
+            len([param for param in flattened_params if param is not None]) > 0
+        )
+        if request is not None and has_flattened_params:
+            raise ValueError(
+                "If the `request` argument is set, then none of "
+                "the individual field arguments should be set."
+            )
+
+        # - Use the request object if provided (there's no risk of modifying the input as
+        #   there are no flattened fields), or create one.
+        if not isinstance(
+            request,
+            support_event_subscription_service.ExpungeSupportEventSubscriptionRequest,
+        ):
+            request = support_event_subscription_service.ExpungeSupportEventSubscriptionRequest(
+                request
+            )
+            # If we have keyword arguments corresponding to fields on the
+            # request, apply these.
+            if name is not None:
+                request.name = name
+
+        # Wrap the RPC method; this adds retry and timeout information,
+        # and friendly error handling.
+        rpc = self._transport._wrapped_methods[
+            self._transport.expunge_support_event_subscription
+        ]
+
+        # Certain fields should be provided within the metadata header;
+        # add these here.
+        metadata = tuple(metadata) + (
+            gapic_v1.routing_header.to_grpc_metadata((("name", request.name),)),
+        )
+
+        # Validate the universe domain.
+        self._validate_universe_domain()
+
+        # Send the request.
+        rpc(
+            request,
+            retry=retry,
+            timeout=timeout,
+            metadata=metadata,
+        )
 
     def __enter__(self) -> "SupportEventSubscriptionServiceClient":
         return self

--- a/packages/google-cloud-support/google/cloud/support_v2beta/services/support_event_subscription_service/transports/base.py
+++ b/packages/google-cloud-support/google/cloud/support_v2beta/services/support_event_subscription_service/transports/base.py
@@ -19,6 +19,7 @@ from typing import Awaitable, Callable, Dict, Optional, Sequence, Union
 import google.api_core
 import google.auth  # type: ignore
 import google.protobuf
+import google.protobuf.empty_pb2 as empty_pb2  # type: ignore
 from google.api_core import exceptions as core_exceptions
 from google.api_core import gapic_v1
 from google.api_core import retry as retries
@@ -176,6 +177,11 @@ class SupportEventSubscriptionServiceTransport(abc.ABC):
                 default_timeout=None,
                 client_info=client_info,
             ),
+            self.expunge_support_event_subscription: gapic_v1.method.wrap_method(
+                self.expunge_support_event_subscription,
+                default_timeout=None,
+                client_info=client_info,
+            ),
         }
 
     def close(self):
@@ -258,6 +264,15 @@ class SupportEventSubscriptionServiceTransport(abc.ABC):
             support_event_subscription.SupportEventSubscription,
             Awaitable[support_event_subscription.SupportEventSubscription],
         ],
+    ]:
+        raise NotImplementedError()
+
+    @property
+    def expunge_support_event_subscription(
+        self,
+    ) -> Callable[
+        [support_event_subscription_service.ExpungeSupportEventSubscriptionRequest],
+        Union[empty_pb2.Empty, Awaitable[empty_pb2.Empty]],
     ]:
         raise NotImplementedError()
 

--- a/packages/google-cloud-support/google/cloud/support_v2beta/services/support_event_subscription_service/transports/grpc.py
+++ b/packages/google-cloud-support/google/cloud/support_v2beta/services/support_event_subscription_service/transports/grpc.py
@@ -20,6 +20,7 @@ import warnings
 from typing import Callable, Dict, Optional, Sequence, Tuple, Union
 
 import google.auth  # type: ignore
+import google.protobuf.empty_pb2 as empty_pb2  # type: ignore
 import google.protobuf.message
 import grpc  # type: ignore
 import proto  # type: ignore
@@ -407,7 +408,8 @@ class SupportEventSubscriptionServiceGrpcTransport(
         r"""Return a callable for the list support event
         subscriptions method over gRPC.
 
-        Lists support event subscriptions.
+        Lists support event subscriptions for an
+        organization.
 
         Returns:
             Callable[[~.ListSupportEventSubscriptionsRequest],
@@ -524,6 +526,68 @@ class SupportEventSubscriptionServiceGrpcTransport(
                 )
             )
         return self._stubs["undelete_support_event_subscription"]
+
+    @property
+    def expunge_support_event_subscription(
+        self,
+    ) -> Callable[
+        [support_event_subscription_service.ExpungeSupportEventSubscriptionRequest],
+        empty_pb2.Empty,
+    ]:
+        r"""Return a callable for the expunge support event
+        subscription method over gRPC.
+
+        Expunges a support event subscription.
+
+        EXAMPLES:
+
+        cURL:
+
+        .. code:: shell
+
+           support_event_subscription="organizations/123456789/supportEventSubscriptions/abcdef123456"
+           curl \
+             --request POST \
+             --header "Authorization: Bearer $(gcloud auth print-access-token)" \
+             "https://cloudsupport.googleapis.com/v2beta/$support_event_subscription:expunge"
+
+        Python:
+
+        .. code:: python
+
+           import googleapiclient.discovery
+
+           api_version = "v2beta"
+           supportApiService = googleapiclient.discovery.build(
+               serviceName="cloudsupport",
+               version=api_version,
+               discoveryServiceUrl=f"https://cloudsupport.googleapis.com/$discovery/rest?version={api_version}",
+           )
+
+           request = supportApiService.supportEventSubscriptions().expunge(
+               name="organizations/123456789/supportEventSubscriptions/abcdef123456"
+           )
+           print(request.execute())
+
+        Returns:
+            Callable[[~.ExpungeSupportEventSubscriptionRequest],
+                    ~.Empty]:
+                A function that, when called, will call the underlying RPC
+                on the server.
+        """
+        # Generate a "stub function" on-the-fly which will actually make
+        # the request.
+        # gRPC handles serialization and deserialization, so we just need
+        # to pass in the functions for each.
+        if "expunge_support_event_subscription" not in self._stubs:
+            self._stubs["expunge_support_event_subscription"] = (
+                self._logged_channel.unary_unary(
+                    "/google.cloud.support.v2beta.SupportEventSubscriptionService/ExpungeSupportEventSubscription",
+                    request_serializer=support_event_subscription_service.ExpungeSupportEventSubscriptionRequest.serialize,
+                    response_deserializer=empty_pb2.Empty.FromString,
+                )
+            )
+        return self._stubs["expunge_support_event_subscription"]
 
     def close(self):
         self._logged_channel.close()

--- a/packages/google-cloud-support/google/cloud/support_v2beta/services/support_event_subscription_service/transports/grpc_asyncio.py
+++ b/packages/google-cloud-support/google/cloud/support_v2beta/services/support_event_subscription_service/transports/grpc_asyncio.py
@@ -20,6 +20,7 @@ import pickle
 import warnings
 from typing import Awaitable, Callable, Dict, Optional, Sequence, Tuple, Union
 
+import google.protobuf.empty_pb2 as empty_pb2  # type: ignore
 import google.protobuf.message
 import grpc  # type: ignore
 import proto  # type: ignore
@@ -417,7 +418,8 @@ class SupportEventSubscriptionServiceGrpcAsyncIOTransport(
         r"""Return a callable for the list support event
         subscriptions method over gRPC.
 
-        Lists support event subscriptions.
+        Lists support event subscriptions for an
+        organization.
 
         Returns:
             Callable[[~.ListSupportEventSubscriptionsRequest],
@@ -535,6 +537,68 @@ class SupportEventSubscriptionServiceGrpcAsyncIOTransport(
             )
         return self._stubs["undelete_support_event_subscription"]
 
+    @property
+    def expunge_support_event_subscription(
+        self,
+    ) -> Callable[
+        [support_event_subscription_service.ExpungeSupportEventSubscriptionRequest],
+        Awaitable[empty_pb2.Empty],
+    ]:
+        r"""Return a callable for the expunge support event
+        subscription method over gRPC.
+
+        Expunges a support event subscription.
+
+        EXAMPLES:
+
+        cURL:
+
+        .. code:: shell
+
+           support_event_subscription="organizations/123456789/supportEventSubscriptions/abcdef123456"
+           curl \
+             --request POST \
+             --header "Authorization: Bearer $(gcloud auth print-access-token)" \
+             "https://cloudsupport.googleapis.com/v2beta/$support_event_subscription:expunge"
+
+        Python:
+
+        .. code:: python
+
+           import googleapiclient.discovery
+
+           api_version = "v2beta"
+           supportApiService = googleapiclient.discovery.build(
+               serviceName="cloudsupport",
+               version=api_version,
+               discoveryServiceUrl=f"https://cloudsupport.googleapis.com/$discovery/rest?version={api_version}",
+           )
+
+           request = supportApiService.supportEventSubscriptions().expunge(
+               name="organizations/123456789/supportEventSubscriptions/abcdef123456"
+           )
+           print(request.execute())
+
+        Returns:
+            Callable[[~.ExpungeSupportEventSubscriptionRequest],
+                    Awaitable[~.Empty]]:
+                A function that, when called, will call the underlying RPC
+                on the server.
+        """
+        # Generate a "stub function" on-the-fly which will actually make
+        # the request.
+        # gRPC handles serialization and deserialization, so we just need
+        # to pass in the functions for each.
+        if "expunge_support_event_subscription" not in self._stubs:
+            self._stubs["expunge_support_event_subscription"] = (
+                self._logged_channel.unary_unary(
+                    "/google.cloud.support.v2beta.SupportEventSubscriptionService/ExpungeSupportEventSubscription",
+                    request_serializer=support_event_subscription_service.ExpungeSupportEventSubscriptionRequest.serialize,
+                    response_deserializer=empty_pb2.Empty.FromString,
+                )
+            )
+        return self._stubs["expunge_support_event_subscription"]
+
     def _prep_wrapped_messages(self, client_info):
         """Precompute the wrapped methods, overriding the base class method to use async wrappers."""
         self._wrapped_methods = {
@@ -565,6 +629,11 @@ class SupportEventSubscriptionServiceGrpcAsyncIOTransport(
             ),
             self.undelete_support_event_subscription: self._wrap_method(
                 self.undelete_support_event_subscription,
+                default_timeout=None,
+                client_info=client_info,
+            ),
+            self.expunge_support_event_subscription: self._wrap_method(
+                self.expunge_support_event_subscription,
                 default_timeout=None,
                 client_info=client_info,
             ),

--- a/packages/google-cloud-support/google/cloud/support_v2beta/services/support_event_subscription_service/transports/rest.py
+++ b/packages/google-cloud-support/google/cloud/support_v2beta/services/support_event_subscription_service/transports/rest.py
@@ -20,6 +20,7 @@ import warnings
 from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple, Union
 
 import google.protobuf
+import google.protobuf.empty_pb2 as empty_pb2  # type: ignore
 from google.api_core import exceptions as core_exceptions
 from google.api_core import gapic_v1, rest_helpers, rest_streaming
 from google.api_core import retry as retries
@@ -92,6 +93,10 @@ class SupportEventSubscriptionServiceRestInterceptor:
             def post_delete_support_event_subscription(self, response):
                 logging.log(f"Received response: {response}")
                 return response
+
+            def pre_expunge_support_event_subscription(self, request, metadata):
+                logging.log(f"Received request: {request}")
+                return request, metadata
 
             def pre_get_support_event_subscription(self, request, metadata):
                 logging.log(f"Received request: {request}")
@@ -234,6 +239,21 @@ class SupportEventSubscriptionServiceRestInterceptor:
         `post_delete_support_event_subscription_with_metadata`.
         """
         return response, metadata
+
+    def pre_expunge_support_event_subscription(
+        self,
+        request: support_event_subscription_service.ExpungeSupportEventSubscriptionRequest,
+        metadata: Sequence[Tuple[str, Union[str, bytes]]],
+    ) -> Tuple[
+        support_event_subscription_service.ExpungeSupportEventSubscriptionRequest,
+        Sequence[Tuple[str, Union[str, bytes]]],
+    ]:
+        """Pre-rpc interceptor for expunge_support_event_subscription
+
+        Override in a subclass to manipulate the request or metadata
+        before they are sent to the SupportEventSubscriptionService server.
+        """
+        return request, metadata
 
     def pre_get_support_event_subscription(
         self,
@@ -857,6 +877,125 @@ class SupportEventSubscriptionServiceRestTransport(
                     },
                 )
             return resp
+
+    class _ExpungeSupportEventSubscription(
+        _BaseSupportEventSubscriptionServiceRestTransport._BaseExpungeSupportEventSubscription,
+        SupportEventSubscriptionServiceRestStub,
+    ):
+        def __hash__(self):
+            return hash(
+                "SupportEventSubscriptionServiceRestTransport.ExpungeSupportEventSubscription"
+            )
+
+        @staticmethod
+        def _get_response(
+            host,
+            metadata,
+            query_params,
+            session,
+            timeout,
+            transcoded_request,
+            body=None,
+        ):
+            uri = transcoded_request["uri"]
+            method = transcoded_request["method"]
+            headers = dict(metadata)
+            headers["Content-Type"] = "application/json"
+            response = getattr(session, method)(
+                "{host}{uri}".format(host=host, uri=uri),
+                timeout=timeout,
+                headers=headers,
+                params=rest_helpers.flatten_query_params(query_params, strict=True),
+                data=body,
+            )
+            return response
+
+        def __call__(
+            self,
+            request: support_event_subscription_service.ExpungeSupportEventSubscriptionRequest,
+            *,
+            retry: OptionalRetry = gapic_v1.method.DEFAULT,
+            timeout: Optional[float] = None,
+            metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
+        ):
+            r"""Call the expunge support event
+            subscription method over HTTP.
+
+                Args:
+                    request (~.support_event_subscription_service.ExpungeSupportEventSubscriptionRequest):
+                        The request object. Request message for
+                    ExpungeSupportEventSubscription.
+                    retry (google.api_core.retry.Retry): Designation of what errors, if any,
+                        should be retried.
+                    timeout (float): The timeout for this request.
+                    metadata (Sequence[Tuple[str, Union[str, bytes]]]): Key/value pairs which should be
+                        sent along with the request as metadata. Normally, each value must be of type `str`,
+                        but for metadata keys ending with the suffix `-bin`, the corresponding values must
+                        be of type `bytes`.
+            """
+
+            http_options = _BaseSupportEventSubscriptionServiceRestTransport._BaseExpungeSupportEventSubscription._get_http_options()
+
+            request, metadata = (
+                self._interceptor.pre_expunge_support_event_subscription(
+                    request, metadata
+                )
+            )
+            transcoded_request = _BaseSupportEventSubscriptionServiceRestTransport._BaseExpungeSupportEventSubscription._get_transcoded_request(
+                http_options, request
+            )
+
+            body = _BaseSupportEventSubscriptionServiceRestTransport._BaseExpungeSupportEventSubscription._get_request_body_json(
+                transcoded_request
+            )
+
+            # Jsonify the query params
+            query_params = _BaseSupportEventSubscriptionServiceRestTransport._BaseExpungeSupportEventSubscription._get_query_params_json(
+                transcoded_request
+            )
+
+            if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(
+                logging.DEBUG
+            ):  # pragma: NO COVER
+                request_url = "{host}{uri}".format(
+                    host=self._host, uri=transcoded_request["uri"]
+                )
+                method = transcoded_request["method"]
+                try:
+                    request_payload = type(request).to_json(request)
+                except:
+                    request_payload = None
+                http_request = {
+                    "payload": request_payload,
+                    "requestMethod": method,
+                    "requestUrl": request_url,
+                    "headers": dict(metadata),
+                }
+                _LOGGER.debug(
+                    f"Sending request for google.cloud.support_v2beta.SupportEventSubscriptionServiceClient.ExpungeSupportEventSubscription",
+                    extra={
+                        "serviceName": "google.cloud.support.v2beta.SupportEventSubscriptionService",
+                        "rpcName": "ExpungeSupportEventSubscription",
+                        "httpRequest": http_request,
+                        "metadata": http_request["headers"],
+                    },
+                )
+
+            # Send the request
+            response = SupportEventSubscriptionServiceRestTransport._ExpungeSupportEventSubscription._get_response(
+                self._host,
+                metadata,
+                query_params,
+                self._session,
+                timeout,
+                transcoded_request,
+                body,
+            )
+
+            # In case of error, raise the appropriate core_exceptions.GoogleAPICallError exception
+            # subclass.
+            if response.status_code >= 400:
+                raise core_exceptions.from_http_response(response)
 
     class _GetSupportEventSubscription(
         _BaseSupportEventSubscriptionServiceRestTransport._BaseGetSupportEventSubscription,
@@ -1517,6 +1656,19 @@ class SupportEventSubscriptionServiceRestTransport(
         # The return type is fine, but mypy isn't sophisticated enough to determine what's going on here.
         # In C++ this would require a dynamic_cast
         return self._DeleteSupportEventSubscription(
+            self._session, self._host, self._interceptor
+        )  # type: ignore
+
+    @property
+    def expunge_support_event_subscription(
+        self,
+    ) -> Callable[
+        [support_event_subscription_service.ExpungeSupportEventSubscriptionRequest],
+        empty_pb2.Empty,
+    ]:
+        # The return type is fine, but mypy isn't sophisticated enough to determine what's going on here.
+        # In C++ this would require a dynamic_cast
+        return self._ExpungeSupportEventSubscription(
             self._session, self._host, self._interceptor
         )  # type: ignore
 

--- a/packages/google-cloud-support/google/cloud/support_v2beta/services/support_event_subscription_service/transports/rest_base.py
+++ b/packages/google-cloud-support/google/cloud/support_v2beta/services/support_event_subscription_service/transports/rest_base.py
@@ -17,6 +17,7 @@ import json  # type: ignore
 import re
 from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple, Union
 
+import google.protobuf.empty_pb2 as empty_pb2  # type: ignore
 from google.api_core import gapic_v1, path_template
 from google.protobuf import json_format
 
@@ -114,7 +115,7 @@ class _BaseSupportEventSubscriptionServiceRestTransport(
             http_options: List[Dict[str, str]] = [
                 {
                     "method": "post",
-                    "uri": "/v2beta/{parent=*/*}/supportEventSubscriptions",
+                    "uri": "/v2beta/{parent=organizations/*}/supportEventSubscriptions",
                     "body": "support_event_subscription",
                 },
             ]
@@ -173,7 +174,7 @@ class _BaseSupportEventSubscriptionServiceRestTransport(
             http_options: List[Dict[str, str]] = [
                 {
                     "method": "delete",
-                    "uri": "/v2beta/{name=*/*/supportEventSubscriptions/*}",
+                    "uri": "/v2beta/{name=organizations/*/supportEventSubscriptions/*}",
                 },
             ]
             return http_options
@@ -203,6 +204,65 @@ class _BaseSupportEventSubscriptionServiceRestTransport(
             query_params["$alt"] = "json;enum-encoding=int"
             return query_params
 
+    class _BaseExpungeSupportEventSubscription:
+        def __hash__(self):  # pragma: NO COVER
+            return NotImplementedError("__hash__ must be implemented.")
+
+        __REQUIRED_FIELDS_DEFAULT_VALUES: Dict[str, Any] = {}
+
+        @classmethod
+        def _get_unset_required_fields(cls, message_dict):
+            return {
+                k: v
+                for k, v in cls.__REQUIRED_FIELDS_DEFAULT_VALUES.items()
+                if k not in message_dict
+            }
+
+        @staticmethod
+        def _get_http_options():
+            http_options: List[Dict[str, str]] = [
+                {
+                    "method": "post",
+                    "uri": "/v2beta/{name=organizations/*/supportEventSubscriptions/*}:expunge",
+                    "body": "*",
+                },
+            ]
+            return http_options
+
+        @staticmethod
+        def _get_transcoded_request(http_options, request):
+            pb_request = support_event_subscription_service.ExpungeSupportEventSubscriptionRequest.pb(
+                request
+            )
+            transcoded_request = path_template.transcode(http_options, pb_request)
+            return transcoded_request
+
+        @staticmethod
+        def _get_request_body_json(transcoded_request):
+            # Jsonify the request body
+
+            body = json_format.MessageToJson(
+                transcoded_request["body"], use_integers_for_enums=True
+            )
+            return body
+
+        @staticmethod
+        def _get_query_params_json(transcoded_request):
+            query_params = json.loads(
+                json_format.MessageToJson(
+                    transcoded_request["query_params"],
+                    use_integers_for_enums=True,
+                )
+            )
+            query_params.update(
+                _BaseSupportEventSubscriptionServiceRestTransport._BaseExpungeSupportEventSubscription._get_unset_required_fields(
+                    query_params
+                )
+            )
+
+            query_params["$alt"] = "json;enum-encoding=int"
+            return query_params
+
     class _BaseGetSupportEventSubscription:
         def __hash__(self):  # pragma: NO COVER
             return NotImplementedError("__hash__ must be implemented.")
@@ -222,7 +282,7 @@ class _BaseSupportEventSubscriptionServiceRestTransport(
             http_options: List[Dict[str, str]] = [
                 {
                     "method": "get",
-                    "uri": "/v2beta/{name=*/*/supportEventSubscriptions/*}",
+                    "uri": "/v2beta/{name=organizations/*/supportEventSubscriptions/*}",
                 },
             ]
             return http_options
@@ -271,7 +331,7 @@ class _BaseSupportEventSubscriptionServiceRestTransport(
             http_options: List[Dict[str, str]] = [
                 {
                     "method": "get",
-                    "uri": "/v2beta/{parent=*/*}/supportEventSubscriptions",
+                    "uri": "/v2beta/{parent=organizations/*}/supportEventSubscriptions",
                 },
             ]
             return http_options
@@ -320,7 +380,7 @@ class _BaseSupportEventSubscriptionServiceRestTransport(
             http_options: List[Dict[str, str]] = [
                 {
                     "method": "post",
-                    "uri": "/v2beta/{name=*/*/supportEventSubscriptions/*}:undelete",
+                    "uri": "/v2beta/{name=organizations/*/supportEventSubscriptions/*}:undelete",
                     "body": "*",
                 },
             ]
@@ -379,7 +439,7 @@ class _BaseSupportEventSubscriptionServiceRestTransport(
             http_options: List[Dict[str, str]] = [
                 {
                     "method": "patch",
-                    "uri": "/v2beta/{support_event_subscription.name=*/*/supportEventSubscriptions/*}",
+                    "uri": "/v2beta/{support_event_subscription.name=organizations/*/supportEventSubscriptions/*}",
                     "body": "support_event_subscription",
                 },
             ]

--- a/packages/google-cloud-support/google/cloud/support_v2beta/types/__init__.py
+++ b/packages/google-cloud-support/google/cloud/support_v2beta/types/__init__.py
@@ -74,6 +74,7 @@ from .support_event_subscription import (
 from .support_event_subscription_service import (
     CreateSupportEventSubscriptionRequest,
     DeleteSupportEventSubscriptionRequest,
+    ExpungeSupportEventSubscriptionRequest,
     GetSupportEventSubscriptionRequest,
     ListSupportEventSubscriptionsRequest,
     ListSupportEventSubscriptionsResponse,
@@ -116,6 +117,7 @@ __all__ = (
     "SupportEventSubscription",
     "CreateSupportEventSubscriptionRequest",
     "DeleteSupportEventSubscriptionRequest",
+    "ExpungeSupportEventSubscriptionRequest",
     "GetSupportEventSubscriptionRequest",
     "ListSupportEventSubscriptionsRequest",
     "ListSupportEventSubscriptionsResponse",

--- a/packages/google-cloud-support/google/cloud/support_v2beta/types/support_event_subscription_service.py
+++ b/packages/google-cloud-support/google/cloud/support_v2beta/types/support_event_subscription_service.py
@@ -34,6 +34,7 @@ __protobuf__ = proto.module(
         "UpdateSupportEventSubscriptionRequest",
         "DeleteSupportEventSubscriptionRequest",
         "UndeleteSupportEventSubscriptionRequest",
+        "ExpungeSupportEventSubscriptionRequest",
     },
 )
 
@@ -213,6 +214,22 @@ class UndeleteSupportEventSubscriptionRequest(proto.Message):
         name (str):
             Required. The name of the support event subscription to
             undelete. Format:
+            organizations/{organization_id}/supportEventSubscriptions/{subscription_id}
+    """
+
+    name: str = proto.Field(
+        proto.STRING,
+        number=1,
+    )
+
+
+class ExpungeSupportEventSubscriptionRequest(proto.Message):
+    r"""Request message for ExpungeSupportEventSubscription.
+
+    Attributes:
+        name (str):
+            Required. The name of the support event subscription to
+            expunge. Format:
             organizations/{organization_id}/supportEventSubscriptions/{subscription_id}
     """
 

--- a/packages/google-cloud-support/samples/generated_samples/cloudsupport_v2_generated_support_event_subscription_service_expunge_support_event_subscription_async.py
+++ b/packages/google-cloud-support/samples/generated_samples/cloudsupport_v2_generated_support_event_subscription_service_expunge_support_event_subscription_async.py
@@ -1,0 +1,50 @@
+# -*- coding: utf-8 -*-
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Generated code. DO NOT EDIT!
+#
+# Snippet for ExpungeSupportEventSubscription
+# NOTE: This snippet has been automatically generated for illustrative purposes only.
+# It may require modifications to work in your environment.
+
+# To install the latest published package dependency, execute the following:
+#   python3 -m pip install google-cloud-support
+
+
+# [START cloudsupport_v2_generated_SupportEventSubscriptionService_ExpungeSupportEventSubscription_async]
+# This snippet has been automatically generated and should be regarded as a
+# code template only.
+# It will require modifications to work:
+# - It may require correct/in-range values for request initialization.
+# - It may require specifying regional endpoints when creating the service
+#   client as shown in:
+#   https://googleapis.dev/python/google-api-core/latest/client_options.html
+from google.cloud import support_v2
+
+
+async def sample_expunge_support_event_subscription():
+    # Create a client
+    client = support_v2.SupportEventSubscriptionServiceAsyncClient()
+
+    # Initialize request argument(s)
+    request = support_v2.ExpungeSupportEventSubscriptionRequest(
+        name="name_value",
+    )
+
+    # Make the request
+    await client.expunge_support_event_subscription(request=request)
+
+
+# [END cloudsupport_v2_generated_SupportEventSubscriptionService_ExpungeSupportEventSubscription_async]

--- a/packages/google-cloud-support/samples/generated_samples/cloudsupport_v2_generated_support_event_subscription_service_expunge_support_event_subscription_sync.py
+++ b/packages/google-cloud-support/samples/generated_samples/cloudsupport_v2_generated_support_event_subscription_service_expunge_support_event_subscription_sync.py
@@ -1,0 +1,50 @@
+# -*- coding: utf-8 -*-
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Generated code. DO NOT EDIT!
+#
+# Snippet for ExpungeSupportEventSubscription
+# NOTE: This snippet has been automatically generated for illustrative purposes only.
+# It may require modifications to work in your environment.
+
+# To install the latest published package dependency, execute the following:
+#   python3 -m pip install google-cloud-support
+
+
+# [START cloudsupport_v2_generated_SupportEventSubscriptionService_ExpungeSupportEventSubscription_sync]
+# This snippet has been automatically generated and should be regarded as a
+# code template only.
+# It will require modifications to work:
+# - It may require correct/in-range values for request initialization.
+# - It may require specifying regional endpoints when creating the service
+#   client as shown in:
+#   https://googleapis.dev/python/google-api-core/latest/client_options.html
+from google.cloud import support_v2
+
+
+def sample_expunge_support_event_subscription():
+    # Create a client
+    client = support_v2.SupportEventSubscriptionServiceClient()
+
+    # Initialize request argument(s)
+    request = support_v2.ExpungeSupportEventSubscriptionRequest(
+        name="name_value",
+    )
+
+    # Make the request
+    client.expunge_support_event_subscription(request=request)
+
+
+# [END cloudsupport_v2_generated_SupportEventSubscriptionService_ExpungeSupportEventSubscription_sync]

--- a/packages/google-cloud-support/samples/generated_samples/cloudsupport_v2beta_generated_support_event_subscription_service_expunge_support_event_subscription_async.py
+++ b/packages/google-cloud-support/samples/generated_samples/cloudsupport_v2beta_generated_support_event_subscription_service_expunge_support_event_subscription_async.py
@@ -1,0 +1,50 @@
+# -*- coding: utf-8 -*-
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Generated code. DO NOT EDIT!
+#
+# Snippet for ExpungeSupportEventSubscription
+# NOTE: This snippet has been automatically generated for illustrative purposes only.
+# It may require modifications to work in your environment.
+
+# To install the latest published package dependency, execute the following:
+#   python3 -m pip install google-cloud-support
+
+
+# [START cloudsupport_v2beta_generated_SupportEventSubscriptionService_ExpungeSupportEventSubscription_async]
+# This snippet has been automatically generated and should be regarded as a
+# code template only.
+# It will require modifications to work:
+# - It may require correct/in-range values for request initialization.
+# - It may require specifying regional endpoints when creating the service
+#   client as shown in:
+#   https://googleapis.dev/python/google-api-core/latest/client_options.html
+from google.cloud import support_v2beta
+
+
+async def sample_expunge_support_event_subscription():
+    # Create a client
+    client = support_v2beta.SupportEventSubscriptionServiceAsyncClient()
+
+    # Initialize request argument(s)
+    request = support_v2beta.ExpungeSupportEventSubscriptionRequest(
+        name="name_value",
+    )
+
+    # Make the request
+    await client.expunge_support_event_subscription(request=request)
+
+
+# [END cloudsupport_v2beta_generated_SupportEventSubscriptionService_ExpungeSupportEventSubscription_async]

--- a/packages/google-cloud-support/samples/generated_samples/cloudsupport_v2beta_generated_support_event_subscription_service_expunge_support_event_subscription_sync.py
+++ b/packages/google-cloud-support/samples/generated_samples/cloudsupport_v2beta_generated_support_event_subscription_service_expunge_support_event_subscription_sync.py
@@ -1,0 +1,50 @@
+# -*- coding: utf-8 -*-
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Generated code. DO NOT EDIT!
+#
+# Snippet for ExpungeSupportEventSubscription
+# NOTE: This snippet has been automatically generated for illustrative purposes only.
+# It may require modifications to work in your environment.
+
+# To install the latest published package dependency, execute the following:
+#   python3 -m pip install google-cloud-support
+
+
+# [START cloudsupport_v2beta_generated_SupportEventSubscriptionService_ExpungeSupportEventSubscription_sync]
+# This snippet has been automatically generated and should be regarded as a
+# code template only.
+# It will require modifications to work:
+# - It may require correct/in-range values for request initialization.
+# - It may require specifying regional endpoints when creating the service
+#   client as shown in:
+#   https://googleapis.dev/python/google-api-core/latest/client_options.html
+from google.cloud import support_v2beta
+
+
+def sample_expunge_support_event_subscription():
+    # Create a client
+    client = support_v2beta.SupportEventSubscriptionServiceClient()
+
+    # Initialize request argument(s)
+    request = support_v2beta.ExpungeSupportEventSubscriptionRequest(
+        name="name_value",
+    )
+
+    # Make the request
+    client.expunge_support_event_subscription(request=request)
+
+
+# [END cloudsupport_v2beta_generated_SupportEventSubscriptionService_ExpungeSupportEventSubscription_sync]

--- a/packages/google-cloud-support/samples/generated_samples/snippet_metadata_google.cloud.support.v2.json
+++ b/packages/google-cloud-support/samples/generated_samples/snippet_metadata_google.cloud.support.v2.json
@@ -2434,6 +2434,161 @@
           "fullName": "google.cloud.support_v2.SupportEventSubscriptionServiceAsyncClient",
           "shortName": "SupportEventSubscriptionServiceAsyncClient"
         },
+        "fullName": "google.cloud.support_v2.SupportEventSubscriptionServiceAsyncClient.expunge_support_event_subscription",
+        "method": {
+          "fullName": "google.cloud.support.v2.SupportEventSubscriptionService.ExpungeSupportEventSubscription",
+          "service": {
+            "fullName": "google.cloud.support.v2.SupportEventSubscriptionService",
+            "shortName": "SupportEventSubscriptionService"
+          },
+          "shortName": "ExpungeSupportEventSubscription"
+        },
+        "parameters": [
+          {
+            "name": "request",
+            "type": "google.cloud.support_v2.types.ExpungeSupportEventSubscriptionRequest"
+          },
+          {
+            "name": "name",
+            "type": "str"
+          },
+          {
+            "name": "retry",
+            "type": "google.api_core.retry.Retry"
+          },
+          {
+            "name": "timeout",
+            "type": "float"
+          },
+          {
+            "name": "metadata",
+            "type": "Sequence[Tuple[str, Union[str, bytes]]]"
+          }
+        ],
+        "shortName": "expunge_support_event_subscription"
+      },
+      "description": "Sample for ExpungeSupportEventSubscription",
+      "file": "cloudsupport_v2_generated_support_event_subscription_service_expunge_support_event_subscription_async.py",
+      "language": "PYTHON",
+      "origin": "API_DEFINITION",
+      "regionTag": "cloudsupport_v2_generated_SupportEventSubscriptionService_ExpungeSupportEventSubscription_async",
+      "segments": [
+        {
+          "end": 49,
+          "start": 27,
+          "type": "FULL"
+        },
+        {
+          "end": 49,
+          "start": 27,
+          "type": "SHORT"
+        },
+        {
+          "end": 40,
+          "start": 38,
+          "type": "CLIENT_INITIALIZATION"
+        },
+        {
+          "end": 45,
+          "start": 41,
+          "type": "REQUEST_INITIALIZATION"
+        },
+        {
+          "start": 46,
+          "type": "REQUEST_EXECUTION"
+        },
+        {
+          "end": 50,
+          "type": "RESPONSE_HANDLING"
+        }
+      ],
+      "title": "cloudsupport_v2_generated_support_event_subscription_service_expunge_support_event_subscription_async.py"
+    },
+    {
+      "canonical": true,
+      "clientMethod": {
+        "client": {
+          "fullName": "google.cloud.support_v2.SupportEventSubscriptionServiceClient",
+          "shortName": "SupportEventSubscriptionServiceClient"
+        },
+        "fullName": "google.cloud.support_v2.SupportEventSubscriptionServiceClient.expunge_support_event_subscription",
+        "method": {
+          "fullName": "google.cloud.support.v2.SupportEventSubscriptionService.ExpungeSupportEventSubscription",
+          "service": {
+            "fullName": "google.cloud.support.v2.SupportEventSubscriptionService",
+            "shortName": "SupportEventSubscriptionService"
+          },
+          "shortName": "ExpungeSupportEventSubscription"
+        },
+        "parameters": [
+          {
+            "name": "request",
+            "type": "google.cloud.support_v2.types.ExpungeSupportEventSubscriptionRequest"
+          },
+          {
+            "name": "name",
+            "type": "str"
+          },
+          {
+            "name": "retry",
+            "type": "google.api_core.retry.Retry"
+          },
+          {
+            "name": "timeout",
+            "type": "float"
+          },
+          {
+            "name": "metadata",
+            "type": "Sequence[Tuple[str, Union[str, bytes]]]"
+          }
+        ],
+        "shortName": "expunge_support_event_subscription"
+      },
+      "description": "Sample for ExpungeSupportEventSubscription",
+      "file": "cloudsupport_v2_generated_support_event_subscription_service_expunge_support_event_subscription_sync.py",
+      "language": "PYTHON",
+      "origin": "API_DEFINITION",
+      "regionTag": "cloudsupport_v2_generated_SupportEventSubscriptionService_ExpungeSupportEventSubscription_sync",
+      "segments": [
+        {
+          "end": 49,
+          "start": 27,
+          "type": "FULL"
+        },
+        {
+          "end": 49,
+          "start": 27,
+          "type": "SHORT"
+        },
+        {
+          "end": 40,
+          "start": 38,
+          "type": "CLIENT_INITIALIZATION"
+        },
+        {
+          "end": 45,
+          "start": 41,
+          "type": "REQUEST_INITIALIZATION"
+        },
+        {
+          "start": 46,
+          "type": "REQUEST_EXECUTION"
+        },
+        {
+          "end": 50,
+          "type": "RESPONSE_HANDLING"
+        }
+      ],
+      "title": "cloudsupport_v2_generated_support_event_subscription_service_expunge_support_event_subscription_sync.py"
+    },
+    {
+      "canonical": true,
+      "clientMethod": {
+        "async": true,
+        "client": {
+          "fullName": "google.cloud.support_v2.SupportEventSubscriptionServiceAsyncClient",
+          "shortName": "SupportEventSubscriptionServiceAsyncClient"
+        },
         "fullName": "google.cloud.support_v2.SupportEventSubscriptionServiceAsyncClient.get_support_event_subscription",
         "method": {
           "fullName": "google.cloud.support.v2.SupportEventSubscriptionService.GetSupportEventSubscription",

--- a/packages/google-cloud-support/samples/generated_samples/snippet_metadata_google.cloud.support.v2beta.json
+++ b/packages/google-cloud-support/samples/generated_samples/snippet_metadata_google.cloud.support.v2beta.json
@@ -2595,6 +2595,161 @@
           "fullName": "google.cloud.support_v2beta.SupportEventSubscriptionServiceAsyncClient",
           "shortName": "SupportEventSubscriptionServiceAsyncClient"
         },
+        "fullName": "google.cloud.support_v2beta.SupportEventSubscriptionServiceAsyncClient.expunge_support_event_subscription",
+        "method": {
+          "fullName": "google.cloud.support.v2beta.SupportEventSubscriptionService.ExpungeSupportEventSubscription",
+          "service": {
+            "fullName": "google.cloud.support.v2beta.SupportEventSubscriptionService",
+            "shortName": "SupportEventSubscriptionService"
+          },
+          "shortName": "ExpungeSupportEventSubscription"
+        },
+        "parameters": [
+          {
+            "name": "request",
+            "type": "google.cloud.support_v2beta.types.ExpungeSupportEventSubscriptionRequest"
+          },
+          {
+            "name": "name",
+            "type": "str"
+          },
+          {
+            "name": "retry",
+            "type": "google.api_core.retry.Retry"
+          },
+          {
+            "name": "timeout",
+            "type": "float"
+          },
+          {
+            "name": "metadata",
+            "type": "Sequence[Tuple[str, Union[str, bytes]]]"
+          }
+        ],
+        "shortName": "expunge_support_event_subscription"
+      },
+      "description": "Sample for ExpungeSupportEventSubscription",
+      "file": "cloudsupport_v2beta_generated_support_event_subscription_service_expunge_support_event_subscription_async.py",
+      "language": "PYTHON",
+      "origin": "API_DEFINITION",
+      "regionTag": "cloudsupport_v2beta_generated_SupportEventSubscriptionService_ExpungeSupportEventSubscription_async",
+      "segments": [
+        {
+          "end": 49,
+          "start": 27,
+          "type": "FULL"
+        },
+        {
+          "end": 49,
+          "start": 27,
+          "type": "SHORT"
+        },
+        {
+          "end": 40,
+          "start": 38,
+          "type": "CLIENT_INITIALIZATION"
+        },
+        {
+          "end": 45,
+          "start": 41,
+          "type": "REQUEST_INITIALIZATION"
+        },
+        {
+          "start": 46,
+          "type": "REQUEST_EXECUTION"
+        },
+        {
+          "end": 50,
+          "type": "RESPONSE_HANDLING"
+        }
+      ],
+      "title": "cloudsupport_v2beta_generated_support_event_subscription_service_expunge_support_event_subscription_async.py"
+    },
+    {
+      "canonical": true,
+      "clientMethod": {
+        "client": {
+          "fullName": "google.cloud.support_v2beta.SupportEventSubscriptionServiceClient",
+          "shortName": "SupportEventSubscriptionServiceClient"
+        },
+        "fullName": "google.cloud.support_v2beta.SupportEventSubscriptionServiceClient.expunge_support_event_subscription",
+        "method": {
+          "fullName": "google.cloud.support.v2beta.SupportEventSubscriptionService.ExpungeSupportEventSubscription",
+          "service": {
+            "fullName": "google.cloud.support.v2beta.SupportEventSubscriptionService",
+            "shortName": "SupportEventSubscriptionService"
+          },
+          "shortName": "ExpungeSupportEventSubscription"
+        },
+        "parameters": [
+          {
+            "name": "request",
+            "type": "google.cloud.support_v2beta.types.ExpungeSupportEventSubscriptionRequest"
+          },
+          {
+            "name": "name",
+            "type": "str"
+          },
+          {
+            "name": "retry",
+            "type": "google.api_core.retry.Retry"
+          },
+          {
+            "name": "timeout",
+            "type": "float"
+          },
+          {
+            "name": "metadata",
+            "type": "Sequence[Tuple[str, Union[str, bytes]]]"
+          }
+        ],
+        "shortName": "expunge_support_event_subscription"
+      },
+      "description": "Sample for ExpungeSupportEventSubscription",
+      "file": "cloudsupport_v2beta_generated_support_event_subscription_service_expunge_support_event_subscription_sync.py",
+      "language": "PYTHON",
+      "origin": "API_DEFINITION",
+      "regionTag": "cloudsupport_v2beta_generated_SupportEventSubscriptionService_ExpungeSupportEventSubscription_sync",
+      "segments": [
+        {
+          "end": 49,
+          "start": 27,
+          "type": "FULL"
+        },
+        {
+          "end": 49,
+          "start": 27,
+          "type": "SHORT"
+        },
+        {
+          "end": 40,
+          "start": 38,
+          "type": "CLIENT_INITIALIZATION"
+        },
+        {
+          "end": 45,
+          "start": 41,
+          "type": "REQUEST_INITIALIZATION"
+        },
+        {
+          "start": 46,
+          "type": "REQUEST_EXECUTION"
+        },
+        {
+          "end": 50,
+          "type": "RESPONSE_HANDLING"
+        }
+      ],
+      "title": "cloudsupport_v2beta_generated_support_event_subscription_service_expunge_support_event_subscription_sync.py"
+    },
+    {
+      "canonical": true,
+      "clientMethod": {
+        "async": true,
+        "client": {
+          "fullName": "google.cloud.support_v2beta.SupportEventSubscriptionServiceAsyncClient",
+          "shortName": "SupportEventSubscriptionServiceAsyncClient"
+        },
         "fullName": "google.cloud.support_v2beta.SupportEventSubscriptionServiceAsyncClient.get_support_event_subscription",
         "method": {
           "fullName": "google.cloud.support.v2beta.SupportEventSubscriptionService.GetSupportEventSubscription",

--- a/packages/google-cloud-support/tests/unit/gapic/support_v2/test_support_event_subscription_service.py
+++ b/packages/google-cloud-support/tests/unit/gapic/support_v2/test_support_event_subscription_service.py
@@ -3890,6 +3890,349 @@ async def test_undelete_support_event_subscription_field_headers_async():
     ) in kw["metadata"]
 
 
+@pytest.mark.parametrize(
+    "request_type",
+    [
+        support_event_subscription_service.ExpungeSupportEventSubscriptionRequest(),
+        {},
+    ],
+)
+def test_expunge_support_event_subscription(request_type, transport: str = "grpc"):
+    client = SupportEventSubscriptionServiceClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport=transport,
+    )
+
+    # Everything is optional in proto3 as far as the runtime is concerned,
+    # and we are mocking out the actual API, so just send an empty request.
+    request = request_type
+
+    # Mock the actual call within the gRPC stub, and fake the request.
+    with mock.patch.object(
+        type(client.transport.expunge_support_event_subscription), "__call__"
+    ) as call:
+        # Designate an appropriate return value for the call.
+        call.return_value = None
+        response = client.expunge_support_event_subscription(request)
+
+        # Establish that the underlying gRPC stub method was called.
+        assert len(call.mock_calls) == 1
+        _, args, _ = call.mock_calls[0]
+        request = (
+            support_event_subscription_service.ExpungeSupportEventSubscriptionRequest()
+        )
+        assert args[0] == request
+
+    # Establish that the response is the type that we expect.
+    assert response is None
+
+
+def test_expunge_support_event_subscription_non_empty_request_with_auto_populated_field():
+    # This test is a coverage failsafe to make sure that UUID4 fields are
+    # automatically populated, according to AIP-4235, with non-empty requests.
+    client = SupportEventSubscriptionServiceClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
+    )
+
+    # Populate all string fields in the request which are not UUID4
+    # since we want to check that UUID4 are populated automatically
+    # if they meet the requirements of AIP 4235.
+    request = support_event_subscription_service.ExpungeSupportEventSubscriptionRequest(
+        name="name_value",
+    )
+
+    # Mock the actual call within the gRPC stub, and fake the request.
+    with mock.patch.object(
+        type(client.transport.expunge_support_event_subscription), "__call__"
+    ) as call:
+        call.return_value.name = (
+            "foo"  # operation_request.operation in compute client(s) expect a string.
+        )
+        client.expunge_support_event_subscription(request=request)
+        call.assert_called()
+        _, args, _ = call.mock_calls[0]
+        request_msg = (
+            support_event_subscription_service.ExpungeSupportEventSubscriptionRequest(
+                name="name_value",
+            )
+        )
+        assert args[0] == request_msg
+
+
+def test_expunge_support_event_subscription_use_cached_wrapped_rpc():
+    # Clients should use _prep_wrapped_messages to create cached wrapped rpcs,
+    # instead of constructing them on each call
+    with mock.patch("google.api_core.gapic_v1.method.wrap_method") as wrapper_fn:
+        client = SupportEventSubscriptionServiceClient(
+            credentials=ga_credentials.AnonymousCredentials(),
+            transport="grpc",
+        )
+
+        # Should wrap all calls on client creation
+        assert wrapper_fn.call_count > 0
+        wrapper_fn.reset_mock()
+
+        # Ensure method has been cached
+        assert (
+            client._transport.expunge_support_event_subscription
+            in client._transport._wrapped_methods
+        )
+
+        # Replace cached wrapped function with mock
+        mock_rpc = mock.Mock()
+        mock_rpc.return_value.name = (
+            "foo"  # operation_request.operation in compute client(s) expect a string.
+        )
+        client._transport._wrapped_methods[
+            client._transport.expunge_support_event_subscription
+        ] = mock_rpc
+        request = {}
+        client.expunge_support_event_subscription(request)
+
+        # Establish that the underlying gRPC stub method was called.
+        assert mock_rpc.call_count == 1
+
+        client.expunge_support_event_subscription(request)
+
+        # Establish that a new wrapper was not created for this call
+        assert wrapper_fn.call_count == 0
+        assert mock_rpc.call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_expunge_support_event_subscription_async_use_cached_wrapped_rpc(
+    transport: str = "grpc_asyncio",
+):
+    # Clients should use _prep_wrapped_messages to create cached wrapped rpcs,
+    # instead of constructing them on each call
+    with mock.patch("google.api_core.gapic_v1.method_async.wrap_method") as wrapper_fn:
+        client = SupportEventSubscriptionServiceAsyncClient(
+            credentials=async_anonymous_credentials(),
+            transport=transport,
+        )
+
+        # Should wrap all calls on client creation
+        assert wrapper_fn.call_count > 0
+        wrapper_fn.reset_mock()
+
+        # Ensure method has been cached
+        assert (
+            client._client._transport.expunge_support_event_subscription
+            in client._client._transport._wrapped_methods
+        )
+
+        # Replace cached wrapped function with mock
+        mock_rpc = mock.AsyncMock()
+        mock_rpc.return_value = mock.Mock()
+        client._client._transport._wrapped_methods[
+            client._client._transport.expunge_support_event_subscription
+        ] = mock_rpc
+
+        request = {}
+        await client.expunge_support_event_subscription(request)
+
+        # Establish that the underlying gRPC stub method was called.
+        assert mock_rpc.call_count == 1
+
+        await client.expunge_support_event_subscription(request)
+
+        # Establish that a new wrapper was not created for this call
+        assert wrapper_fn.call_count == 0
+        assert mock_rpc.call_count == 2
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "request_type",
+    [
+        support_event_subscription_service.ExpungeSupportEventSubscriptionRequest(),
+        {},
+    ],
+)
+async def test_expunge_support_event_subscription_async(
+    request_type, transport: str = "grpc_asyncio"
+):
+    client = SupportEventSubscriptionServiceAsyncClient(
+        credentials=async_anonymous_credentials(),
+        transport=transport,
+    )
+
+    # Everything is optional in proto3 as far as the runtime is concerned,
+    # and we are mocking out the actual API, so just send an empty request.
+    request = request_type
+
+    # Mock the actual call within the gRPC stub, and fake the request.
+    with mock.patch.object(
+        type(client.transport.expunge_support_event_subscription), "__call__"
+    ) as call:
+        # Designate an appropriate return value for the call.
+        call.return_value = grpc_helpers_async.FakeUnaryUnaryCall(None)
+        response = await client.expunge_support_event_subscription(request)
+
+        # Establish that the underlying gRPC stub method was called.
+        assert len(call.mock_calls)
+        _, args, _ = call.mock_calls[0]
+        request = (
+            support_event_subscription_service.ExpungeSupportEventSubscriptionRequest()
+        )
+        assert args[0] == request
+
+    # Establish that the response is the type that we expect.
+    assert response is None
+
+
+def test_expunge_support_event_subscription_field_headers():
+    client = SupportEventSubscriptionServiceClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+    )
+
+    # Any value that is part of the HTTP/1.1 URI should be sent as
+    # a field header. Set these to a non-empty value.
+    request = (
+        support_event_subscription_service.ExpungeSupportEventSubscriptionRequest()
+    )
+
+    request.name = "name_value"
+
+    # Mock the actual call within the gRPC stub, and fake the request.
+    with mock.patch.object(
+        type(client.transport.expunge_support_event_subscription), "__call__"
+    ) as call:
+        call.return_value = None
+        client.expunge_support_event_subscription(request)
+
+        # Establish that the underlying gRPC stub method was called.
+        assert len(call.mock_calls) == 1
+        _, args, _ = call.mock_calls[0]
+        assert args[0] == request
+
+    # Establish that the field header was sent.
+    _, _, kw = call.mock_calls[0]
+    assert (
+        "x-goog-request-params",
+        "name=name_value",
+    ) in kw["metadata"]
+
+
+@pytest.mark.asyncio
+async def test_expunge_support_event_subscription_field_headers_async():
+    client = SupportEventSubscriptionServiceAsyncClient(
+        credentials=async_anonymous_credentials(),
+    )
+
+    # Any value that is part of the HTTP/1.1 URI should be sent as
+    # a field header. Set these to a non-empty value.
+    request = (
+        support_event_subscription_service.ExpungeSupportEventSubscriptionRequest()
+    )
+
+    request.name = "name_value"
+
+    # Mock the actual call within the gRPC stub, and fake the request.
+    with mock.patch.object(
+        type(client.transport.expunge_support_event_subscription), "__call__"
+    ) as call:
+        call.return_value = grpc_helpers_async.FakeUnaryUnaryCall(None)
+        await client.expunge_support_event_subscription(request)
+
+        # Establish that the underlying gRPC stub method was called.
+        assert len(call.mock_calls)
+        _, args, _ = call.mock_calls[0]
+        assert args[0] == request
+
+    # Establish that the field header was sent.
+    _, _, kw = call.mock_calls[0]
+    assert (
+        "x-goog-request-params",
+        "name=name_value",
+    ) in kw["metadata"]
+
+
+def test_expunge_support_event_subscription_flattened():
+    client = SupportEventSubscriptionServiceClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+    )
+
+    # Mock the actual call within the gRPC stub, and fake the request.
+    with mock.patch.object(
+        type(client.transport.expunge_support_event_subscription), "__call__"
+    ) as call:
+        # Designate an appropriate return value for the call.
+        call.return_value = None
+        # Call the method with a truthy value for each flattened field,
+        # using the keyword arguments to the method.
+        client.expunge_support_event_subscription(
+            name="name_value",
+        )
+
+        # Establish that the underlying call was made with the expected
+        # request object values.
+        assert len(call.mock_calls) == 1
+        _, args, _ = call.mock_calls[0]
+        arg = args[0].name
+        mock_val = "name_value"
+        assert arg == mock_val
+
+
+def test_expunge_support_event_subscription_flattened_error():
+    client = SupportEventSubscriptionServiceClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+    )
+
+    # Attempting to call a method with both a request object and flattened
+    # fields is an error.
+    with pytest.raises(ValueError):
+        client.expunge_support_event_subscription(
+            support_event_subscription_service.ExpungeSupportEventSubscriptionRequest(),
+            name="name_value",
+        )
+
+
+@pytest.mark.asyncio
+async def test_expunge_support_event_subscription_flattened_async():
+    client = SupportEventSubscriptionServiceAsyncClient(
+        credentials=async_anonymous_credentials(),
+    )
+
+    # Mock the actual call within the gRPC stub, and fake the request.
+    with mock.patch.object(
+        type(client.transport.expunge_support_event_subscription), "__call__"
+    ) as call:
+        # Designate an appropriate return value for the call.
+        call.return_value = None
+
+        call.return_value = grpc_helpers_async.FakeUnaryUnaryCall(None)
+        # Call the method with a truthy value for each flattened field,
+        # using the keyword arguments to the method.
+        response = await client.expunge_support_event_subscription(
+            name="name_value",
+        )
+
+        # Establish that the underlying call was made with the expected
+        # request object values.
+        assert len(call.mock_calls)
+        _, args, _ = call.mock_calls[0]
+        arg = args[0].name
+        mock_val = "name_value"
+        assert arg == mock_val
+
+
+@pytest.mark.asyncio
+async def test_expunge_support_event_subscription_flattened_error_async():
+    client = SupportEventSubscriptionServiceAsyncClient(
+        credentials=async_anonymous_credentials(),
+    )
+
+    # Attempting to call a method with both a request object and flattened
+    # fields is an error.
+    with pytest.raises(ValueError):
+        await client.expunge_support_event_subscription(
+            support_event_subscription_service.ExpungeSupportEventSubscriptionRequest(),
+            name="name_value",
+        )
+
+
 def test_create_support_event_subscription_rest_use_cached_wrapped_rpc():
     # Clients should use _prep_wrapped_messages to create cached wrapped rpcs,
     # instead of constructing them on each call
@@ -4040,7 +4383,7 @@ def test_create_support_event_subscription_rest_flattened():
         return_value = gcs_support_event_subscription.SupportEventSubscription()
 
         # get arguments that satisfy an http rule for this method
-        sample_request = {"parent": "sample1/sample2"}
+        sample_request = {"parent": "organizations/sample1"}
 
         # get truthy value for each flattened field
         mock_args = dict(
@@ -4070,7 +4413,8 @@ def test_create_support_event_subscription_rest_flattened():
         assert len(req.mock_calls) == 1
         _, args, _ = req.mock_calls[0]
         assert path_template.validate(
-            "%s/v2/{parent=*/*}/supportEventSubscriptions" % client.transport._host,
+            "%s/v2/{parent=organizations/*}/supportEventSubscriptions"
+            % client.transport._host,
             args[1],
         )
 
@@ -4236,7 +4580,9 @@ def test_get_support_event_subscription_rest_flattened():
         return_value = support_event_subscription.SupportEventSubscription()
 
         # get arguments that satisfy an http rule for this method
-        sample_request = {"name": "sample1/sample2/supportEventSubscriptions/sample3"}
+        sample_request = {
+            "name": "organizations/sample1/supportEventSubscriptions/sample2"
+        }
 
         # get truthy value for each flattened field
         mock_args = dict(
@@ -4263,7 +4609,8 @@ def test_get_support_event_subscription_rest_flattened():
         assert len(req.mock_calls) == 1
         _, args, _ = req.mock_calls[0]
         assert path_template.validate(
-            "%s/v2/{name=*/*/supportEventSubscriptions/*}" % client.transport._host,
+            "%s/v2/{name=organizations/*/supportEventSubscriptions/*}"
+            % client.transport._host,
             args[1],
         )
 
@@ -4447,7 +4794,7 @@ def test_list_support_event_subscriptions_rest_flattened():
         )
 
         # get arguments that satisfy an http rule for this method
-        sample_request = {"parent": "sample1/sample2"}
+        sample_request = {"parent": "organizations/sample1"}
 
         # get truthy value for each flattened field
         mock_args = dict(
@@ -4476,7 +4823,8 @@ def test_list_support_event_subscriptions_rest_flattened():
         assert len(req.mock_calls) == 1
         _, args, _ = req.mock_calls[0]
         assert path_template.validate(
-            "%s/v2/{parent=*/*}/supportEventSubscriptions" % client.transport._host,
+            "%s/v2/{parent=organizations/*}/supportEventSubscriptions"
+            % client.transport._host,
             args[1],
         )
 
@@ -4549,7 +4897,7 @@ def test_list_support_event_subscriptions_rest_pager(transport: str = "rest"):
             return_val.status_code = 200
         req.side_effect = return_values
 
-        sample_request = {"parent": "sample1/sample2"}
+        sample_request = {"parent": "organizations/sample1"}
 
         pager = client.list_support_event_subscriptions(request=sample_request)
 
@@ -4713,7 +5061,7 @@ def test_update_support_event_subscription_rest_flattened():
         # get arguments that satisfy an http rule for this method
         sample_request = {
             "support_event_subscription": {
-                "name": "sample1/sample2/supportEventSubscriptions/sample3"
+                "name": "organizations/sample1/supportEventSubscriptions/sample2"
             }
         }
 
@@ -4745,7 +5093,7 @@ def test_update_support_event_subscription_rest_flattened():
         assert len(req.mock_calls) == 1
         _, args, _ = req.mock_calls[0]
         assert path_template.validate(
-            "%s/v2/{support_event_subscription.name=*/*/supportEventSubscriptions/*}"
+            "%s/v2/{support_event_subscription.name=organizations/*/supportEventSubscriptions/*}"
             % client.transport._host,
             args[1],
         )
@@ -4912,7 +5260,9 @@ def test_delete_support_event_subscription_rest_flattened():
         return_value = support_event_subscription.SupportEventSubscription()
 
         # get arguments that satisfy an http rule for this method
-        sample_request = {"name": "sample1/sample2/supportEventSubscriptions/sample3"}
+        sample_request = {
+            "name": "organizations/sample1/supportEventSubscriptions/sample2"
+        }
 
         # get truthy value for each flattened field
         mock_args = dict(
@@ -4939,7 +5289,8 @@ def test_delete_support_event_subscription_rest_flattened():
         assert len(req.mock_calls) == 1
         _, args, _ = req.mock_calls[0]
         assert path_template.validate(
-            "%s/v2/{name=*/*/supportEventSubscriptions/*}" % client.transport._host,
+            "%s/v2/{name=organizations/*/supportEventSubscriptions/*}"
+            % client.transport._host,
             args[1],
         )
 
@@ -5089,6 +5440,191 @@ def test_undelete_support_event_subscription_rest_unset_required_fields():
         transport.undelete_support_event_subscription._get_unset_required_fields({})
     )
     assert set(unset_fields) == (set(()) & set(("name",)))
+
+
+def test_expunge_support_event_subscription_rest_use_cached_wrapped_rpc():
+    # Clients should use _prep_wrapped_messages to create cached wrapped rpcs,
+    # instead of constructing them on each call
+    with mock.patch("google.api_core.gapic_v1.method.wrap_method") as wrapper_fn:
+        client = SupportEventSubscriptionServiceClient(
+            credentials=ga_credentials.AnonymousCredentials(),
+            transport="rest",
+        )
+
+        # Should wrap all calls on client creation
+        assert wrapper_fn.call_count > 0
+        wrapper_fn.reset_mock()
+
+        # Ensure method has been cached
+        assert (
+            client._transport.expunge_support_event_subscription
+            in client._transport._wrapped_methods
+        )
+
+        # Replace cached wrapped function with mock
+        mock_rpc = mock.Mock()
+        mock_rpc.return_value.name = (
+            "foo"  # operation_request.operation in compute client(s) expect a string.
+        )
+        client._transport._wrapped_methods[
+            client._transport.expunge_support_event_subscription
+        ] = mock_rpc
+
+        request = {}
+        client.expunge_support_event_subscription(request)
+
+        # Establish that the underlying gRPC stub method was called.
+        assert mock_rpc.call_count == 1
+
+        client.expunge_support_event_subscription(request)
+
+        # Establish that a new wrapper was not created for this call
+        assert wrapper_fn.call_count == 0
+        assert mock_rpc.call_count == 2
+
+
+def test_expunge_support_event_subscription_rest_required_fields(
+    request_type=support_event_subscription_service.ExpungeSupportEventSubscriptionRequest,
+):
+    transport_class = transports.SupportEventSubscriptionServiceRestTransport
+
+    request_init = {}
+    request_init["name"] = ""
+    request = request_type(**request_init)
+    pb_request = request_type.pb(request)
+    jsonified_request = json.loads(
+        json_format.MessageToJson(pb_request, use_integers_for_enums=False)
+    )
+
+    # verify fields with default values are dropped
+
+    unset_fields = transport_class(
+        credentials=ga_credentials.AnonymousCredentials()
+    ).expunge_support_event_subscription._get_unset_required_fields(jsonified_request)
+    jsonified_request.update(unset_fields)
+
+    # verify required fields with default values are now present
+
+    jsonified_request["name"] = "name_value"
+
+    unset_fields = transport_class(
+        credentials=ga_credentials.AnonymousCredentials()
+    ).expunge_support_event_subscription._get_unset_required_fields(jsonified_request)
+    jsonified_request.update(unset_fields)
+
+    # verify required fields with non-default values are left alone
+    assert "name" in jsonified_request
+    assert jsonified_request["name"] == "name_value"
+
+    client = SupportEventSubscriptionServiceClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="rest",
+    )
+    request = request_type(**request_init)
+
+    # Designate an appropriate value for the returned response.
+    return_value = None
+    # Mock the http request call within the method and fake a response.
+    with mock.patch.object(Session, "request") as req:
+        # We need to mock transcode() because providing default values
+        # for required fields will fail the real version if the http_options
+        # expect actual values for those fields.
+        with mock.patch.object(path_template, "transcode") as transcode:
+            # A uri without fields and an empty body will force all the
+            # request fields to show up in the query_params.
+            pb_request = request_type.pb(request)
+            transcode_result = {
+                "uri": "v1/sample_method",
+                "method": "post",
+                "query_params": pb_request,
+            }
+            transcode_result["body"] = pb_request
+            transcode.return_value = transcode_result
+
+            response_value = Response()
+            response_value.status_code = 200
+            json_return_value = ""
+
+            response_value._content = json_return_value.encode("UTF-8")
+            req.return_value = response_value
+            req.return_value.headers = {"header-1": "value-1", "header-2": "value-2"}
+
+            response = client.expunge_support_event_subscription(request)
+
+            expected_params = [("$alt", "json;enum-encoding=int")]
+            actual_params = req.call_args.kwargs["params"]
+            assert sorted(expected_params) == sorted(actual_params)
+
+
+def test_expunge_support_event_subscription_rest_unset_required_fields():
+    transport = transports.SupportEventSubscriptionServiceRestTransport(
+        credentials=ga_credentials.AnonymousCredentials
+    )
+
+    unset_fields = (
+        transport.expunge_support_event_subscription._get_unset_required_fields({})
+    )
+    assert set(unset_fields) == (set(()) & set(("name",)))
+
+
+def test_expunge_support_event_subscription_rest_flattened():
+    client = SupportEventSubscriptionServiceClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="rest",
+    )
+
+    # Mock the http request call within the method and fake a response.
+    with mock.patch.object(type(client.transport._session), "request") as req:
+        # Designate an appropriate value for the returned response.
+        return_value = None
+
+        # get arguments that satisfy an http rule for this method
+        sample_request = {
+            "name": "organizations/sample1/supportEventSubscriptions/sample2"
+        }
+
+        # get truthy value for each flattened field
+        mock_args = dict(
+            name="name_value",
+        )
+        mock_args.update(sample_request)
+
+        # Wrap the value into a proper Response obj
+        response_value = Response()
+        response_value.status_code = 200
+        json_return_value = ""
+        response_value._content = json_return_value.encode("UTF-8")
+        req.return_value = response_value
+        req.return_value.headers = {"header-1": "value-1", "header-2": "value-2"}
+
+        client.expunge_support_event_subscription(**mock_args)
+
+        # Establish that the underlying call was made with the expected
+        # request object values.
+        assert len(req.mock_calls) == 1
+        _, args, _ = req.mock_calls[0]
+        assert path_template.validate(
+            "%s/v2/{name=organizations/*/supportEventSubscriptions/*}:expunge"
+            % client.transport._host,
+            args[1],
+        )
+
+
+def test_expunge_support_event_subscription_rest_flattened_error(
+    transport: str = "rest",
+):
+    client = SupportEventSubscriptionServiceClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport=transport,
+    )
+
+    # Attempting to call a method with both a request object and flattened
+    # fields is an error.
+    with pytest.raises(ValueError):
+        client.expunge_support_event_subscription(
+            support_event_subscription_service.ExpungeSupportEventSubscriptionRequest(),
+            name="name_value",
+        )
 
 
 def test_credentials_transport_error():
@@ -5343,6 +5879,30 @@ def test_undelete_support_event_subscription_empty_call_grpc():
         assert args[0] == request_msg
 
 
+# This test is a coverage failsafe to make sure that totally empty calls,
+# i.e. request == None and no flattened fields passed, work.
+def test_expunge_support_event_subscription_empty_call_grpc():
+    client = SupportEventSubscriptionServiceClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
+    )
+
+    # Mock the actual call, and fake the request.
+    with mock.patch.object(
+        type(client.transport.expunge_support_event_subscription), "__call__"
+    ) as call:
+        call.return_value = None
+        client.expunge_support_event_subscription(request=None)
+
+        # Establish that the underlying stub method was called.
+        call.assert_called()
+        _, args, _ = call.mock_calls[0]
+        request_msg = (
+            support_event_subscription_service.ExpungeSupportEventSubscriptionRequest()
+        )
+        assert args[0] == request_msg
+
+
 def test_transport_kind_grpc_asyncio():
     transport = SupportEventSubscriptionServiceAsyncClient.get_transport_class(
         "grpc_asyncio"
@@ -5552,6 +6112,32 @@ async def test_undelete_support_event_subscription_empty_call_grpc_asyncio():
         assert args[0] == request_msg
 
 
+# This test is a coverage failsafe to make sure that totally empty calls,
+# i.e. request == None and no flattened fields passed, work.
+@pytest.mark.asyncio
+async def test_expunge_support_event_subscription_empty_call_grpc_asyncio():
+    client = SupportEventSubscriptionServiceAsyncClient(
+        credentials=async_anonymous_credentials(),
+        transport="grpc_asyncio",
+    )
+
+    # Mock the actual call, and fake the request.
+    with mock.patch.object(
+        type(client.transport.expunge_support_event_subscription), "__call__"
+    ) as call:
+        # Designate an appropriate return value for the call.
+        call.return_value = grpc_helpers_async.FakeUnaryUnaryCall(None)
+        await client.expunge_support_event_subscription(request=None)
+
+        # Establish that the underlying stub method was called.
+        call.assert_called()
+        _, args, _ = call.mock_calls[0]
+        request_msg = (
+            support_event_subscription_service.ExpungeSupportEventSubscriptionRequest()
+        )
+        assert args[0] == request_msg
+
+
 def test_transport_kind_rest():
     transport = SupportEventSubscriptionServiceClient.get_transport_class("rest")(
         credentials=ga_credentials.AnonymousCredentials()
@@ -5566,7 +6152,7 @@ def test_create_support_event_subscription_rest_bad_request(
         credentials=ga_credentials.AnonymousCredentials(), transport="rest"
     )
     # send a request that will satisfy transcoding
-    request_init = {"parent": "sample1/sample2"}
+    request_init = {"parent": "organizations/sample1"}
     request = request_type(**request_init)
 
     # Mock the http request call within the method and fake a BadRequest error.
@@ -5598,7 +6184,7 @@ def test_create_support_event_subscription_rest_call_success(request_type):
     )
 
     # send a request that will satisfy transcoding
-    request_init = {"parent": "sample1/sample2"}
+    request_init = {"parent": "organizations/sample1"}
     request_init["support_event_subscription"] = {
         "name": "name_value",
         "pub_sub_topic": "pub_sub_topic_value",
@@ -5803,7 +6389,7 @@ def test_get_support_event_subscription_rest_bad_request(
         credentials=ga_credentials.AnonymousCredentials(), transport="rest"
     )
     # send a request that will satisfy transcoding
-    request_init = {"name": "sample1/sample2/supportEventSubscriptions/sample3"}
+    request_init = {"name": "organizations/sample1/supportEventSubscriptions/sample2"}
     request = request_type(**request_init)
 
     # Mock the http request call within the method and fake a BadRequest error.
@@ -5835,7 +6421,7 @@ def test_get_support_event_subscription_rest_call_success(request_type):
     )
 
     # send a request that will satisfy transcoding
-    request_init = {"name": "sample1/sample2/supportEventSubscriptions/sample3"}
+    request_init = {"name": "organizations/sample1/supportEventSubscriptions/sample2"}
     request = request_type(**request_init)
 
     # Mock the http request call within the method and fake a response.
@@ -5959,7 +6545,7 @@ def test_list_support_event_subscriptions_rest_bad_request(
         credentials=ga_credentials.AnonymousCredentials(), transport="rest"
     )
     # send a request that will satisfy transcoding
-    request_init = {"parent": "sample1/sample2"}
+    request_init = {"parent": "organizations/sample1"}
     request = request_type(**request_init)
 
     # Mock the http request call within the method and fake a BadRequest error.
@@ -5991,7 +6577,7 @@ def test_list_support_event_subscriptions_rest_call_success(request_type):
     )
 
     # send a request that will satisfy transcoding
-    request_init = {"parent": "sample1/sample2"}
+    request_init = {"parent": "organizations/sample1"}
     request = request_type(**request_init)
 
     # Mock the http request call within the method and fake a response.
@@ -6109,7 +6695,7 @@ def test_update_support_event_subscription_rest_bad_request(
     # send a request that will satisfy transcoding
     request_init = {
         "support_event_subscription": {
-            "name": "sample1/sample2/supportEventSubscriptions/sample3"
+            "name": "organizations/sample1/supportEventSubscriptions/sample2"
         }
     }
     request = request_type(**request_init)
@@ -6145,11 +6731,11 @@ def test_update_support_event_subscription_rest_call_success(request_type):
     # send a request that will satisfy transcoding
     request_init = {
         "support_event_subscription": {
-            "name": "sample1/sample2/supportEventSubscriptions/sample3"
+            "name": "organizations/sample1/supportEventSubscriptions/sample2"
         }
     }
     request_init["support_event_subscription"] = {
-        "name": "sample1/sample2/supportEventSubscriptions/sample3",
+        "name": "organizations/sample1/supportEventSubscriptions/sample2",
         "pub_sub_topic": "pub_sub_topic_value",
         "state": 1,
         "failure_reason": 1,
@@ -6352,7 +6938,7 @@ def test_delete_support_event_subscription_rest_bad_request(
         credentials=ga_credentials.AnonymousCredentials(), transport="rest"
     )
     # send a request that will satisfy transcoding
-    request_init = {"name": "sample1/sample2/supportEventSubscriptions/sample3"}
+    request_init = {"name": "organizations/sample1/supportEventSubscriptions/sample2"}
     request = request_type(**request_init)
 
     # Mock the http request call within the method and fake a BadRequest error.
@@ -6384,7 +6970,7 @@ def test_delete_support_event_subscription_rest_call_success(request_type):
     )
 
     # send a request that will satisfy transcoding
-    request_init = {"name": "sample1/sample2/supportEventSubscriptions/sample3"}
+    request_init = {"name": "organizations/sample1/supportEventSubscriptions/sample2"}
     request = request_type(**request_init)
 
     # Mock the http request call within the method and fake a response.
@@ -6506,7 +7092,7 @@ def test_undelete_support_event_subscription_rest_bad_request(
         credentials=ga_credentials.AnonymousCredentials(), transport="rest"
     )
     # send a request that will satisfy transcoding
-    request_init = {"name": "sample1/sample2/supportEventSubscriptions/sample3"}
+    request_init = {"name": "organizations/sample1/supportEventSubscriptions/sample2"}
     request = request_type(**request_init)
 
     # Mock the http request call within the method and fake a BadRequest error.
@@ -6538,7 +7124,7 @@ def test_undelete_support_event_subscription_rest_call_success(request_type):
     )
 
     # send a request that will satisfy transcoding
-    request_init = {"name": "sample1/sample2/supportEventSubscriptions/sample3"}
+    request_init = {"name": "organizations/sample1/supportEventSubscriptions/sample2"}
     request = request_type(**request_init)
 
     # Mock the http request call within the method and fake a response.
@@ -6651,6 +7237,119 @@ def test_undelete_support_event_subscription_rest_interceptors(null_interceptor)
         pre.assert_called_once()
         post.assert_called_once()
         post_with_metadata.assert_called_once()
+
+
+def test_expunge_support_event_subscription_rest_bad_request(
+    request_type=support_event_subscription_service.ExpungeSupportEventSubscriptionRequest,
+):
+    client = SupportEventSubscriptionServiceClient(
+        credentials=ga_credentials.AnonymousCredentials(), transport="rest"
+    )
+    # send a request that will satisfy transcoding
+    request_init = {"name": "organizations/sample1/supportEventSubscriptions/sample2"}
+    request = request_type(**request_init)
+
+    # Mock the http request call within the method and fake a BadRequest error.
+    with (
+        mock.patch.object(Session, "request") as req,
+        pytest.raises(core_exceptions.BadRequest),
+    ):
+        # Wrap the value into a proper Response obj
+        response_value = mock.Mock()
+        json_return_value = ""
+        response_value.json = mock.Mock(return_value={})
+        response_value.status_code = 400
+        response_value.request = mock.Mock()
+        req.return_value = response_value
+        req.return_value.headers = {"header-1": "value-1", "header-2": "value-2"}
+        client.expunge_support_event_subscription(request)
+
+
+@pytest.mark.parametrize(
+    "request_type",
+    [
+        support_event_subscription_service.ExpungeSupportEventSubscriptionRequest,
+        dict,
+    ],
+)
+def test_expunge_support_event_subscription_rest_call_success(request_type):
+    client = SupportEventSubscriptionServiceClient(
+        credentials=ga_credentials.AnonymousCredentials(), transport="rest"
+    )
+
+    # send a request that will satisfy transcoding
+    request_init = {"name": "organizations/sample1/supportEventSubscriptions/sample2"}
+    request = request_type(**request_init)
+
+    # Mock the http request call within the method and fake a response.
+    with mock.patch.object(type(client.transport._session), "request") as req:
+        # Designate an appropriate value for the returned response.
+        return_value = None
+
+        # Wrap the value into a proper Response obj
+        response_value = mock.Mock()
+        response_value.status_code = 200
+        json_return_value = ""
+        response_value.content = json_return_value.encode("UTF-8")
+        req.return_value = response_value
+        req.return_value.headers = {"header-1": "value-1", "header-2": "value-2"}
+        response = client.expunge_support_event_subscription(request)
+
+    # Establish that the response is the type that we expect.
+    assert response is None
+
+
+@pytest.mark.parametrize("null_interceptor", [True, False])
+def test_expunge_support_event_subscription_rest_interceptors(null_interceptor):
+    transport = transports.SupportEventSubscriptionServiceRestTransport(
+        credentials=ga_credentials.AnonymousCredentials(),
+        interceptor=None
+        if null_interceptor
+        else transports.SupportEventSubscriptionServiceRestInterceptor(),
+    )
+    client = SupportEventSubscriptionServiceClient(transport=transport)
+
+    with (
+        mock.patch.object(type(client.transport._session), "request") as req,
+        mock.patch.object(path_template, "transcode") as transcode,
+        mock.patch.object(
+            transports.SupportEventSubscriptionServiceRestInterceptor,
+            "pre_expunge_support_event_subscription",
+        ) as pre,
+    ):
+        pre.assert_not_called()
+        pb_message = support_event_subscription_service.ExpungeSupportEventSubscriptionRequest.pb(
+            support_event_subscription_service.ExpungeSupportEventSubscriptionRequest()
+        )
+        transcode.return_value = {
+            "method": "post",
+            "uri": "my_uri",
+            "body": pb_message,
+            "query_params": pb_message,
+        }
+
+        req.return_value = mock.Mock()
+        req.return_value.status_code = 200
+        req.return_value.headers = {"header-1": "value-1", "header-2": "value-2"}
+
+        request = (
+            support_event_subscription_service.ExpungeSupportEventSubscriptionRequest()
+        )
+        metadata = [
+            ("key", "val"),
+            ("cephalopod", "squid"),
+        ]
+        pre.return_value = request, metadata
+
+        client.expunge_support_event_subscription(
+            request,
+            metadata=[
+                ("key", "val"),
+                ("cephalopod", "squid"),
+            ],
+        )
+
+        pre.assert_called_once()
 
 
 def test_initialize_client_w_rest():
@@ -6798,6 +7497,29 @@ def test_undelete_support_event_subscription_empty_call_rest():
         assert args[0] == request_msg
 
 
+# This test is a coverage failsafe to make sure that totally empty calls,
+# i.e. request == None and no flattened fields passed, work.
+def test_expunge_support_event_subscription_empty_call_rest():
+    client = SupportEventSubscriptionServiceClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="rest",
+    )
+
+    # Mock the actual call, and fake the request.
+    with mock.patch.object(
+        type(client.transport.expunge_support_event_subscription), "__call__"
+    ) as call:
+        client.expunge_support_event_subscription(request=None)
+
+        # Establish that the underlying stub method was called.
+        call.assert_called()
+        _, args, _ = call.mock_calls[0]
+        request_msg = (
+            support_event_subscription_service.ExpungeSupportEventSubscriptionRequest()
+        )
+        assert args[0] == request_msg
+
+
 def test_transport_grpc_default():
     # A client should use the gRPC transport by default.
     client = SupportEventSubscriptionServiceClient(
@@ -6837,6 +7559,7 @@ def test_support_event_subscription_service_base_transport():
         "update_support_event_subscription",
         "delete_support_event_subscription",
         "undelete_support_event_subscription",
+        "expunge_support_event_subscription",
     )
     for method in methods:
         with pytest.raises(NotImplementedError):
@@ -7130,6 +7853,9 @@ def test_support_event_subscription_service_client_transport_session_collision(
     assert session1 != session2
     session1 = client1.transport.undelete_support_event_subscription._session
     session2 = client2.transport.undelete_support_event_subscription._session
+    assert session1 != session2
+    session1 = client1.transport.expunge_support_event_subscription._session
+    session2 = client2.transport.expunge_support_event_subscription._session
     assert session1 != session2
 
 

--- a/packages/google-cloud-support/tests/unit/gapic/support_v2beta/test_support_event_subscription_service.py
+++ b/packages/google-cloud-support/tests/unit/gapic/support_v2beta/test_support_event_subscription_service.py
@@ -3890,6 +3890,349 @@ async def test_undelete_support_event_subscription_field_headers_async():
     ) in kw["metadata"]
 
 
+@pytest.mark.parametrize(
+    "request_type",
+    [
+        support_event_subscription_service.ExpungeSupportEventSubscriptionRequest(),
+        {},
+    ],
+)
+def test_expunge_support_event_subscription(request_type, transport: str = "grpc"):
+    client = SupportEventSubscriptionServiceClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport=transport,
+    )
+
+    # Everything is optional in proto3 as far as the runtime is concerned,
+    # and we are mocking out the actual API, so just send an empty request.
+    request = request_type
+
+    # Mock the actual call within the gRPC stub, and fake the request.
+    with mock.patch.object(
+        type(client.transport.expunge_support_event_subscription), "__call__"
+    ) as call:
+        # Designate an appropriate return value for the call.
+        call.return_value = None
+        response = client.expunge_support_event_subscription(request)
+
+        # Establish that the underlying gRPC stub method was called.
+        assert len(call.mock_calls) == 1
+        _, args, _ = call.mock_calls[0]
+        request = (
+            support_event_subscription_service.ExpungeSupportEventSubscriptionRequest()
+        )
+        assert args[0] == request
+
+    # Establish that the response is the type that we expect.
+    assert response is None
+
+
+def test_expunge_support_event_subscription_non_empty_request_with_auto_populated_field():
+    # This test is a coverage failsafe to make sure that UUID4 fields are
+    # automatically populated, according to AIP-4235, with non-empty requests.
+    client = SupportEventSubscriptionServiceClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
+    )
+
+    # Populate all string fields in the request which are not UUID4
+    # since we want to check that UUID4 are populated automatically
+    # if they meet the requirements of AIP 4235.
+    request = support_event_subscription_service.ExpungeSupportEventSubscriptionRequest(
+        name="name_value",
+    )
+
+    # Mock the actual call within the gRPC stub, and fake the request.
+    with mock.patch.object(
+        type(client.transport.expunge_support_event_subscription), "__call__"
+    ) as call:
+        call.return_value.name = (
+            "foo"  # operation_request.operation in compute client(s) expect a string.
+        )
+        client.expunge_support_event_subscription(request=request)
+        call.assert_called()
+        _, args, _ = call.mock_calls[0]
+        request_msg = (
+            support_event_subscription_service.ExpungeSupportEventSubscriptionRequest(
+                name="name_value",
+            )
+        )
+        assert args[0] == request_msg
+
+
+def test_expunge_support_event_subscription_use_cached_wrapped_rpc():
+    # Clients should use _prep_wrapped_messages to create cached wrapped rpcs,
+    # instead of constructing them on each call
+    with mock.patch("google.api_core.gapic_v1.method.wrap_method") as wrapper_fn:
+        client = SupportEventSubscriptionServiceClient(
+            credentials=ga_credentials.AnonymousCredentials(),
+            transport="grpc",
+        )
+
+        # Should wrap all calls on client creation
+        assert wrapper_fn.call_count > 0
+        wrapper_fn.reset_mock()
+
+        # Ensure method has been cached
+        assert (
+            client._transport.expunge_support_event_subscription
+            in client._transport._wrapped_methods
+        )
+
+        # Replace cached wrapped function with mock
+        mock_rpc = mock.Mock()
+        mock_rpc.return_value.name = (
+            "foo"  # operation_request.operation in compute client(s) expect a string.
+        )
+        client._transport._wrapped_methods[
+            client._transport.expunge_support_event_subscription
+        ] = mock_rpc
+        request = {}
+        client.expunge_support_event_subscription(request)
+
+        # Establish that the underlying gRPC stub method was called.
+        assert mock_rpc.call_count == 1
+
+        client.expunge_support_event_subscription(request)
+
+        # Establish that a new wrapper was not created for this call
+        assert wrapper_fn.call_count == 0
+        assert mock_rpc.call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_expunge_support_event_subscription_async_use_cached_wrapped_rpc(
+    transport: str = "grpc_asyncio",
+):
+    # Clients should use _prep_wrapped_messages to create cached wrapped rpcs,
+    # instead of constructing them on each call
+    with mock.patch("google.api_core.gapic_v1.method_async.wrap_method") as wrapper_fn:
+        client = SupportEventSubscriptionServiceAsyncClient(
+            credentials=async_anonymous_credentials(),
+            transport=transport,
+        )
+
+        # Should wrap all calls on client creation
+        assert wrapper_fn.call_count > 0
+        wrapper_fn.reset_mock()
+
+        # Ensure method has been cached
+        assert (
+            client._client._transport.expunge_support_event_subscription
+            in client._client._transport._wrapped_methods
+        )
+
+        # Replace cached wrapped function with mock
+        mock_rpc = mock.AsyncMock()
+        mock_rpc.return_value = mock.Mock()
+        client._client._transport._wrapped_methods[
+            client._client._transport.expunge_support_event_subscription
+        ] = mock_rpc
+
+        request = {}
+        await client.expunge_support_event_subscription(request)
+
+        # Establish that the underlying gRPC stub method was called.
+        assert mock_rpc.call_count == 1
+
+        await client.expunge_support_event_subscription(request)
+
+        # Establish that a new wrapper was not created for this call
+        assert wrapper_fn.call_count == 0
+        assert mock_rpc.call_count == 2
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "request_type",
+    [
+        support_event_subscription_service.ExpungeSupportEventSubscriptionRequest(),
+        {},
+    ],
+)
+async def test_expunge_support_event_subscription_async(
+    request_type, transport: str = "grpc_asyncio"
+):
+    client = SupportEventSubscriptionServiceAsyncClient(
+        credentials=async_anonymous_credentials(),
+        transport=transport,
+    )
+
+    # Everything is optional in proto3 as far as the runtime is concerned,
+    # and we are mocking out the actual API, so just send an empty request.
+    request = request_type
+
+    # Mock the actual call within the gRPC stub, and fake the request.
+    with mock.patch.object(
+        type(client.transport.expunge_support_event_subscription), "__call__"
+    ) as call:
+        # Designate an appropriate return value for the call.
+        call.return_value = grpc_helpers_async.FakeUnaryUnaryCall(None)
+        response = await client.expunge_support_event_subscription(request)
+
+        # Establish that the underlying gRPC stub method was called.
+        assert len(call.mock_calls)
+        _, args, _ = call.mock_calls[0]
+        request = (
+            support_event_subscription_service.ExpungeSupportEventSubscriptionRequest()
+        )
+        assert args[0] == request
+
+    # Establish that the response is the type that we expect.
+    assert response is None
+
+
+def test_expunge_support_event_subscription_field_headers():
+    client = SupportEventSubscriptionServiceClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+    )
+
+    # Any value that is part of the HTTP/1.1 URI should be sent as
+    # a field header. Set these to a non-empty value.
+    request = (
+        support_event_subscription_service.ExpungeSupportEventSubscriptionRequest()
+    )
+
+    request.name = "name_value"
+
+    # Mock the actual call within the gRPC stub, and fake the request.
+    with mock.patch.object(
+        type(client.transport.expunge_support_event_subscription), "__call__"
+    ) as call:
+        call.return_value = None
+        client.expunge_support_event_subscription(request)
+
+        # Establish that the underlying gRPC stub method was called.
+        assert len(call.mock_calls) == 1
+        _, args, _ = call.mock_calls[0]
+        assert args[0] == request
+
+    # Establish that the field header was sent.
+    _, _, kw = call.mock_calls[0]
+    assert (
+        "x-goog-request-params",
+        "name=name_value",
+    ) in kw["metadata"]
+
+
+@pytest.mark.asyncio
+async def test_expunge_support_event_subscription_field_headers_async():
+    client = SupportEventSubscriptionServiceAsyncClient(
+        credentials=async_anonymous_credentials(),
+    )
+
+    # Any value that is part of the HTTP/1.1 URI should be sent as
+    # a field header. Set these to a non-empty value.
+    request = (
+        support_event_subscription_service.ExpungeSupportEventSubscriptionRequest()
+    )
+
+    request.name = "name_value"
+
+    # Mock the actual call within the gRPC stub, and fake the request.
+    with mock.patch.object(
+        type(client.transport.expunge_support_event_subscription), "__call__"
+    ) as call:
+        call.return_value = grpc_helpers_async.FakeUnaryUnaryCall(None)
+        await client.expunge_support_event_subscription(request)
+
+        # Establish that the underlying gRPC stub method was called.
+        assert len(call.mock_calls)
+        _, args, _ = call.mock_calls[0]
+        assert args[0] == request
+
+    # Establish that the field header was sent.
+    _, _, kw = call.mock_calls[0]
+    assert (
+        "x-goog-request-params",
+        "name=name_value",
+    ) in kw["metadata"]
+
+
+def test_expunge_support_event_subscription_flattened():
+    client = SupportEventSubscriptionServiceClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+    )
+
+    # Mock the actual call within the gRPC stub, and fake the request.
+    with mock.patch.object(
+        type(client.transport.expunge_support_event_subscription), "__call__"
+    ) as call:
+        # Designate an appropriate return value for the call.
+        call.return_value = None
+        # Call the method with a truthy value for each flattened field,
+        # using the keyword arguments to the method.
+        client.expunge_support_event_subscription(
+            name="name_value",
+        )
+
+        # Establish that the underlying call was made with the expected
+        # request object values.
+        assert len(call.mock_calls) == 1
+        _, args, _ = call.mock_calls[0]
+        arg = args[0].name
+        mock_val = "name_value"
+        assert arg == mock_val
+
+
+def test_expunge_support_event_subscription_flattened_error():
+    client = SupportEventSubscriptionServiceClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+    )
+
+    # Attempting to call a method with both a request object and flattened
+    # fields is an error.
+    with pytest.raises(ValueError):
+        client.expunge_support_event_subscription(
+            support_event_subscription_service.ExpungeSupportEventSubscriptionRequest(),
+            name="name_value",
+        )
+
+
+@pytest.mark.asyncio
+async def test_expunge_support_event_subscription_flattened_async():
+    client = SupportEventSubscriptionServiceAsyncClient(
+        credentials=async_anonymous_credentials(),
+    )
+
+    # Mock the actual call within the gRPC stub, and fake the request.
+    with mock.patch.object(
+        type(client.transport.expunge_support_event_subscription), "__call__"
+    ) as call:
+        # Designate an appropriate return value for the call.
+        call.return_value = None
+
+        call.return_value = grpc_helpers_async.FakeUnaryUnaryCall(None)
+        # Call the method with a truthy value for each flattened field,
+        # using the keyword arguments to the method.
+        response = await client.expunge_support_event_subscription(
+            name="name_value",
+        )
+
+        # Establish that the underlying call was made with the expected
+        # request object values.
+        assert len(call.mock_calls)
+        _, args, _ = call.mock_calls[0]
+        arg = args[0].name
+        mock_val = "name_value"
+        assert arg == mock_val
+
+
+@pytest.mark.asyncio
+async def test_expunge_support_event_subscription_flattened_error_async():
+    client = SupportEventSubscriptionServiceAsyncClient(
+        credentials=async_anonymous_credentials(),
+    )
+
+    # Attempting to call a method with both a request object and flattened
+    # fields is an error.
+    with pytest.raises(ValueError):
+        await client.expunge_support_event_subscription(
+            support_event_subscription_service.ExpungeSupportEventSubscriptionRequest(),
+            name="name_value",
+        )
+
+
 def test_create_support_event_subscription_rest_use_cached_wrapped_rpc():
     # Clients should use _prep_wrapped_messages to create cached wrapped rpcs,
     # instead of constructing them on each call
@@ -4040,7 +4383,7 @@ def test_create_support_event_subscription_rest_flattened():
         return_value = gcs_support_event_subscription.SupportEventSubscription()
 
         # get arguments that satisfy an http rule for this method
-        sample_request = {"parent": "sample1/sample2"}
+        sample_request = {"parent": "organizations/sample1"}
 
         # get truthy value for each flattened field
         mock_args = dict(
@@ -4070,7 +4413,8 @@ def test_create_support_event_subscription_rest_flattened():
         assert len(req.mock_calls) == 1
         _, args, _ = req.mock_calls[0]
         assert path_template.validate(
-            "%s/v2beta/{parent=*/*}/supportEventSubscriptions" % client.transport._host,
+            "%s/v2beta/{parent=organizations/*}/supportEventSubscriptions"
+            % client.transport._host,
             args[1],
         )
 
@@ -4236,7 +4580,9 @@ def test_get_support_event_subscription_rest_flattened():
         return_value = support_event_subscription.SupportEventSubscription()
 
         # get arguments that satisfy an http rule for this method
-        sample_request = {"name": "sample1/sample2/supportEventSubscriptions/sample3"}
+        sample_request = {
+            "name": "organizations/sample1/supportEventSubscriptions/sample2"
+        }
 
         # get truthy value for each flattened field
         mock_args = dict(
@@ -4263,7 +4609,8 @@ def test_get_support_event_subscription_rest_flattened():
         assert len(req.mock_calls) == 1
         _, args, _ = req.mock_calls[0]
         assert path_template.validate(
-            "%s/v2beta/{name=*/*/supportEventSubscriptions/*}" % client.transport._host,
+            "%s/v2beta/{name=organizations/*/supportEventSubscriptions/*}"
+            % client.transport._host,
             args[1],
         )
 
@@ -4447,7 +4794,7 @@ def test_list_support_event_subscriptions_rest_flattened():
         )
 
         # get arguments that satisfy an http rule for this method
-        sample_request = {"parent": "sample1/sample2"}
+        sample_request = {"parent": "organizations/sample1"}
 
         # get truthy value for each flattened field
         mock_args = dict(
@@ -4476,7 +4823,8 @@ def test_list_support_event_subscriptions_rest_flattened():
         assert len(req.mock_calls) == 1
         _, args, _ = req.mock_calls[0]
         assert path_template.validate(
-            "%s/v2beta/{parent=*/*}/supportEventSubscriptions" % client.transport._host,
+            "%s/v2beta/{parent=organizations/*}/supportEventSubscriptions"
+            % client.transport._host,
             args[1],
         )
 
@@ -4549,7 +4897,7 @@ def test_list_support_event_subscriptions_rest_pager(transport: str = "rest"):
             return_val.status_code = 200
         req.side_effect = return_values
 
-        sample_request = {"parent": "sample1/sample2"}
+        sample_request = {"parent": "organizations/sample1"}
 
         pager = client.list_support_event_subscriptions(request=sample_request)
 
@@ -4713,7 +5061,7 @@ def test_update_support_event_subscription_rest_flattened():
         # get arguments that satisfy an http rule for this method
         sample_request = {
             "support_event_subscription": {
-                "name": "sample1/sample2/supportEventSubscriptions/sample3"
+                "name": "organizations/sample1/supportEventSubscriptions/sample2"
             }
         }
 
@@ -4745,7 +5093,7 @@ def test_update_support_event_subscription_rest_flattened():
         assert len(req.mock_calls) == 1
         _, args, _ = req.mock_calls[0]
         assert path_template.validate(
-            "%s/v2beta/{support_event_subscription.name=*/*/supportEventSubscriptions/*}"
+            "%s/v2beta/{support_event_subscription.name=organizations/*/supportEventSubscriptions/*}"
             % client.transport._host,
             args[1],
         )
@@ -4912,7 +5260,9 @@ def test_delete_support_event_subscription_rest_flattened():
         return_value = support_event_subscription.SupportEventSubscription()
 
         # get arguments that satisfy an http rule for this method
-        sample_request = {"name": "sample1/sample2/supportEventSubscriptions/sample3"}
+        sample_request = {
+            "name": "organizations/sample1/supportEventSubscriptions/sample2"
+        }
 
         # get truthy value for each flattened field
         mock_args = dict(
@@ -4939,7 +5289,8 @@ def test_delete_support_event_subscription_rest_flattened():
         assert len(req.mock_calls) == 1
         _, args, _ = req.mock_calls[0]
         assert path_template.validate(
-            "%s/v2beta/{name=*/*/supportEventSubscriptions/*}" % client.transport._host,
+            "%s/v2beta/{name=organizations/*/supportEventSubscriptions/*}"
+            % client.transport._host,
             args[1],
         )
 
@@ -5089,6 +5440,191 @@ def test_undelete_support_event_subscription_rest_unset_required_fields():
         transport.undelete_support_event_subscription._get_unset_required_fields({})
     )
     assert set(unset_fields) == (set(()) & set(("name",)))
+
+
+def test_expunge_support_event_subscription_rest_use_cached_wrapped_rpc():
+    # Clients should use _prep_wrapped_messages to create cached wrapped rpcs,
+    # instead of constructing them on each call
+    with mock.patch("google.api_core.gapic_v1.method.wrap_method") as wrapper_fn:
+        client = SupportEventSubscriptionServiceClient(
+            credentials=ga_credentials.AnonymousCredentials(),
+            transport="rest",
+        )
+
+        # Should wrap all calls on client creation
+        assert wrapper_fn.call_count > 0
+        wrapper_fn.reset_mock()
+
+        # Ensure method has been cached
+        assert (
+            client._transport.expunge_support_event_subscription
+            in client._transport._wrapped_methods
+        )
+
+        # Replace cached wrapped function with mock
+        mock_rpc = mock.Mock()
+        mock_rpc.return_value.name = (
+            "foo"  # operation_request.operation in compute client(s) expect a string.
+        )
+        client._transport._wrapped_methods[
+            client._transport.expunge_support_event_subscription
+        ] = mock_rpc
+
+        request = {}
+        client.expunge_support_event_subscription(request)
+
+        # Establish that the underlying gRPC stub method was called.
+        assert mock_rpc.call_count == 1
+
+        client.expunge_support_event_subscription(request)
+
+        # Establish that a new wrapper was not created for this call
+        assert wrapper_fn.call_count == 0
+        assert mock_rpc.call_count == 2
+
+
+def test_expunge_support_event_subscription_rest_required_fields(
+    request_type=support_event_subscription_service.ExpungeSupportEventSubscriptionRequest,
+):
+    transport_class = transports.SupportEventSubscriptionServiceRestTransport
+
+    request_init = {}
+    request_init["name"] = ""
+    request = request_type(**request_init)
+    pb_request = request_type.pb(request)
+    jsonified_request = json.loads(
+        json_format.MessageToJson(pb_request, use_integers_for_enums=False)
+    )
+
+    # verify fields with default values are dropped
+
+    unset_fields = transport_class(
+        credentials=ga_credentials.AnonymousCredentials()
+    ).expunge_support_event_subscription._get_unset_required_fields(jsonified_request)
+    jsonified_request.update(unset_fields)
+
+    # verify required fields with default values are now present
+
+    jsonified_request["name"] = "name_value"
+
+    unset_fields = transport_class(
+        credentials=ga_credentials.AnonymousCredentials()
+    ).expunge_support_event_subscription._get_unset_required_fields(jsonified_request)
+    jsonified_request.update(unset_fields)
+
+    # verify required fields with non-default values are left alone
+    assert "name" in jsonified_request
+    assert jsonified_request["name"] == "name_value"
+
+    client = SupportEventSubscriptionServiceClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="rest",
+    )
+    request = request_type(**request_init)
+
+    # Designate an appropriate value for the returned response.
+    return_value = None
+    # Mock the http request call within the method and fake a response.
+    with mock.patch.object(Session, "request") as req:
+        # We need to mock transcode() because providing default values
+        # for required fields will fail the real version if the http_options
+        # expect actual values for those fields.
+        with mock.patch.object(path_template, "transcode") as transcode:
+            # A uri without fields and an empty body will force all the
+            # request fields to show up in the query_params.
+            pb_request = request_type.pb(request)
+            transcode_result = {
+                "uri": "v1/sample_method",
+                "method": "post",
+                "query_params": pb_request,
+            }
+            transcode_result["body"] = pb_request
+            transcode.return_value = transcode_result
+
+            response_value = Response()
+            response_value.status_code = 200
+            json_return_value = ""
+
+            response_value._content = json_return_value.encode("UTF-8")
+            req.return_value = response_value
+            req.return_value.headers = {"header-1": "value-1", "header-2": "value-2"}
+
+            response = client.expunge_support_event_subscription(request)
+
+            expected_params = [("$alt", "json;enum-encoding=int")]
+            actual_params = req.call_args.kwargs["params"]
+            assert sorted(expected_params) == sorted(actual_params)
+
+
+def test_expunge_support_event_subscription_rest_unset_required_fields():
+    transport = transports.SupportEventSubscriptionServiceRestTransport(
+        credentials=ga_credentials.AnonymousCredentials
+    )
+
+    unset_fields = (
+        transport.expunge_support_event_subscription._get_unset_required_fields({})
+    )
+    assert set(unset_fields) == (set(()) & set(("name",)))
+
+
+def test_expunge_support_event_subscription_rest_flattened():
+    client = SupportEventSubscriptionServiceClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="rest",
+    )
+
+    # Mock the http request call within the method and fake a response.
+    with mock.patch.object(type(client.transport._session), "request") as req:
+        # Designate an appropriate value for the returned response.
+        return_value = None
+
+        # get arguments that satisfy an http rule for this method
+        sample_request = {
+            "name": "organizations/sample1/supportEventSubscriptions/sample2"
+        }
+
+        # get truthy value for each flattened field
+        mock_args = dict(
+            name="name_value",
+        )
+        mock_args.update(sample_request)
+
+        # Wrap the value into a proper Response obj
+        response_value = Response()
+        response_value.status_code = 200
+        json_return_value = ""
+        response_value._content = json_return_value.encode("UTF-8")
+        req.return_value = response_value
+        req.return_value.headers = {"header-1": "value-1", "header-2": "value-2"}
+
+        client.expunge_support_event_subscription(**mock_args)
+
+        # Establish that the underlying call was made with the expected
+        # request object values.
+        assert len(req.mock_calls) == 1
+        _, args, _ = req.mock_calls[0]
+        assert path_template.validate(
+            "%s/v2beta/{name=organizations/*/supportEventSubscriptions/*}:expunge"
+            % client.transport._host,
+            args[1],
+        )
+
+
+def test_expunge_support_event_subscription_rest_flattened_error(
+    transport: str = "rest",
+):
+    client = SupportEventSubscriptionServiceClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport=transport,
+    )
+
+    # Attempting to call a method with both a request object and flattened
+    # fields is an error.
+    with pytest.raises(ValueError):
+        client.expunge_support_event_subscription(
+            support_event_subscription_service.ExpungeSupportEventSubscriptionRequest(),
+            name="name_value",
+        )
 
 
 def test_credentials_transport_error():
@@ -5343,6 +5879,30 @@ def test_undelete_support_event_subscription_empty_call_grpc():
         assert args[0] == request_msg
 
 
+# This test is a coverage failsafe to make sure that totally empty calls,
+# i.e. request == None and no flattened fields passed, work.
+def test_expunge_support_event_subscription_empty_call_grpc():
+    client = SupportEventSubscriptionServiceClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
+    )
+
+    # Mock the actual call, and fake the request.
+    with mock.patch.object(
+        type(client.transport.expunge_support_event_subscription), "__call__"
+    ) as call:
+        call.return_value = None
+        client.expunge_support_event_subscription(request=None)
+
+        # Establish that the underlying stub method was called.
+        call.assert_called()
+        _, args, _ = call.mock_calls[0]
+        request_msg = (
+            support_event_subscription_service.ExpungeSupportEventSubscriptionRequest()
+        )
+        assert args[0] == request_msg
+
+
 def test_transport_kind_grpc_asyncio():
     transport = SupportEventSubscriptionServiceAsyncClient.get_transport_class(
         "grpc_asyncio"
@@ -5552,6 +6112,32 @@ async def test_undelete_support_event_subscription_empty_call_grpc_asyncio():
         assert args[0] == request_msg
 
 
+# This test is a coverage failsafe to make sure that totally empty calls,
+# i.e. request == None and no flattened fields passed, work.
+@pytest.mark.asyncio
+async def test_expunge_support_event_subscription_empty_call_grpc_asyncio():
+    client = SupportEventSubscriptionServiceAsyncClient(
+        credentials=async_anonymous_credentials(),
+        transport="grpc_asyncio",
+    )
+
+    # Mock the actual call, and fake the request.
+    with mock.patch.object(
+        type(client.transport.expunge_support_event_subscription), "__call__"
+    ) as call:
+        # Designate an appropriate return value for the call.
+        call.return_value = grpc_helpers_async.FakeUnaryUnaryCall(None)
+        await client.expunge_support_event_subscription(request=None)
+
+        # Establish that the underlying stub method was called.
+        call.assert_called()
+        _, args, _ = call.mock_calls[0]
+        request_msg = (
+            support_event_subscription_service.ExpungeSupportEventSubscriptionRequest()
+        )
+        assert args[0] == request_msg
+
+
 def test_transport_kind_rest():
     transport = SupportEventSubscriptionServiceClient.get_transport_class("rest")(
         credentials=ga_credentials.AnonymousCredentials()
@@ -5566,7 +6152,7 @@ def test_create_support_event_subscription_rest_bad_request(
         credentials=ga_credentials.AnonymousCredentials(), transport="rest"
     )
     # send a request that will satisfy transcoding
-    request_init = {"parent": "sample1/sample2"}
+    request_init = {"parent": "organizations/sample1"}
     request = request_type(**request_init)
 
     # Mock the http request call within the method and fake a BadRequest error.
@@ -5598,7 +6184,7 @@ def test_create_support_event_subscription_rest_call_success(request_type):
     )
 
     # send a request that will satisfy transcoding
-    request_init = {"parent": "sample1/sample2"}
+    request_init = {"parent": "organizations/sample1"}
     request_init["support_event_subscription"] = {
         "name": "name_value",
         "pub_sub_topic": "pub_sub_topic_value",
@@ -5803,7 +6389,7 @@ def test_get_support_event_subscription_rest_bad_request(
         credentials=ga_credentials.AnonymousCredentials(), transport="rest"
     )
     # send a request that will satisfy transcoding
-    request_init = {"name": "sample1/sample2/supportEventSubscriptions/sample3"}
+    request_init = {"name": "organizations/sample1/supportEventSubscriptions/sample2"}
     request = request_type(**request_init)
 
     # Mock the http request call within the method and fake a BadRequest error.
@@ -5835,7 +6421,7 @@ def test_get_support_event_subscription_rest_call_success(request_type):
     )
 
     # send a request that will satisfy transcoding
-    request_init = {"name": "sample1/sample2/supportEventSubscriptions/sample3"}
+    request_init = {"name": "organizations/sample1/supportEventSubscriptions/sample2"}
     request = request_type(**request_init)
 
     # Mock the http request call within the method and fake a response.
@@ -5959,7 +6545,7 @@ def test_list_support_event_subscriptions_rest_bad_request(
         credentials=ga_credentials.AnonymousCredentials(), transport="rest"
     )
     # send a request that will satisfy transcoding
-    request_init = {"parent": "sample1/sample2"}
+    request_init = {"parent": "organizations/sample1"}
     request = request_type(**request_init)
 
     # Mock the http request call within the method and fake a BadRequest error.
@@ -5991,7 +6577,7 @@ def test_list_support_event_subscriptions_rest_call_success(request_type):
     )
 
     # send a request that will satisfy transcoding
-    request_init = {"parent": "sample1/sample2"}
+    request_init = {"parent": "organizations/sample1"}
     request = request_type(**request_init)
 
     # Mock the http request call within the method and fake a response.
@@ -6109,7 +6695,7 @@ def test_update_support_event_subscription_rest_bad_request(
     # send a request that will satisfy transcoding
     request_init = {
         "support_event_subscription": {
-            "name": "sample1/sample2/supportEventSubscriptions/sample3"
+            "name": "organizations/sample1/supportEventSubscriptions/sample2"
         }
     }
     request = request_type(**request_init)
@@ -6145,11 +6731,11 @@ def test_update_support_event_subscription_rest_call_success(request_type):
     # send a request that will satisfy transcoding
     request_init = {
         "support_event_subscription": {
-            "name": "sample1/sample2/supportEventSubscriptions/sample3"
+            "name": "organizations/sample1/supportEventSubscriptions/sample2"
         }
     }
     request_init["support_event_subscription"] = {
-        "name": "sample1/sample2/supportEventSubscriptions/sample3",
+        "name": "organizations/sample1/supportEventSubscriptions/sample2",
         "pub_sub_topic": "pub_sub_topic_value",
         "state": 1,
         "failure_reason": 1,
@@ -6352,7 +6938,7 @@ def test_delete_support_event_subscription_rest_bad_request(
         credentials=ga_credentials.AnonymousCredentials(), transport="rest"
     )
     # send a request that will satisfy transcoding
-    request_init = {"name": "sample1/sample2/supportEventSubscriptions/sample3"}
+    request_init = {"name": "organizations/sample1/supportEventSubscriptions/sample2"}
     request = request_type(**request_init)
 
     # Mock the http request call within the method and fake a BadRequest error.
@@ -6384,7 +6970,7 @@ def test_delete_support_event_subscription_rest_call_success(request_type):
     )
 
     # send a request that will satisfy transcoding
-    request_init = {"name": "sample1/sample2/supportEventSubscriptions/sample3"}
+    request_init = {"name": "organizations/sample1/supportEventSubscriptions/sample2"}
     request = request_type(**request_init)
 
     # Mock the http request call within the method and fake a response.
@@ -6506,7 +7092,7 @@ def test_undelete_support_event_subscription_rest_bad_request(
         credentials=ga_credentials.AnonymousCredentials(), transport="rest"
     )
     # send a request that will satisfy transcoding
-    request_init = {"name": "sample1/sample2/supportEventSubscriptions/sample3"}
+    request_init = {"name": "organizations/sample1/supportEventSubscriptions/sample2"}
     request = request_type(**request_init)
 
     # Mock the http request call within the method and fake a BadRequest error.
@@ -6538,7 +7124,7 @@ def test_undelete_support_event_subscription_rest_call_success(request_type):
     )
 
     # send a request that will satisfy transcoding
-    request_init = {"name": "sample1/sample2/supportEventSubscriptions/sample3"}
+    request_init = {"name": "organizations/sample1/supportEventSubscriptions/sample2"}
     request = request_type(**request_init)
 
     # Mock the http request call within the method and fake a response.
@@ -6651,6 +7237,119 @@ def test_undelete_support_event_subscription_rest_interceptors(null_interceptor)
         pre.assert_called_once()
         post.assert_called_once()
         post_with_metadata.assert_called_once()
+
+
+def test_expunge_support_event_subscription_rest_bad_request(
+    request_type=support_event_subscription_service.ExpungeSupportEventSubscriptionRequest,
+):
+    client = SupportEventSubscriptionServiceClient(
+        credentials=ga_credentials.AnonymousCredentials(), transport="rest"
+    )
+    # send a request that will satisfy transcoding
+    request_init = {"name": "organizations/sample1/supportEventSubscriptions/sample2"}
+    request = request_type(**request_init)
+
+    # Mock the http request call within the method and fake a BadRequest error.
+    with (
+        mock.patch.object(Session, "request") as req,
+        pytest.raises(core_exceptions.BadRequest),
+    ):
+        # Wrap the value into a proper Response obj
+        response_value = mock.Mock()
+        json_return_value = ""
+        response_value.json = mock.Mock(return_value={})
+        response_value.status_code = 400
+        response_value.request = mock.Mock()
+        req.return_value = response_value
+        req.return_value.headers = {"header-1": "value-1", "header-2": "value-2"}
+        client.expunge_support_event_subscription(request)
+
+
+@pytest.mark.parametrize(
+    "request_type",
+    [
+        support_event_subscription_service.ExpungeSupportEventSubscriptionRequest,
+        dict,
+    ],
+)
+def test_expunge_support_event_subscription_rest_call_success(request_type):
+    client = SupportEventSubscriptionServiceClient(
+        credentials=ga_credentials.AnonymousCredentials(), transport="rest"
+    )
+
+    # send a request that will satisfy transcoding
+    request_init = {"name": "organizations/sample1/supportEventSubscriptions/sample2"}
+    request = request_type(**request_init)
+
+    # Mock the http request call within the method and fake a response.
+    with mock.patch.object(type(client.transport._session), "request") as req:
+        # Designate an appropriate value for the returned response.
+        return_value = None
+
+        # Wrap the value into a proper Response obj
+        response_value = mock.Mock()
+        response_value.status_code = 200
+        json_return_value = ""
+        response_value.content = json_return_value.encode("UTF-8")
+        req.return_value = response_value
+        req.return_value.headers = {"header-1": "value-1", "header-2": "value-2"}
+        response = client.expunge_support_event_subscription(request)
+
+    # Establish that the response is the type that we expect.
+    assert response is None
+
+
+@pytest.mark.parametrize("null_interceptor", [True, False])
+def test_expunge_support_event_subscription_rest_interceptors(null_interceptor):
+    transport = transports.SupportEventSubscriptionServiceRestTransport(
+        credentials=ga_credentials.AnonymousCredentials(),
+        interceptor=None
+        if null_interceptor
+        else transports.SupportEventSubscriptionServiceRestInterceptor(),
+    )
+    client = SupportEventSubscriptionServiceClient(transport=transport)
+
+    with (
+        mock.patch.object(type(client.transport._session), "request") as req,
+        mock.patch.object(path_template, "transcode") as transcode,
+        mock.patch.object(
+            transports.SupportEventSubscriptionServiceRestInterceptor,
+            "pre_expunge_support_event_subscription",
+        ) as pre,
+    ):
+        pre.assert_not_called()
+        pb_message = support_event_subscription_service.ExpungeSupportEventSubscriptionRequest.pb(
+            support_event_subscription_service.ExpungeSupportEventSubscriptionRequest()
+        )
+        transcode.return_value = {
+            "method": "post",
+            "uri": "my_uri",
+            "body": pb_message,
+            "query_params": pb_message,
+        }
+
+        req.return_value = mock.Mock()
+        req.return_value.status_code = 200
+        req.return_value.headers = {"header-1": "value-1", "header-2": "value-2"}
+
+        request = (
+            support_event_subscription_service.ExpungeSupportEventSubscriptionRequest()
+        )
+        metadata = [
+            ("key", "val"),
+            ("cephalopod", "squid"),
+        ]
+        pre.return_value = request, metadata
+
+        client.expunge_support_event_subscription(
+            request,
+            metadata=[
+                ("key", "val"),
+                ("cephalopod", "squid"),
+            ],
+        )
+
+        pre.assert_called_once()
 
 
 def test_initialize_client_w_rest():
@@ -6798,6 +7497,29 @@ def test_undelete_support_event_subscription_empty_call_rest():
         assert args[0] == request_msg
 
 
+# This test is a coverage failsafe to make sure that totally empty calls,
+# i.e. request == None and no flattened fields passed, work.
+def test_expunge_support_event_subscription_empty_call_rest():
+    client = SupportEventSubscriptionServiceClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="rest",
+    )
+
+    # Mock the actual call, and fake the request.
+    with mock.patch.object(
+        type(client.transport.expunge_support_event_subscription), "__call__"
+    ) as call:
+        client.expunge_support_event_subscription(request=None)
+
+        # Establish that the underlying stub method was called.
+        call.assert_called()
+        _, args, _ = call.mock_calls[0]
+        request_msg = (
+            support_event_subscription_service.ExpungeSupportEventSubscriptionRequest()
+        )
+        assert args[0] == request_msg
+
+
 def test_transport_grpc_default():
     # A client should use the gRPC transport by default.
     client = SupportEventSubscriptionServiceClient(
@@ -6837,6 +7559,7 @@ def test_support_event_subscription_service_base_transport():
         "update_support_event_subscription",
         "delete_support_event_subscription",
         "undelete_support_event_subscription",
+        "expunge_support_event_subscription",
     )
     for method in methods:
         with pytest.raises(NotImplementedError):
@@ -7130,6 +7853,9 @@ def test_support_event_subscription_service_client_transport_session_collision(
     assert session1 != session2
     session1 = client1.transport.undelete_support_event_subscription._session
     session2 = client2.transport.undelete_support_event_subscription._session
+    assert session1 != session2
+    session1 = client1.transport.expunge_support_event_subscription._session
+    session2 = client2.transport.expunge_support_event_subscription._session
     assert session1 != session2
 
 

--- a/packages/grafeas/grafeas/grafeas_v1/types/cvss.py
+++ b/packages/grafeas/grafeas/grafeas_v1/types/cvss.py
@@ -34,16 +34,19 @@ class CVSSVersion(proto.Enum):
 
     Values:
         CVSS_VERSION_UNSPECIFIED (0):
-            No description available.
+            Unspecified.
         CVSS_VERSION_2 (1):
-            No description available.
+            CVSS v2.
         CVSS_VERSION_3 (2):
-            No description available.
+            CVSS v3.
+        CVSS_VERSION_4 (3):
+            CVSS v4.
     """
 
     CVSS_VERSION_UNSPECIFIED = 0
     CVSS_VERSION_2 = 1
     CVSS_VERSION_3 = 2
+    CVSS_VERSION_4 = 3
 
 
 class CVSSv3(proto.Message):
@@ -259,42 +262,71 @@ class CVSS(proto.Message):
         impact_score (float):
 
         attack_vector (grafeas.grafeas_v1.types.CVSS.AttackVector):
-            Base Metrics
-            Represents the intrinsic characteristics of a
-            vulnerability that are constant over time and
-            across user environments.
+            Attack Vector (AV). Defined in CVSS v2, v3,
+            v4.
         attack_complexity (grafeas.grafeas_v1.types.CVSS.AttackComplexity):
-
+            Attack Complexity (AC). Defined in CVSS v2,
+            v3, v4.
         authentication (grafeas.grafeas_v1.types.CVSS.Authentication):
-
+            Authentication (Au). Defined in CVSS v2.
         privileges_required (grafeas.grafeas_v1.types.CVSS.PrivilegesRequired):
-
+            Privileges Required (PR). Defined in CVSS v3,
+            v4.
         user_interaction (grafeas.grafeas_v1.types.CVSS.UserInteraction):
-
+            User Interaction (UI). Defined in CVSS v3,
+            v4.
         scope (grafeas.grafeas_v1.types.CVSS.Scope):
-
+            Scope (S). Defined in CVSS v3.
         confidentiality_impact (grafeas.grafeas_v1.types.CVSS.Impact):
-
+            Confidentiality Impact (C). Defined in CVSS
+            v2, v3.
         integrity_impact (grafeas.grafeas_v1.types.CVSS.Impact):
-
+            Integrity Impact (I). Defined in CVSS v2, v3.
         availability_impact (grafeas.grafeas_v1.types.CVSS.Impact):
-
+            Availability Impact (A). Defined in CVSS v2,
+            v3.
+        attack_requirements (grafeas.grafeas_v1.types.CVSS.AttackRequirements):
+            Attack Requirements (AT). Defined in CVSS v4.
+        vulnerable_system_confidentiality_impact (grafeas.grafeas_v1.types.CVSS.Impact):
+            Vulnerable System Confidentiality Impact
+            (VC). Defined in CVSS v4.
+        vulnerable_system_integrity_impact (grafeas.grafeas_v1.types.CVSS.Impact):
+            Vulnerable System Integrity Impact (VI).
+            Defined in CVSS v4.
+        vulnerable_system_availability_impact (grafeas.grafeas_v1.types.CVSS.Impact):
+            Vulnerable System Availability Impact (VA).
+            Defined in CVSS v4.
+        subsequent_system_confidentiality_impact (grafeas.grafeas_v1.types.CVSS.Impact):
+            Subsequent System Confidentiality Impact
+            (SC). Defined in CVSS v4.
+        subsequent_system_integrity_impact (grafeas.grafeas_v1.types.CVSS.Impact):
+            Subsequent System Integrity Impact (SI).
+            Defined in CVSS v4.
+        subsequent_system_availability_impact (grafeas.grafeas_v1.types.CVSS.Impact):
+            Subsequent System Availability Impact (SA).
+            Defined in CVSS v4.
+        exploit_maturity (grafeas.grafeas_v1.types.CVSS.ExploitMaturity):
+            Exploit Maturity (E). Defined in CVSS v4.
     """
 
     class AttackVector(proto.Enum):
-        r"""
+        r"""Attack Vector.
 
         Values:
             ATTACK_VECTOR_UNSPECIFIED (0):
-                No description available.
+                Unspecified.
             ATTACK_VECTOR_NETWORK (1):
-                No description available.
+                Attack Vector: Network (AV:N). Defined in
+                CVSS v2, v3, v4.
             ATTACK_VECTOR_ADJACENT (2):
-                No description available.
+                Attack Vector: Adjacent (AV:A). Defined in
+                CVSS v2, v3, v4.
             ATTACK_VECTOR_LOCAL (3):
-                No description available.
+                Attack Vector: Local (AV:L). Defined in CVSS
+                v2, v3, v4.
             ATTACK_VECTOR_PHYSICAL (4):
-                No description available.
+                Attack Vector: Physical (AV:P). Defined in
+                CVSS v3, v4.
         """
 
         ATTACK_VECTOR_UNSPECIFIED = 0
@@ -304,17 +336,20 @@ class CVSS(proto.Message):
         ATTACK_VECTOR_PHYSICAL = 4
 
     class AttackComplexity(proto.Enum):
-        r"""
+        r"""Attack Complexity.
 
         Values:
             ATTACK_COMPLEXITY_UNSPECIFIED (0):
-                No description available.
+                Unspecified.
             ATTACK_COMPLEXITY_LOW (1):
-                No description available.
+                Low attack complexity (AC:L). Defined in CVSS
+                v2, v3, v4.
             ATTACK_COMPLEXITY_HIGH (2):
-                No description available.
+                High attack complexity (AC:H). Defined in
+                CVSS v2, v3, v4.
             ATTACK_COMPLEXITY_MEDIUM (3):
-                No description available.
+                Medium attack complexity (AC:M). Defined in
+                CVSS v2.
         """
 
         ATTACK_COMPLEXITY_UNSPECIFIED = 0
@@ -323,17 +358,20 @@ class CVSS(proto.Message):
         ATTACK_COMPLEXITY_MEDIUM = 3
 
     class Authentication(proto.Enum):
-        r"""
+        r"""Authentication.
 
         Values:
             AUTHENTICATION_UNSPECIFIED (0):
-                No description available.
+                Unspecified.
             AUTHENTICATION_MULTIPLE (1):
-                No description available.
+                Multiple authentication required (Au:M).
+                Defined in CVSS v2.
             AUTHENTICATION_SINGLE (2):
-                No description available.
+                Single authentication required (Au:S).
+                Defined in CVSS v2.
             AUTHENTICATION_NONE (3):
-                No description available.
+                No authentication required (Au:N). Defined in
+                CVSS v2.
         """
 
         AUTHENTICATION_UNSPECIFIED = 0
@@ -342,17 +380,20 @@ class CVSS(proto.Message):
         AUTHENTICATION_NONE = 3
 
     class PrivilegesRequired(proto.Enum):
-        r"""
+        r"""Privileges Required.
 
         Values:
             PRIVILEGES_REQUIRED_UNSPECIFIED (0):
-                No description available.
+                Unspecified.
             PRIVILEGES_REQUIRED_NONE (1):
-                No description available.
+                No privileges required (PR:N). Defined in
+                CVSS v3, v4.
             PRIVILEGES_REQUIRED_LOW (2):
-                No description available.
+                Low privileges required (PR:L). Defined in
+                CVSS v3, v4.
             PRIVILEGES_REQUIRED_HIGH (3):
-                No description available.
+                High privileges required (PR:H). Defined in
+                CVSS v3, v4.
         """
 
         PRIVILEGES_REQUIRED_UNSPECIFIED = 0
@@ -361,31 +402,41 @@ class CVSS(proto.Message):
         PRIVILEGES_REQUIRED_HIGH = 3
 
     class UserInteraction(proto.Enum):
-        r"""
+        r"""User Interaction.
 
         Values:
             USER_INTERACTION_UNSPECIFIED (0):
-                No description available.
+                Unspecified.
             USER_INTERACTION_NONE (1):
-                No description available.
+                No user interaction required (UI:N). Defined
+                in CVSS v3, v4.
             USER_INTERACTION_REQUIRED (2):
-                No description available.
+                User interaction required (UI:R). Defined in
+                CVSS v3.
+            USER_INTERACTION_PASSIVE (3):
+                Passive user interaction required (UI:P).
+                Defined in CVSS v4.
+            USER_INTERACTION_ACTIVE (4):
+                Active user interaction required (UI:A).
+                Defined in CVSS v4.
         """
 
         USER_INTERACTION_UNSPECIFIED = 0
         USER_INTERACTION_NONE = 1
         USER_INTERACTION_REQUIRED = 2
+        USER_INTERACTION_PASSIVE = 3
+        USER_INTERACTION_ACTIVE = 4
 
     class Scope(proto.Enum):
-        r"""
+        r"""Scope.
 
         Values:
             SCOPE_UNSPECIFIED (0):
-                No description available.
+                Unspecified.
             SCOPE_UNCHANGED (1):
-                No description available.
+                Scope: Unchanged (S:U). Defined in CVSS v3.
             SCOPE_CHANGED (2):
-                No description available.
+                Scope: Changed (S:C). Defined in CVSS v3.
         """
 
         SCOPE_UNSPECIFIED = 0
@@ -393,21 +444,21 @@ class CVSS(proto.Message):
         SCOPE_CHANGED = 2
 
     class Impact(proto.Enum):
-        r"""
+        r"""Impact.
 
         Values:
             IMPACT_UNSPECIFIED (0):
-                No description available.
+                Unspecified.
             IMPACT_HIGH (1):
-                No description available.
+                High impact (H). Defined in CVSS v3, v4.
             IMPACT_LOW (2):
-                No description available.
+                Low impact (L). Defined in CVSS v3, v4.
             IMPACT_NONE (3):
-                No description available.
+                No impact (N). Defined in CVSS v2, v3, v4.
             IMPACT_PARTIAL (4):
-                No description available.
+                Partial impact (P). Defined in CVSS v2.
             IMPACT_COMPLETE (5):
-                No description available.
+                Complete impact (C). Defined in CVSS v2.
         """
 
         IMPACT_UNSPECIFIED = 0
@@ -416,6 +467,50 @@ class CVSS(proto.Message):
         IMPACT_NONE = 3
         IMPACT_PARTIAL = 4
         IMPACT_COMPLETE = 5
+
+    class AttackRequirements(proto.Enum):
+        r"""Attack Requirements.
+
+        Values:
+            ATTACK_REQUIREMENTS_UNSPECIFIED (0):
+                Unspecified.
+            ATTACK_REQUIREMENTS_NONE (1):
+                No attack requirements (AT:N). Defined in
+                CVSS v4.
+            ATTACK_REQUIREMENTS_PRESENT (2):
+                Attack requirements: Present (AT:P). Defined
+                in CVSS v4.
+        """
+
+        ATTACK_REQUIREMENTS_UNSPECIFIED = 0
+        ATTACK_REQUIREMENTS_NONE = 1
+        ATTACK_REQUIREMENTS_PRESENT = 2
+
+    class ExploitMaturity(proto.Enum):
+        r"""Exploit Maturity (E). Defined in CVSS v4.
+
+        Values:
+            EXPLOIT_MATURITY_UNSPECIFIED (0):
+                Unspecified.
+            EXPLOIT_MATURITY_NOT_DEFINED (1):
+                Exploit maturity: Not defined (E:X). Defined
+                in CVSS v4.
+            EXPLOIT_MATURITY_ATTACKED (2):
+                Exploit maturity: Attacked (E:A). Defined in
+                CVSS v4.
+            EXPLOIT_MATURITY_POC (3):
+                Exploit maturity: Proof-of-concept (E:P).
+                Defined in CVSS v4.
+            EXPLOIT_MATURITY_UNREPORTED (4):
+                Exploit maturity: Unreported (E:U). Defined
+                in CVSS v4.
+        """
+
+        EXPLOIT_MATURITY_UNSPECIFIED = 0
+        EXPLOIT_MATURITY_NOT_DEFINED = 1
+        EXPLOIT_MATURITY_ATTACKED = 2
+        EXPLOIT_MATURITY_POC = 3
+        EXPLOIT_MATURITY_UNREPORTED = 4
 
     base_score: float = proto.Field(
         proto.FLOAT,
@@ -473,6 +568,46 @@ class CVSS(proto.Message):
         proto.ENUM,
         number=12,
         enum=Impact,
+    )
+    attack_requirements: AttackRequirements = proto.Field(
+        proto.ENUM,
+        number=13,
+        enum=AttackRequirements,
+    )
+    vulnerable_system_confidentiality_impact: Impact = proto.Field(
+        proto.ENUM,
+        number=14,
+        enum=Impact,
+    )
+    vulnerable_system_integrity_impact: Impact = proto.Field(
+        proto.ENUM,
+        number=15,
+        enum=Impact,
+    )
+    vulnerable_system_availability_impact: Impact = proto.Field(
+        proto.ENUM,
+        number=16,
+        enum=Impact,
+    )
+    subsequent_system_confidentiality_impact: Impact = proto.Field(
+        proto.ENUM,
+        number=17,
+        enum=Impact,
+    )
+    subsequent_system_integrity_impact: Impact = proto.Field(
+        proto.ENUM,
+        number=18,
+        enum=Impact,
+    )
+    subsequent_system_availability_impact: Impact = proto.Field(
+        proto.ENUM,
+        number=19,
+        enum=Impact,
+    )
+    exploit_maturity: ExploitMaturity = proto.Field(
+        proto.ENUM,
+        number=20,
+        enum=ExploitMaturity,
     )
 
 

--- a/packages/grafeas/grafeas/grafeas_v1/types/vulnerability.py
+++ b/packages/grafeas/grafeas/grafeas_v1/types/vulnerability.py
@@ -70,6 +70,9 @@ class VulnerabilityNote(proto.Message):
         advisory_publish_time (google.protobuf.timestamp_pb2.Timestamp):
             The time this advisory was published by the
             source.
+        cvss_v4 (grafeas.grafeas_v1.types.CVSS):
+            The full description of the v4 CVSS for this
+            vulnerability.
     """
 
     class Detail(proto.Message):
@@ -308,6 +311,11 @@ class VulnerabilityNote(proto.Message):
         number=9,
         message=timestamp_pb2.Timestamp,
     )
+    cvss_v4: cvss.CVSS = proto.Field(
+        proto.MESSAGE,
+        number=10,
+        message=cvss.CVSS,
+    )
 
 
 class VulnerabilityOccurrence(proto.Message):
@@ -372,6 +380,8 @@ class VulnerabilityOccurrence(proto.Message):
         risk (grafeas.grafeas_v1.types.Risk):
             Risk information about the vulnerability,
             such as CISA, EPSS, etc.
+        cvss_v4 (grafeas.grafeas_v1.types.CVSS):
+            The cvss v4 score for the vulnerability.
     """
 
     class PackageIssue(proto.Message):
@@ -607,6 +617,11 @@ class VulnerabilityOccurrence(proto.Message):
         proto.MESSAGE,
         number=15,
         message=g_risk.Risk,
+    )
+    cvss_v4: cvss.CVSS = proto.Field(
+        proto.MESSAGE,
+        number=16,
+        message=cvss.CVSS,
     )
 
 

--- a/packages/grafeas/tests/unit/gapic/grafeas_v1/test_grafeas.py
+++ b/packages/grafeas/tests/unit/gapic/grafeas_v1/test_grafeas.py
@@ -9591,6 +9591,14 @@ def test_create_occurrence_rest_call_success(request_type):
                 "confidentiality_impact": 1,
                 "integrity_impact": 1,
                 "availability_impact": 1,
+                "attack_requirements": 1,
+                "vulnerable_system_confidentiality_impact": 1,
+                "vulnerable_system_integrity_impact": 1,
+                "vulnerable_system_availability_impact": 1,
+                "subsequent_system_confidentiality_impact": 1,
+                "subsequent_system_integrity_impact": 1,
+                "subsequent_system_availability_impact": 1,
+                "exploit_maturity": 1,
             },
             "package_issue": [
                 {
@@ -9662,6 +9670,7 @@ def test_create_occurrence_rest_call_success(request_type):
                 },
                 "epss": {"percentile": 0.1067, "score": 0.54},
             },
+            "cvss_v4": {},
         },
         "build": {
             "provenance": {
@@ -10329,6 +10338,14 @@ def test_update_occurrence_rest_call_success(request_type):
                 "confidentiality_impact": 1,
                 "integrity_impact": 1,
                 "availability_impact": 1,
+                "attack_requirements": 1,
+                "vulnerable_system_confidentiality_impact": 1,
+                "vulnerable_system_integrity_impact": 1,
+                "vulnerable_system_availability_impact": 1,
+                "subsequent_system_confidentiality_impact": 1,
+                "subsequent_system_integrity_impact": 1,
+                "subsequent_system_availability_impact": 1,
+                "exploit_maturity": 1,
             },
             "package_issue": [
                 {
@@ -10400,6 +10417,7 @@ def test_update_occurrence_rest_call_success(request_type):
                 },
                 "epss": {"percentile": 0.1067, "score": 0.54},
             },
+            "cvss_v4": {},
         },
         "build": {
             "provenance": {
@@ -11474,8 +11492,17 @@ def test_create_note_rest_call_success(request_type):
                 "confidentiality_impact": 1,
                 "integrity_impact": 1,
                 "availability_impact": 1,
+                "attack_requirements": 1,
+                "vulnerable_system_confidentiality_impact": 1,
+                "vulnerable_system_integrity_impact": 1,
+                "vulnerable_system_availability_impact": 1,
+                "subsequent_system_confidentiality_impact": 1,
+                "subsequent_system_integrity_impact": 1,
+                "subsequent_system_availability_impact": 1,
+                "exploit_maturity": 1,
             },
             "advisory_publish_time": {},
+            "cvss_v4": {},
         },
         "build": {"builder_version": "builder_version_value"},
         "image": {
@@ -11993,8 +12020,17 @@ def test_update_note_rest_call_success(request_type):
                 "confidentiality_impact": 1,
                 "integrity_impact": 1,
                 "availability_impact": 1,
+                "attack_requirements": 1,
+                "vulnerable_system_confidentiality_impact": 1,
+                "vulnerable_system_integrity_impact": 1,
+                "vulnerable_system_availability_impact": 1,
+                "subsequent_system_confidentiality_impact": 1,
+                "subsequent_system_integrity_impact": 1,
+                "subsequent_system_availability_impact": 1,
+                "exploit_maturity": 1,
             },
             "advisory_publish_time": {},
+            "cvss_v4": {},
         },
         "build": {"builder_version": "builder_version_value"},
         "image": {


### PR DESCRIPTION
update source and re-generate. Commands used:

```
V=$(go run github.com/googleapis/librarian/cmd/librarian@latest config get version)
go run github.com/googleapis/librarian/tool/cmd/builddockerimages@${V} --version ${V} --language python
go run github.com/googleapis/librarian/cmd/librarian@${V} update sources.googleapis
 docker run -u $(id -u):$(id -g) -v .:/repo -v ~/.cache:/.cache -w /repo docker.io/library/librarian-python:${V}  generate -v --all
```

reverted one change (cfd21f9) to be resolved separately, tracked at https://github.com/googleapis/google-cloud-python/issues/17930