### PR TITLE
fix: avoid retaining routing parameter instances in cache

### DIFF
--- a/packages/gapic-generator/gapic/schema/wrappers.py
+++ b/packages/gapic-generator/gapic/schema/wrappers.py
@@ -30,7 +30,6 @@ Documentation is consistently at ``{thing}.meta.doc``.
 import collections
 import copy
 import dataclasses
-import functools
 import json
 import keyword
 import re
@@ -1289,14 +1288,14 @@ class RoutingParameter:
         """
         return re.compile(f"^{self._convert_to_regex(path_template)}$")
 
-    # Use caching to avoid repeated computation
-    @functools.cache
-    def to_regex(self) -> Pattern:
+    @utils.cached_property
+    def _regex(self) -> Pattern:
         return self._to_regex(self.path_template)
 
-    @property
-    # Use caching to avoid repeated computation
-    @functools.cache
+    def to_regex(self) -> Pattern:
+        return self._regex
+
+    @utils.cached_property
     def key(self) -> Union[str, None]:
         if self.path_template == "":
             return self.field

--- a/packages/gapic-generator/tests/unit/schema/wrappers/test_routing.py
+++ b/packages/gapic-generator/tests/unit/schema/wrappers/test_routing.py
@@ -14,7 +14,9 @@
 
 from gapic.schema import wrappers
 
+import gc
 import json
+import weakref
 import proto
 import pytest
 
@@ -144,6 +146,20 @@ def test_routing_rule_resolve(routing_parameters, req, expected):
 def test_routing_parameter_key(field, path_template, expected):
     param = wrappers.RoutingParameter(field, path_template)
     assert param.key == expected
+
+
+def test_routing_parameter_cache_does_not_retain_instance():
+    param = wrappers.RoutingParameter(
+        "table_name", "{project_id=projects/*}/instances/*/**"
+    )
+    _ = param.to_regex()
+    _ = param.key
+    param_ref = weakref.ref(param)
+
+    del param
+    gc.collect()
+
+    assert param_ref() is None
 
 
 def test_routing_parameter_multi_segment_raises():

--- a/packages/gapic-generator/tests/unit/schema/wrappers/test_routing.py
+++ b/packages/gapic-generator/tests/unit/schema/wrappers/test_routing.py
@@ -16,6 +16,7 @@ from gapic.schema import wrappers
 
 import gc
 import json
+import uuid
 import weakref
 import proto
 import pytest
@@ -149,8 +150,9 @@ def test_routing_parameter_key(field, path_template, expected):
 
 
 def test_routing_parameter_cache_does_not_retain_instance():
+    unique_id = f"id_{uuid.uuid4().hex}"
     param = wrappers.RoutingParameter(
-        "table_name", "{project_id=projects/*}/instances/*/**"
+        f"table_name_{unique_id}", f"{{{unique_id}=projects/*}}/instances/*/**"
     )
     _ = param.to_regex()
     _ = param.key


### PR DESCRIPTION
functools.cache keeps method arguments, including self, in its unbounded cache. As a result, RoutingParameter instances remain alive after routing resolution.

Use the existing instance-scoped utils.cached_property for the compiled regex and routing key while preserving the to_regex() method API. Add a regression test that verifies a populated cache does not retain the instance.

Testing:
- pytest packages/gapic-generator/tests/unit/schema/wrappers/test_routing.py -q (Python 3.10 and 3.14)
- pytest packages/gapic-generator/tests/unit/schema/wrappers -q (Python 3.14)