### PR TITLE
fix(bigframes): fix mypy errors in _magics.py related to get_ipython

### DIFF
--- a/packages/bigframes/bigframes/_magics.py
+++ b/packages/bigframes/bigframes/_magics.py
@@ -37,6 +37,9 @@ import bigframes.pandas
 )
 def _cell_magic(line, cell):
     ipython = get_ipython()
+    if ipython is None:
+        raise RuntimeError("BigQuery magic must be run in an IPython environment.")
+
     args = magic_arguments.parse_argstring(_cell_magic, line)
     if not cell:
         print("Query is missing.")


### PR DESCRIPTION
Fixes mypy error in `bigframes/_magics.py` caused by `get_ipython()` potentially returning `None`.

The issue was seen as:
```
nox > mypy bigframes tests/system tests/unit --check-untyped-defs --explicit-package-bases '--exclude="^third_party"'
bigframes/_magics.py:44: error: Item "None" of "InteractiveShell | None" has no attribute "user_ns"  [union-attr]
bigframes/_magics.py:49: error: Item "None" of "InteractiveShell | None" has no attribute "push"  [union-attr]
```

Resolved by adding a guard clause that checks if `ipython` is `None`, which then raises a `RuntimeError`, naturally helping mypy narrow down the types.

---
*PR created automatically by Jules for task [13181547226489082485](https://jules.google.com/task/13181547226489082485) started by @tswast*