### PR TITLE
chore(generator): move `read_environment_variables` to `_compat.py.j2`

### DIFF
--- a/packages/gapic-generator/gapic/templates/%namespace/%name_%version/%sub/_compat.py.j2
+++ b/packages/gapic-generator/gapic/templates/%namespace/%name_%version/%sub/_compat.py.j2
@@ -58,7 +58,7 @@ def read_environment_variables():
     """Returns the environment variables used by the client.
 
     Returns:
-        Tuple[bool, str, bool]: returns the GOOGLE_API_USE_CLIENT_CERTIFICATE,
+        Tuple[bool, str, str]: returns the GOOGLE_API_USE_CLIENT_CERTIFICATE,
         GOOGLE_API_USE_MTLS_ENDPOINT, and GOOGLE_CLOUD_UNIVERSE_DOMAIN environment variables.
 
     Raises:
@@ -75,9 +75,7 @@ def read_environment_variables():
             "Environment variable `GOOGLE_API_USE_MTLS_ENDPOINT` must be `never`,"
             " `auto` or `always`"
         )
-    else:
-        use_mtls = use_mtls_endpoint == "always" or (use_mtls_endpoint == "auto" and use_client_cert)
-    return use_client_cert, use_mtls, universe_domain_env
+    return use_client_cert, use_mtls_endpoint, universe_domain_env
 
 
 DEFAULT_UNIVERSE = "googleapis.com"

--- a/packages/gapic-generator/gapic/templates/%namespace/%name_%version/%sub/_compat.py.j2
+++ b/packages/gapic-generator/gapic/templates/%namespace/%name_%version/%sub/_compat.py.j2
@@ -47,8 +47,35 @@ except ImportError:  # pragma: NO COVER
             raise ValueError(
                 "Environment variable `GOOGLE_API_USE_CLIENT_CERTIFICATE` must be"
                 " either `true` or `false`"
-            )
         return use_client_cert == "true"
+
+
+{# TODO(https://github.com/googleapis/google-cloud-python/issues/17883):
+Defer to google.auth.transport.mtls.should_use_mtls_endpoint to parse
+GOOGLE_API_USE_MTLS_ENDPOINT when available in minimum supported google-auth. #}
+def read_environment_variables():
+    """Returns the environment variables used by the client.
+
+    Returns:
+        Tuple[bool, str, str]: returns the GOOGLE_API_USE_CLIENT_CERTIFICATE,
+        GOOGLE_API_USE_MTLS_ENDPOINT, and GOOGLE_CLOUD_UNIVERSE_DOMAIN environment variables.
+
+    Raises:
+        ValueError: If GOOGLE_API_USE_CLIENT_CERTIFICATE is not
+            any of ["true", "false"].
+        google.auth.exceptions.MutualTLSChannelError: If GOOGLE_API_USE_MTLS_ENDPOINT
+            is not any of ["auto", "never", "always"].
+    """
+    use_client_cert = should_use_client_cert()
+    use_mtls_endpoint = os.getenv("GOOGLE_API_USE_MTLS_ENDPOINT", "auto").lower()
+    universe_domain_env = os.getenv("GOOGLE_CLOUD_UNIVERSE_DOMAIN")
+    if use_mtls_endpoint not in ("auto", "never", "always"):
+        raise MutualTLSChannelError(
+            "Environment variable `GOOGLE_API_USE_MTLS_ENDPOINT` must be `never`,"
+            " `auto` or `always`"
+        )
+    return use_client_cert, use_mtls_endpoint, universe_domain_env
+
 
 DEFAULT_UNIVERSE = "googleapis.com"
 

--- a/packages/gapic-generator/gapic/templates/%namespace/%name_%version/%sub/_compat.py.j2
+++ b/packages/gapic-generator/gapic/templates/%namespace/%name_%version/%sub/_compat.py.j2
@@ -47,6 +47,7 @@ except ImportError:  # pragma: NO COVER
             raise ValueError(
                 "Environment variable `GOOGLE_API_USE_CLIENT_CERTIFICATE` must be"
                 " either `true` or `false`"
+            )
         return use_client_cert == "true"
 
 

--- a/packages/gapic-generator/gapic/templates/%namespace/%name_%version/%sub/_compat.py.j2
+++ b/packages/gapic-generator/gapic/templates/%namespace/%name_%version/%sub/_compat.py.j2
@@ -58,7 +58,7 @@ def read_environment_variables():
     """Returns the environment variables used by the client.
 
     Returns:
-        Tuple[bool, str, str]: returns the GOOGLE_API_USE_CLIENT_CERTIFICATE,
+        Tuple[bool, str, bool]: returns the GOOGLE_API_USE_CLIENT_CERTIFICATE,
         GOOGLE_API_USE_MTLS_ENDPOINT, and GOOGLE_CLOUD_UNIVERSE_DOMAIN environment variables.
 
     Raises:
@@ -75,7 +75,9 @@ def read_environment_variables():
             "Environment variable `GOOGLE_API_USE_MTLS_ENDPOINT` must be `never`,"
             " `auto` or `always`"
         )
-    return use_client_cert, use_mtls_endpoint, universe_domain_env
+    else:
+        use_mtls = use_mtls_endpoint == "always" or (use_mtls_endpoint == "auto" and use_client_cert)
+    return use_client_cert, use_mtls, universe_domain_env
 
 
 DEFAULT_UNIVERSE = "googleapis.com"

--- a/packages/gapic-generator/gapic/templates/%namespace/%name_%version/%sub/_compat.py.j2
+++ b/packages/gapic-generator/gapic/templates/%namespace/%name_%version/%sub/_compat.py.j2
@@ -52,8 +52,8 @@ except ImportError:  # pragma: NO COVER
 
 
 {# TODO(https://github.com/googleapis/google-cloud-python/issues/17883):
-Defer to google.auth.transport.mtls.should_use_mtls_endpoint to parse
-GOOGLE_API_USE_MTLS_ENDPOINT when available in minimum supported google-auth. #}
+Defer to google.auth.transport.mtls.should_use_mtls_endpoint (available in google-auth >= 2.56.0)
+to parse GOOGLE_API_USE_MTLS_ENDPOINT when available in minimum supported google-auth. #}
 def read_environment_variables():
     """Returns the environment variables used by the client.
 

--- a/packages/gapic-generator/gapic/templates/%namespace/%name_%version/%sub/services/%service/client.py.j2
+++ b/packages/gapic-generator/gapic/templates/%namespace/%name_%version/%sub/services/%service/client.py.j2
@@ -30,7 +30,7 @@ from google.api_core import exceptions as core_exceptions
 from google.api_core import extended_operation
 {% endif %}
 from google.api_core import gapic_v1
-from {{package_path}}._compat import get_universe_domain, get_api_endpoint, get_default_mtls_endpoint, should_use_client_cert
+from {{package_path}}._compat import get_universe_domain, get_api_endpoint, get_default_mtls_endpoint, should_use_client_cert, read_environment_variables
 {% if has_auto_populated_fields %}
 from {{package_path}}._compat import setup_request_id
 {% endif %}
@@ -293,26 +293,7 @@ class {{ service.client_name }}(metaclass={{ service.client_name }}Meta):
 
         return api_endpoint, client_cert_source
 
-    @staticmethod
-    def _read_environment_variables():
-        """Returns the environment variables used by the client.
 
-        Returns:
-            Tuple[bool, str, str]: returns the GOOGLE_API_USE_CLIENT_CERTIFICATE,
-            GOOGLE_API_USE_MTLS_ENDPOINT, and GOOGLE_CLOUD_UNIVERSE_DOMAIN environment variables.
-
-        Raises:
-            ValueError: If GOOGLE_API_USE_CLIENT_CERTIFICATE is not
-                any of ["true", "false"].
-            google.auth.exceptions.MutualTLSChannelError: If GOOGLE_API_USE_MTLS_ENDPOINT
-                is not any of ["auto", "never", "always"].
-        """
-        use_client_cert = should_use_client_cert()
-        use_mtls_endpoint = os.getenv("GOOGLE_API_USE_MTLS_ENDPOINT", "auto").lower()
-        universe_domain_env = os.getenv("GOOGLE_CLOUD_UNIVERSE_DOMAIN")
-        if use_mtls_endpoint not in ("auto", "never", "always"):
-            raise MutualTLSChannelError("Environment variable `GOOGLE_API_USE_MTLS_ENDPOINT` must be `never`, `auto` or `always`")
-        return use_client_cert, use_mtls_endpoint, universe_domain_env
 
     @staticmethod
     def _get_client_cert_source(provided_cert_source, use_cert_flag):
@@ -459,7 +440,7 @@ class {{ service.client_name }}(metaclass={{ service.client_name }}Meta):
 
         universe_domain_opt = getattr(self._client_options, 'universe_domain', None)
 
-        self._use_client_cert, self._use_mtls_endpoint, self._universe_domain_env = {{ service.client_name }}._read_environment_variables()
+        self._use_client_cert, self._use_mtls_endpoint, self._universe_domain_env = read_environment_variables()
         self._client_cert_source = {{ service.client_name }}._get_client_cert_source(self._client_options.client_cert_source, self._use_client_cert)
         self._universe_domain = get_universe_domain(universe_domain_opt, self._universe_domain_env)
         self._api_endpoint: str = ""  # updated below, depending on `transport`

--- a/packages/gapic-generator/gapic/templates/tests/unit/gapic/%name_%version/%sub/test_compat.py.j2
+++ b/packages/gapic-generator/gapic/templates/tests/unit/gapic/%name_%version/%sub/test_compat.py.j2
@@ -23,7 +23,7 @@ import google.auth.transport.mtls
 
 {% set package_path = api.naming.module_namespace|join('.') + "." + api.naming.versioned_module_name %}
 from {{package_path}}._compat import transcode_request
-from {{package_path}}._compat import get_universe_domain, get_api_endpoint, get_default_mtls_endpoint, should_use_client_cert
+from {{package_path}}._compat import get_universe_domain, get_api_endpoint, get_default_mtls_endpoint, should_use_client_cert, read_environment_variables
 {% if has_auto_populated_fields %}
 from {{package_path}}._compat import setup_request_id
 {% endif %}
@@ -496,5 +496,17 @@ def test_transcode_request_proto_plus_wrapper():
 
     transcoded, _, _ = transcode_request(http_options, mock_proto_plus)
     assert transcoded["uri"] == "/v1/test/proto-plus-field"
+
+
+def test_read_environment_variables():
+    with mock.patch.dict(os.environ, {"GOOGLE_API_USE_CLIENT_CERTIFICATE": "true", "GOOGLE_API_USE_MTLS_ENDPOINT": "always", "GOOGLE_CLOUD_UNIVERSE_DOMAIN": "foo.com"}):
+        use_cert, mtls_endpoint, universe_domain = read_environment_variables()
+        assert use_cert is True
+        assert mtls_endpoint == "always"
+        assert universe_domain == "foo.com"
+
+    with mock.patch.dict(os.environ, {"GOOGLE_API_USE_MTLS_ENDPOINT": "invalid"}):
+        with pytest.raises(MutualTLSChannelError):
+            read_environment_variables()
 
 {% endblock %}

--- a/packages/gapic-generator/tests/integration/goldens/asset/google/cloud/asset_v1/_compat.py
+++ b/packages/gapic-generator/tests/integration/goldens/asset/google/cloud/asset_v1/_compat.py
@@ -47,7 +47,7 @@ def read_environment_variables():
     """Returns the environment variables used by the client.
 
     Returns:
-        Tuple[bool, str, bool]: returns the GOOGLE_API_USE_CLIENT_CERTIFICATE,
+        Tuple[bool, str, str]: returns the GOOGLE_API_USE_CLIENT_CERTIFICATE,
         GOOGLE_API_USE_MTLS_ENDPOINT, and GOOGLE_CLOUD_UNIVERSE_DOMAIN environment variables.
 
     Raises:
@@ -64,9 +64,7 @@ def read_environment_variables():
             "Environment variable `GOOGLE_API_USE_MTLS_ENDPOINT` must be `never`,"
             " `auto` or `always`"
         )
-    else:
-        use_mtls = use_mtls_endpoint == "always" or (use_mtls_endpoint == "auto" and use_client_cert)
-    return use_client_cert, use_mtls, universe_domain_env
+    return use_client_cert, use_mtls_endpoint, universe_domain_env
 
 
 DEFAULT_UNIVERSE = "googleapis.com"

