### PR TITLE
fix: Use user_verification=discouraged for Reauth WebAuthn challenge.

### DIFF
--- a/packages/google-auth/google/oauth2/challenges.py
+++ b/packages/google-auth/google/oauth2/challenges.py
@@ -225,7 +225,7 @@ class SecurityKeyChallenge(ReauthChallenge):
             challenge=self._unpadded_urlsafe_b64recode(challenge),
             timeout_ms=WEBAUTHN_TIMEOUT_MS,
             allow_credentials=allow_credentials,
-            user_verification="preferred",
+            user_verification="discouraged",
             extensions=extension,
         )
 

--- a/packages/google-auth/tests/oauth2/test_challenges.py
+++ b/packages/google-auth/tests/oauth2/test_challenges.py
@@ -235,7 +235,7 @@ def test_security_key_webauthn():
         challenge=challenge._unpadded_urlsafe_b64recode(sk_challenge["challenge"]),
         timeout_ms=challenges.WEBAUTHN_TIMEOUT_MS,
         allow_credentials=allow_credentials,
-        user_verification="preferred",
+        user_verification="discouraged",
         extensions=extension,
     )
 

--- a/packages/google-auth/tests/oauth2/test_webauthn_types.py
+++ b/packages/google-auth/tests/oauth2/test_webauthn_types.py
@@ -69,7 +69,7 @@ def test_GetRequest(has_allow_credentials):
         challenge="fake_challenge",
         timeout_ms=123,
         allow_credentials=allow_credentials if has_allow_credentials else None,
-        user_verification="preferred",
+        user_verification="discouraged",
         extensions=webauthn_types.AuthenticationExtensionsClientInputs(
             appid="fake_appid"
         ),
@@ -85,7 +85,7 @@ def test_GetRequest(has_allow_credentials):
             "rpId": "fake_rpid",
             "timeout": 123,
             "challenge": "fake_challenge",
-            "userVerification": "preferred",
+            "userVerification": "discouraged",
             "extensions": {"appid": "fake_appid"},
         },
     }


### PR DESCRIPTION
When a fido2 compliant security key is used, and a PIN is configured, the user_verification=preferred value forces PIN authentication.

The Reauth API security key challenge is modeled on U2F which does not expose UV requirements. This change removes the PIN prompt requirement for Google Cloud customers with fido2 security keys and session length controls enabled which require security key reauth.

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [x] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/google-cloud-python/issues) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)

Fixes #17975 