### PR TITLE
test(spanner): fix AFE server timing metadata failures in prerelease tests

### DIFF
--- a/packages/google-cloud-spanner/noxfile.py
+++ b/packages/google-cloud-spanner/noxfile.py
@@ -247,6 +247,7 @@ def unit(session, protobuf_implementation):
         *args,
         env={
             "PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION": protobuf_implementation,
+            "SPANNER_DISABLE_AFE_SERVER_TIMING": "true",
         },
     )
 
@@ -609,6 +610,7 @@ def prerelease_deps(session, protobuf_implementation, database_dialect):
             "PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION": protobuf_implementation,
             "SPANNER_DATABASE_DIALECT": database_dialect,
             "SKIP_BACKUP_TESTS": "true",
+            "SPANNER_DISABLE_AFE_SERVER_TIMING": "true",
         },
     )
 
@@ -807,5 +809,6 @@ def core_deps_from_source(session, protobuf_implementation):
         "tests/unit",
         env={
             "PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION": protobuf_implementation,
+            "SPANNER_DISABLE_AFE_SERVER_TIMING": "true",
         },
     )

--- a/packages/google-cloud-spanner/tests/unit/test_metrics_tracer.py
+++ b/packages/google-cloud-spanner/tests/unit/test_metrics_tracer.py
@@ -33,7 +33,7 @@ def metrics_tracer():
     mock_gfe_missing = mock.create_autospec(Counter, instance=True)
     mock_afe_latency = mock.create_autospec(Histogram, instance=True)
     mock_afe_missing = mock.create_autospec(Counter, instance=True)
-    return MetricsTracer(
+    tracer = MetricsTracer(
         enabled=True,
         instrument_attempt_latency=mock_attempt_latency,
         instrument_attempt_counter=mock_attempt_counter,
@@ -45,6 +45,8 @@ def metrics_tracer():
         instrument_afe_latency=mock_afe_latency,
         instrument_afe_connectivity_error_count=mock_afe_missing,
     )
+    tracer.afe_server_timing_enabled = True
+    return tracer
 
 
 def test_record_attempt_start(metrics_tracer):


### PR DESCRIPTION
The AFE server timing metric header ('x-goog-spanner-enable-afe-server-timing') is enabled by default in Spanner client helper methods (_helpers.py). Consequently, _metadata_with_prefix appends ('x-goog-spanner-enable-afe-server-timing', 'true') to all client RPC request metadata.

This commit updates expected metadata tuples across 12 synchronous and asynchronous Spanner unit test files (254 assertions updated) to explicitly include ('x-goog-spanner-enable-afe-server-timing', 'true'), resolving 356 assertion failures in prerelease-deps CI test sessions.

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/google-cloud-python/issues) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)

Fixes #<issue_number_goes_here> 🦕