### PR TITLE
fix(bigquery): Fix bigquery socket leak

### DIFF
--- a/packages/google-cloud-bigquery/google/cloud/bigquery/dbapi/connection.py
+++ b/packages/google-cloud-bigquery/google/cloud/bigquery/dbapi/connection.py
@@ -78,10 +78,14 @@ class Connection(object):
         """
         self._closed = True
 
-        if self._owns_client:
+        for cursor_ in list(self._cursors_created):
+            if not cursor_._closed:
+                cursor_.close()
+
+        if self._owns_client and self._client is not None:
             self._client.close()
 
-        if self._owns_bqstorage_client:
+        if self._owns_bqstorage_client and self._bqstorage_client is not None:
             # There is no close() on the BQ Storage client itself.
             transport = self._bqstorage_client.transport
             transport.close()
@@ -94,10 +98,6 @@ class Connection(object):
             channel = getattr(transport, "_grpc_channel", None)
             if channel is not None:
                 channel.close()
-
-        for cursor_ in self._cursors_created:
-            if not cursor_._closed:
-                cursor_.close()
 
     def commit(self):
         """No-op, but for consistency raise an error if connection is closed."""

--- a/packages/google-cloud-bigquery/tests/system/test_client.py
+++ b/packages/google-cloud-bigquery/tests/system/test_client.py
@@ -2230,22 +2230,23 @@ class TestBigQuery(unittest.TestCase):
         google.api_core.grpc_helpers.create_channel = patched_create_channel
 
         try:
-            # Provide no explicit clients, so that the connection will create and own them.
-            connection = dbapi.connect()
-            cursor = connection.cursor()
+            with helpers.patch_tracked_requests():
+                # Provide no explicit clients, so that the connection will create and own them.
+                connection = dbapi.connect()
+                cursor = connection.cursor()
 
-            cursor.execute(
+                cursor.execute(
+                    """
+                    SELECT id, `by`, timestamp
+                    FROM `bigquery-public-data.hacker_news.full`
+                    ORDER BY `id` ASC
+                    LIMIT 100000
                 """
-                SELECT id, `by`, timestamp
-                FROM `bigquery-public-data.hacker_news.full`
-                ORDER BY `id` ASC
-                LIMIT 100000
-            """
-            )
-            rows = cursor.fetchall()
-            self.assertEqual(len(rows), 100000)
+                )
+                rows = cursor.fetchall()
+                self.assertEqual(len(rows), 100000)
 
-            connection.close()
+                connection.close()
 
             # Assertions
             created_session_ids = {id(s) for s in created_sessions}

--- a/packages/google-cloud-bigquery/tests/system/test_client.py
+++ b/packages/google-cloud-bigquery/tests/system/test_client.py
@@ -2191,15 +2191,18 @@ class TestBigQuery(unittest.TestCase):
         closed_sessions = set()
 
         original_session_init = requests.Session.__init__
-        original_session_close = requests.Session.close
 
         def patched_session_init(self, *args, **kwargs):
             original_session_init(self, *args, **kwargs)
             created_sessions.add(self)
 
-        def patched_session_close(self):
-            original_session_close(self)
-            closed_sessions.add(self)
+            original_close = self.close
+
+            def patched_close(*s_args, **s_kwargs):
+                original_close(*s_args, **s_kwargs)
+                closed_sessions.add(self)
+
+            self.close = patched_close
 
         # Track gRPC Channels
         created_channels = set()
@@ -2222,7 +2225,6 @@ class TestBigQuery(unittest.TestCase):
 
         # Apply patches
         requests.Session.__init__ = patched_session_init
-        requests.Session.close = patched_session_close
         google.api_core.grpc_helpers.create_channel = patched_create_channel
 
         try:
@@ -2260,7 +2262,6 @@ class TestBigQuery(unittest.TestCase):
         finally:
             # Revert patches
             requests.Session.__init__ = original_session_init
-            requests.Session.close = original_session_close
             google.api_core.grpc_helpers.create_channel = original_create_channel
 
             # Clean up any unclosed sessions/channels to avoid leaking in the test runner

--- a/packages/google-cloud-bigquery/tests/system/test_client.py
+++ b/packages/google-cloud-bigquery/tests/system/test_client.py
@@ -2244,16 +2244,28 @@ class TestBigQuery(unittest.TestCase):
             connection.close()
 
             # Assertions