--- a/packages/gapic-generator/tests/integration/goldens/asset/google/cloud/asset_v1/_compat.py
+++ b/packages/gapic-generator/tests/integration/goldens/asset/google/cloud/asset_v1/_compat.py
@@ -42,6 +42,31 @@ except ImportError:  # pragma: NO COVER
             )
         return use_client_cert == "true"
 
+
+def read_environment_variables():
+    """Returns the environment variables used by the client.
+
+    Returns:
+        Tuple[bool, str, str]: returns the GOOGLE_API_USE_CLIENT_CERTIFICATE,
+        GOOGLE_API_USE_MTLS_ENDPOINT, and GOOGLE_CLOUD_UNIVERSE_DOMAIN environment variables.
+
+    Raises:
+        ValueError: If GOOGLE_API_USE_CLIENT_CERTIFICATE is not
+            any of ["true", "false"].
+        google.auth.exceptions.MutualTLSChannelError: If GOOGLE_API_USE_MTLS_ENDPOINT
+            is not any of ["auto", "never", "always"].
+    """
+    use_client_cert = should_use_client_cert()
+    use_mtls_endpoint = os.getenv("GOOGLE_API_USE_MTLS_ENDPOINT", "auto").lower()
+    universe_domain_env = os.getenv("GOOGLE_CLOUD_UNIVERSE_DOMAIN")
+    if use_mtls_endpoint not in ("auto", "never", "always"):
+        raise MutualTLSChannelError(
+            "Environment variable `GOOGLE_API_USE_MTLS_ENDPOINT` must be `never`,"
+            " `auto` or `always`"
+        )
+    return use_client_cert, use_mtls_endpoint, universe_domain_env
+
+
 DEFAULT_UNIVERSE = "googleapis.com"
 
 

--- a/packages/gapic-generator/tests/integration/goldens/asset/google/cloud/asset_v1/_compat.py
+++ b/packages/gapic-generator/tests/integration/goldens/asset/google/cloud/asset_v1/_compat.py
@@ -47,7 +47,7 @@ def read_environment_variables():
     """Returns the environment variables used by the client.
 
     Returns:
-        Tuple[bool, str, str]: returns the GOOGLE_API_USE_CLIENT_CERTIFICATE,
+        Tuple[bool, str, bool]: returns the GOOGLE_API_USE_CLIENT_CERTIFICATE,
         GOOGLE_API_USE_MTLS_ENDPOINT, and GOOGLE_CLOUD_UNIVERSE_DOMAIN environment variables.
 
     Raises:
@@ -64,7 +64,9 @@ def read_environment_variables():
             "Environment variable `GOOGLE_API_USE_MTLS_ENDPOINT` must be `never`,"
             " `auto` or `always`"
         )
-    return use_client_cert, use_mtls_endpoint, universe_domain_env
+    else:
+        use_mtls = use_mtls_endpoint == "always" or (use_mtls_endpoint == "auto" and use_client_cert)
+    return use_client_cert, use_mtls, universe_domain_env
 
 
 DEFAULT_UNIVERSE = "googleapis.com"

--- a/packages/gapic-generator/tests/integration/goldens/asset/google/cloud/asset_v1/services/asset_service/client.py
+++ b/packages/gapic-generator/tests/integration/goldens/asset/google/cloud/asset_v1/services/asset_service/client.py
@@ -27,7 +27,7 @@ from google.cloud.asset_v1 import gapic_version as package_version
 from google.api_core import client_options as client_options_lib
 from google.api_core import exceptions as core_exceptions
 from google.api_core import gapic_v1
-from google.cloud.asset_v1._compat import get_universe_domain, get_api_endpoint, get_default_mtls_endpoint, should_use_client_cert
+from google.cloud.asset_v1._compat import get_universe_domain, get_api_endpoint, get_default_mtls_endpoint, should_use_client_cert, read_environment_variables
 from google.api_core import retry as retries
 from google.auth import credentials as ga_credentials             # type: ignore
 from google.auth.transport import mtls                            # type: ignore
@@ -349,27 +349,6 @@ class AssetServiceClient(metaclass=AssetServiceClientMeta):
         return api_endpoint, client_cert_source
 
     @staticmethod
-    def _read_environment_variables():
-        """Returns the environment variables used by the client.
-
-        Returns:
-            Tuple[bool, str, str]: returns the GOOGLE_API_USE_CLIENT_CERTIFICATE,
-            GOOGLE_API_USE_MTLS_ENDPOINT, and GOOGLE_CLOUD_UNIVERSE_DOMAIN environment variables.
-
-        Raises:
-            ValueError: If GOOGLE_API_USE_CLIENT_CERTIFICATE is not
-                any of ["true", "false"].
-            google.auth.exceptions.MutualTLSChannelError: If GOOGLE_API_USE_MTLS_ENDPOINT
-                is not any of ["auto", "never", "always"].
-        """
-        use_client_cert = should_use_client_cert()
-        use_mtls_endpoint = os.getenv("GOOGLE_API_USE_MTLS_ENDPOINT", "auto").lower()
-        universe_domain_env = os.getenv("GOOGLE_CLOUD_UNIVERSE_DOMAIN")
-        if use_mtls_endpoint not in ("auto", "never", "always"):
-            raise MutualTLSChannelError("Environment variable `GOOGLE_API_USE_MTLS_ENDPOINT` must be `never`, `auto` or `always`")
-        return use_client_cert, use_mtls_endpoint, universe_domain_env
-
-    @staticmethod
     def _get_client_cert_source(provided_cert_source, use_cert_flag):
         """Return the client cert source to be used by the client.
 
@@ -510,7 +489,7 @@ class AssetServiceClient(metaclass=AssetServiceClientMeta):
 
         universe_domain_opt = getattr(self._client_options, 'universe_domain', None)
 
-        self._use_client_cert, self._use_mtls_endpoint, self._universe_domain_env = AssetServiceClient._read_environment_variables()
+        self._use_client_cert, self._use_mtls_endpoint, self._universe_domain_env = read_environment_variables()
         self._client_cert_source = AssetServiceClient._get_client_cert_source(self._client_options.client_cert_source, self._use_client_cert)
         self._universe_domain = get_universe_domain(universe_domain_opt, self._universe_domain_env)
         self._api_endpoint: str = ""  # updated below, depending on `transport`

--- a/packages/gapic-generator/tests/integration/goldens/asset/tests/unit/gapic/asset_v1/test_compat.py
+++ b/packages/gapic-generator/tests/integration/goldens/asset/tests/unit/gapic/asset_v1/test_compat.py
@@ -24,7 +24,7 @@ from unittest import mock
 import google.auth.transport.mtls
 
 from google.cloud.asset_v1._compat import transcode_request
-from google.cloud.asset_v1._compat import get_universe_domain, get_api_endpoint, get_default_mtls_endpoint, should_use_client_cert
+from google.cloud.asset_v1._compat import get_universe_domain, get_api_endpoint, get_default_mtls_endpoint, should_use_client_cert, read_environment_variables
 
 from google.auth.exceptions import MutualTLSChannelError
 from google.api_core.universe import EmptyUniverseError
@@ -411,3 +411,15 @@ def test_transcode_request_proto_plus_wrapper():
 
     transcoded, _, _ = transcode_request(http_options, mock_proto_plus)
     assert transcoded["uri"] == "/v1/test/proto-plus-field"
+
+
+def test_read_environment_variables():
+    with mock.patch.dict(os.environ, {"GOOGLE_API_USE_CLIENT_CERTIFICATE": "true", "GOOGLE_API_USE_MTLS_ENDPOINT": "always", "GOOGLE_CLOUD_UNIVERSE_DOMAIN": "foo.com"}):
+        use_cert, mtls_endpoint, universe_domain = read_environment_variables()
+        assert use_cert is True
+        assert mtls_endpoint == "always"
+        assert universe_domain == "foo.com"
+
+    with mock.patch.dict(os.environ, {"GOOGLE_API_USE_MTLS_ENDPOINT": "invalid"}):
+        with pytest.raises(MutualTLSChannelError):
+            read_environment_variables()

--- a/packages/gapic-generator/tests/integration/goldens/credentials/google/iam/credentials_v1/_compat.py
+++ b/packages/gapic-generator/tests/integration/goldens/credentials/google/iam/credentials_v1/_compat.py
@@ -47,7 +47,7 @@ def read_environment_variables():
     """Returns the environment variables used by the client.
 
     Returns:
-        Tuple[bool, str, bool]: returns the GOOGLE_API_USE_CLIENT_CERTIFICATE,
+        Tuple[bool, str, str]: returns the GOOGLE_API_USE_CLIENT_CERTIFICATE,
         GOOGLE_API_USE_MTLS_ENDPOINT, and GOOGLE_CLOUD_UNIVERSE_DOMAIN environment variables.
 
     Raises:
@@ -64,9 +64,7 @@ def read_environment_variables():
             "Environment variable `GOOGLE_API_USE_MTLS_ENDPOINT` must be `never`,"
             " `auto` or `always`"
         )
-    else:
-        use_mtls = use_mtls_endpoint == "always" or (use_mtls_endpoint == "auto" and use_client_cert)
-    return use_client_cert, use_mtls, universe_domain_env
+    return use_client_cert, use_mtls_endpoint, universe_domain_env
 
 
 DEFAULT_UNIVERSE = "googleapis.com"

--- a/packages/gapic-generator/tests/integration/goldens/credentials/google/iam/credentials_v1/_compat.py
+++ b/packages/gapic-generator/tests/integration/goldens/credentials/google/iam/credentials_v1/_compat.py
@@ -42,6 +42,31 @@ except ImportError:  # pragma: NO COVER
             )
         return use_client_cert == "true"
 
+
+def read_environment_variables():
+    """Returns the environment variables used by the client.
+
+    Returns:
+        Tuple[bool, str, str]: returns the GOOGLE_API_USE_CLIENT_CERTIFICATE,
+        GOOGLE_API_USE_MTLS_ENDPOINT, and GOOGLE_CLOUD_UNIVERSE_DOMAIN environment variables.
+
+    Raises:
+        ValueError: If GOOGLE_API_USE_CLIENT_CERTIFICATE is not
+            any of ["true", "false"].
+        google.auth.exceptions.MutualTLSChannelError: If GOOGLE_API_USE_MTLS_ENDPOINT
+            is not any of ["auto", "never", "always"].
+    """
+    use_client_cert = should_use_client_cert()
+    use_mtls_endpoint = os.getenv("GOOGLE_API_USE_MTLS_ENDPOINT", "auto").lower()
+    universe_domain_env = os.getenv("GOOGLE_CLOUD_UNIVERSE_DOMAIN")
+    if use_mtls_endpoint not in ("auto", "never", "always"):
+        raise MutualTLSChannelError(
+            "Environment variable `GOOGLE_API_USE_MTLS_ENDPOINT` must be `never`,"
+            " `auto` or `always`"
+        )
+    return use_client_cert, use_mtls_endpoint, universe_domain_env
+
+
 DEFAULT_UNIVERSE = "googleapis.com"
 
 

--- a/packages/gapic-generator/tests/integration/goldens/credentials/google/iam/credentials_v1/_compat.py
+++ b/packages/gapic-generator/tests/integration/goldens/credentials/google/iam/credentials_v1/_compat.py
@@ -47,7 +47,7 @@ def read_environment_variables():
     """Returns the environment variables used by the client.
 
     Returns:
-        Tuple[bool, str, str]: returns the GOOGLE_API_USE_CLIENT_CERTIFICATE,
+        Tuple[bool, str, bool]: returns the GOOGLE_API_USE_CLIENT_CERTIFICATE,
         GOOGLE_API_USE_MTLS_ENDPOINT, and GOOGLE_CLOUD_UNIVERSE_DOMAIN environment variables.
 
     Raises:
@@ -64,7 +64,9 @@ def read_environment_variables():
             "Environment variable `GOOGLE_API_USE_MTLS_ENDPOINT` must be `never`,"
             " `auto` or `always`"
         )
-    return use_client_cert, use_mtls_endpoint, universe_domain_env
+    else:
+        use_mtls = use_mtls_endpoint == "always" or (use_mtls_endpoint == "auto" and use_client_cert)
+    return use_client_cert, use_mtls, universe_domain_env
 
 
 DEFAULT_UNIVERSE = "googleapis.com"

--- a/packages/gapic-generator/tests/integration/goldens/credentials/google/iam/credentials_v1/services/iam_credentials/client.py
+++ b/packages/gapic-generator/tests/integration/goldens/credentials/google/iam/credentials_v1/services/iam_credentials/client.py
@@ -27,7 +27,7 @@ from google.iam.credentials_v1 import gapic_version as package_version
 from google.api_core import client_options as client_options_lib
 from google.api_core import exceptions as core_exceptions
 from google.api_core import gapic_v1
