### PR TITLE
fix(bigquery): [WIP] add gc.collect before socket leak test to reduce flakiness

### DIFF
--- a/packages/google-cloud-bigquery/tests/system/test_client.py
+++ b/packages/google-cloud-bigquery/tests/system/test_client.py
@@ -2182,6 +2182,11 @@ class TestBigQuery(unittest.TestCase):
 
     def test_dbapi_connection_does_not_leak_sockets(self):
         pytest.importorskip("google.cloud.bigquery_storage")
+
+        # Ensure any garbage collection from previous tests is done to avoid false positives.
+        import gc
+        gc.collect()
+
         current_process = psutil.Process()
         conn_start = current_process.net_connections()
         conn_count_start = len(conn_start)


### PR DESCRIPTION
## Problem
The system test `test_dbapi_connection_does_not_leak_sockets` can be flaky, failing with assertions that more sockets are open at the end than at the start. This is often caused by non-deterministic garbage collection of sockets from *previous* tests running in the same process, which are finally collected during the test execution, or background noise that wasn't cleaned up before the test started.

## Solution
Added `gc.collect()` explicitly at the very beginning of `test_dbapi_connection_does_not_leak_sockets`, before taking the initial socket count (`conn_start`). This ensures a cleaner baseline and reduces false positives caused by delayed cleanup from other tests.

## Notes to Reviewers
This is a standard pattern for stabilizing process-wide socket count assertions in noisy test environments (like parallel execution with `pytest-xdist`). It complements the previous fixes that ensured explicit closure of channels and releasing of references.
