### PR TITLE
chore: remove google-cloud-bigquery from bulk release due to failing system test

### DIFF
--- a/.release-please-bulk-manifest.json
+++ b/.release-please-bulk-manifest.json
@@ -54,7 +54,6 @@
   "packages/google-cloud-beyondcorp-clientgateways": "0.8.0",
   "packages/google-cloud-biglake": "0.5.0",
   "packages/google-cloud-biglake-hive": "0.3.1",
-  "packages/google-cloud-bigquery": "3.42.2",
   "packages/google-cloud-bigquery-analyticshub": "0.9.0",
   "packages/google-cloud-bigquery-biglake": "0.8.0",
   "packages/google-cloud-bigquery-connection": "1.22.0",

--- a/.release-please-individual-manifest.json
+++ b/.release-please-individual-manifest.json
@@ -1,5 +1,6 @@
 {
   "packages/bigframes": "2.46.0",
+  "packages/google-cloud-bigquery": "3.42.2",
   "packages/google-crc32c": "1.8.0",
   "packages/pandas-gbq": "0.35.0"
 }

--- a/release-please-bulk-config.json
+++ b/release-please-bulk-config.json
@@ -653,6 +653,18 @@
         }
       ]
     },
+    "packages/google-cloud-bigquery-analyticshub": {
+      "component": "google-cloud-bigquery-analyticshub",
+      "extra-files": [
+        "google/cloud/bigquery_analyticshub/gapic_version.py",
+        "google/cloud/bigquery_analyticshub_v1/gapic_version.py",
+        {
+          "jsonpath": "$.clientLibrary.version",
+          "path": "samples/generated_samples/snippet_metadata_google.cloud.bigquery.analyticshub.v1.json",
+          "type": "json"
+        }
+      ]
+    },
     "packages/google-cloud-bigquery-biglake": {
       "component": "google-cloud-bigquery-biglake",
       "extra-files": [

--- a/release-please-bulk-config.json
+++ b/release-please-bulk-config.json
@@ -653,21 +653,6 @@
         }
       ]
     },
