### PR TITLE
chore: setup compute preview release config

### DIFF
--- a/.release-please-individual-manifest.json
+++ b/.release-please-individual-manifest.json
@@ -2,5 +2,6 @@
   "packages/bigframes": "2.47.0",
   "packages/google-cloud-bigquery": "3.42.3",
   "packages/google-crc32c": "1.8.0",
-  "packages/pandas-gbq": "0.35.0"
+  "packages/pandas-gbq": "0.35.0",
+  "preview-packages/google-cloud-compute": "1.51.0-preview.1"
 }

--- a/release-please-individual-config.json
+++ b/release-please-individual-config.json
@@ -13,6 +13,17 @@
     },
     "packages/pandas-gbq": {
       "component": "pandas-gbq"
+    },
+    "preview-packages/google-cloud-compute": {
+      "package-name": "google-cloud-compute",
+      "versioning": "prerelease",
+      "prerelease": true,
+      "prerelease-type": "preview",
+      "extra-files": [
+        "google/cloud/compute/gapic_version.py",
+        "google/cloud/compute_v1/gapic_version.py"
+      ],
+      "draft-pull-request": true
     }
   },
   "release-type": "python-librarian",


### PR DESCRIPTION
Adds the preview client package `preview-packages/google-cloud-compute` to the individual `release-please` configuration.

The PR will be created in draft mode because the version bumps may require manual intervention (see [playbook](http://go/sdk:previews-ug)). Manual `release-please` PR creation is also reasonable, but there is no way to turn off automated release PR creation while still retaining GitHub release creation/tagging automation.