### PR TITLE
test(spanner): revert noxfile changes and disable AFE server timing in conftest

### DIFF
--- a/packages/google-cloud-spanner/noxfile.py
+++ b/packages/google-cloud-spanner/noxfile.py
@@ -247,7 +247,6 @@ def unit(session, protobuf_implementation):
         *args,
         env={
             "PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION": protobuf_implementation,
-            "SPANNER_DISABLE_AFE_SERVER_TIMING": "true",
         },
     )
 
@@ -610,7 +609,6 @@ def prerelease_deps(session, protobuf_implementation, database_dialect):
             "PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION": protobuf_implementation,
             "SPANNER_DATABASE_DIALECT": database_dialect,
             "SKIP_BACKUP_TESTS": "true",
-            "SPANNER_DISABLE_AFE_SERVER_TIMING": "true",
         },
     )
 
@@ -809,6 +807,5 @@ def core_deps_from_source(session, protobuf_implementation):
         "tests/unit",
         env={
             "PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION": protobuf_implementation,
-            "SPANNER_DISABLE_AFE_SERVER_TIMING": "true",
         },
     )

--- a/packages/google-cloud-spanner/tests/unit/conftest.py
+++ b/packages/google-cloud-spanner/tests/unit/conftest.py
@@ -16,21 +16,27 @@ import os
 
 import pytest
 
+from google.cloud.spanner_v1 import _helpers
 from google.cloud.spanner_v1.metrics.spanner_metrics_tracer_factory import (
     SpannerMetricsTracerFactory,
 )
 
-# Disable builtin metrics to avoid background thread noise and 401 errors in unit tests
+# Disable builtin metrics and AFE server timing in unit tests
 os.environ["SPANNER_DISABLE_BUILTIN_METRICS"] = "true"
+os.environ["SPANNER_DISABLE_AFE_SERVER_TIMING"] = "true"
+_helpers.ENABLE_AFE_SERVER_TIMING = False
 
 
 @pytest.fixture(autouse=True)
 def reset_metrics_singletons(monkeypatch):
     # Reset singletons and env var before test to avoid state pollution
     monkeypatch.setenv("SPANNER_DISABLE_BUILTIN_METRICS", "true")
+    monkeypatch.setenv("SPANNER_DISABLE_AFE_SERVER_TIMING", "true")
+    _helpers.ENABLE_AFE_SERVER_TIMING = False
     SpannerMetricsTracerFactory._metrics_tracer_factory = None
     SpannerMetricsTracerFactory._current_metrics_tracer_ctx.set(None)
     yield
     # Reset singletons after test to ensure no leakage
+    _helpers.ENABLE_AFE_SERVER_TIMING = False
     SpannerMetricsTracerFactory._metrics_tracer_factory = None
     SpannerMetricsTracerFactory._current_metrics_tracer_ctx.set(None)

--- a/packages/google-cloud-spanner/tests/unit/conftest.py
+++ b/packages/google-cloud-spanner/tests/unit/conftest.py
@@ -32,11 +32,10 @@ def reset_metrics_singletons(monkeypatch):
     # Reset singletons and env var before test to avoid state pollution
     monkeypatch.setenv("SPANNER_DISABLE_BUILTIN_METRICS", "true")
     monkeypatch.setenv("SPANNER_DISABLE_AFE_SERVER_TIMING", "true")
-    _helpers.ENABLE_AFE_SERVER_TIMING = False
+    monkeypatch.setattr(_helpers, "ENABLE_AFE_SERVER_TIMING", False)
     SpannerMetricsTracerFactory._metrics_tracer_factory = None
     SpannerMetricsTracerFactory._current_metrics_tracer_ctx.set(None)
     yield
     # Reset singletons after test to ensure no leakage
-    _helpers.ENABLE_AFE_SERVER_TIMING = False
     SpannerMetricsTracerFactory._metrics_tracer_factory = None
     SpannerMetricsTracerFactory._current_metrics_tracer_ctx.set(None)


### PR DESCRIPTION
Reverts the edits to packages/google-cloud-spanner/noxfile.py from PR #17970 to restore compliance with owlbot/librarian autogeneration and fix issue #17974.

Disables AFE server timing in unit tests directly inside tests/unit/conftest.py by setting SPANNER_DISABLE_AFE_SERVER_TIMING="true" and _helpers.ENABLE_AFE_SERVER_TIMING = False. This ensures both standard unit tests and prerelease-deps unit tests pass cleanly without modifying autogenerated files or existing unit test assertions.

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/google-cloud-python/issues) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)

Fixes #<issue_number_goes_here> 🦕