-from google.iam.credentials_v1._compat import get_universe_domain, get_api_endpoint, get_default_mtls_endpoint, should_use_client_cert
+from google.iam.credentials_v1._compat import get_universe_domain, get_api_endpoint, get_default_mtls_endpoint, should_use_client_cert, read_environment_variables
 from google.api_core import retry as retries
 from google.auth import credentials as ga_credentials             # type: ignore
 from google.auth.transport import mtls                            # type: ignore
@@ -286,27 +286,6 @@ class IAMCredentialsClient(metaclass=IAMCredentialsClientMeta):
         return api_endpoint, client_cert_source
 
     @staticmethod
-    def _read_environment_variables():
-        """Returns the environment variables used by the client.
-
-        Returns:
-            Tuple[bool, str, str]: returns the GOOGLE_API_USE_CLIENT_CERTIFICATE,
-            GOOGLE_API_USE_MTLS_ENDPOINT, and GOOGLE_CLOUD_UNIVERSE_DOMAIN environment variables.
-
-        Raises:
-            ValueError: If GOOGLE_API_USE_CLIENT_CERTIFICATE is not
-                any of ["true", "false"].
-            google.auth.exceptions.MutualTLSChannelError: If GOOGLE_API_USE_MTLS_ENDPOINT
-                is not any of ["auto", "never", "always"].
-        """
-        use_client_cert = should_use_client_cert()
-        use_mtls_endpoint = os.getenv("GOOGLE_API_USE_MTLS_ENDPOINT", "auto").lower()
-        universe_domain_env = os.getenv("GOOGLE_CLOUD_UNIVERSE_DOMAIN")
-        if use_mtls_endpoint not in ("auto", "never", "always"):
-            raise MutualTLSChannelError("Environment variable `GOOGLE_API_USE_MTLS_ENDPOINT` must be `never`, `auto` or `always`")
-        return use_client_cert, use_mtls_endpoint, universe_domain_env
-
-    @staticmethod
     def _get_client_cert_source(provided_cert_source, use_cert_flag):
         """Return the client cert source to be used by the client.
 
@@ -447,7 +426,7 @@ class IAMCredentialsClient(metaclass=IAMCredentialsClientMeta):
 
         universe_domain_opt = getattr(self._client_options, 'universe_domain', None)
 
-        self._use_client_cert, self._use_mtls_endpoint, self._universe_domain_env = IAMCredentialsClient._read_environment_variables()
+        self._use_client_cert, self._use_mtls_endpoint, self._universe_domain_env = read_environment_variables()
         self._client_cert_source = IAMCredentialsClient._get_client_cert_source(self._client_options.client_cert_source, self._use_client_cert)
         self._universe_domain = get_universe_domain(universe_domain_opt, self._universe_domain_env)
         self._api_endpoint: str = ""  # updated below, depending on `transport`

--- a/packages/gapic-generator/tests/integration/goldens/credentials/tests/unit/gapic/credentials_v1/test_compat.py
+++ b/packages/gapic-generator/tests/integration/goldens/credentials/tests/unit/gapic/credentials_v1/test_compat.py
@@ -24,7 +24,7 @@ from unittest import mock
 import google.auth.transport.mtls
 
 from google.iam.credentials_v1._compat import transcode_request
-from google.iam.credentials_v1._compat import get_universe_domain, get_api_endpoint, get_default_mtls_endpoint, should_use_client_cert
+from google.iam.credentials_v1._compat import get_universe_domain, get_api_endpoint, get_default_mtls_endpoint, should_use_client_cert, read_environment_variables
 
 from google.auth.exceptions import MutualTLSChannelError
 from google.api_core.universe import EmptyUniverseError
@@ -411,3 +411,15 @@ def test_transcode_request_proto_plus_wrapper():
 
     transcoded, _, _ = transcode_request(http_options, mock_proto_plus)
     assert transcoded["uri"] == "/v1/test/proto-plus-field"
+
+
+def test_read_environment_variables():
+    with mock.patch.dict(os.environ, {"GOOGLE_API_USE_CLIENT_CERTIFICATE": "true", "GOOGLE_API_USE_MTLS_ENDPOINT": "always", "GOOGLE_CLOUD_UNIVERSE_DOMAIN": "foo.com"}):
+        use_cert, mtls_endpoint, universe_domain = read_environment_variables()
+        assert use_cert is True
+        assert mtls_endpoint == "always"
+        assert universe_domain == "foo.com"
+
+    with mock.patch.dict(os.environ, {"GOOGLE_API_USE_MTLS_ENDPOINT": "invalid"}):
+        with pytest.raises(MutualTLSChannelError):
+            read_environment_variables()

--- a/packages/gapic-generator/tests/integration/goldens/eventarc/google/cloud/eventarc_v1/_compat.py
+++ b/packages/gapic-generator/tests/integration/goldens/eventarc/google/cloud/eventarc_v1/_compat.py
@@ -47,7 +47,7 @@ def read_environment_variables():
     """Returns the environment variables used by the client.
 
     Returns:
-        Tuple[bool, str, bool]: returns the GOOGLE_API_USE_CLIENT_CERTIFICATE,
+        Tuple[bool, str, str]: returns the GOOGLE_API_USE_CLIENT_CERTIFICATE,
         GOOGLE_API_USE_MTLS_ENDPOINT, and GOOGLE_CLOUD_UNIVERSE_DOMAIN environment variables.
 
     Raises:
@@ -64,9 +64,7 @@ def read_environment_variables():
             "Environment variable `GOOGLE_API_USE_MTLS_ENDPOINT` must be `never`,"
             " `auto` or `always`"
         )
-    else:
-        use_mtls = use_mtls_endpoint == "always" or (use_mtls_endpoint == "auto" and use_client_cert)
-    return use_client_cert, use_mtls, universe_domain_env
+    return use_client_cert, use_mtls_endpoint, universe_domain_env
 
 
 DEFAULT_UNIVERSE = "googleapis.com"

--- a/packages/gapic-generator/tests/integration/goldens/eventarc/google/cloud/eventarc_v1/_compat.py
+++ b/packages/gapic-generator/tests/integration/goldens/eventarc/google/cloud/eventarc_v1/_compat.py
@@ -42,6 +42,31 @@ except ImportError:  # pragma: NO COVER
             )
         return use_client_cert == "true"
 
+
+def read_environment_variables():
+    """Returns the environment variables used by the client.
+
+    Returns:
+        Tuple[bool, str, str]: returns the GOOGLE_API_USE_CLIENT_CERTIFICATE,
+        GOOGLE_API_USE_MTLS_ENDPOINT, and GOOGLE_CLOUD_UNIVERSE_DOMAIN environment variables.
+
+    Raises:
+        ValueError: If GOOGLE_API_USE_CLIENT_CERTIFICATE is not
+            any of ["true", "false"].
+        google.auth.exceptions.MutualTLSChannelError: If GOOGLE_API_USE_MTLS_ENDPOINT
+            is not any of ["auto", "never", "always"].
+    """
+    use_client_cert = should_use_client_cert()
+    use_mtls_endpoint = os.getenv("GOOGLE_API_USE_MTLS_ENDPOINT", "auto").lower()
+    universe_domain_env = os.getenv("GOOGLE_CLOUD_UNIVERSE_DOMAIN")
+    if use_mtls_endpoint not in ("auto", "never", "always"):
+        raise MutualTLSChannelError(
+            "Environment variable `GOOGLE_API_USE_MTLS_ENDPOINT` must be `never`,"
+            " `auto` or `always`"
+        )
+    return use_client_cert, use_mtls_endpoint, universe_domain_env
+
+
 DEFAULT_UNIVERSE = "googleapis.com"
 
 

--- a/packages/gapic-generator/tests/integration/goldens/eventarc/google/cloud/eventarc_v1/_compat.py
+++ b/packages/gapic-generator/tests/integration/goldens/eventarc/google/cloud/eventarc_v1/_compat.py
@@ -47,7 +47,7 @@ def read_environment_variables():
     """Returns the environment variables used by the client.
 
     Returns:
-        Tuple[bool, str, str]: returns the GOOGLE_API_USE_CLIENT_CERTIFICATE,
+        Tuple[bool, str, bool]: returns the GOOGLE_API_USE_CLIENT_CERTIFICATE,
         GOOGLE_API_USE_MTLS_ENDPOINT, and GOOGLE_CLOUD_UNIVERSE_DOMAIN environment variables.
 
     Raises:
@@ -64,7 +64,9 @@ def read_environment_variables():
             "Environment variable `GOOGLE_API_USE_MTLS_ENDPOINT` must be `never`,"
             " `auto` or `always`"
         )
-    return use_client_cert, use_mtls_endpoint, universe_domain_env
+    else:
+        use_mtls = use_mtls_endpoint == "always" or (use_mtls_endpoint == "auto" and use_client_cert)
+    return use_client_cert, use_mtls, universe_domain_env
 
 
 DEFAULT_UNIVERSE = "googleapis.com"

--- a/packages/gapic-generator/tests/integration/goldens/eventarc/google/cloud/eventarc_v1/services/eventarc/client.py
+++ b/packages/gapic-generator/tests/integration/goldens/eventarc/google/cloud/eventarc_v1/services/eventarc/client.py
@@ -27,7 +27,7 @@ from google.cloud.eventarc_v1 import gapic_version as package_version
 from google.api_core import client_options as client_options_lib
 from google.api_core import exceptions as core_exceptions
 from google.api_core import gapic_v1
-from google.cloud.eventarc_v1._compat import get_universe_domain, get_api_endpoint, get_default_mtls_endpoint, should_use_client_cert
+from google.cloud.eventarc_v1._compat import get_universe_domain, get_api_endpoint, get_default_mtls_endpoint, should_use_client_cert, read_environment_variables
 from google.api_core import retry as retries
 from google.auth import credentials as ga_credentials             # type: ignore
 from google.auth.transport import mtls                            # type: ignore
@@ -469,27 +469,6 @@ class EventarcClient(metaclass=EventarcClientMeta):
         return api_endpoint, client_cert_source
 
     @staticmethod
-    def _read_environment_variables():
-        """Returns the environment variables used by the client.
-
-        Returns:
-            Tuple[bool, str, str]: returns the GOOGLE_API_USE_CLIENT_CERTIFICATE,
-            GOOGLE_API_USE_MTLS_ENDPOINT, and GOOGLE_CLOUD_UNIVERSE_DOMAIN environment variables.
-
-        Raises:
-            ValueError: If GOOGLE_API_USE_CLIENT_CERTIFICATE is not
-                any of ["true", "false"].
-            google.auth.exceptions.MutualTLSChannelError: If GOOGLE_API_USE_MTLS_ENDPOINT
-                is not any of ["auto", "never", "always"].
-        """
-        use_client_cert = should_use_client_cert()
-        use_mtls_endpoint = os.getenv("GOOGLE_API_USE_MTLS_ENDPOINT", "auto").lower()
-        universe_domain_env = os.getenv("GOOGLE_CLOUD_UNIVERSE_DOMAIN")
-        if use_mtls_endpoint not in ("auto", "never", "always"):
-            raise MutualTLSChannelError("Environment variable `GOOGLE_API_USE_MTLS_ENDPOINT` must be `never`, `auto` or `always`")
-        return use_client_cert, use_mtls_endpoint, universe_domain_env
-
-    @staticmethod
     def _get_client_cert_source(provided_cert_source, use_cert_flag):
         """Return the client cert source to be used by the client.
 
@@ -630,7 +609,7 @@ class EventarcClient(metaclass=EventarcClientMeta):
 
         universe_domain_opt = getattr(self._client_options, 'universe_domain', None)
 
-        self._use_client_cert, self._use_mtls_endpoint, self._universe_domain_env = EventarcClient._read_environment_variables()
+        self._use_client_cert, self._use_mtls_endpoint, self._universe_domain_env = read_environment_variables()
         self._client_cert_source = EventarcClient._get_client_cert_source(self._client_options.client_cert_source, self._use_client_cert)
         self._universe_domain = get_universe_domain(universe_domain_opt, self._universe_domain_env)
         self._api_endpoint: str = ""  # updated below, depending on `transport`

