### PR TITLE
chore(ci): revamp parallel test outputs clarity and conciseness

### DIFF
--- a/.kokoro/system.sh
+++ b/.kokoro/system.sh
@@ -263,16 +263,23 @@ for path in `find 'packages' \
     files_to_check=("${package_path}")
   fi
 
-  echo "checking changes with 'git diff ${KOKORO_GITHUB_PULL_REQUEST_TARGET_BRANCH}...${KOKORO_GITHUB_PULL_REQUEST_COMMIT} -- ${files_to_check[*]}'"
   set +e
   # Passing the array expanded as arguments to git diff
   package_modified=$(git diff "${KOKORO_GITHUB_PULL_REQUEST_TARGET_BRANCH}...${KOKORO_GITHUB_PULL_REQUEST_COMMIT}" -- "${files_to_check[@]}" | wc -l)
   set -e
 
-  if [[ "${package_modified}" -gt 0 || "$KOKORO_BUILD_ARTIFACTS_SUBDIR" == *"continuous"* ]]; then
+  states=()
+  [[ "${package_modified}" -gt 0 ]] && states+=("changed")
+  [[ "$KOKORO_BUILD_ARTIFACTS_SUBDIR" == *"continuous"* ]] && states+=("continuous")
+
+  # Join states with a comma
+  state_str=$(IFS=, ; echo "${states[*]}")
+
+  if [[ ${#states[@]} -gt 0 ]]; then
+      echo "[checking] ${package_name}:${KOKORO_GITHUB_PULL_REQUEST_COMMIT:-HEAD}, state: ${state_str}"
       PACKAGES_TO_TEST+=("$package_name")
   else
-      echo "No changes in ${package_name} and not a continuous build, skipping."
+      echo "[checking] ${package_name}:${KOKORO_GITHUB_PULL_REQUEST_COMMIT:-HEAD}, state: skipped (no changes)"
   fi
 done
 

--- a/.kokoro/system.sh
+++ b/.kokoro/system.sh
@@ -264,7 +264,7 @@ for path in `find 'packages' \
   fi
 
   set +e
-  # Passing the array expanded as arguments to git diff
+  # Passing the array expanded as arguments to git diff.
   package_modified=$(git diff "${KOKORO_GITHUB_PULL_REQUEST_TARGET_BRANCH}...${KOKORO_GITHUB_PULL_REQUEST_COMMIT}" -- "${files_to_check[@]}" | wc -l)
   set -e
 

--- a/.kokoro/system.sh
+++ b/.kokoro/system.sh
@@ -275,11 +275,13 @@ for path in `find 'packages' \
   # Join states with a comma
   state_str=$(IFS=, ; echo "${states[*]}")
 
+  commit_hash="${KOKORO_GITHUB_PULL_REQUEST_COMMIT:-HEAD}"
+
   if [[ ${#states[@]} -gt 0 ]]; then
-      echo "[checking] ${package_name}:${KOKORO_GITHUB_PULL_REQUEST_COMMIT:-HEAD}, state: ${state_str}"
+      printf "TEST %-20s %-40s %s\n" "[${state_str}]" "${package_name}" "${commit_hash}"
       PACKAGES_TO_TEST+=("$package_name")
   else
-      echo "[checking] ${package_name}:${KOKORO_GITHUB_PULL_REQUEST_COMMIT:-HEAD}, state: skipped (no changes)"
+      printf "SKIP %-20s %-40s %s\n" "[no_changes]" "${package_name}" "${commit_hash}"
   fi
 done
 

--- a/packages/google-cloud-testutils/setup.py
+++ b/packages/google-cloud-testutils/setup.py
@@ -1,4 +1,5 @@
 # Copyright 2017 Google LLC
+# Trigger parallel system test run
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,6 +16,7 @@
 import io
 import os
 import re
+
 import setuptools  # type: ignore
 
 version = None

--- a/packages/google-cloud-testutils/setup.py
+++ b/packages/google-cloud-testutils/setup.py
@@ -16,7 +16,6 @@
 import io
 import os
 import re
-
 import setuptools  # type: ignore
 
 version = None

--- a/packages/google-cloud-testutils/setup.py
+++ b/packages/google-cloud-testutils/setup.py
@@ -1,5 +1,4 @@
 # Copyright 2017 Google LLC
-# Trigger parallel system test run
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
## Problem
The current output from the **package checking phase** (where we determine if a package should be tested OR not) in parallel `system tests` is noisy and difficult to read. It prints internal debug commands and multiple lines of text for every package, making it hard to quickly scan and see which packages are being tested or skipped.

## Solution
This Pull Request revamps the output format of the package checking phase to be highly readable and aligned.
- Internal debug commands have been silenced.
- The output now uses a "State-First" format, where the decision (TEST or SKIP) and the reason are displayed first, followed by the package name and commit hash.
- The output is aligned in columns using `printf`, making vertical scanning easy for humans and parsing easy for tools.

## Notes to Reviewers
- This change is purely cosmetic and does not alter the logic of package selection or test execution.
- A harmless trigger comment was added to `packages/google-cloud-testutils/setup.py` to force this package to be tested in CI, allowing you to see the new output format in action. This will be removed before merging.

## Example Output
```text
TEST [changed]     google-cloud-testutils c3bdf0971c1884aac6a4690834030583e87254e1
SKIP [no_changes]  google-cloud-tasks     c3bdf0971c1884aac6a4690834030583e87254e1
SKIP [no_changes]  google-cloud-storage   c3bdf0971c1884aac6a4690834030583e87254e1
```

## Pre-planning For Adhoc Testing:
While ad hoc testing is not yet merged to main and is not processed as a part of this PR, the expectation is that a future PR will refine this format when adhoc is added> At that time we will be able to determine why a TEST state was chosen (changed, adhoc, or both if a package has changes AND is inadvertantly included in the ad hoc list).

```text
TEST [changed]        google-cloud-testutils c3bdf0971c1884aac6a4690834030583e87254e1
TEST [adhoc]          google-cloud-tasks     c3bdf0971c1884aac6a4690834030583e87254e1
TEST [changed,adhoc]  google-cloud-tasks     c3bdf0971c1884aac6a4690834030583e87254e1
SKIP [no_changes]     google-cloud-storage   c3bdf0971c1884aac6a4690834030583e87254e1
```



