### PR TITLE
fix(ci): inject KOKORO_ROOT fallback for Ubuntu 22.04

### DIFF
--- a/.kokoro/trampoline.sh
+++ b/.kokoro/trampoline.sh
@@ -18,6 +18,9 @@
 # or zero if all commands in the pipeline exit successfully.
 set -eo pipefail
 
+export KOKORO_ROOT="${KOKORO_ROOT:-/tmpfs}"
+
+
 # Always run the cleanup script, regardless of the success of bouncing into
 # the container.
 function cleanup() {

--- a/packages/google-cloud-vision/google/cloud/vision_helpers/__init__.py
+++ b/packages/google-cloud-vision/google/cloud/vision_helpers/__init__.py
@@ -17,6 +17,8 @@ from __future__ import absolute_import
 import proto  # type: ignore
 from google.api_core import protobuf_helpers as protobuf
 
+# Trigger comment for system tests
+
 
 class VisionHelpers(object):
     """A set of convenience methods to make the Vision GAPIC easier to use.


### PR DESCRIPTION
# Description

## Problem
Kokoro jobs running on the newer Ubuntu 22.04 environment fail because the `KOKORO_ROOT` environment variable is missing. This causes the Python script `trampoline_v1.py` to crash with a `KeyError`.

## Solution
This change modifies `.kokoro/trampoline.sh` to set a default value for `KOKORO_ROOT` (`/tmpfs`) if it is not already set. This ensures compatibility with the new environment without breaking existing workflows.

A temporary comment was also added to `packages/google-cloud-vision/google/cloud/vision_helpers/__init__.py` to ensure that system tests are triggered for this change.

## Notes to Reviewers
This is a repository-level workaround to verify if the missing environment variable is the main cause of the Kokoro build failures on Ubuntu 22.04. If this fixes the tests, we can discuss whether to keep this fallback in the script or address it in the environment setup.