--- a/packages/gapic-generator/tests/integration/goldens/eventarc/tests/unit/gapic/eventarc_v1/test_compat.py
+++ b/packages/gapic-generator/tests/integration/goldens/eventarc/tests/unit/gapic/eventarc_v1/test_compat.py
@@ -24,7 +24,7 @@ from unittest import mock
 import google.auth.transport.mtls
 
 from google.cloud.eventarc_v1._compat import transcode_request
-from google.cloud.eventarc_v1._compat import get_universe_domain, get_api_endpoint, get_default_mtls_endpoint, should_use_client_cert
+from google.cloud.eventarc_v1._compat import get_universe_domain, get_api_endpoint, get_default_mtls_endpoint, should_use_client_cert, read_environment_variables
 
 from google.auth.exceptions import MutualTLSChannelError
 from google.api_core.universe import EmptyUniverseError
@@ -411,3 +411,15 @@ def test_transcode_request_proto_plus_wrapper():
 
     transcoded, _, _ = transcode_request(http_options, mock_proto_plus)
     assert transcoded["uri"] == "/v1/test/proto-plus-field"
+
+
+def test_read_environment_variables():
+    with mock.patch.dict(os.environ, {"GOOGLE_API_USE_CLIENT_CERTIFICATE": "true", "GOOGLE_API_USE_MTLS_ENDPOINT": "always", "GOOGLE_CLOUD_UNIVERSE_DOMAIN": "foo.com"}):
+        use_cert, mtls_endpoint, universe_domain = read_environment_variables()
+        assert use_cert is True
+        assert mtls_endpoint == "always"
+        assert universe_domain == "foo.com"
+
+    with mock.patch.dict(os.environ, {"GOOGLE_API_USE_MTLS_ENDPOINT": "invalid"}):
+        with pytest.raises(MutualTLSChannelError):
+            read_environment_variables()

--- a/packages/gapic-generator/tests/integration/goldens/logging/google/cloud/logging_v2/_compat.py
+++ b/packages/gapic-generator/tests/integration/goldens/logging/google/cloud/logging_v2/_compat.py
@@ -47,7 +47,7 @@ def read_environment_variables():
     """Returns the environment variables used by the client.
 
     Returns:
-        Tuple[bool, str, bool]: returns the GOOGLE_API_USE_CLIENT_CERTIFICATE,
+        Tuple[bool, str, str]: returns the GOOGLE_API_USE_CLIENT_CERTIFICATE,
         GOOGLE_API_USE_MTLS_ENDPOINT, and GOOGLE_CLOUD_UNIVERSE_DOMAIN environment variables.
 
     Raises:
@@ -64,9 +64,7 @@ def read_environment_variables():
             "Environment variable `GOOGLE_API_USE_MTLS_ENDPOINT` must be `never`,"
             " `auto` or `always`"
         )
-    else:
-        use_mtls = use_mtls_endpoint == "always" or (use_mtls_endpoint == "auto" and use_client_cert)
-    return use_client_cert, use_mtls, universe_domain_env
+    return use_client_cert, use_mtls_endpoint, universe_domain_env
 
 
 DEFAULT_UNIVERSE = "googleapis.com"

--- a/packages/gapic-generator/tests/integration/goldens/logging/google/cloud/logging_v2/_compat.py
+++ b/packages/gapic-generator/tests/integration/goldens/logging/google/cloud/logging_v2/_compat.py
@@ -42,6 +42,31 @@ except ImportError:  # pragma: NO COVER
             )
         return use_client_cert == "true"
 
+
+def read_environment_variables():
+    """Returns the environment variables used by the client.
+
+    Returns:
+        Tuple[bool, str, str]: returns the GOOGLE_API_USE_CLIENT_CERTIFICATE,
+        GOOGLE_API_USE_MTLS_ENDPOINT, and GOOGLE_CLOUD_UNIVERSE_DOMAIN environment variables.
+
+    Raises:
+        ValueError: If GOOGLE_API_USE_CLIENT_CERTIFICATE is not
+            any of ["true", "false"].
+        google.auth.exceptions.MutualTLSChannelError: If GOOGLE_API_USE_MTLS_ENDPOINT
+            is not any of ["auto", "never", "always"].
+    """
+    use_client_cert = should_use_client_cert()
+    use_mtls_endpoint = os.getenv("GOOGLE_API_USE_MTLS_ENDPOINT", "auto").lower()
+    universe_domain_env = os.getenv("GOOGLE_CLOUD_UNIVERSE_DOMAIN")
+    if use_mtls_endpoint not in ("auto", "never", "always"):
+        raise MutualTLSChannelError(
+            "Environment variable `GOOGLE_API_USE_MTLS_ENDPOINT` must be `never`,"
+            " `auto` or `always`"
+        )
+    return use_client_cert, use_mtls_endpoint, universe_domain_env
+
+
 DEFAULT_UNIVERSE = "googleapis.com"
 
 

--- a/packages/gapic-generator/tests/integration/goldens/logging/google/cloud/logging_v2/_compat.py
+++ b/packages/gapic-generator/tests/integration/goldens/logging/google/cloud/logging_v2/_compat.py
@@ -47,7 +47,7 @@ def read_environment_variables():
     """Returns the environment variables used by the client.
 
     Returns:
-        Tuple[bool, str, str]: returns the GOOGLE_API_USE_CLIENT_CERTIFICATE,
+        Tuple[bool, str, bool]: returns the GOOGLE_API_USE_CLIENT_CERTIFICATE,
         GOOGLE_API_USE_MTLS_ENDPOINT, and GOOGLE_CLOUD_UNIVERSE_DOMAIN environment variables.
 
     Raises:
@@ -64,7 +64,9 @@ def read_environment_variables():
             "Environment variable `GOOGLE_API_USE_MTLS_ENDPOINT` must be `never`,"
             " `auto` or `always`"
         )
-    return use_client_cert, use_mtls_endpoint, universe_domain_env
+    else:
+        use_mtls = use_mtls_endpoint == "always" or (use_mtls_endpoint == "auto" and use_client_cert)
+    return use_client_cert, use_mtls, universe_domain_env
 
 
 DEFAULT_UNIVERSE = "googleapis.com"

--- a/packages/gapic-generator/tests/integration/goldens/logging/google/cloud/logging_v2/services/config_service_v2/client.py
+++ b/packages/gapic-generator/tests/integration/goldens/logging/google/cloud/logging_v2/services/config_service_v2/client.py
@@ -27,7 +27,7 @@ from google.cloud.logging_v2 import gapic_version as package_version
 from google.api_core import client_options as client_options_lib
 from google.api_core import exceptions as core_exceptions
 from google.api_core import gapic_v1
-from google.cloud.logging_v2._compat import get_universe_domain, get_api_endpoint, get_default_mtls_endpoint, should_use_client_cert
+from google.cloud.logging_v2._compat import get_universe_domain, get_api_endpoint, get_default_mtls_endpoint, should_use_client_cert, read_environment_variables
 from google.api_core import retry as retries
 from google.auth import credentials as ga_credentials             # type: ignore
 from google.auth.transport import mtls                            # type: ignore
@@ -345,27 +345,6 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
         return api_endpoint, client_cert_source
 
     @staticmethod
-    def _read_environment_variables():
-        """Returns the environment variables used by the client.
-
-        Returns:
-            Tuple[bool, str, str]: returns the GOOGLE_API_USE_CLIENT_CERTIFICATE,
-            GOOGLE_API_USE_MTLS_ENDPOINT, and GOOGLE_CLOUD_UNIVERSE_DOMAIN environment variables.
-
-        Raises:
-            ValueError: If GOOGLE_API_USE_CLIENT_CERTIFICATE is not
-                any of ["true", "false"].
-            google.auth.exceptions.MutualTLSChannelError: If GOOGLE_API_USE_MTLS_ENDPOINT
-                is not any of ["auto", "never", "always"].
-        """
-        use_client_cert = should_use_client_cert()
-        use_mtls_endpoint = os.getenv("GOOGLE_API_USE_MTLS_ENDPOINT", "auto").lower()
-        universe_domain_env = os.getenv("GOOGLE_CLOUD_UNIVERSE_DOMAIN")
-        if use_mtls_endpoint not in ("auto", "never", "always"):
-            raise MutualTLSChannelError("Environment variable `GOOGLE_API_USE_MTLS_ENDPOINT` must be `never`, `auto` or `always`")
-        return use_client_cert, use_mtls_endpoint, universe_domain_env
-
-    @staticmethod
     def _get_client_cert_source(provided_cert_source, use_cert_flag):
         """Return the client cert source to be used by the client.
 
@@ -503,7 +482,7 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
 
         universe_domain_opt = getattr(self._client_options, 'universe_domain', None)
 
-        self._use_client_cert, self._use_mtls_endpoint, self._universe_domain_env = ConfigServiceV2Client._read_environment_variables()
+        self._use_client_cert, self._use_mtls_endpoint, self._universe_domain_env = read_environment_variables()
         self._client_cert_source = ConfigServiceV2Client._get_client_cert_source(self._client_options.client_cert_source, self._use_client_cert)
         self._universe_domain = get_universe_domain(universe_domain_opt, self._universe_domain_env)
         self._api_endpoint: str = ""  # updated below, depending on `transport`

--- a/packages/gapic-generator/tests/integration/goldens/logging/google/cloud/logging_v2/services/logging_service_v2/client.py
+++ b/packages/gapic-generator/tests/integration/goldens/logging/google/cloud/logging_v2/services/logging_service_v2/client.py
@@ -27,7 +27,7 @@ from google.cloud.logging_v2 import gapic_version as package_version
 from google.api_core import client_options as client_options_lib
 from google.api_core import exceptions as core_exceptions
 from google.api_core import gapic_v1
-from google.cloud.logging_v2._compat import get_universe_domain, get_api_endpoint, get_default_mtls_endpoint, should_use_client_cert
+from google.cloud.logging_v2._compat import get_universe_domain, get_api_endpoint, get_default_mtls_endpoint, should_use_client_cert, read_environment_variables
 from google.api_core import retry as retries
 from google.auth import credentials as ga_credentials             # type: ignore
 from google.auth.transport import mtls                            # type: ignore
@@ -276,27 +276,6 @@ class LoggingServiceV2Client(metaclass=LoggingServiceV2ClientMeta):
         return api_endpoint, client_cert_source
 
     @staticmethod
-    def _read_environment_variables():
-        """Returns the environment variables used by the client.
-
-        Returns:
-            Tuple[bool, str, str]: returns the GOOGLE_API_USE_CLIENT_CERTIFICATE,
-            GOOGLE_API_USE_MTLS_ENDPOINT, and GOOGLE_CLOUD_UNIVERSE_DOMAIN environment variables.
-
-        Raises:
-            ValueError: If GOOGLE_API_USE_CLIENT_CERTIFICATE is not
-                any of ["true", "false"].
-            google.auth.exceptions.MutualTLSChannelError: If GOOGLE_API_USE_MTLS_ENDPOINT
-                is not any of ["auto", "never", "always"].
-        """
-        use_client_cert = should_use_client_cert()
-        use_mtls_endpoint = os.getenv("GOOGLE_API_USE_MTLS_ENDPOINT", "auto").lower()
-        universe_domain_env = os.getenv("GOOGLE_CLOUD_UNIVERSE_DOMAIN")
-        if use_mtls_endpoint not in ("auto", "never", "always"):
-            raise MutualTLSChannelError("Environment variable `GOOGLE_API_USE_MTLS_ENDPOINT` must be `never`, `auto` or `always`")
-        return use_client_cert, use_mtls_endpoint, universe_domain_env
-
-    @staticmethod
     def _get_client_cert_source(provided_cert_source, use_cert_flag):
         """Return the client cert source to be used by the client.
 
@@ -434,7 +413,7 @@ class LoggingServiceV2Client(metaclass=LoggingServiceV2ClientMeta):
 
         universe_domain_opt = getattr(self._client_options, 'universe_domain', None)
 
-        self._use_client_cert, self._use_mtls_endpoint, self._universe_domain_env = LoggingServiceV2Client._read_environment_variables()
+        self._use_client_cert, self._use_mtls_endpoint, self._universe_domain_env = read_environment_variables()
         self._client_cert_source = LoggingServiceV2Client._get_client_cert_source(self._client_options.client_cert_source, self._use_client_cert)
         self._universe_domain = get_universe_domain(universe_domain_opt, self._universe_domain_env)
         self._api_endpoint: str = ""  # updated below, depending on `transport`