-            self.assertEqual(
-                len(created_sessions),
-                len(closed_sessions),
-                f"HTTP Sessions leak detected! Created: {len(created_sessions)}, Closed: {len(closed_sessions)}",
-            )
+            created_session_ids = {id(s) for s in created_sessions}
+            closed_session_ids = {id(s) for s in closed_sessions}
+            leaked_session_ids = created_session_ids - closed_session_ids
 
             self.assertEqual(
-                len(created_channels),
-                len(closed_channels),
-                f"gRPC Channels leak detected! Created: {len(created_channels)}, Closed: {len(closed_channels)}",
+                len(leaked_session_ids),
+                0,
+                f"HTTP Sessions leak detected! Leaked: {len(leaked_session_ids)}. "
+                f"Unique Created: {len(created_session_ids)}, Unique Closed: {len(closed_session_ids)}. "
+                f"Total Created: {len(created_sessions)}, Total Closed: {len(closed_sessions)}",
+            )
+
+            created_channel_ids = {id(c) for c in created_channels}
+            closed_channel_ids = {id(c) for c in closed_channels}
+            leaked_channel_ids = created_channel_ids - closed_channel_ids
+
+            self.assertEqual(
+                len(leaked_channel_ids),
+                0,
+                f"gRPC Channels leak detected! Leaked: {len(leaked_channel_ids)}. "
+                f"Unique Created: {len(created_channel_ids)}, Unique Closed: {len(closed_channel_ids)}. "
+                f"Total Created: {len(created_channels)}, Total Closed: {len(closed_channels)}",
             )
 
         finally:

--- a/packages/google-cloud-bigquery/tests/system/test_client.py
+++ b/packages/google-cloud-bigquery/tests/system/test_client.py
@@ -2187,39 +2187,35 @@ class TestBigQuery(unittest.TestCase):
         import requests
 
         # Track HTTP Sessions
-        created_sessions = []
-        closed_sessions = []
-        session_creation_stacks = {}
+        created_sessions = set()
+        closed_sessions = set()
 
         original_session_init = requests.Session.__init__
         original_session_close = requests.Session.close
 
-        import traceback
-
         def patched_session_init(self, *args, **kwargs):
             original_session_init(self, *args, **kwargs)
-            created_sessions.append(self)
-            session_creation_stacks[id(self)] = traceback.format_stack(limit=10)
+            created_sessions.add(self)
 
         def patched_session_close(self):
             original_session_close(self)
-            closed_sessions.append(self)
+            closed_sessions.add(self)
 
         # Track gRPC Channels
-        created_channels = []
-        closed_channels = []
+        created_channels = set()
+        closed_channels = set()
 
         original_create_channel = google.api_core.grpc_helpers.create_channel
 
         def patched_create_channel(*args, **kwargs):
             channel = original_create_channel(*args, **kwargs)
-            created_channels.append(channel)
+            created_channels.add(channel)
 
             original_channel_close = channel.close
 
             def patched_channel_close(*c_args, **c_kwargs):
                 original_channel_close(*c_args, **c_kwargs)
-                closed_channels.append(channel)
+                closed_channels.add(channel)
 
             channel.close = patched_channel_close
             return channel
@@ -2249,39 +2245,16 @@ class TestBigQuery(unittest.TestCase):
                 connection.close()
 
             # Assertions
-            created_session_ids = {id(s) for s in created_sessions}
-            closed_session_ids = {id(s) for s in closed_sessions}
-            leaked_session_ids = created_session_ids - closed_session_ids
-
-            debug_info = ""
-            if leaked_session_ids:
-                debug_info += "\n--- Leaked Sessions Creation Stacks ---\n"
-                for s_id in leaked_session_ids:
-                    debug_info += f"\nSession ID: {s_id}\n"
-                    debug_info += "".join(
-                        session_creation_stacks.get(s_id, ["No stack trace available"])
-                    )
-                    debug_info += "----------------------------------------\n"
-
             self.assertEqual(
-                len(leaked_session_ids),
-                0,
-                f"HTTP Sessions leak detected! Leaked: {len(leaked_session_ids)}. "
-                f"Unique Created: {len(created_session_ids)}, Unique Closed: {len(closed_session_ids)}. "
-                f"Total Created: {len(created_sessions)}, Total Closed: {len(closed_sessions)}"
-                f"{debug_info}",
+                created_sessions,
+                closed_sessions,
+                f"HTTP Sessions leak detected! Leaked: {created_sessions - closed_sessions}",
             )
 
-            created_channel_ids = {id(c) for c in created_channels}
-            closed_channel_ids = {id(c) for c in closed_channels}
-            leaked_channel_ids = created_channel_ids - closed_channel_ids
-
             self.assertEqual(
-                len(leaked_channel_ids),
-                0,
-                f"gRPC Channels leak detected! Leaked: {len(leaked_channel_ids)}. "
-                f"Unique Created: {len(created_channel_ids)}, Unique Closed: {len(closed_channel_ids)}. "
-                f"Total Created: {len(created_channels)}, Total Closed: {len(closed_channels)}",
+                created_channels,
+                closed_channels,
+                f"gRPC Channels leak detected! Leaked: {created_channels - closed_channels}",
             )
 
         finally:
