### PR TITLE
chore: move google-cloud-bigquery to bulk release

### DIFF
--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -140,7 +140,7 @@ jobs:
           echo "All unit tests passed or were skipped"
 
   cover:
-    if: always() && !cancelled() && needs.all-tests.result == 'success'
+    if: always() && !cancelled() && needs.all-tests.result == 'success' && needs.unit.result != 'skipped'
     runs-on: ubuntu-latest
     needs:
         - all-tests

--- a/.release-please-bulk-manifest.json
+++ b/.release-please-bulk-manifest.json
@@ -54,6 +54,7 @@
   "packages/google-cloud-beyondcorp-clientgateways": "0.8.0",
   "packages/google-cloud-biglake": "0.5.0",
   "packages/google-cloud-biglake-hive": "0.3.1",
+  "packages/google-cloud-bigquery": "3.42.3",
   "packages/google-cloud-bigquery-analyticshub": "0.9.0",
   "packages/google-cloud-bigquery-biglake": "0.8.0",
   "packages/google-cloud-bigquery-connection": "1.22.0",

--- a/.release-please-individual-manifest.json
+++ b/.release-please-individual-manifest.json
@@ -1,6 +1,5 @@
 {
   "packages/bigframes": "2.47.0",
-  "packages/google-cloud-bigquery": "3.42.3",
   "packages/google-crc32c": "1.8.0",
   "packages/pandas-gbq": "0.35.0",
   "preview-packages/google-cloud-compute": "1.51.0-preview.1"

--- a/release-please-bulk-config.json
+++ b/release-please-bulk-config.json
@@ -653,6 +653,9 @@
         }
       ]
     },
+    "packages/google-cloud-bigquery": {
+      "component": "google-cloud-bigquery"
+    },
     "packages/google-cloud-bigquery-analyticshub": {
       "component": "google-cloud-bigquery-analyticshub",
       "extra-files": [

--- a/release-please-individual-config.json
+++ b/release-please-individual-config.json
@@ -5,9 +5,6 @@
     "packages/bigframes": {
       "component": "bigframes"
     },
-    "packages/google-cloud-bigquery": {
-      "component": "google-cloud-bigquery"
-    },
     "packages/google-crc32c": {
       "component": "google-crc32c"
     },


### PR DESCRIPTION
Reverts https://github.com/googleapis/google-cloud-python/pull/17944

`google-cloud-bigquery` system tests were fixed in https://github.com/googleapis/google-cloud-python/pull/17953 and https://github.com/googleapis/google-cloud-python/pull/17964

Closes https://github.com/googleapis/google-cloud-python/pull/17965