--- a/packages/gapic-generator/tests/integration/goldens/logging/google/cloud/logging_v2/services/metrics_service_v2/client.py
+++ b/packages/gapic-generator/tests/integration/goldens/logging/google/cloud/logging_v2/services/metrics_service_v2/client.py
@@ -27,7 +27,7 @@ from google.cloud.logging_v2 import gapic_version as package_version
 from google.api_core import client_options as client_options_lib
 from google.api_core import exceptions as core_exceptions
 from google.api_core import gapic_v1
-from google.cloud.logging_v2._compat import get_universe_domain, get_api_endpoint, get_default_mtls_endpoint, should_use_client_cert
+from google.cloud.logging_v2._compat import get_universe_domain, get_api_endpoint, get_default_mtls_endpoint, should_use_client_cert, read_environment_variables
 from google.api_core import retry as retries
 from google.auth import credentials as ga_credentials             # type: ignore
 from google.auth.transport import mtls                            # type: ignore
@@ -277,27 +277,6 @@ class MetricsServiceV2Client(metaclass=MetricsServiceV2ClientMeta):
         return api_endpoint, client_cert_source
 
     @staticmethod
-    def _read_environment_variables():
-        """Returns the environment variables used by the client.
-
-        Returns:
-            Tuple[bool, str, str]: returns the GOOGLE_API_USE_CLIENT_CERTIFICATE,
-            GOOGLE_API_USE_MTLS_ENDPOINT, and GOOGLE_CLOUD_UNIVERSE_DOMAIN environment variables.
-
-        Raises:
-            ValueError: If GOOGLE_API_USE_CLIENT_CERTIFICATE is not
-                any of ["true", "false"].
-            google.auth.exceptions.MutualTLSChannelError: If GOOGLE_API_USE_MTLS_ENDPOINT
-                is not any of ["auto", "never", "always"].
-        """
-        use_client_cert = should_use_client_cert()
-        use_mtls_endpoint = os.getenv("GOOGLE_API_USE_MTLS_ENDPOINT", "auto").lower()
-        universe_domain_env = os.getenv("GOOGLE_CLOUD_UNIVERSE_DOMAIN")
-        if use_mtls_endpoint not in ("auto", "never", "always"):
-            raise MutualTLSChannelError("Environment variable `GOOGLE_API_USE_MTLS_ENDPOINT` must be `never`, `auto` or `always`")
-        return use_client_cert, use_mtls_endpoint, universe_domain_env
-
-    @staticmethod
     def _get_client_cert_source(provided_cert_source, use_cert_flag):
         """Return the client cert source to be used by the client.
 
@@ -435,7 +414,7 @@ class MetricsServiceV2Client(metaclass=MetricsServiceV2ClientMeta):
 
         universe_domain_opt = getattr(self._client_options, 'universe_domain', None)
 
-        self._use_client_cert, self._use_mtls_endpoint, self._universe_domain_env = MetricsServiceV2Client._read_environment_variables()
+        self._use_client_cert, self._use_mtls_endpoint, self._universe_domain_env = read_environment_variables()
         self._client_cert_source = MetricsServiceV2Client._get_client_cert_source(self._client_options.client_cert_source, self._use_client_cert)
         self._universe_domain = get_universe_domain(universe_domain_opt, self._universe_domain_env)
         self._api_endpoint: str = ""  # updated below, depending on `transport`

--- a/packages/gapic-generator/tests/integration/goldens/logging/tests/unit/gapic/logging_v2/test_compat.py
+++ b/packages/gapic-generator/tests/integration/goldens/logging/tests/unit/gapic/logging_v2/test_compat.py
@@ -24,7 +24,7 @@ from unittest import mock
 import google.auth.transport.mtls
 
 from google.cloud.logging_v2._compat import transcode_request
-from google.cloud.logging_v2._compat import get_universe_domain, get_api_endpoint, get_default_mtls_endpoint, should_use_client_cert
+from google.cloud.logging_v2._compat import get_universe_domain, get_api_endpoint, get_default_mtls_endpoint, should_use_client_cert, read_environment_variables
 
 from google.auth.exceptions import MutualTLSChannelError
 from google.api_core.universe import EmptyUniverseError
@@ -411,3 +411,15 @@ def test_transcode_request_proto_plus_wrapper():
 
     transcoded, _, _ = transcode_request(http_options, mock_proto_plus)
     assert transcoded["uri"] == "/v1/test/proto-plus-field"
+
+
+def test_read_environment_variables():
+    with mock.patch.dict(os.environ, {"GOOGLE_API_USE_CLIENT_CERTIFICATE": "true", "GOOGLE_API_USE_MTLS_ENDPOINT": "always", "GOOGLE_CLOUD_UNIVERSE_DOMAIN": "foo.com"}):
+        use_cert, mtls_endpoint, universe_domain = read_environment_variables()
+        assert use_cert is True
+        assert mtls_endpoint == "always"
+        assert universe_domain == "foo.com"
+
+    with mock.patch.dict(os.environ, {"GOOGLE_API_USE_MTLS_ENDPOINT": "invalid"}):
+        with pytest.raises(MutualTLSChannelError):
+            read_environment_variables()

--- a/packages/gapic-generator/tests/integration/goldens/logging_internal/google/cloud/logging_v2/_compat.py
+++ b/packages/gapic-generator/tests/integration/goldens/logging_internal/google/cloud/logging_v2/_compat.py
@@ -47,7 +47,7 @@ def read_environment_variables():
     """Returns the environment variables used by the client.
 
     Returns:
-        Tuple[bool, str, bool]: returns the GOOGLE_API_USE_CLIENT_CERTIFICATE,
+        Tuple[bool, str, str]: returns the GOOGLE_API_USE_CLIENT_CERTIFICATE,
         GOOGLE_API_USE_MTLS_ENDPOINT, and GOOGLE_CLOUD_UNIVERSE_DOMAIN environment variables.
 
     Raises:
@@ -64,9 +64,7 @@ def read_environment_variables():
             "Environment variable `GOOGLE_API_USE_MTLS_ENDPOINT` must be `never`,"
             " `auto` or `always`"
         )
-    else:
-        use_mtls = use_mtls_endpoint == "always" or (use_mtls_endpoint == "auto" and use_client_cert)
-    return use_client_cert, use_mtls, universe_domain_env
+    return use_client_cert, use_mtls_endpoint, universe_domain_env
 
 
 DEFAULT_UNIVERSE = "googleapis.com"

--- a/packages/gapic-generator/tests/integration/goldens/logging_internal/google/cloud/logging_v2/_compat.py
+++ b/packages/gapic-generator/tests/integration/goldens/logging_internal/google/cloud/logging_v2/_compat.py
@@ -42,6 +42,31 @@ except ImportError:  # pragma: NO COVER
             )
         return use_client_cert == "true"
 
+
+def read_environment_variables():
+    """Returns the environment variables used by the client.
+
+    Returns:
+        Tuple[bool, str, str]: returns the GOOGLE_API_USE_CLIENT_CERTIFICATE,
+        GOOGLE_API_USE_MTLS_ENDPOINT, and GOOGLE_CLOUD_UNIVERSE_DOMAIN environment variables.
+
+    Raises:
+        ValueError: If GOOGLE_API_USE_CLIENT_CERTIFICATE is not
+            any of ["true", "false"].
+        google.auth.exceptions.MutualTLSChannelError: If GOOGLE_API_USE_MTLS_ENDPOINT
+            is not any of ["auto", "never", "always"].
+    """
+    use_client_cert = should_use_client_cert()
+    use_mtls_endpoint = os.getenv("GOOGLE_API_USE_MTLS_ENDPOINT", "auto").lower()
+    universe_domain_env = os.getenv("GOOGLE_CLOUD_UNIVERSE_DOMAIN")
+    if use_mtls_endpoint not in ("auto", "never", "always"):
+        raise MutualTLSChannelError(
+            "Environment variable `GOOGLE_API_USE_MTLS_ENDPOINT` must be `never`,"
+            " `auto` or `always`"
+        )
+    return use_client_cert, use_mtls_endpoint, universe_domain_env
+
+
 DEFAULT_UNIVERSE = "googleapis.com"
 
 

--- a/packages/gapic-generator/tests/integration/goldens/logging_internal/google/cloud/logging_v2/_compat.py
+++ b/packages/gapic-generator/tests/integration/goldens/logging_internal/google/cloud/logging_v2/_compat.py
@@ -47,7 +47,7 @@ def read_environment_variables():
     """Returns the environment variables used by the client.
 
     Returns:
-        Tuple[bool, str, str]: returns the GOOGLE_API_USE_CLIENT_CERTIFICATE,
+        Tuple[bool, str, bool]: returns the GOOGLE_API_USE_CLIENT_CERTIFICATE,
         GOOGLE_API_USE_MTLS_ENDPOINT, and GOOGLE_CLOUD_UNIVERSE_DOMAIN environment variables.
 
     Raises:
@@ -64,7 +64,9 @@ def read_environment_variables():
             "Environment variable `GOOGLE_API_USE_MTLS_ENDPOINT` must be `never`,"
             " `auto` or `always`"
         )
-    return use_client_cert, use_mtls_endpoint, universe_domain_env
+    else:
+        use_mtls = use_mtls_endpoint == "always" or (use_mtls_endpoint == "auto" and use_client_cert)
+    return use_client_cert, use_mtls, universe_domain_env
 
 
 DEFAULT_UNIVERSE = "googleapis.com"

--- a/packages/gapic-generator/tests/integration/goldens/logging_internal/google/cloud/logging_v2/services/config_service_v2/client.py
+++ b/packages/gapic-generator/tests/integration/goldens/logging_internal/google/cloud/logging_v2/services/config_service_v2/client.py
@@ -27,7 +27,7 @@ from google.cloud.logging_v2 import gapic_version as package_version
 from google.api_core import client_options as client_options_lib
 from google.api_core import exceptions as core_exceptions
 from google.api_core import gapic_v1
-from google.cloud.logging_v2._compat import get_universe_domain, get_api_endpoint, get_default_mtls_endpoint, should_use_client_cert
+from google.cloud.logging_v2._compat import get_universe_domain, get_api_endpoint, get_default_mtls_endpoint, should_use_client_cert, read_environment_variables
 from google.api_core import retry as retries
 from google.auth import credentials as ga_credentials             # type: ignore
 from google.auth.transport import mtls                            # type: ignore
@@ -345,27 +345,6 @@ class BaseConfigServiceV2Client(metaclass=BaseConfigServiceV2ClientMeta):
         return api_endpoint, client_cert_source
 
     @staticmethod
-    def _read_environment_variables():
-        """Returns the environment variables used by the client.
-
-        Returns:
-            Tuple[bool, str, str]: returns the GOOGLE_API_USE_CLIENT_CERTIFICATE,
-            GOOGLE_API_USE_MTLS_ENDPOINT, and GOOGLE_CLOUD_UNIVERSE_DOMAIN environment variables.
-
-        Raises:
-            ValueError: If GOOGLE_API_USE_CLIENT_CERTIFICATE is not
-                any of ["true", "false"].
-            google.auth.exceptions.MutualTLSChannelError: If GOOGLE_API_USE_MTLS_ENDPOINT
-                is not any of ["auto", "never", "always"].
-        """
-        use_client_cert = should_use_client_cert()
-        use_mtls_endpoint = os.getenv("GOOGLE_API_USE_MTLS_ENDPOINT", "auto").lower()
-        universe_domain_env = os.getenv("GOOGLE_CLOUD_UNIVERSE_DOMAIN")
-        if use_mtls_endpoint not in ("auto", "never", "always"):
-            raise MutualTLSChannelError("Environment variable `GOOGLE_API_USE_MTLS_ENDPOINT` must be `never`, `auto` or `always`")
-        return use_client_cert, use_mtls_endpoint, universe_domain_env
-
-    @staticmethod
     def _get_client_cert_source(provided_cert_source, use_cert_flag):
         """Return the client cert source to be used by the client.
 
@@ -503,7 +482,7 @@ class BaseConfigServiceV2Client(metaclass=BaseConfigServiceV2ClientMeta):
 
         universe_domain_opt = getattr(self._client_options, 'universe_domain', None)
 
-        self._use_client_cert, self._use_mtls_endpoint, self._universe_domain_env = BaseConfigServiceV2Client._read_environment_variables()
+        self._use_client_cert, self._use_mtls_endpoint, self._universe_domain_env = read_environment_variables()
         self._client_cert_source = BaseConfigServiceV2Client._get_client_cert_source(self._client_options.client_cert_source, self._use_client_cert)
         self._universe_domain = get_universe_domain(universe_domain_opt, self._universe_domain_env)
         self._api_endpoint: str = ""  # updated below, depending on `transport`