@@ -2291,19 +2264,17 @@ class TestBigQuery(unittest.TestCase):
             google.api_core.grpc_helpers.create_channel = original_create_channel
 
             # Clean up any unclosed sessions/channels to avoid leaking in the test runner
-            for s in created_sessions:
-                if s not in closed_sessions:
-                    try:
-                        s.close()
-                    except Exception:
-                        pass
+            for s in created_sessions - closed_sessions:
+                try:
+                    s.close()
+                except Exception:
+                    pass
 
-            for c in created_channels:
-                if c not in closed_channels:
-                    try:
-                        c.close()
-                    except Exception:
-                        pass
+            for c in created_channels - closed_channels:
+                try:
+                    c.close()
+                except Exception:
+                    pass
 
     def _load_table_for_dml(self, rows, dataset_id, table_id):
         from google.cloud._testing import _NamedTemporaryFile

--- a/packages/google-cloud-bigquery/tests/system/test_client.py
+++ b/packages/google-cloud-bigquery/tests/system/test_client.py
@@ -2189,13 +2189,17 @@ class TestBigQuery(unittest.TestCase):
         # Track HTTP Sessions
         created_sessions = []
         closed_sessions = []
+        session_creation_stacks = {}
 
         original_session_init = requests.Session.__init__
         original_session_close = requests.Session.close
 
+        import traceback
+
         def patched_session_init(self, *args, **kwargs):
             original_session_init(self, *args, **kwargs)
             created_sessions.append(self)
+            session_creation_stacks[id(self)] = traceback.format_stack(limit=10)
 
         def patched_session_close(self):
             original_session_close(self)
@@ -2248,12 +2252,23 @@ class TestBigQuery(unittest.TestCase):
             closed_session_ids = {id(s) for s in closed_sessions}
             leaked_session_ids = created_session_ids - closed_session_ids
 
+            debug_info = ""
+            if leaked_session_ids:
+                debug_info += "\n--- Leaked Sessions Creation Stacks ---\n"
+                for s_id in leaked_session_ids:
+                    debug_info += f"\nSession ID: {s_id}\n"
+                    debug_info += "".join(
+                        session_creation_stacks.get(s_id, ["No stack trace available"])
+                    )
+                    debug_info += "----------------------------------------\n"
+
             self.assertEqual(
                 len(leaked_session_ids),
                 0,
                 f"HTTP Sessions leak detected! Leaked: {len(leaked_session_ids)}. "
                 f"Unique Created: {len(created_session_ids)}, Unique Closed: {len(closed_session_ids)}. "
-                f"Total Created: {len(created_sessions)}, Total Closed: {len(closed_sessions)}",
+                f"Total Created: {len(created_sessions)}, Total Closed: {len(closed_sessions)}"
+                f"{debug_info}",
             )
 
             created_channel_ids = {id(c) for c in created_channels}

--- a/packages/google-cloud-bigquery/tests/system/test_client.py
+++ b/packages/google-cloud-bigquery/tests/system/test_client.py
@@ -2182,6 +2182,11 @@ class TestBigQuery(unittest.TestCase):
 
     def test_dbapi_connection_does_not_leak_sockets(self):
         pytest.importorskip("google.cloud.bigquery_storage")
+
+        # Ensure any garbage collection from previous tests is done to avoid false positives.
+        import gc
+        gc.collect()
+
         current_process = psutil.Process()
         conn_start = current_process.net_connections()
         conn_count_start = len(conn_start)

--- a/packages/google-cloud-bigquery/tests/system/test_client.py
+++ b/packages/google-cloud-bigquery/tests/system/test_client.py
@@ -2183,15 +2183,49 @@ class TestBigQuery(unittest.TestCase):
     def test_dbapi_connection_does_not_leak_sockets(self):
         pytest.importorskip("google.cloud.bigquery_storage")
 
-        # Ensure any garbage collection from previous tests is done to avoid false positives.
-        import gc
-        gc.collect()
+        import google.api_core.grpc_helpers
+        import requests
 
-        current_process = psutil.Process()
-        conn_start = current_process.net_connections()
-        conn_count_start = len(conn_start)
+        # Track HTTP Sessions
+        created_sessions = []
+        closed_sessions = []
 
