### PR TITLE
test(spanner): initialize _client_info with ClientInfo instance in mock client

### DIFF
--- a/packages/google-cloud-spanner/tests/unit/_async/test_database.py
+++ b/packages/google-cloud-spanner/tests/unit/_async/test_database.py
@@ -4124,7 +4124,7 @@ class _Client(object):
         self._endpoint_cache = {}
         self.database_admin_api = _make_database_admin_api()
         self.instance_admin_api = _make_instance_api()
-        self._client_info = CrossSync.Mock()
+        self._client_info = gapic_v1.client_info.ClientInfo()
         self._client_options = CrossSync.Mock()
         self._client_options.universe_domain = "googleapis.com"
         self._client_options.api_key = None

--- a/packages/google-cloud-spanner/tests/unit/test_database.py
+++ b/packages/google-cloud-spanner/tests/unit/test_database.py
@@ -3557,7 +3557,7 @@ class _Client(object):
         self._endpoint_cache = {}
         self.database_admin_api = _make_database_admin_api()
         self.instance_admin_api = _make_instance_api()
-        self._client_info = mock.Mock()
+        self._client_info = gapic_v1.client_info.ClientInfo()
         self._client_options = mock.Mock()
         self._client_options.universe_domain = "googleapis.com"
         self._client_options.api_key = None


### PR DESCRIPTION
Replace CrossSync.Mock() and mock.Mock() with gapic_v1.client_info.ClientInfo() in _Client test helper mocks in test_database.py and _async/test_database.py.

In google-api-core (PR #17616), GapicCallable pre-extracts the metrics header from metadata at initialization time via client_info.to_grpc_metadata(). Using an AsyncMock or Mock for client_info caused to_grpc_metadata() to return a coroutine or Mock object instead of the expected (key, value) metadata tuple, leading to a TypeError in core_deps_from_source sessions.

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/google-cloud-python/issues) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)

Fixes #<issue_number_goes_here> 🦕