--- a/packages/gapic-generator/tests/integration/goldens/logging_internal/google/cloud/logging_v2/services/logging_service_v2/client.py
+++ b/packages/gapic-generator/tests/integration/goldens/logging_internal/google/cloud/logging_v2/services/logging_service_v2/client.py
@@ -27,7 +27,7 @@ from google.cloud.logging_v2 import gapic_version as package_version
 from google.api_core import client_options as client_options_lib
 from google.api_core import exceptions as core_exceptions
 from google.api_core import gapic_v1
-from google.cloud.logging_v2._compat import get_universe_domain, get_api_endpoint, get_default_mtls_endpoint, should_use_client_cert
+from google.cloud.logging_v2._compat import get_universe_domain, get_api_endpoint, get_default_mtls_endpoint, should_use_client_cert, read_environment_variables
 from google.api_core import retry as retries
 from google.auth import credentials as ga_credentials             # type: ignore
 from google.auth.transport import mtls                            # type: ignore
@@ -276,27 +276,6 @@ class LoggingServiceV2Client(metaclass=LoggingServiceV2ClientMeta):
         return api_endpoint, client_cert_source
 
     @staticmethod
-    def _read_environment_variables():
-        """Returns the environment variables used by the client.
-
-        Returns:
-            Tuple[bool, str, str]: returns the GOOGLE_API_USE_CLIENT_CERTIFICATE,
-            GOOGLE_API_USE_MTLS_ENDPOINT, and GOOGLE_CLOUD_UNIVERSE_DOMAIN environment variables.
-
-        Raises:
-            ValueError: If GOOGLE_API_USE_CLIENT_CERTIFICATE is not
-                any of ["true", "false"].
-            google.auth.exceptions.MutualTLSChannelError: If GOOGLE_API_USE_MTLS_ENDPOINT
-                is not any of ["auto", "never", "always"].
-        """
-        use_client_cert = should_use_client_cert()
-        use_mtls_endpoint = os.getenv("GOOGLE_API_USE_MTLS_ENDPOINT", "auto").lower()
-        universe_domain_env = os.getenv("GOOGLE_CLOUD_UNIVERSE_DOMAIN")
-        if use_mtls_endpoint not in ("auto", "never", "always"):
-            raise MutualTLSChannelError("Environment variable `GOOGLE_API_USE_MTLS_ENDPOINT` must be `never`, `auto` or `always`")
-        return use_client_cert, use_mtls_endpoint, universe_domain_env
-
-    @staticmethod
     def _get_client_cert_source(provided_cert_source, use_cert_flag):
         """Return the client cert source to be used by the client.
 
@@ -434,7 +413,7 @@ class LoggingServiceV2Client(metaclass=LoggingServiceV2ClientMeta):
 
         universe_domain_opt = getattr(self._client_options, 'universe_domain', None)
 
-        self._use_client_cert, self._use_mtls_endpoint, self._universe_domain_env = LoggingServiceV2Client._read_environment_variables()
+        self._use_client_cert, self._use_mtls_endpoint, self._universe_domain_env = read_environment_variables()
         self._client_cert_source = LoggingServiceV2Client._get_client_cert_source(self._client_options.client_cert_source, self._use_client_cert)
         self._universe_domain = get_universe_domain(universe_domain_opt, self._universe_domain_env)
         self._api_endpoint: str = ""  # updated below, depending on `transport`

--- a/packages/gapic-generator/tests/integration/goldens/logging_internal/google/cloud/logging_v2/services/metrics_service_v2/client.py
+++ b/packages/gapic-generator/tests/integration/goldens/logging_internal/google/cloud/logging_v2/services/metrics_service_v2/client.py
@@ -27,7 +27,7 @@ from google.cloud.logging_v2 import gapic_version as package_version
 from google.api_core import client_options as client_options_lib
 from google.api_core import exceptions as core_exceptions
 from google.api_core import gapic_v1
-from google.cloud.logging_v2._compat import get_universe_domain, get_api_endpoint, get_default_mtls_endpoint, should_use_client_cert
+from google.cloud.logging_v2._compat import get_universe_domain, get_api_endpoint, get_default_mtls_endpoint, should_use_client_cert, read_environment_variables
 from google.api_core import retry as retries
 from google.auth import credentials as ga_credentials             # type: ignore
 from google.auth.transport import mtls                            # type: ignore
@@ -277,27 +277,6 @@ class BaseMetricsServiceV2Client(metaclass=BaseMetricsServiceV2ClientMeta):
         return api_endpoint, client_cert_source
 
     @staticmethod
-    def _read_environment_variables():
-        """Returns the environment variables used by the client.
-
-        Returns:
-            Tuple[bool, str, str]: returns the GOOGLE_API_USE_CLIENT_CERTIFICATE,
-            GOOGLE_API_USE_MTLS_ENDPOINT, and GOOGLE_CLOUD_UNIVERSE_DOMAIN environment variables.
-
-        Raises:
-            ValueError: If GOOGLE_API_USE_CLIENT_CERTIFICATE is not
-                any of ["true", "false"].
-            google.auth.exceptions.MutualTLSChannelError: If GOOGLE_API_USE_MTLS_ENDPOINT
-                is not any of ["auto", "never", "always"].
-        """
-        use_client_cert = should_use_client_cert()
-        use_mtls_endpoint = os.getenv("GOOGLE_API_USE_MTLS_ENDPOINT", "auto").lower()
-        universe_domain_env = os.getenv("GOOGLE_CLOUD_UNIVERSE_DOMAIN")
-        if use_mtls_endpoint not in ("auto", "never", "always"):
-            raise MutualTLSChannelError("Environment variable `GOOGLE_API_USE_MTLS_ENDPOINT` must be `never`, `auto` or `always`")
-        return use_client_cert, use_mtls_endpoint, universe_domain_env
-
-    @staticmethod
     def _get_client_cert_source(provided_cert_source, use_cert_flag):
         """Return the client cert source to be used by the client.
 
@@ -435,7 +414,7 @@ class BaseMetricsServiceV2Client(metaclass=BaseMetricsServiceV2ClientMeta):
 
         universe_domain_opt = getattr(self._client_options, 'universe_domain', None)
 
-        self._use_client_cert, self._use_mtls_endpoint, self._universe_domain_env = BaseMetricsServiceV2Client._read_environment_variables()
+        self._use_client_cert, self._use_mtls_endpoint, self._universe_domain_env = read_environment_variables()
         self._client_cert_source = BaseMetricsServiceV2Client._get_client_cert_source(self._client_options.client_cert_source, self._use_client_cert)
         self._universe_domain = get_universe_domain(universe_domain_opt, self._universe_domain_env)
         self._api_endpoint: str = ""  # updated below, depending on `transport`

--- a/packages/gapic-generator/tests/integration/goldens/logging_internal/tests/unit/gapic/logging_v2/test_compat.py
+++ b/packages/gapic-generator/tests/integration/goldens/logging_internal/tests/unit/gapic/logging_v2/test_compat.py
@@ -24,7 +24,7 @@ from unittest import mock
 import google.auth.transport.mtls
 
 from google.cloud.logging_v2._compat import transcode_request
-from google.cloud.logging_v2._compat import get_universe_domain, get_api_endpoint, get_default_mtls_endpoint, should_use_client_cert
+from google.cloud.logging_v2._compat import get_universe_domain, get_api_endpoint, get_default_mtls_endpoint, should_use_client_cert, read_environment_variables
 
 from google.auth.exceptions import MutualTLSChannelError
 from google.api_core.universe import EmptyUniverseError
@@ -411,3 +411,15 @@ def test_transcode_request_proto_plus_wrapper():
 
     transcoded, _, _ = transcode_request(http_options, mock_proto_plus)
     assert transcoded["uri"] == "/v1/test/proto-plus-field"
+
+
+def test_read_environment_variables():
+    with mock.patch.dict(os.environ, {"GOOGLE_API_USE_CLIENT_CERTIFICATE": "true", "GOOGLE_API_USE_MTLS_ENDPOINT": "always", "GOOGLE_CLOUD_UNIVERSE_DOMAIN": "foo.com"}):
+        use_cert, mtls_endpoint, universe_domain = read_environment_variables()
+        assert use_cert is True
+        assert mtls_endpoint == "always"
+        assert universe_domain == "foo.com"
+
+    with mock.patch.dict(os.environ, {"GOOGLE_API_USE_MTLS_ENDPOINT": "invalid"}):
+        with pytest.raises(MutualTLSChannelError):
+            read_environment_variables()

--- a/packages/gapic-generator/tests/integration/goldens/redis/google/cloud/redis_v1/_compat.py
+++ b/packages/gapic-generator/tests/integration/goldens/redis/google/cloud/redis_v1/_compat.py
@@ -47,7 +47,7 @@ def read_environment_variables():
     """Returns the environment variables used by the client.
 
     Returns:
-        Tuple[bool, str, bool]: returns the GOOGLE_API_USE_CLIENT_CERTIFICATE,
+        Tuple[bool, str, str]: returns the GOOGLE_API_USE_CLIENT_CERTIFICATE,
         GOOGLE_API_USE_MTLS_ENDPOINT, and GOOGLE_CLOUD_UNIVERSE_DOMAIN environment variables.
 
     Raises:
@@ -64,9 +64,7 @@ def read_environment_variables():
             "Environment variable `GOOGLE_API_USE_MTLS_ENDPOINT` must be `never`,"
             " `auto` or `always`"
         )
-    else:
-        use_mtls = use_mtls_endpoint == "always" or (use_mtls_endpoint == "auto" and use_client_cert)
-    return use_client_cert, use_mtls, universe_domain_env
+    return use_client_cert, use_mtls_endpoint, universe_domain_env
 
 
 DEFAULT_UNIVERSE = "googleapis.com"

--- a/packages/gapic-generator/tests/integration/goldens/redis/google/cloud/redis_v1/_compat.py
+++ b/packages/gapic-generator/tests/integration/goldens/redis/google/cloud/redis_v1/_compat.py
@@ -42,6 +42,31 @@ except ImportError:  # pragma: NO COVER
             )
         return use_client_cert == "true"
 
+
+def read_environment_variables():
+    """Returns the environment variables used by the client.
+
+    Returns:
+        Tuple[bool, str, str]: returns the GOOGLE_API_USE_CLIENT_CERTIFICATE,
+        GOOGLE_API_USE_MTLS_ENDPOINT, and GOOGLE_CLOUD_UNIVERSE_DOMAIN environment variables.
+
+    Raises:
+        ValueError: If GOOGLE_API_USE_CLIENT_CERTIFICATE is not
+            any of ["true", "false"].
+        google.auth.exceptions.MutualTLSChannelError: If GOOGLE_API_USE_MTLS_ENDPOINT
+            is not any of ["auto", "never", "always"].
+    """
+    use_client_cert = should_use_client_cert()
+    use_mtls_endpoint = os.getenv("GOOGLE_API_USE_MTLS_ENDPOINT", "auto").lower()
+    universe_domain_env = os.getenv("GOOGLE_CLOUD_UNIVERSE_DOMAIN")
+    if use_mtls_endpoint not in ("auto", "never", "always"):
+        raise MutualTLSChannelError(
+            "Environment variable `GOOGLE_API_USE_MTLS_ENDPOINT` must be `never`,"
+            " `auto` or `always`"
+        )
+    return use_client_cert, use_mtls_endpoint, universe_domain_env
+
+
 DEFAULT_UNIVERSE = "googleapis.com"
 
 

--- a/packages/gapic-generator/tests/integration/goldens/redis/google/cloud/redis_v1/_compat.py
+++ b/packages/gapic-generator/tests/integration/goldens/redis/google/cloud/redis_v1/_compat.py
@@ -47,7 +47,7 @@ def read_environment_variables():
     """Returns the environment variables used by the client.
 
     Returns:
-        Tuple[bool, str, str]: returns the GOOGLE_API_USE_CLIENT_CERTIFICATE,
+        Tuple[bool, str, bool]: returns the GOOGLE_API_USE_CLIENT_CERTIFICATE,
         GOOGLE_API_USE_MTLS_ENDPOINT, and GOOGLE_CLOUD_UNIVERSE_DOMAIN environment variables.
 
     Raises:
@@ -64,7 +64,9 @@ def read_environment_variables():
             "Environment variable `GOOGLE_API_USE_MTLS_ENDPOINT` must be `never`,"
             " `auto` or `always`"
         )
