### PR TITLE
chore: bump google-api-core to 2.28.0

### DIFF
--- a/packages/gapic-generator/gapic/ads-templates/setup.py.j2
+++ b/packages/gapic-generator/gapic/ads-templates/setup.py.j2
@@ -29,7 +29,7 @@ else:
     release_status = "Development Status :: 5 - Production/Stable"
 
 dependencies = [
-    "google-api-core[grpc] >= 2.25.0, < 3.0.0",
+    "google-api-core[grpc] >= 2.28.0, < 3.0.0",
     "google-auth >= 2.14.1, <3.0.0",
     "googleapis-common-protos >= 1.53.0",
     "grpcio >= 1.59.0, < 2.0.0",

--- a/packages/gapic-generator/gapic/templates/%namespace/%name_%version/%sub/__init__.py.j2
+++ b/packages/gapic-generator/gapic/templates/%namespace/%name_%version/%sub/__init__.py.j2
@@ -6,11 +6,8 @@
 from {{package_path}} import gapic_version as package_version
 
 import google.api_core as api_core
-import sys
 
 __version__ = package_version.__version__
-
-from importlib import metadata
 
 # PEP 0810: Explicit Lazy Imports
 # Python 3.15+ natively intercepts and defers these imports.
@@ -63,87 +60,8 @@ from .types.{{ proto.module_name }} import {{ enum.name }}
 {% endfor %}
 {% endfor %}
 
-if hasattr(api_core, "check_python_version") and hasattr(api_core, "check_dependency_versions"):   # pragma: NO COVER
-    {# TODO(api_core): remove `type:ignore` below when minimum version of api_core makes the else clause unnecessary. #}
-    api_core.check_python_version("{{package_path}}") # type: ignore
-    api_core.check_dependency_versions("{{package_path}}") # type: ignore
-else:   # pragma: NO COVER
-{# TODO(api_core): Remove this try-catch when we require api-core at a version that
-   supports the changes in https://github.com/googleapis/python-api-core/pull/832
-
-    In the meantime, please ensure the functionality here mirrors the
-    equivalent functionality in api_core, in those two functions above.
-#}
-    # An older version of api_core is installed which does not define the
-    # functions above. We do equivalent checks manually.
-    try:
-        import warnings
-
-        _py_version_str = sys.version.split()[0]
-        _package_label = "{{package_path}}"
-        if sys.version_info < (3, 10):
-            warnings.warn("You are using a non-supported Python version " +
-                          f"({_py_version_str}).  Google will not post any further " +
-                          f"updates to {_package_label} supporting this Python version. " +
-                          "Please upgrade to the latest Python version, or at " +
-                          f"least to Python 3.10, and then update {_package_label}.",
-                          FutureWarning)
-
-        def parse_version_to_tuple(version_string: str):
-            """Safely converts a semantic version string to a comparable tuple of integers.
-            Example: "6.33.5" -> (6, 33, 5)
-            Ignores non-numeric parts and handles common version formats.
-            Args:
-                version_string: Version string in the format "x.y.z" or "x.y.z<suffix>"
-            Returns:
-                Tuple of integers for the parsed version string.
-            """
-            parts = []
-            for part in version_string.split("."):
-                try:
-                    parts.append(int(part))
-                except ValueError:
-                    # If it's a non-numeric part (e.g., '1.0.0b1' -> 'b1'), stop here.
-                    # This is a simplification compared to 'packaging.parse_version', but sufficient
-                    # for comparing strictly numeric semantic versions.
-                    break
-            return tuple(parts)
-
-        def _get_version(dependency_name):
-            try:
-                version_string: str = metadata.version(dependency_name)
-                parsed_version = parse_version_to_tuple(version_string)
-                return (parsed_version, version_string)
-            except Exception:
-                # Catch exceptions from metadata.version() (e.g., PackageNotFoundError)
-                # or errors during parse_version_to_tuple
-                return (None, "--")
-
-        _dependency_package = "google.protobuf"
-        _next_supported_version = "6.33.5"
-        _next_supported_version_tuple = (6, 33, 5)
-        _recommendation = " (we recommend 7.x)"
-        (_version_used, _version_used_string) = _get_version(_dependency_package)
-        if _version_used and _version_used < _next_supported_version_tuple:
-            warnings.warn(f"Package {_package_label} depends on " +
-                          f"{_dependency_package}, currently installed at version " +
-                          f"{_version_used_string}. Future updates to " +
-                          f"{_package_label} will require {_dependency_package} at " +
-                          f"version {_next_supported_version} or higher{_recommendation}." +
-                          " Please ensure " +
-                          "that either (a) your Python environment doesn't pin the " +
-                          f"version of {_dependency_package}, so that updates to " +
-                          f"{_package_label} can require the higher version, or " +
-                          "(b) you manually update your Python environment to use at " +
-                          f"least version {_next_supported_version} of " +
-                          f"{_dependency_package}.",
-                          FutureWarning)
-    except Exception:
-            warnings.warn("Could not determine the version of Python " +
-                          "currently being used. To continue receiving " +
-                          "updates for {_package_label}, ensure you are " +
-                          "using a supported version of Python; see " +
-                          "https://devguide.python.org/versions/")
+api_core.check_python_version("{{package_path}}")
+api_core.check_dependency_versions("{{package_path}}")
 
 {#  Define __all__.
     This requires the full set of imported names, so we iterate over

--- a/packages/gapic-generator/gapic/templates/setup.py.j2
+++ b/packages/gapic-generator/gapic/templates/setup.py.j2
@@ -36,7 +36,7 @@ else:
     release_status = "Development Status :: 5 - Production/Stable"
 
 dependencies = [
-    "google-api-core[grpc] >= 2.25.0, <3.0.0",
+    "google-api-core[grpc] >= 2.28.0, <3.0.0",
     # Exclude incompatible versions of `google-auth`
     # See https://github.com/googleapis/google-cloud-python/issues/12364
     "google-auth >= 2.14.1, <3.0.0,!=2.24.0,!=2.25.0",

--- a/packages/gapic-generator/gapic/templates/testing/constraints-3.10-async-rest.txt.j2
+++ b/packages/gapic-generator/gapic/templates/testing/constraints-3.10-async-rest.txt.j2
@@ -8,7 +8,7 @@
 # pinning their versions to their lower bounds.
 # For example, if setup.py has "google-cloud-foo >= 1.14.0, < 2.0.0",
 # then this file should have google-cloud-foo==1.14.0
-google-api-core==2.25.0
+google-api-core==2.28.0
 google-auth==2.35.0
 grpcio==1.59.0
 proto-plus==1.26.1

--- a/packages/gapic-generator/gapic/templates/testing/constraints-3.10.txt.j2
+++ b/packages/gapic-generator/gapic/templates/testing/constraints-3.10.txt.j2
@@ -5,7 +5,7 @@
 # pinning their versions to their lower bounds.
 # For example, if setup.py has "google-cloud-foo >= 1.14.0, < 2.0.0",
 # then this file should have google-cloud-foo==1.14.0
-google-api-core==2.25.0
+google-api-core==2.28.0
 google-auth==2.14.1
 grpcio==1.59.0
 proto-plus==1.26.1

--- a/packages/gapic-generator/tests/integration/goldens/asset/google/cloud/asset_v1/__init__.py
+++ b/packages/gapic-generator/tests/integration/goldens/asset/google/cloud/asset_v1/__init__.py
@@ -16,11 +16,8 @@
 from google.cloud.asset_v1 import gapic_version as package_version
 
 import google.api_core as api_core
-import sys
 
 __version__ = package_version.__version__
-
-from importlib import metadata
 
 # PEP 0810: Explicit Lazy Imports
 # Python 3.15+ natively intercepts and defers these imports.
@@ -121,80 +118,8 @@ from .types.assets import TemporalAsset
 from .types.assets import TimeWindow
 from .types.assets import VersionedResource
 
-if hasattr(api_core, "check_python_version") and hasattr(api_core, "check_dependency_versions"):   # pragma: NO COVER
-    api_core.check_python_version("google.cloud.asset_v1") # type: ignore
-    api_core.check_dependency_versions("google.cloud.asset_v1") # type: ignore
-else:   # pragma: NO COVER
-    # An older version of api_core is installed which does not define the
-    # functions above. We do equivalent checks manually.
-    try:
-        import warnings
-
-        _py_version_str = sys.version.split()[0]
-        _package_label = "google.cloud.asset_v1"
-        if sys.version_info < (3, 10):
-            warnings.warn("You are using a non-supported Python version " +
-                          f"({_py_version_str}).  Google will not post any further " +
-                          f"updates to {_package_label} supporting this Python version. " +
-                          "Please upgrade to the latest Python version, or at " +
-                          f"least to Python 3.10, and then update {_package_label}.",
-                          FutureWarning)
-
-        def parse_version_to_tuple(version_string: str):
-            """Safely converts a semantic version string to a comparable tuple of integers.
-            Example: "6.33.5" -> (6, 33, 5)
-            Ignores non-numeric parts and handles common version formats.
-            Args:
-                version_string: Version string in the format "x.y.z" or "x.y.z<suffix>"
-            Returns:
-                Tuple of integers for the parsed version string.
-            """
-            parts = []
-            for part in version_string.split("."):
-                try:
-                    parts.append(int(part))
-                except ValueError:
-                    # If it's a non-numeric part (e.g., '1.0.0b1' -> 'b1'), stop here.
-                    # This is a simplification compared to 'packaging.parse_version', but sufficient
-                    # for comparing strictly numeric semantic versions.
-                    break
-            return tuple(parts)
-
-        def _get_version(dependency_name):
-            try:
-                version_string: str = metadata.version(dependency_name)
-                parsed_version = parse_version_to_tuple(version_string)
-                return (parsed_version, version_string)
-            except Exception:
-                # Catch exceptions from metadata.version() (e.g., PackageNotFoundError)
-                # or errors during parse_version_to_tuple
-                return (None, "--")
-
-        _dependency_package = "google.protobuf"
-        _next_supported_version = "6.33.5"
-        _next_supported_version_tuple = (6, 33, 5)
-        _recommendation = " (we recommend 7.x)"
-        (_version_used, _version_used_string) = _get_version(_dependency_package)
-        if _version_used and _version_used < _next_supported_version_tuple:
-            warnings.warn(f"Package {_package_label} depends on " +
-                          f"{_dependency_package}, currently installed at version " +
-                          f"{_version_used_string}. Future updates to " +
-                          f"{_package_label} will require {_dependency_package} at " +
-                          f"version {_next_supported_version} or higher{_recommendation}." +
-                          " Please ensure " +
-                          "that either (a) your Python environment doesn't pin the " +
-                          f"version of {_dependency_package}, so that updates to " +
-                          f"{_package_label} can require the higher version, or " +
-                          "(b) you manually update your Python environment to use at " +
-                          f"least version {_next_supported_version} of " +
-                          f"{_dependency_package}.",
-                          FutureWarning)
-    except Exception:
-            warnings.warn("Could not determine the version of Python " +
-                          "currently being used. To continue receiving " +
-                          "updates for {_package_label}, ensure you are " +
-                          "using a supported version of Python; see " +
-                          "https://devguide.python.org/versions/")
+api_core.check_python_version("google.cloud.asset_v1")
+api_core.check_dependency_versions("google.cloud.asset_v1")
 
 __all__ = (
     'AssetServiceAsyncClient',

--- a/packages/gapic-generator/tests/integration/goldens/asset/setup.py
+++ b/packages/gapic-generator/tests/integration/goldens/asset/setup.py
@@ -42,7 +42,7 @@ else:
     release_status = "Development Status :: 5 - Production/Stable"
 
 dependencies = [
-    "google-api-core[grpc] >= 2.25.0, <3.0.0",
+    "google-api-core[grpc] >= 2.28.0, <3.0.0",
     # Exclude incompatible versions of `google-auth`
     # See https://github.com/googleapis/google-cloud-python/issues/12364
     "google-auth >= 2.14.1, <3.0.0,!=2.24.0,!=2.25.0",

--- a/packages/gapic-generator/tests/integration/goldens/asset/testing/constraints-3.10.txt
+++ b/packages/gapic-generator/tests/integration/goldens/asset/testing/constraints-3.10.txt
@@ -4,7 +4,7 @@
 # pinning their versions to their lower bounds.
 # For example, if setup.py has "google-cloud-foo >= 1.14.0, < 2.0.0",
 # then this file should have google-cloud-foo==1.14.0
-google-api-core==2.25.0
+google-api-core==2.28.0
 google-auth==2.14.1
 grpcio==1.59.0
 proto-plus==1.26.1

--- a/packages/gapic-generator/tests/integration/goldens/credentials/google/iam/credentials_v1/__init__.py
+++ b/packages/gapic-generator/tests/integration/goldens/credentials/google/iam/credentials_v1/__init__.py
@@ -16,11 +16,8 @@
 from google.iam.credentials_v1 import gapic_version as package_version
 
 import google.api_core as api_core
-import sys
 
 __version__ = package_version.__version__
-
-from importlib import metadata
 
 # PEP 0810: Explicit Lazy Imports
 # Python 3.15+ natively intercepts and defers these imports.
@@ -47,80 +44,8 @@ from .types.common import SignBlobResponse
 from .types.common import SignJwtRequest
 from .types.common import SignJwtResponse
 
-if hasattr(api_core, "check_python_version") and hasattr(api_core, "check_dependency_versions"):   # pragma: NO COVER
-    api_core.check_python_version("google.iam.credentials_v1") # type: ignore
-    api_core.check_dependency_versions("google.iam.credentials_v1") # type: ignore
-else:   # pragma: NO COVER
-    # An older version of api_core is installed which does not define the
-    # functions above. We do equivalent checks manually.
-    try:
-        import warnings
-
-        _py_version_str = sys.version.split()[0]
-        _package_label = "google.iam.credentials_v1"
-        if sys.version_info < (3, 10):
-            warnings.warn("You are using a non-supported Python version " +
-                          f"({_py_version_str}).  Google will not post any further " +
-                          f"updates to {_package_label} supporting this Python version. " +
-                          "Please upgrade to the latest Python version, or at " +
-                          f"least to Python 3.10, and then update {_package_label}.",
-                          FutureWarning)
-
-        def parse_version_to_tuple(version_string: str):
-            """Safely converts a semantic version string to a comparable tuple of integers.
-            Example: "6.33.5" -> (6, 33, 5)
-            Ignores non-numeric parts and handles common version formats.
-            Args:
-                version_string: Version string in the format "x.y.z" or "x.y.z<suffix>"
-            Returns:
-                Tuple of integers for the parsed version string.
-            """
-            parts = []
-            for part in version_string.split("."):
-                try:
-                    parts.append(int(part))
-                except ValueError:
-                    # If it's a non-numeric part (e.g., '1.0.0b1' -> 'b1'), stop here.
-                    # This is a simplification compared to 'packaging.parse_version', but sufficient
-                    # for comparing strictly numeric semantic versions.
-                    break
-            return tuple(parts)
-
-        def _get_version(dependency_name):
-            try:
-                version_string: str = metadata.version(dependency_name)
-                parsed_version = parse_version_to_tuple(version_string)
-                return (parsed_version, version_string)
-            except Exception:
-                # Catch exceptions from metadata.version() (e.g., PackageNotFoundError)
-                # or errors during parse_version_to_tuple
-                return (None, "--")
-
-        _dependency_package = "google.protobuf"
-        _next_supported_version = "6.33.5"
-        _next_supported_version_tuple = (6, 33, 5)
-        _recommendation = " (we recommend 7.x)"
-        (_version_used, _version_used_string) = _get_version(_dependency_package)
-        if _version_used and _version_used < _next_supported_version_tuple:
-            warnings.warn(f"Package {_package_label} depends on " +
-                          f"{_dependency_package}, currently installed at version " +
-                          f"{_version_used_string}. Future updates to " +
-                          f"{_package_label} will require {_dependency_package} at " +
-                          f"version {_next_supported_version} or higher{_recommendation}." +
-                          " Please ensure " +
-                          "that either (a) your Python environment doesn't pin the " +
-                          f"version of {_dependency_package}, so that updates to " +
-                          f"{_package_label} can require the higher version, or " +
-                          "(b) you manually update your Python environment to use at " +
-                          f"least version {_next_supported_version} of " +
-                          f"{_dependency_package}.",
-                          FutureWarning)
-    except Exception:
-            warnings.warn("Could not determine the version of Python " +
-                          "currently being used. To continue receiving " +
-                          "updates for {_package_label}, ensure you are " +
-                          "using a supported version of Python; see " +
-                          "https://devguide.python.org/versions/")
+api_core.check_python_version("google.iam.credentials_v1")
+api_core.check_dependency_versions("google.iam.credentials_v1")
 
 __all__ = (
     'IAMCredentialsAsyncClient',

--- a/packages/gapic-generator/tests/integration/goldens/credentials/setup.py
+++ b/packages/gapic-generator/tests/integration/goldens/credentials/setup.py
@@ -42,7 +42,7 @@ else:
     release_status = "Development Status :: 5 - Production/Stable"
 
 dependencies = [
-    "google-api-core[grpc] >= 2.25.0, <3.0.0",
+    "google-api-core[grpc] >= 2.28.0, <3.0.0",
     # Exclude incompatible versions of `google-auth`
     # See https://github.com/googleapis/google-cloud-python/issues/12364
     "google-auth >= 2.14.1, <3.0.0,!=2.24.0,!=2.25.0",

--- a/packages/gapic-generator/tests/integration/goldens/credentials/testing/constraints-3.10.txt
+++ b/packages/gapic-generator/tests/integration/goldens/credentials/testing/constraints-3.10.txt
@@ -4,7 +4,7 @@
 # pinning their versions to their lower bounds.
 # For example, if setup.py has "google-cloud-foo >= 1.14.0, < 2.0.0",
 # then this file should have google-cloud-foo==1.14.0
-google-api-core==2.25.0
+google-api-core==2.28.0
 google-auth==2.14.1
 grpcio==1.59.0
 proto-plus==1.26.1

--- a/packages/gapic-generator/tests/integration/goldens/eventarc/google/cloud/eventarc_v1/__init__.py
+++ b/packages/gapic-generator/tests/integration/goldens/eventarc/google/cloud/eventarc_v1/__init__.py
@@ -16,11 +16,8 @@
 from google.cloud.eventarc_v1 import gapic_version as package_version
 
 import google.api_core as api_core
-import sys
 
 __version__ = package_version.__version__
-
-from importlib import metadata
 
 # PEP 0810: Explicit Lazy Imports
 # Python 3.15+ natively intercepts and defers these imports.
@@ -119,80 +116,8 @@ from .types.trigger import StateCondition
 from .types.trigger import Transport
 from .types.trigger import Trigger
 
-if hasattr(api_core, "check_python_version") and hasattr(api_core, "check_dependency_versions"):   # pragma: NO COVER
-    api_core.check_python_version("google.cloud.eventarc_v1") # type: ignore
-    api_core.check_dependency_versions("google.cloud.eventarc_v1") # type: ignore
-else:   # pragma: NO COVER
-    # An older version of api_core is installed which does not define the
-    # functions above. We do equivalent checks manually.
-    try:
-        import warnings
-
-        _py_version_str = sys.version.split()[0]
-        _package_label = "google.cloud.eventarc_v1"
-        if sys.version_info < (3, 10):
-            warnings.warn("You are using a non-supported Python version " +
-                          f"({_py_version_str}).  Google will not post any further " +
-                          f"updates to {_package_label} supporting this Python version. " +
-                          "Please upgrade to the latest Python version, or at " +
-                          f"least to Python 3.10, and then update {_package_label}.",
-                          FutureWarning)
-
-        def parse_version_to_tuple(version_string: str):
-            """Safely converts a semantic version string to a comparable tuple of integers.
-            Example: "6.33.5" -> (6, 33, 5)
-            Ignores non-numeric parts and handles common version formats.
-            Args:
-                version_string: Version string in the format "x.y.z" or "x.y.z<suffix>"
-            Returns:
-                Tuple of integers for the parsed version string.
-            """
-            parts = []
-            for part in version_string.split("."):
-                try:
-                    parts.append(int(part))
-                except ValueError:
-                    # If it's a non-numeric part (e.g., '1.0.0b1' -> 'b1'), stop here.
-                    # This is a simplification compared to 'packaging.parse_version', but sufficient
-                    # for comparing strictly numeric semantic versions.
-                    break
-            return tuple(parts)
-
-        def _get_version(dependency_name):
-            try:
-                version_string: str = metadata.version(dependency_name)
-                parsed_version = parse_version_to_tuple(version_string)
-                return (parsed_version, version_string)
-            except Exception:
-                # Catch exceptions from metadata.version() (e.g., PackageNotFoundError)
-                # or errors during parse_version_to_tuple
-                return (None, "--")
-
-        _dependency_package = "google.protobuf"
-        _next_supported_version = "6.33.5"
-        _next_supported_version_tuple = (6, 33, 5)
-        _recommendation = " (we recommend 7.x)"
-        (_version_used, _version_used_string) = _get_version(_dependency_package)
-        if _version_used and _version_used < _next_supported_version_tuple:
-            warnings.warn(f"Package {_package_label} depends on " +
-                          f"{_dependency_package}, currently installed at version " +
-                          f"{_version_used_string}. Future updates to " +
-                          f"{_package_label} will require {_dependency_package} at " +
-                          f"version {_next_supported_version} or higher{_recommendation}." +
-                          " Please ensure " +
-                          "that either (a) your Python environment doesn't pin the " +
-                          f"version of {_dependency_package}, so that updates to " +
-                          f"{_package_label} can require the higher version, or " +
-                          "(b) you manually update your Python environment to use at " +
-                          f"least version {_next_supported_version} of " +
-                          f"{_dependency_package}.",
-                          FutureWarning)
-    except Exception:
-            warnings.warn("Could not determine the version of Python " +
-                          "currently being used. To continue receiving " +
-                          "updates for {_package_label}, ensure you are " +
-                          "using a supported version of Python; see " +
-                          "https://devguide.python.org/versions/")
+api_core.check_python_version("google.cloud.eventarc_v1")
+api_core.check_dependency_versions("google.cloud.eventarc_v1")
 
 __all__ = (
     'EventarcAsyncClient',

--- a/packages/gapic-generator/tests/integration/goldens/eventarc/setup.py
+++ b/packages/gapic-generator/tests/integration/goldens/eventarc/setup.py
@@ -42,7 +42,7 @@ else:
     release_status = "Development Status :: 5 - Production/Stable"
 
 dependencies = [
-    "google-api-core[grpc] >= 2.25.0, <3.0.0",
+    "google-api-core[grpc] >= 2.28.0, <3.0.0",
     # Exclude incompatible versions of `google-auth`
     # See https://github.com/googleapis/google-cloud-python/issues/12364
     "google-auth >= 2.14.1, <3.0.0,!=2.24.0,!=2.25.0",

--- a/packages/gapic-generator/tests/integration/goldens/eventarc/testing/constraints-3.10.txt
+++ b/packages/gapic-generator/tests/integration/goldens/eventarc/testing/constraints-3.10.txt
@@ -4,7 +4,7 @@
 # pinning their versions to their lower bounds.
 # For example, if setup.py has "google-cloud-foo >= 1.14.0, < 2.0.0",
 # then this file should have google-cloud-foo==1.14.0
-google-api-core==2.25.0
+google-api-core==2.28.0
 google-auth==2.14.1
 grpcio==1.59.0
 proto-plus==1.26.1

--- a/packages/gapic-generator/tests/integration/goldens/logging/google/cloud/logging_v2/__init__.py
+++ b/packages/gapic-generator/tests/integration/goldens/logging/google/cloud/logging_v2/__init__.py
@@ -16,11 +16,8 @@
 from google.cloud.logging_v2 import gapic_version as package_version
 
 import google.api_core as api_core
-import sys
 
 __version__ = package_version.__version__
-
-from importlib import metadata
 
 # PEP 0810: Explicit Lazy Imports
 # Python 3.15+ natively intercepts and defers these imports.
@@ -123,80 +120,8 @@ from .types.logging_metrics import ListLogMetricsResponse
 from .types.logging_metrics import LogMetric
 from .types.logging_metrics import UpdateLogMetricRequest
 
-if hasattr(api_core, "check_python_version") and hasattr(api_core, "check_dependency_versions"):   # pragma: NO COVER
-    api_core.check_python_version("google.cloud.logging_v2") # type: ignore
-    api_core.check_dependency_versions("google.cloud.logging_v2") # type: ignore
-else:   # pragma: NO COVER
-    # An older version of api_core is installed which does not define the
-    # functions above. We do equivalent checks manually.
-    try:
-        import warnings
-
-        _py_version_str = sys.version.split()[0]
-        _package_label = "google.cloud.logging_v2"
-        if sys.version_info < (3, 10):
-            warnings.warn("You are using a non-supported Python version " +
-                          f"({_py_version_str}).  Google will not post any further " +
-                          f"updates to {_package_label} supporting this Python version. " +
-                          "Please upgrade to the latest Python version, or at " +
-                          f"least to Python 3.10, and then update {_package_label}.",
-                          FutureWarning)
-
-        def parse_version_to_tuple(version_string: str):
-            """Safely converts a semantic version string to a comparable tuple of integers.
-            Example: "6.33.5" -> (6, 33, 5)
-            Ignores non-numeric parts and handles common version formats.
-            Args:
-                version_string: Version string in the format "x.y.z" or "x.y.z<suffix>"
-            Returns:
-                Tuple of integers for the parsed version string.
-            """
-            parts = []
-            for part in version_string.split("."):
-                try:
-                    parts.append(int(part))
-                except ValueError:
-                    # If it's a non-numeric part (e.g., '1.0.0b1' -> 'b1'), stop here.
-                    # This is a simplification compared to 'packaging.parse_version', but sufficient
-                    # for comparing strictly numeric semantic versions.
-                    break
-            return tuple(parts)
-
-        def _get_version(dependency_name):
-            try:
-                version_string: str = metadata.version(dependency_name)
-                parsed_version = parse_version_to_tuple(version_string)
-                return (parsed_version, version_string)
-            except Exception:
-                # Catch exceptions from metadata.version() (e.g., PackageNotFoundError)
-                # or errors during parse_version_to_tuple
-                return (None, "--")
-
-        _dependency_package = "google.protobuf"
-        _next_supported_version = "6.33.5"
-        _next_supported_version_tuple = (6, 33, 5)
-        _recommendation = " (we recommend 7.x)"
-        (_version_used, _version_used_string) = _get_version(_dependency_package)
-        if _version_used and _version_used < _next_supported_version_tuple:
-            warnings.warn(f"Package {_package_label} depends on " +
-                          f"{_dependency_package}, currently installed at version " +
-                          f"{_version_used_string}. Future updates to " +
-                          f"{_package_label} will require {_dependency_package} at " +
-                          f"version {_next_supported_version} or higher{_recommendation}." +
-                          " Please ensure " +
-                          "that either (a) your Python environment doesn't pin the " +
-                          f"version of {_dependency_package}, so that updates to " +
-                          f"{_package_label} can require the higher version, or " +
-                          "(b) you manually update your Python environment to use at " +
-                          f"least version {_next_supported_version} of " +
-                          f"{_dependency_package}.",
-                          FutureWarning)
-    except Exception:
-            warnings.warn("Could not determine the version of Python " +
-                          "currently being used. To continue receiving " +
-                          "updates for {_package_label}, ensure you are " +
-                          "using a supported version of Python; see " +
-                          "https://devguide.python.org/versions/")
+api_core.check_python_version("google.cloud.logging_v2")
+api_core.check_dependency_versions("google.cloud.logging_v2")
 
 __all__ = (
     'ConfigServiceV2AsyncClient',

--- a/packages/gapic-generator/tests/integration/goldens/logging/setup.py
+++ b/packages/gapic-generator/tests/integration/goldens/logging/setup.py
@@ -42,7 +42,7 @@ else:
     release_status = "Development Status :: 5 - Production/Stable"
 
 dependencies = [
-    "google-api-core[grpc] >= 2.25.0, <3.0.0",
+    "google-api-core[grpc] >= 2.28.0, <3.0.0",
     # Exclude incompatible versions of `google-auth`
     # See https://github.com/googleapis/google-cloud-python/issues/12364
     "google-auth >= 2.14.1, <3.0.0,!=2.24.0,!=2.25.0",

--- a/packages/gapic-generator/tests/integration/goldens/logging/testing/constraints-3.10.txt
+++ b/packages/gapic-generator/tests/integration/goldens/logging/testing/constraints-3.10.txt
@@ -4,7 +4,7 @@
 # pinning their versions to their lower bounds.
 # For example, if setup.py has "google-cloud-foo >= 1.14.0, < 2.0.0",
 # then this file should have google-cloud-foo==1.14.0
-google-api-core==2.25.0
+google-api-core==2.28.0
 google-auth==2.14.1
 grpcio==1.59.0
 proto-plus==1.26.1

--- a/packages/gapic-generator/tests/integration/goldens/logging_internal/google/cloud/logging_v2/__init__.py
+++ b/packages/gapic-generator/tests/integration/goldens/logging_internal/google/cloud/logging_v2/__init__.py
@@ -16,11 +16,8 @@
 from google.cloud.logging_v2 import gapic_version as package_version
 
 import google.api_core as api_core
-import sys
 
 __version__ = package_version.__version__
-
-from importlib import metadata
 
 # PEP 0810: Explicit Lazy Imports
 # Python 3.15+ natively intercepts and defers these imports.
@@ -123,80 +120,8 @@ from .types.logging_metrics import ListLogMetricsResponse
 from .types.logging_metrics import LogMetric
 from .types.logging_metrics import UpdateLogMetricRequest
 
-if hasattr(api_core, "check_python_version") and hasattr(api_core, "check_dependency_versions"):   # pragma: NO COVER
-    api_core.check_python_version("google.cloud.logging_v2") # type: ignore
-    api_core.check_dependency_versions("google.cloud.logging_v2") # type: ignore
-else:   # pragma: NO COVER
-    # An older version of api_core is installed which does not define the
-    # functions above. We do equivalent checks manually.
-    try:
-        import warnings
-
-        _py_version_str = sys.version.split()[0]
-        _package_label = "google.cloud.logging_v2"
-        if sys.version_info < (3, 10):
-            warnings.warn("You are using a non-supported Python version " +
-                          f"({_py_version_str}).  Google will not post any further " +
-                          f"updates to {_package_label} supporting this Python version. " +
-                          "Please upgrade to the latest Python version, or at " +
-                          f"least to Python 3.10, and then update {_package_label}.",
-                          FutureWarning)
-
-        def parse_version_to_tuple(version_string: str):
-            """Safely converts a semantic version string to a comparable tuple of integers.
-            Example: "6.33.5" -> (6, 33, 5)
-            Ignores non-numeric parts and handles common version formats.
-            Args:
-                version_string: Version string in the format "x.y.z" or "x.y.z<suffix>"
-            Returns:
-                Tuple of integers for the parsed version string.
-            """
-            parts = []
-            for part in version_string.split("."):
-                try:
-                    parts.append(int(part))
-                except ValueError:
-                    # If it's a non-numeric part (e.g., '1.0.0b1' -> 'b1'), stop here.
-                    # This is a simplification compared to 'packaging.parse_version', but sufficient
-                    # for comparing strictly numeric semantic versions.
-                    break
-            return tuple(parts)
-
-        def _get_version(dependency_name):
-            try:
-                version_string: str = metadata.version(dependency_name)
-                parsed_version = parse_version_to_tuple(version_string)
-                return (parsed_version, version_string)
-            except Exception:
-                # Catch exceptions from metadata.version() (e.g., PackageNotFoundError)
-                # or errors during parse_version_to_tuple
-                return (None, "--")
-
-        _dependency_package = "google.protobuf"
-        _next_supported_version = "6.33.5"
-        _next_supported_version_tuple = (6, 33, 5)
-        _recommendation = " (we recommend 7.x)"
-        (_version_used, _version_used_string) = _get_version(_dependency_package)
-        if _version_used and _version_used < _next_supported_version_tuple:
-            warnings.warn(f"Package {_package_label} depends on " +
-                          f"{_dependency_package}, currently installed at version " +
-                          f"{_version_used_string}. Future updates to " +
-                          f"{_package_label} will require {_dependency_package} at " +
-                          f"version {_next_supported_version} or higher{_recommendation}." +
-                          " Please ensure " +
-                          "that either (a) your Python environment doesn't pin the " +
-                          f"version of {_dependency_package}, so that updates to " +
-                          f"{_package_label} can require the higher version, or " +
-                          "(b) you manually update your Python environment to use at " +
-                          f"least version {_next_supported_version} of " +
-                          f"{_dependency_package}.",
-                          FutureWarning)
-    except Exception:
-            warnings.warn("Could not determine the version of Python " +
-                          "currently being used. To continue receiving " +
-                          "updates for {_package_label}, ensure you are " +
-                          "using a supported version of Python; see " +
-                          "https://devguide.python.org/versions/")
+api_core.check_python_version("google.cloud.logging_v2")
+api_core.check_dependency_versions("google.cloud.logging_v2")
 
 __all__ = (
     'BaseConfigServiceV2AsyncClient',

--- a/packages/gapic-generator/tests/integration/goldens/logging_internal/setup.py
+++ b/packages/gapic-generator/tests/integration/goldens/logging_internal/setup.py
@@ -42,7 +42,7 @@ else:
     release_status = "Development Status :: 5 - Production/Stable"
 
 dependencies = [
-    "google-api-core[grpc] >= 2.25.0, <3.0.0",
+    "google-api-core[grpc] >= 2.28.0, <3.0.0",
     # Exclude incompatible versions of `google-auth`
     # See https://github.com/googleapis/google-cloud-python/issues/12364
     "google-auth >= 2.14.1, <3.0.0,!=2.24.0,!=2.25.0",

--- a/packages/gapic-generator/tests/integration/goldens/logging_internal/testing/constraints-3.10.txt
+++ b/packages/gapic-generator/tests/integration/goldens/logging_internal/testing/constraints-3.10.txt
@@ -4,7 +4,7 @@
 # pinning their versions to their lower bounds.
 # For example, if setup.py has "google-cloud-foo >= 1.14.0, < 2.0.0",
 # then this file should have google-cloud-foo==1.14.0
-google-api-core==2.25.0
+google-api-core==2.28.0
 google-auth==2.14.1
 grpcio==1.59.0
 proto-plus==1.26.1

--- a/packages/gapic-generator/tests/integration/goldens/redis/google/cloud/redis_v1/__init__.py
+++ b/packages/gapic-generator/tests/integration/goldens/redis/google/cloud/redis_v1/__init__.py
@@ -16,11 +16,8 @@
 from google.cloud.redis_v1 import gapic_version as package_version
 
 import google.api_core as api_core
-import sys
 
 __version__ = package_version.__version__
-
-from importlib import metadata
 
 # PEP 0810: Explicit Lazy Imports
 # Python 3.15+ natively intercepts and defers these imports.
@@ -65,80 +62,8 @@ from .types.cloud_redis import UpgradeInstanceRequest
 from .types.cloud_redis import WeeklyMaintenanceWindow
 from .types.cloud_redis import ZoneMetadata
 
-if hasattr(api_core, "check_python_version") and hasattr(api_core, "check_dependency_versions"):   # pragma: NO COVER
-    api_core.check_python_version("google.cloud.redis_v1") # type: ignore
-    api_core.check_dependency_versions("google.cloud.redis_v1") # type: ignore
-else:   # pragma: NO COVER
-    # An older version of api_core is installed which does not define the
-    # functions above. We do equivalent checks manually.
-    try:
-        import warnings
-
-        _py_version_str = sys.version.split()[0]
-        _package_label = "google.cloud.redis_v1"
-        if sys.version_info < (3, 10):
-            warnings.warn("You are using a non-supported Python version " +
-                          f"({_py_version_str}).  Google will not post any further " +
-                          f"updates to {_package_label} supporting this Python version. " +
-                          "Please upgrade to the latest Python version, or at " +
-                          f"least to Python 3.10, and then update {_package_label}.",
-                          FutureWarning)
-
-        def parse_version_to_tuple(version_string: str):
-            """Safely converts a semantic version string to a comparable tuple of integers.
-            Example: "6.33.5" -> (6, 33, 5)
-            Ignores non-numeric parts and handles common version formats.
-            Args:
-                version_string: Version string in the format "x.y.z" or "x.y.z<suffix>"
-            Returns:
-                Tuple of integers for the parsed version string.
-            """
-            parts = []
-            for part in version_string.split("."):
-                try:
-                    parts.append(int(part))
-                except ValueError:
-                    # If it's a non-numeric part (e.g., '1.0.0b1' -> 'b1'), stop here.
-                    # This is a simplification compared to 'packaging.parse_version', but sufficient
-                    # for comparing strictly numeric semantic versions.
-                    break
-            return tuple(parts)
-
-        def _get_version(dependency_name):
-            try:
-                version_string: str = metadata.version(dependency_name)
-                parsed_version = parse_version_to_tuple(version_string)
-                return (parsed_version, version_string)
-            except Exception:
-                # Catch exceptions from metadata.version() (e.g., PackageNotFoundError)
-                # or errors during parse_version_to_tuple
-                return (None, "--")
-
-        _dependency_package = "google.protobuf"
-        _next_supported_version = "6.33.5"
-        _next_supported_version_tuple = (6, 33, 5)
-        _recommendation = " (we recommend 7.x)"
-        (_version_used, _version_used_string) = _get_version(_dependency_package)
-        if _version_used and _version_used < _next_supported_version_tuple:
-            warnings.warn(f"Package {_package_label} depends on " +
-                          f"{_dependency_package}, currently installed at version " +
-                          f"{_version_used_string}. Future updates to " +
-                          f"{_package_label} will require {_dependency_package} at " +
-                          f"version {_next_supported_version} or higher{_recommendation}." +
-                          " Please ensure " +
-                          "that either (a) your Python environment doesn't pin the " +
-                          f"version of {_dependency_package}, so that updates to " +
-                          f"{_package_label} can require the higher version, or " +
-                          "(b) you manually update your Python environment to use at " +
-                          f"least version {_next_supported_version} of " +
-                          f"{_dependency_package}.",
-                          FutureWarning)
-    except Exception:
-            warnings.warn("Could not determine the version of Python " +
-                          "currently being used. To continue receiving " +
-                          "updates for {_package_label}, ensure you are " +
-                          "using a supported version of Python; see " +
-                          "https://devguide.python.org/versions/")
+api_core.check_python_version("google.cloud.redis_v1")
+api_core.check_dependency_versions("google.cloud.redis_v1")
 
 __all__ = (
     'CloudRedisAsyncClient',

--- a/packages/gapic-generator/tests/integration/goldens/redis/setup.py
+++ b/packages/gapic-generator/tests/integration/goldens/redis/setup.py
@@ -42,7 +42,7 @@ else:
     release_status = "Development Status :: 5 - Production/Stable"
 
 dependencies = [
-    "google-api-core[grpc] >= 2.25.0, <3.0.0",
+    "google-api-core[grpc] >= 2.28.0, <3.0.0",
     # Exclude incompatible versions of `google-auth`
     # See https://github.com/googleapis/google-cloud-python/issues/12364
     "google-auth >= 2.14.1, <3.0.0,!=2.24.0,!=2.25.0",

--- a/packages/gapic-generator/tests/integration/goldens/redis/testing/constraints-3.10-async-rest.txt
+++ b/packages/gapic-generator/tests/integration/goldens/redis/testing/constraints-3.10-async-rest.txt
@@ -5,7 +5,7 @@
 # pinning their versions to their lower bounds.
 # For example, if setup.py has "google-cloud-foo >= 1.14.0, < 2.0.0",
 # then this file should have google-cloud-foo==1.14.0
-google-api-core==2.25.0
+google-api-core==2.28.0
 google-auth==2.35.0
 grpcio==1.59.0
 proto-plus==1.26.1

--- a/packages/gapic-generator/tests/integration/goldens/redis/testing/constraints-3.10.txt
+++ b/packages/gapic-generator/tests/integration/goldens/redis/testing/constraints-3.10.txt
@@ -4,7 +4,7 @@
 # pinning their versions to their lower bounds.
 # For example, if setup.py has "google-cloud-foo >= 1.14.0, < 2.0.0",
 # then this file should have google-cloud-foo==1.14.0
-google-api-core==2.25.0
+google-api-core==2.28.0
 google-auth==2.14.1
 grpcio==1.59.0
 proto-plus==1.26.1

--- a/packages/gapic-generator/tests/integration/goldens/redis_selective/google/cloud/redis_v1/__init__.py
+++ b/packages/gapic-generator/tests/integration/goldens/redis_selective/google/cloud/redis_v1/__init__.py
@@ -16,11 +16,8 @@
 from google.cloud.redis_v1 import gapic_version as package_version
 
 import google.api_core as api_core
-import sys
 
 __version__ = package_version.__version__
-
-from importlib import metadata
 
 # PEP 0810: Explicit Lazy Imports
 # Python 3.15+ natively intercepts and defers these imports.
@@ -58,80 +55,8 @@ from .types.cloud_redis import UpdateInstanceRequest
 from .types.cloud_redis import WeeklyMaintenanceWindow
 from .types.cloud_redis import ZoneMetadata
 
-if hasattr(api_core, "check_python_version") and hasattr(api_core, "check_dependency_versions"):   # pragma: NO COVER
-    api_core.check_python_version("google.cloud.redis_v1") # type: ignore
-    api_core.check_dependency_versions("google.cloud.redis_v1") # type: ignore
-else:   # pragma: NO COVER
-    # An older version of api_core is installed which does not define the
-    # functions above. We do equivalent checks manually.
-    try:
-        import warnings
-
-        _py_version_str = sys.version.split()[0]
-        _package_label = "google.cloud.redis_v1"
-        if sys.version_info < (3, 10):
-            warnings.warn("You are using a non-supported Python version " +
-                          f"({_py_version_str}).  Google will not post any further " +
-                          f"updates to {_package_label} supporting this Python version. " +
-                          "Please upgrade to the latest Python version, or at " +
-                          f"least to Python 3.10, and then update {_package_label}.",
-                          FutureWarning)
-
-        def parse_version_to_tuple(version_string: str):
-            """Safely converts a semantic version string to a comparable tuple of integers.
-            Example: "6.33.5" -> (6, 33, 5)
-            Ignores non-numeric parts and handles common version formats.
-            Args:
-                version_string: Version string in the format "x.y.z" or "x.y.z<suffix>"
-            Returns:
-                Tuple of integers for the parsed version string.
-            """
-            parts = []
-            for part in version_string.split("."):
-                try:
-                    parts.append(int(part))
-                except ValueError:
-                    # If it's a non-numeric part (e.g., '1.0.0b1' -> 'b1'), stop here.
-                    # This is a simplification compared to 'packaging.parse_version', but sufficient
-                    # for comparing strictly numeric semantic versions.
-                    break
-            return tuple(parts)
-
-        def _get_version(dependency_name):
-            try:
-                version_string: str = metadata.version(dependency_name)
-                parsed_version = parse_version_to_tuple(version_string)
-                return (parsed_version, version_string)
-            except Exception:
-                # Catch exceptions from metadata.version() (e.g., PackageNotFoundError)
-                # or errors during parse_version_to_tuple
-                return (None, "--")
-
-        _dependency_package = "google.protobuf"
-        _next_supported_version = "6.33.5"
-        _next_supported_version_tuple = (6, 33, 5)
-        _recommendation = " (we recommend 7.x)"
-        (_version_used, _version_used_string) = _get_version(_dependency_package)
-        if _version_used and _version_used < _next_supported_version_tuple:
-            warnings.warn(f"Package {_package_label} depends on " +
-                          f"{_dependency_package}, currently installed at version " +
-                          f"{_version_used_string}. Future updates to " +
-                          f"{_package_label} will require {_dependency_package} at " +
-                          f"version {_next_supported_version} or higher{_recommendation}." +
-                          " Please ensure " +
-                          "that either (a) your Python environment doesn't pin the " +
-                          f"version of {_dependency_package}, so that updates to " +
-                          f"{_package_label} can require the higher version, or " +
-                          "(b) you manually update your Python environment to use at " +
-                          f"least version {_next_supported_version} of " +
-                          f"{_dependency_package}.",
-                          FutureWarning)
-    except Exception:
-            warnings.warn("Could not determine the version of Python " +
-                          "currently being used. To continue receiving " +
-                          "updates for {_package_label}, ensure you are " +
-                          "using a supported version of Python; see " +
-                          "https://devguide.python.org/versions/")
+api_core.check_python_version("google.cloud.redis_v1")
+api_core.check_dependency_versions("google.cloud.redis_v1")
 
 __all__ = (
     'CloudRedisAsyncClient',

--- a/packages/gapic-generator/tests/integration/goldens/redis_selective/setup.py
+++ b/packages/gapic-generator/tests/integration/goldens/redis_selective/setup.py
@@ -42,7 +42,7 @@ else:
     release_status = "Development Status :: 5 - Production/Stable"
 
 dependencies = [
-    "google-api-core[grpc] >= 2.25.0, <3.0.0",
+    "google-api-core[grpc] >= 2.28.0, <3.0.0",
     # Exclude incompatible versions of `google-auth`
     # See https://github.com/googleapis/google-cloud-python/issues/12364
     "google-auth >= 2.14.1, <3.0.0,!=2.24.0,!=2.25.0",

--- a/packages/gapic-generator/tests/integration/goldens/redis_selective/testing/constraints-3.10-async-rest.txt
+++ b/packages/gapic-generator/tests/integration/goldens/redis_selective/testing/constraints-3.10-async-rest.txt
@@ -5,7 +5,7 @@
 # pinning their versions to their lower bounds.
 # For example, if setup.py has "google-cloud-foo >= 1.14.0, < 2.0.0",
 # then this file should have google-cloud-foo==1.14.0
-google-api-core==2.25.0
+google-api-core==2.28.0
 google-auth==2.35.0
 grpcio==1.59.0
 proto-plus==1.26.1

--- a/packages/gapic-generator/tests/integration/goldens/redis_selective/testing/constraints-3.10.txt
+++ b/packages/gapic-generator/tests/integration/goldens/redis_selective/testing/constraints-3.10.txt
@@ -4,7 +4,7 @@
 # pinning their versions to their lower bounds.
 # For example, if setup.py has "google-cloud-foo >= 1.14.0, < 2.0.0",
 # then this file should have google-cloud-foo==1.14.0
-google-api-core==2.25.0
+google-api-core==2.28.0
 google-auth==2.14.1
 grpcio==1.59.0
 proto-plus==1.26.1

--- a/packages/gapic-generator/tests/integration/goldens/storagebatchoperations/google/cloud/storagebatchoperations_v1/__init__.py
+++ b/packages/gapic-generator/tests/integration/goldens/storagebatchoperations/google/cloud/storagebatchoperations_v1/__init__.py
@@ -16,11 +16,8 @@
 from google.cloud.storagebatchoperations_v1 import gapic_version as package_version
 
 import google.api_core as api_core
-import sys
 
 __version__ = package_version.__version__
-
-from importlib import metadata
 
 # PEP 0810: Explicit Lazy Imports
 # Python 3.15+ natively intercepts and defers these imports.
@@ -67,80 +64,8 @@ from .types.storage_batch_operations_types import PutObjectHold
 from .types.storage_batch_operations_types import RewriteObject
 from .types.storage_batch_operations_types import UpdateObjectCustomContext
 
-if hasattr(api_core, "check_python_version") and hasattr(api_core, "check_dependency_versions"):   # pragma: NO COVER
-    api_core.check_python_version("google.cloud.storagebatchoperations_v1") # type: ignore
-    api_core.check_dependency_versions("google.cloud.storagebatchoperations_v1") # type: ignore
-else:   # pragma: NO COVER
-    # An older version of api_core is installed which does not define the
-    # functions above. We do equivalent checks manually.
-    try:
-        import warnings
-
-        _py_version_str = sys.version.split()[0]
-        _package_label = "google.cloud.storagebatchoperations_v1"
-        if sys.version_info < (3, 10):
-            warnings.warn("You are using a non-supported Python version " +
-                          f"({_py_version_str}).  Google will not post any further " +
-                          f"updates to {_package_label} supporting this Python version. " +
-                          "Please upgrade to the latest Python version, or at " +
-                          f"least to Python 3.10, and then update {_package_label}.",
-                          FutureWarning)
-
-        def parse_version_to_tuple(version_string: str):
-            """Safely converts a semantic version string to a comparable tuple of integers.
-            Example: "6.33.5" -> (6, 33, 5)
-            Ignores non-numeric parts and handles common version formats.
-            Args:
-                version_string: Version string in the format "x.y.z" or "x.y.z<suffix>"
-            Returns:
-                Tuple of integers for the parsed version string.
-            """
-            parts = []
-            for part in version_string.split("."):
-                try:
-                    parts.append(int(part))
-                except ValueError:
-                    # If it's a non-numeric part (e.g., '1.0.0b1' -> 'b1'), stop here.
-                    # This is a simplification compared to 'packaging.parse_version', but sufficient
-                    # for comparing strictly numeric semantic versions.
-                    break
-            return tuple(parts)
-
-        def _get_version(dependency_name):
-            try:
-                version_string: str = metadata.version(dependency_name)
-                parsed_version = parse_version_to_tuple(version_string)
-                return (parsed_version, version_string)
-            except Exception:
-                # Catch exceptions from metadata.version() (e.g., PackageNotFoundError)
-                # or errors during parse_version_to_tuple
-                return (None, "--")
-
-        _dependency_package = "google.protobuf"
-        _next_supported_version = "6.33.5"
-        _next_supported_version_tuple = (6, 33, 5)
-        _recommendation = " (we recommend 7.x)"
-        (_version_used, _version_used_string) = _get_version(_dependency_package)
-        if _version_used and _version_used < _next_supported_version_tuple:
-            warnings.warn(f"Package {_package_label} depends on " +
-                          f"{_dependency_package}, currently installed at version " +
-                          f"{_version_used_string}. Future updates to " +
-                          f"{_package_label} will require {_dependency_package} at " +
-                          f"version {_next_supported_version} or higher{_recommendation}." +
-                          " Please ensure " +
-                          "that either (a) your Python environment doesn't pin the " +
-                          f"version of {_dependency_package}, so that updates to " +
-                          f"{_package_label} can require the higher version, or " +
-                          "(b) you manually update your Python environment to use at " +
-                          f"least version {_next_supported_version} of " +
-                          f"{_dependency_package}.",
-                          FutureWarning)
-    except Exception:
-            warnings.warn("Could not determine the version of Python " +
-                          "currently being used. To continue receiving " +
-                          "updates for {_package_label}, ensure you are " +
-                          "using a supported version of Python; see " +
-                          "https://devguide.python.org/versions/")
+api_core.check_python_version("google.cloud.storagebatchoperations_v1")
+api_core.check_dependency_versions("google.cloud.storagebatchoperations_v1")
 
 __all__ = (
     'StorageBatchOperationsAsyncClient',

--- a/packages/gapic-generator/tests/integration/goldens/storagebatchoperations/setup.py
+++ b/packages/gapic-generator/tests/integration/goldens/storagebatchoperations/setup.py
@@ -42,7 +42,7 @@ else:
     release_status = "Development Status :: 5 - Production/Stable"
 
 dependencies = [
-    "google-api-core[grpc] >= 2.25.0, <3.0.0",
+    "google-api-core[grpc] >= 2.28.0, <3.0.0",
     # Exclude incompatible versions of `google-auth`
     # See https://github.com/googleapis/google-cloud-python/issues/12364
     "google-auth >= 2.14.1, <3.0.0,!=2.24.0,!=2.25.0",

--- a/packages/gapic-generator/tests/integration/goldens/storagebatchoperations/testing/constraints-3.10.txt
+++ b/packages/gapic-generator/tests/integration/goldens/storagebatchoperations/testing/constraints-3.10.txt
@@ -4,7 +4,7 @@
 # pinning their versions to their lower bounds.
 # For example, if setup.py has "google-cloud-foo >= 1.14.0, < 2.0.0",
 # then this file should have google-cloud-foo==1.14.0
-google-api-core==2.25.0
+google-api-core==2.28.0
 google-auth==2.14.1
 grpcio==1.59.0
 proto-plus==1.26.1

--- a/packages/google-cloud-bigquery/pyproject.toml
+++ b/packages/google-cloud-bigquery/pyproject.toml
@@ -41,7 +41,7 @@ classifiers = [
   "Topic :: Internet",
 ]
 dependencies = [
-  "google-api-core[grpc] >= 2.25.0, < 3.0.0",
+  "google-api-core[grpc] >= 2.28.0, < 3.0.0",
   "google-auth[pyopenssl] >= 2.14.1, < 3.0.0",
   "google-cloud-core >= 2.4.1, < 3.0.0",
   "google-resumable-media >= 2.0.0, < 3.0.0",

--- a/packages/google-cloud-bigquery/testing/constraints-3.10.txt
+++ b/packages/google-cloud-bigquery/testing/constraints-3.10.txt
@@ -1,4 +1,4 @@
-google-api-core==2.25.0
+google-api-core==2.28.0
 google-auth==2.14.1
 google-cloud-core==2.4.1
 google-resumable-media==2.0.0

--- a/packages/google-cloud-core/setup.py
+++ b/packages/google-cloud-core/setup.py
@@ -27,7 +27,7 @@ description = "Google Cloud API client core library"
 # 'Development Status :: 5 - Production/Stable'
 release_status = "Development Status :: 5 - Production/Stable"
 dependencies = [
-    "google-api-core >= 2.25.0, <3.0.0",
+    "google-api-core >= 2.28.0, <3.0.0",
     "google-auth >= 2.14.1, <3.0.0,!=2.24.0,!=2.25.0",
 ]
 extras = {

--- a/packages/google-cloud-core/testing/constraints-3.10.txt
+++ b/packages/google-cloud-core/testing/constraints-3.10.txt
@@ -5,7 +5,7 @@
 #
 # e.g., if setup.py has "foo >= 1.14.0, < 2.0.0dev",
 # Then this file should have foo==1.14.0
-google-api-core==2.25.0
+google-api-core==2.28.0
 google-auth==2.14.1
 grpcio==1.59.0
 grpcio-status==1.59.0

--- a/packages/google-cloud-ndb/setup.py
+++ b/packages/google-cloud-ndb/setup.py
@@ -40,7 +40,7 @@ def main():
     with io.open(readme_filename, encoding="utf-8") as readme_file:
         readme = readme_file.read()
     dependencies = [
-        "google-api-core[grpc] >= 2.25.0, <3.0.0",
+        "google-api-core[grpc] >= 2.28.0, <3.0.0",
         "google-cloud-datastore >= 2.21.0, < 3.0.0",
         "protobuf >= 6.33.5, < 8.0.0",
         "pymemcache >= 2.1.0, < 5.0.0",

--- a/packages/google-cloud-ndb/testing/constraints-3.10.txt
+++ b/packages/google-cloud-ndb/testing/constraints-3.10.txt
@@ -6,7 +6,7 @@
 # e.g., if setup.py has "foo >= 1.14.0, < 2.0.0dev",
 # Then this file should have foo==1.14.0
 google-cloud-datastore==2.21.0
-google-api-core==2.25.0
+google-api-core==2.28.0
 protobuf==6.33.5
 pymemcache==2.1.0
 redis==3.0.0


### PR DESCRIPTION
As per our discussion in https://github.com/googleapis/google-cloud-python/pull/17995, we're bumping api-core to `2.28.0` to limit code duplication and make version parser logic from api-core availably by default.