-        with helpers.patch_tracked_requests():
+        original_session_init = requests.Session.__init__
+        original_session_close = requests.Session.close
+
+        def patched_session_init(self, *args, **kwargs):
+            original_session_init(self, *args, **kwargs)
+            created_sessions.append(self)
+
+        def patched_session_close(self):
+            original_session_close(self)
+            closed_sessions.append(self)
+
+        # Track gRPC Channels
+        created_channels = []
+        closed_channels = []
+
+        original_create_channel = google.api_core.grpc_helpers.create_channel
+
+        def patched_create_channel(*args, **kwargs):
+            channel = original_create_channel(*args, **kwargs)
+            created_channels.append(channel)
+
+            original_channel_close = channel.close
+
+            def patched_channel_close(*c_args, **c_kwargs):
+                original_channel_close(*c_args, **c_kwargs)
+                closed_channels.append(channel)
+
+            channel.close = patched_channel_close
+            return channel
+
+        # Apply patches
+        requests.Session.__init__ = patched_session_init
+        requests.Session.close = patched_session_close
+        google.api_core.grpc_helpers.create_channel = patched_create_channel
+
+        try:
             # Provide no explicit clients, so that the connection will create and own them.
             connection = dbapi.connect()
             cursor = connection.cursor()
@@ -2208,36 +2242,40 @@ class TestBigQuery(unittest.TestCase):
             self.assertEqual(len(rows), 100000)
 
             connection.close()
-        import gc
 
-        gc.collect()
-        for _ in range(30):  # Wait up to 3 seconds
-            conn_end = current_process.net_connections()
-            conn_count_end = len(conn_end)
-            if conn_count_end <= conn_count_start:
-                break
-            time.sleep(0.1)
-
-        try:
-            self.assertLessEqual(conn_count_end, conn_count_start)
-        except AssertionError as e:
-            # Due to flakiness in this test (likely caused by OS cleanup delays or
-            # non-deterministic garbage collection of sockets), we want to capture
-            # the detailed state of connections in future failing runs to help
-            # decrease false positives and identify the root cause.
-            conn_debug = [
-                f"Status: {c.status}, Laddr: {c.laddr}, Raddr: {c.raddr}"
-                for c in current_process.net_connections()
-            ]
-            debug_msg = "\n".join(conn_debug)
-
-            raise AssertionError(
-                f"{e}\n\n"
-                f"--- Socket Leak Debug Info ---\n"
-                f"Start Count: {conn_count_start}\n"
-                f"End Count: {conn_count_end}\n"
-                f"Current Connections:\n{debug_msg}"
+            # Assertions
+            self.assertEqual(
+                len(created_sessions),
+                len(closed_sessions),
+                f"HTTP Sessions leak detected! Created: {len(created_sessions)}, Closed: {len(closed_sessions)}",
             )
+
+            self.assertEqual(
+                len(created_channels),
+                len(closed_channels),
+                f"gRPC Channels leak detected! Created: {len(created_channels)}, Closed: {len(closed_channels)}",
+            )
+
+        finally:
+            # Revert patches
+            requests.Session.__init__ = original_session_init
+            requests.Session.close = original_session_close
+            google.api_core.grpc_helpers.create_channel = original_create_channel
+
+            # Clean up any unclosed sessions/channels to avoid leaking in the test runner
+            for s in created_sessions:
+                if s not in closed_sessions:
+                    try:
+                        s.close()
+                    except Exception:
+                        pass
+
+            for c in created_channels:
+                if c not in closed_channels:
+                    try:
+                        c.close()
+                    except Exception:
+                        pass
 
     def _load_table_for_dml(self, rows, dataset_id, table_id):
         from google.cloud._testing import _NamedTemporaryFile


### PR DESCRIPTION
This Pull Request addresses flakiness in the socket leak system test and improves resource cleanup in the Database API (DB-API) connection.

## Problem

1. The test `test_dbapi_connection_does_not_leak_sockets` was flaky in Continuous Integration (CI) environments because it relied on the `psutil` library to count Operating System sockets. Socket pooling, delayed garbage collection, and background noise (other processes in multiprocess systems creating sockets in parallelized systems) make counting Operating System sockets non-deterministic.
2. Closing a database connection could leave underlying resources hanging if cursors were not closed in the correct order or if clients were not fully initialized.

## Solution

1. **Deterministic Testing:** Rewrote the test to use **Whitebox Object Tracking**. Instead of counting Operating System sockets, the test intercepts the creation and closure of `requests.Session` and `grpc.Channel` objects using instance-level monkey patching. This ensures that every session or channel opened by the connection is explicitly accounted for and closed, independent of Operating System quirks.
2. **Improved Cleanup:** Updated `Connection.close()` in `connection.py` to close all created cursors **before** closing the clients themselves. This ensures that cursors release their references to query data and transports first. Added defensive checks to prevent errors if clients are `None`.

> [!note]
> - This test no longer uses `psutil` or artificial sleeps (that were used to try and wait long enough for garbage collection to kick in), making it faster and fully deterministic.
> - Uses Python `sets` to track objects thus avoiding false positives due to double closures.
> - Instance-level patching is used to isolate tracking to only the objects created within the test block.

Closes https://github.com/googleapis/google-cloud-python/pull/17956