-    return use_client_cert, use_mtls_endpoint, universe_domain_env
+    else:
+        use_mtls = use_mtls_endpoint == "always" or (use_mtls_endpoint == "auto" and use_client_cert)
+    return use_client_cert, use_mtls, universe_domain_env
 
 
 DEFAULT_UNIVERSE = "googleapis.com"

--- a/packages/gapic-generator/tests/integration/goldens/redis/google/cloud/redis_v1/services/cloud_redis/client.py
+++ b/packages/gapic-generator/tests/integration/goldens/redis/google/cloud/redis_v1/services/cloud_redis/client.py
@@ -27,7 +27,7 @@ from google.cloud.redis_v1 import gapic_version as package_version
 from google.api_core import client_options as client_options_lib
 from google.api_core import exceptions as core_exceptions
 from google.api_core import gapic_v1
-from google.cloud.redis_v1._compat import get_universe_domain, get_api_endpoint, get_default_mtls_endpoint, should_use_client_cert
+from google.cloud.redis_v1._compat import get_universe_domain, get_api_endpoint, get_default_mtls_endpoint, should_use_client_cert, read_environment_variables
 from google.api_core import retry as retries
 from google.auth import credentials as ga_credentials             # type: ignore
 from google.auth.transport import mtls                            # type: ignore
@@ -314,27 +314,6 @@ class CloudRedisClient(metaclass=CloudRedisClientMeta):
         return api_endpoint, client_cert_source
 
     @staticmethod
-    def _read_environment_variables():
-        """Returns the environment variables used by the client.
-
-        Returns:
-            Tuple[bool, str, str]: returns the GOOGLE_API_USE_CLIENT_CERTIFICATE,
-            GOOGLE_API_USE_MTLS_ENDPOINT, and GOOGLE_CLOUD_UNIVERSE_DOMAIN environment variables.
-
-        Raises:
-            ValueError: If GOOGLE_API_USE_CLIENT_CERTIFICATE is not
-                any of ["true", "false"].
-            google.auth.exceptions.MutualTLSChannelError: If GOOGLE_API_USE_MTLS_ENDPOINT
-                is not any of ["auto", "never", "always"].
-        """
-        use_client_cert = should_use_client_cert()
-        use_mtls_endpoint = os.getenv("GOOGLE_API_USE_MTLS_ENDPOINT", "auto").lower()
-        universe_domain_env = os.getenv("GOOGLE_CLOUD_UNIVERSE_DOMAIN")
-        if use_mtls_endpoint not in ("auto", "never", "always"):
-            raise MutualTLSChannelError("Environment variable `GOOGLE_API_USE_MTLS_ENDPOINT` must be `never`, `auto` or `always`")
-        return use_client_cert, use_mtls_endpoint, universe_domain_env
-
-    @staticmethod
     def _get_client_cert_source(provided_cert_source, use_cert_flag):
         """Return the client cert source to be used by the client.
 
@@ -475,7 +454,7 @@ class CloudRedisClient(metaclass=CloudRedisClientMeta):
 
         universe_domain_opt = getattr(self._client_options, 'universe_domain', None)
 
-        self._use_client_cert, self._use_mtls_endpoint, self._universe_domain_env = CloudRedisClient._read_environment_variables()
+        self._use_client_cert, self._use_mtls_endpoint, self._universe_domain_env = read_environment_variables()
         self._client_cert_source = CloudRedisClient._get_client_cert_source(self._client_options.client_cert_source, self._use_client_cert)
         self._universe_domain = get_universe_domain(universe_domain_opt, self._universe_domain_env)
         self._api_endpoint: str = ""  # updated below, depending on `transport`

--- a/packages/gapic-generator/tests/integration/goldens/redis/tests/unit/gapic/redis_v1/test_compat.py
+++ b/packages/gapic-generator/tests/integration/goldens/redis/tests/unit/gapic/redis_v1/test_compat.py
@@ -24,7 +24,7 @@ from unittest import mock
 import google.auth.transport.mtls
 
 from google.cloud.redis_v1._compat import transcode_request
-from google.cloud.redis_v1._compat import get_universe_domain, get_api_endpoint, get_default_mtls_endpoint, should_use_client_cert
+from google.cloud.redis_v1._compat import get_universe_domain, get_api_endpoint, get_default_mtls_endpoint, should_use_client_cert, read_environment_variables
 
 from google.auth.exceptions import MutualTLSChannelError
 from google.api_core.universe import EmptyUniverseError
@@ -411,3 +411,15 @@ def test_transcode_request_proto_plus_wrapper():
 
     transcoded, _, _ = transcode_request(http_options, mock_proto_plus)
     assert transcoded["uri"] == "/v1/test/proto-plus-field"
+
+
+def test_read_environment_variables():
+    with mock.patch.dict(os.environ, {"GOOGLE_API_USE_CLIENT_CERTIFICATE": "true", "GOOGLE_API_USE_MTLS_ENDPOINT": "always", "GOOGLE_CLOUD_UNIVERSE_DOMAIN": "foo.com"}):
+        use_cert, mtls_endpoint, universe_domain = read_environment_variables()
+        assert use_cert is True
+        assert mtls_endpoint == "always"
+        assert universe_domain == "foo.com"
+
+    with mock.patch.dict(os.environ, {"GOOGLE_API_USE_MTLS_ENDPOINT": "invalid"}):
+        with pytest.raises(MutualTLSChannelError):
+            read_environment_variables()

--- a/packages/gapic-generator/tests/integration/goldens/redis_selective/google/cloud/redis_v1/_compat.py
+++ b/packages/gapic-generator/tests/integration/goldens/redis_selective/google/cloud/redis_v1/_compat.py
@@ -47,7 +47,7 @@ def read_environment_variables():
     """Returns the environment variables used by the client.
 
     Returns:
-        Tuple[bool, str, bool]: returns the GOOGLE_API_USE_CLIENT_CERTIFICATE,
+        Tuple[bool, str, str]: returns the GOOGLE_API_USE_CLIENT_CERTIFICATE,
         GOOGLE_API_USE_MTLS_ENDPOINT, and GOOGLE_CLOUD_UNIVERSE_DOMAIN environment variables.
 
     Raises:
@@ -64,9 +64,7 @@ def read_environment_variables():
             "Environment variable `GOOGLE_API_USE_MTLS_ENDPOINT` must be `never`,"
             " `auto` or `always`"
         )
-    else:
-        use_mtls = use_mtls_endpoint == "always" or (use_mtls_endpoint == "auto" and use_client_cert)
-    return use_client_cert, use_mtls, universe_domain_env
+    return use_client_cert, use_mtls_endpoint, universe_domain_env
 
 
 DEFAULT_UNIVERSE = "googleapis.com"

--- a/packages/gapic-generator/tests/integration/goldens/redis_selective/google/cloud/redis_v1/_compat.py
+++ b/packages/gapic-generator/tests/integration/goldens/redis_selective/google/cloud/redis_v1/_compat.py
@@ -42,6 +42,31 @@ except ImportError:  # pragma: NO COVER
             )
         return use_client_cert == "true"
 
+
+def read_environment_variables():
+    """Returns the environment variables used by the client.
+
+    Returns:
+        Tuple[bool, str, str]: returns the GOOGLE_API_USE_CLIENT_CERTIFICATE,
+        GOOGLE_API_USE_MTLS_ENDPOINT, and GOOGLE_CLOUD_UNIVERSE_DOMAIN environment variables.
+
+    Raises:
+        ValueError: If GOOGLE_API_USE_CLIENT_CERTIFICATE is not
+            any of ["true", "false"].
+        google.auth.exceptions.MutualTLSChannelError: If GOOGLE_API_USE_MTLS_ENDPOINT
+            is not any of ["auto", "never", "always"].
+    """
+    use_client_cert = should_use_client_cert()
+    use_mtls_endpoint = os.getenv("GOOGLE_API_USE_MTLS_ENDPOINT", "auto").lower()
+    universe_domain_env = os.getenv("GOOGLE_CLOUD_UNIVERSE_DOMAIN")
+    if use_mtls_endpoint not in ("auto", "never", "always"):
+        raise MutualTLSChannelError(
+            "Environment variable `GOOGLE_API_USE_MTLS_ENDPOINT` must be `never`,"
+            " `auto` or `always`"
+        )
+    return use_client_cert, use_mtls_endpoint, universe_domain_env
+
+
 DEFAULT_UNIVERSE = "googleapis.com"
 
 

--- a/packages/gapic-generator/tests/integration/goldens/redis_selective/google/cloud/redis_v1/_compat.py
+++ b/packages/gapic-generator/tests/integration/goldens/redis_selective/google/cloud/redis_v1/_compat.py
@@ -47,7 +47,7 @@ def read_environment_variables():
     """Returns the environment variables used by the client.
 
     Returns:
-        Tuple[bool, str, str]: returns the GOOGLE_API_USE_CLIENT_CERTIFICATE,
+        Tuple[bool, str, bool]: returns the GOOGLE_API_USE_CLIENT_CERTIFICATE,
         GOOGLE_API_USE_MTLS_ENDPOINT, and GOOGLE_CLOUD_UNIVERSE_DOMAIN environment variables.
 
     Raises:
@@ -64,7 +64,9 @@ def read_environment_variables():
             "Environment variable `GOOGLE_API_USE_MTLS_ENDPOINT` must be `never`,"
             " `auto` or `always`"
         )
-    return use_client_cert, use_mtls_endpoint, universe_domain_env
+    else:
+        use_mtls = use_mtls_endpoint == "always" or (use_mtls_endpoint == "auto" and use_client_cert)
+    return use_client_cert, use_mtls, universe_domain_env
 
 
 DEFAULT_UNIVERSE = "googleapis.com"

--- a/packages/gapic-generator/tests/integration/goldens/redis_selective/google/cloud/redis_v1/services/cloud_redis/client.py
+++ b/packages/gapic-generator/tests/integration/goldens/redis_selective/google/cloud/redis_v1/services/cloud_redis/client.py
@@ -27,7 +27,7 @@ from google.cloud.redis_v1 import gapic_version as package_version
 from google.api_core import client_options as client_options_lib
 from google.api_core import exceptions as core_exceptions
 from google.api_core import gapic_v1
-from google.cloud.redis_v1._compat import get_universe_domain, get_api_endpoint, get_default_mtls_endpoint, should_use_client_cert
+from google.cloud.redis_v1._compat import get_universe_domain, get_api_endpoint, get_default_mtls_endpoint, should_use_client_cert, read_environment_variables
 from google.api_core import retry as retries
 from google.auth import credentials as ga_credentials             # type: ignore
 from google.auth.transport import mtls                            # type: ignore
@@ -314,27 +314,6 @@ class CloudRedisClient(metaclass=CloudRedisClientMeta):
         return api_endpoint, client_cert_source
 
     @staticmethod
-    def _read_environment_variables():
-        """Returns the environment variables used by the client.
-
-        Returns:
-            Tuple[bool, str, str]: returns the GOOGLE_API_USE_CLIENT_CERTIFICATE,
-            GOOGLE_API_USE_MTLS_ENDPOINT, and GOOGLE_CLOUD_UNIVERSE_DOMAIN environment variables.
-
-        Raises:
-            ValueError: If GOOGLE_API_USE_CLIENT_CERTIFICATE is not
-                any of ["true", "false"].
-            google.auth.exceptions.MutualTLSChannelError: If GOOGLE_API_USE_MTLS_ENDPOINT
-                is not any of ["auto", "never", "always"].
-        """
-        use_client_cert = should_use_client_cert()
-        use_mtls_endpoint = os.getenv("GOOGLE_API_USE_MTLS_ENDPOINT", "auto").lower()
-        universe_domain_env = os.getenv("GOOGLE_CLOUD_UNIVERSE_DOMAIN")
-        if use_mtls_endpoint not in ("auto", "never", "always"):
-            raise MutualTLSChannelError("Environment variable `GOOGLE_API_USE_MTLS_ENDPOINT` must be `never`, `auto` or `always`")
-        return use_client_cert, use_mtls_endpoint, universe_domain_env
-
-    @staticmethod
     def _get_client_cert_source(provided_cert_source, use_cert_flag):
         """Return the client cert source to be used by the client.
 
@@ -475,7 +454,7 @@ class CloudRedisClient(metaclass=CloudRedisClientMeta):
 
         universe_domain_opt = getattr(self._client_options, 'universe_domain', None)
 