-    "packages/google-cloud-bigquery": {
-      "component": "google-cloud-bigquery"
-    },
-    "packages/google-cloud-bigquery-analyticshub": {
-      "component": "google-cloud-bigquery-analyticshub",
-      "extra-files": [
-        "google/cloud/bigquery_analyticshub/gapic_version.py",
-        "google/cloud/bigquery_analyticshub_v1/gapic_version.py",
-        {
-          "jsonpath": "$.clientLibrary.version",
-          "path": "samples/generated_samples/snippet_metadata_google.cloud.bigquery.analyticshub.v1.json",
-          "type": "json"
-        }
-      ]
-    },
     "packages/google-cloud-bigquery-biglake": {
       "component": "google-cloud-bigquery-biglake",
       "extra-files": [

--- a/release-please-individual-config.json
+++ b/release-please-individual-config.json
@@ -8,18 +8,6 @@
     "packages/google-cloud-bigquery": {
       "component": "google-cloud-bigquery"
     },
-    "packages/google-cloud-bigquery-analyticshub": {
-      "component": "google-cloud-bigquery-analyticshub",
-      "extra-files": [
-        "google/cloud/bigquery_analyticshub/gapic_version.py",
-        "google/cloud/bigquery_analyticshub_v1/gapic_version.py",
-        {
-          "jsonpath": "$.clientLibrary.version",
-          "path": "samples/generated_samples/snippet_metadata_google.cloud.bigquery.analyticshub.v1.json",
-          "type": "json"
-        }
-      ]
-    },
     "packages/google-crc32c": {
       "component": "google-crc32c"
     },

--- a/release-please-individual-config.json
+++ b/release-please-individual-config.json
@@ -5,6 +5,21 @@
     "packages/bigframes": {
       "component": "bigframes"
     },
+    "packages/google-cloud-bigquery": {
+      "component": "google-cloud-bigquery"
+    },
+    "packages/google-cloud-bigquery-analyticshub": {
+      "component": "google-cloud-bigquery-analyticshub",
+      "extra-files": [
+        "google/cloud/bigquery_analyticshub/gapic_version.py",
+        "google/cloud/bigquery_analyticshub_v1/gapic_version.py",
+        {
+          "jsonpath": "$.clientLibrary.version",
+          "path": "samples/generated_samples/snippet_metadata_google.cloud.bigquery.analyticshub.v1.json",
+          "type": "json"
+        }
+      ]
+    },
     "packages/google-crc32c": {
       "component": "google-crc32c"
     },


### PR DESCRIPTION
Temporarily remove `google-cloud-bigquery` from the bulk release due to this system test failure

```
=================================== FAILURES ===================================
___________ TestBigQuery.test_dbapi_connection_does_not_leak_sockets ___________
[gw1] linux -- Python 3.12.12 /tmpfs/src/github/google-cloud-python/packages/google-cloud-bigquery/.nox/system-3-12/bin/python

self = 

    def test_dbapi_connection_does_not_leak_sockets(self):
        pytest.importorskip("google.cloud.bigquery_storage")
        current_process = psutil.Process()
        conn_start = current_process.net_connections()
        conn_count_start = len(conn_start)
    
        with helpers.patch_tracked_requests():
            # Provide no explicit clients, so that the connection will create and own them.
            connection = dbapi.connect()
            cursor = connection.cursor()
    
            cursor.execute(
                """
                SELECT id, `by`, timestamp
                FROM `bigquery-public-data.hacker_news.full`
                ORDER BY `id` ASC
                LIMIT 100000
            """
            )
            rows = cursor.fetchall()
            self.assertEqual(len(rows), 100000)
    
            connection.close()
        import gc
    
        gc.collect()
        for _ in range(30):  # Wait up to 3 seconds
            conn_end = current_process.net_connections()
            conn_count_end = len(conn_end)
            if conn_count_end <= conn_count_start:
                break
            time.sleep(0.1)
    
        try:
>           self.assertLessEqual(conn_count_end, conn_count_start)
E           AssertionError: 7 not less than or equal to 6

tests/system/test_client.py:2217: AssertionError

During handling of the above exception, another exception occurred:

self = 

    def test_dbapi_connection_does_not_leak_sockets(self):
        pytest.importorskip("google.cloud.bigquery_storage")
        current_process = psutil.Process()
        conn_start = current_process.net_connections()
        conn_count_start = len(conn_start)
    
        with helpers.patch_tracked_requests():
            # Provide no explicit clients, so that the connection will create and own them.
            connection = dbapi.connect()
            cursor = connection.cursor()
    
            cursor.execute(
                """
                SELECT id, `by`, timestamp
                FROM `bigquery-public-data.hacker_news.full`
                ORDER BY `id` ASC
                LIMIT 100000
            """
            )
            rows = cursor.fetchall()
            self.assertEqual(len(rows), 100000)
    
            connection.close()
        import gc
    
        gc.collect()
        for _ in range(30):  # Wait up to 3 seconds
            conn_end = current_process.net_connections()
            conn_count_end = len(conn_end)
            if conn_count_end <= conn_count_start:
                break
            time.sleep(0.1)
    
        try:
            self.assertLessEqual(conn_count_end, conn_count_start)
        except AssertionError as e:
            # Due to flakiness in this test (likely caused by OS cleanup delays or
            # non-deterministic garbage collection of sockets), we want to capture
            # the detailed state of connections in future failing runs to help
            # decrease false positives and identify the root cause.
            conn_debug = [
                f"Status: {c.status}, Laddr: {c.laddr}, Raddr: {c.raddr}"
                for c in current_process.net_connections()
            ]
            debug_msg = "\n".join(conn_debug)
    
>           raise AssertionError(
                f"{e}\n\n"
                f"--- Socket Leak Debug Info ---\n"
                f"Start Count: {conn_count_start}\n"
                f"End Count: {conn_count_end}\n"
                f"Current Connections:\n{debug_msg}"
            )
E           AssertionError: 7 not less than or equal to 6
E           
E           --- Socket Leak Debug Info ---
E           Start Count: 6
E           End Count: 7
E           Current Connections:
....

tests/system/test_client.py:2229: AssertionError
=========================== short test summary info ============================
FAILED tests/system/test_client.py::TestBigQuery::test_dbapi_connection_does_not_leak_sockets
```