-        self._use_client_cert, self._use_mtls_endpoint, self._universe_domain_env = CloudRedisClient._read_environment_variables()
+        self._use_client_cert, self._use_mtls_endpoint, self._universe_domain_env = read_environment_variables()
         self._client_cert_source = CloudRedisClient._get_client_cert_source(self._client_options.client_cert_source, self._use_client_cert)
         self._universe_domain = get_universe_domain(universe_domain_opt, self._universe_domain_env)
         self._api_endpoint: str = ""  # updated below, depending on `transport`

--- a/packages/gapic-generator/tests/integration/goldens/redis_selective/tests/unit/gapic/redis_v1/test_compat.py
+++ b/packages/gapic-generator/tests/integration/goldens/redis_selective/tests/unit/gapic/redis_v1/test_compat.py
@@ -24,7 +24,7 @@ from unittest import mock
 import google.auth.transport.mtls
 
 from google.cloud.redis_v1._compat import transcode_request
-from google.cloud.redis_v1._compat import get_universe_domain, get_api_endpoint, get_default_mtls_endpoint, should_use_client_cert
+from google.cloud.redis_v1._compat import get_universe_domain, get_api_endpoint, get_default_mtls_endpoint, should_use_client_cert, read_environment_variables
 
 from google.auth.exceptions import MutualTLSChannelError
 from google.api_core.universe import EmptyUniverseError
@@ -411,3 +411,15 @@ def test_transcode_request_proto_plus_wrapper():
 
     transcoded, _, _ = transcode_request(http_options, mock_proto_plus)
     assert transcoded["uri"] == "/v1/test/proto-plus-field"
+
+
+def test_read_environment_variables():
+    with mock.patch.dict(os.environ, {"GOOGLE_API_USE_CLIENT_CERTIFICATE": "true", "GOOGLE_API_USE_MTLS_ENDPOINT": "always", "GOOGLE_CLOUD_UNIVERSE_DOMAIN": "foo.com"}):
+        use_cert, mtls_endpoint, universe_domain = read_environment_variables()
+        assert use_cert is True
+        assert mtls_endpoint == "always"
+        assert universe_domain == "foo.com"
+
+    with mock.patch.dict(os.environ, {"GOOGLE_API_USE_MTLS_ENDPOINT": "invalid"}):
+        with pytest.raises(MutualTLSChannelError):
+            read_environment_variables()

--- a/packages/gapic-generator/tests/integration/goldens/storagebatchoperations/google/cloud/storagebatchoperations_v1/_compat.py
+++ b/packages/gapic-generator/tests/integration/goldens/storagebatchoperations/google/cloud/storagebatchoperations_v1/_compat.py
@@ -51,7 +51,7 @@ def read_environment_variables():
     """Returns the environment variables used by the client.
 
     Returns:
-        Tuple[bool, str, bool]: returns the GOOGLE_API_USE_CLIENT_CERTIFICATE,
+        Tuple[bool, str, str]: returns the GOOGLE_API_USE_CLIENT_CERTIFICATE,
         GOOGLE_API_USE_MTLS_ENDPOINT, and GOOGLE_CLOUD_UNIVERSE_DOMAIN environment variables.
 
     Raises:
@@ -68,9 +68,7 @@ def read_environment_variables():
             "Environment variable `GOOGLE_API_USE_MTLS_ENDPOINT` must be `never`,"
             " `auto` or `always`"
         )
-    else:
-        use_mtls = use_mtls_endpoint == "always" or (use_mtls_endpoint == "auto" and use_client_cert)
-    return use_client_cert, use_mtls, universe_domain_env
+    return use_client_cert, use_mtls_endpoint, universe_domain_env
 
 
 DEFAULT_UNIVERSE = "googleapis.com"

--- a/packages/gapic-generator/tests/integration/goldens/storagebatchoperations/google/cloud/storagebatchoperations_v1/_compat.py
+++ b/packages/gapic-generator/tests/integration/goldens/storagebatchoperations/google/cloud/storagebatchoperations_v1/_compat.py
@@ -51,7 +51,7 @@ def read_environment_variables():
     """Returns the environment variables used by the client.
 
     Returns:
-        Tuple[bool, str, str]: returns the GOOGLE_API_USE_CLIENT_CERTIFICATE,
+        Tuple[bool, str, bool]: returns the GOOGLE_API_USE_CLIENT_CERTIFICATE,
         GOOGLE_API_USE_MTLS_ENDPOINT, and GOOGLE_CLOUD_UNIVERSE_DOMAIN environment variables.
 
     Raises:
@@ -68,7 +68,9 @@ def read_environment_variables():
             "Environment variable `GOOGLE_API_USE_MTLS_ENDPOINT` must be `never`,"
             " `auto` or `always`"
         )
-    return use_client_cert, use_mtls_endpoint, universe_domain_env
+    else:
+        use_mtls = use_mtls_endpoint == "always" or (use_mtls_endpoint == "auto" and use_client_cert)
+    return use_client_cert, use_mtls, universe_domain_env
 
 
 DEFAULT_UNIVERSE = "googleapis.com"

--- a/packages/gapic-generator/tests/integration/goldens/storagebatchoperations/google/cloud/storagebatchoperations_v1/_compat.py
+++ b/packages/gapic-generator/tests/integration/goldens/storagebatchoperations/google/cloud/storagebatchoperations_v1/_compat.py
@@ -46,6 +46,31 @@ except ImportError:  # pragma: NO COVER
             )
         return use_client_cert == "true"
 
+
+def read_environment_variables():
+    """Returns the environment variables used by the client.
+
+    Returns:
+        Tuple[bool, str, str]: returns the GOOGLE_API_USE_CLIENT_CERTIFICATE,
+        GOOGLE_API_USE_MTLS_ENDPOINT, and GOOGLE_CLOUD_UNIVERSE_DOMAIN environment variables.
+
+    Raises:
+        ValueError: If GOOGLE_API_USE_CLIENT_CERTIFICATE is not
+            any of ["true", "false"].
+        google.auth.exceptions.MutualTLSChannelError: If GOOGLE_API_USE_MTLS_ENDPOINT
+            is not any of ["auto", "never", "always"].
+    """
+    use_client_cert = should_use_client_cert()
+    use_mtls_endpoint = os.getenv("GOOGLE_API_USE_MTLS_ENDPOINT", "auto").lower()
+    universe_domain_env = os.getenv("GOOGLE_CLOUD_UNIVERSE_DOMAIN")
+    if use_mtls_endpoint not in ("auto", "never", "always"):
+        raise MutualTLSChannelError(
+            "Environment variable `GOOGLE_API_USE_MTLS_ENDPOINT` must be `never`,"
+            " `auto` or `always`"
+        )
+    return use_client_cert, use_mtls_endpoint, universe_domain_env
+
+
 DEFAULT_UNIVERSE = "googleapis.com"
 
 

--- a/packages/gapic-generator/tests/integration/goldens/storagebatchoperations/google/cloud/storagebatchoperations_v1/services/storage_batch_operations/client.py
+++ b/packages/gapic-generator/tests/integration/goldens/storagebatchoperations/google/cloud/storagebatchoperations_v1/services/storage_batch_operations/client.py
@@ -28,7 +28,7 @@ from google.cloud.storagebatchoperations_v1 import gapic_version as package_vers
 from google.api_core import client_options as client_options_lib
 from google.api_core import exceptions as core_exceptions
 from google.api_core import gapic_v1
-from google.cloud.storagebatchoperations_v1._compat import get_universe_domain, get_api_endpoint, get_default_mtls_endpoint, should_use_client_cert
+from google.cloud.storagebatchoperations_v1._compat import get_universe_domain, get_api_endpoint, get_default_mtls_endpoint, should_use_client_cert, read_environment_variables
 from google.cloud.storagebatchoperations_v1._compat import setup_request_id
 from google.api_core import retry as retries
 from google.auth import credentials as ga_credentials             # type: ignore
@@ -310,27 +310,6 @@ class StorageBatchOperationsClient(metaclass=StorageBatchOperationsClientMeta):
         return api_endpoint, client_cert_source
 
     @staticmethod
-    def _read_environment_variables():
-        """Returns the environment variables used by the client.
-
-        Returns:
-            Tuple[bool, str, str]: returns the GOOGLE_API_USE_CLIENT_CERTIFICATE,
-            GOOGLE_API_USE_MTLS_ENDPOINT, and GOOGLE_CLOUD_UNIVERSE_DOMAIN environment variables.
-
-        Raises:
-            ValueError: If GOOGLE_API_USE_CLIENT_CERTIFICATE is not
-                any of ["true", "false"].
-            google.auth.exceptions.MutualTLSChannelError: If GOOGLE_API_USE_MTLS_ENDPOINT
-                is not any of ["auto", "never", "always"].
-        """
-        use_client_cert = should_use_client_cert()
-        use_mtls_endpoint = os.getenv("GOOGLE_API_USE_MTLS_ENDPOINT", "auto").lower()
-        universe_domain_env = os.getenv("GOOGLE_CLOUD_UNIVERSE_DOMAIN")
-        if use_mtls_endpoint not in ("auto", "never", "always"):
-            raise MutualTLSChannelError("Environment variable `GOOGLE_API_USE_MTLS_ENDPOINT` must be `never`, `auto` or `always`")
-        return use_client_cert, use_mtls_endpoint, universe_domain_env
-
-    @staticmethod
     def _get_client_cert_source(provided_cert_source, use_cert_flag):
         """Return the client cert source to be used by the client.
 
@@ -471,7 +450,7 @@ class StorageBatchOperationsClient(metaclass=StorageBatchOperationsClientMeta):
 
         universe_domain_opt = getattr(self._client_options, 'universe_domain', None)
 
-        self._use_client_cert, self._use_mtls_endpoint, self._universe_domain_env = StorageBatchOperationsClient._read_environment_variables()
+        self._use_client_cert, self._use_mtls_endpoint, self._universe_domain_env = read_environment_variables()
         self._client_cert_source = StorageBatchOperationsClient._get_client_cert_source(self._client_options.client_cert_source, self._use_client_cert)
         self._universe_domain = get_universe_domain(universe_domain_opt, self._universe_domain_env)
         self._api_endpoint: str = ""  # updated below, depending on `transport`

--- a/packages/gapic-generator/tests/integration/goldens/storagebatchoperations/tests/unit/gapic/storagebatchoperations_v1/test_compat.py
+++ b/packages/gapic-generator/tests/integration/goldens/storagebatchoperations/tests/unit/gapic/storagebatchoperations_v1/test_compat.py
@@ -25,7 +25,7 @@ from unittest import mock
 import google.auth.transport.mtls
 
 from google.cloud.storagebatchoperations_v1._compat import transcode_request
-from google.cloud.storagebatchoperations_v1._compat import get_universe_domain, get_api_endpoint, get_default_mtls_endpoint, should_use_client_cert
+from google.cloud.storagebatchoperations_v1._compat import get_universe_domain, get_api_endpoint, get_default_mtls_endpoint, should_use_client_cert, read_environment_variables
 from google.cloud.storagebatchoperations_v1._compat import setup_request_id
 
 from google.auth.exceptions import MutualTLSChannelError
@@ -494,3 +494,15 @@ def test_transcode_request_proto_plus_wrapper():
 
     transcoded, _, _ = transcode_request(http_options, mock_proto_plus)
     assert transcoded["uri"] == "/v1/test/proto-plus-field"
+
+
+def test_read_environment_variables():
+    with mock.patch.dict(os.environ, {"GOOGLE_API_USE_CLIENT_CERTIFICATE": "true", "GOOGLE_API_USE_MTLS_ENDPOINT": "always", "GOOGLE_CLOUD_UNIVERSE_DOMAIN": "foo.com"}):
+        use_cert, mtls_endpoint, universe_domain = read_environment_variables()
+        assert use_cert is True
+        assert mtls_endpoint == "always"
+        assert universe_domain == "foo.com"
+
+    with mock.patch.dict(os.environ, {"GOOGLE_API_USE_MTLS_ENDPOINT": "invalid"}):
+        with pytest.raises(MutualTLSChannelError):
+            read_environment_variables()


### PR DESCRIPTION
We move `_read_environment_variables` and its associated unit tests into `_compat.py.j2` as `read_environment_variables`.

This reduces code duplication in packages that have multiple services. In the future, once `should_use_mtls_endpoint` is added to `google-auth`, we can defer parsing `GOOGLE_API_USE_MTLS_ENDPOINT` upstream.

Towards: https://github.com/googleapis/google-cloud-python/issues/17883
