### PR TITLE
feat: add PendingDeprecationWarning for to_dataframe and to_arrow conversion methods

### DIFF
--- a/packages/google-cloud-bigquery/google/cloud/bigquery/table.py
+++ b/packages/google-cloud-bigquery/google/cloud/bigquery/table.py
@@ -21,9 +21,8 @@ import datetime
 import functools
 import operator
 import typing
-from typing import Any, Dict, Iterable, Iterator, List, Optional, Tuple, Union, Sequence
-
 import warnings
+from typing import Any, Dict, Iterable, Iterator, List, Optional, Sequence, Tuple, Union
 
 try:
     import pandas  # type: ignore
@@ -56,30 +55,33 @@ else:
     _read_wkt = wkt.loads
 
 import google.api_core.exceptions
-from google.api_core.page_iterator import HTTPIterator
-
 import google.cloud._helpers  # type: ignore
-from google.cloud.bigquery import _helpers
-from google.cloud.bigquery import _pandas_helpers
-from google.cloud.bigquery import _versions_helpers
+from google.api_core.page_iterator import HTTPIterator
+from google.cloud.bigquery import (
+    _helpers,
+    _pandas_helpers,
+    _string_references,
+    _versions_helpers,
+    external_config,
+)
 from google.cloud.bigquery import exceptions as bq_exceptions
+from google.cloud.bigquery import schema as _schema
 from google.cloud.bigquery._tqdm_helpers import get_progress_bar
 from google.cloud.bigquery.encryption_configuration import EncryptionConfiguration
 from google.cloud.bigquery.enums import DefaultPandasDTypes
 from google.cloud.bigquery.external_config import ExternalConfig
-from google.cloud.bigquery import schema as _schema
-from google.cloud.bigquery.schema import _build_schema_resource
-from google.cloud.bigquery.schema import _parse_schema_resource
-from google.cloud.bigquery.schema import _to_schema_fields
-from google.cloud.bigquery import external_config
-from google.cloud.bigquery import _string_references
+from google.cloud.bigquery.schema import (
+    _build_schema_resource,
+    _parse_schema_resource,
+    _to_schema_fields,
+)
 
 if typing.TYPE_CHECKING:  # pragma: NO COVER
     # Unconditionally import optional dependencies again to tell pytype that
     # they are not None, avoiding false "no attribute" errors.
+    import geopandas  # type: ignore
     import pandas
     import pyarrow
-    import geopandas  # type: ignore
     from google.cloud import bigquery_storage  # type: ignore
     from google.cloud.bigquery.dataset import DatasetReference
 
@@ -108,6 +110,17 @@ _RANGE_PYARROW_WARNING = (
     "Unable to represent RANGE schema as struct using pandas ArrowDtype. Using "
     "`object` instead. To use ArrowDtype, use pandas >= 1.5 and "
     "pyarrow >= 10.0.1."
+)
+
+_TO_DATAFRAME_DEPRECATED = (
+    "Retrieving DataFrames via core SDK conversion methods is deprecated. "
+    "For direct, optimized access, please call 'pandas_gbq.read_gbq()' directly."
+)
+
+_TO_ARROW_DEPRECATED = (
+    "Retrieving PyArrow Tables via core SDK conversion methods is deprecated. "
+    "For direct, optimized access, please call 'pandas_gbq.arrow.read_bigquery_table()' "
+    "or 'pandas_gbq.arrow.read_bigquery_query()' directly."
 )
 
 # How many of the total rows need to be downloaded already for us to skip
@@ -2316,6 +2329,12 @@ class RowIterator(HTTPIterator):
 
         .. versionadded:: 1.17.0
         """
+        warnings.warn(
+            _TO_ARROW_DEPRECATED,
+            PendingDeprecationWarning,
+            stacklevel=2,
+        )
+
         if pyarrow is None:
             raise ValueError(_NO_PYARROW_ERROR)
 
@@ -2709,6 +2728,12 @@ class RowIterator(HTTPIterator):
                 is not supported dtype.
 
         """
+        warnings.warn(
+            _TO_DATAFRAME_DEPRECATED,
+            PendingDeprecationWarning,
+            stacklevel=2,
+        )
+
         _pandas_helpers.verify_pandas_imports()
 
         if geography_as_object and shapely is None:
@@ -2801,12 +2826,18 @@ class RowIterator(HTTPIterator):
             create_bqstorage_client = False
             bqstorage_client = None
 
-        record_batch = self.to_arrow(
-            progress_bar_type=progress_bar_type,
-            bqstorage_client=bqstorage_client,
-            create_bqstorage_client=create_bqstorage_client,
-            timeout=timeout,
-        )
+        with warnings.catch_warnings():
+            warnings.filterwarnings(
+                "ignore",
+                category=PendingDeprecationWarning,
+                message="Retrieving PyArrow Tables.*",
+            )
+            record_batch = self.to_arrow(
+                progress_bar_type=progress_bar_type,
+                bqstorage_client=bqstorage_client,
+                create_bqstorage_client=create_bqstorage_client,
+                timeout=timeout,
+            )
 
         # Default date dtype is `db_dtypes.DateDtype()` that could cause out of bounds error,
         # when pyarrow converts date values to nanosecond precision. To avoid the error, we
@@ -3068,6 +3099,11 @@ class _EmptyRowIterator(RowIterator):
         """
         if pyarrow is None:
             raise ValueError(_NO_PYARROW_ERROR)
+        warnings.warn(
+            _TO_ARROW_DEPRECATED,
+            PendingDeprecationWarning,
+            stacklevel=2,
+        )
         return pyarrow.Table.from_arrays(())
 
     def to_dataframe(
@@ -3114,6 +3150,11 @@ class _EmptyRowIterator(RowIterator):
         Returns:
             pandas.DataFrame: An empty :class:`~pandas.DataFrame`.
         """
+        warnings.warn(
+            _TO_DATAFRAME_DEPRECATED,
+            PendingDeprecationWarning,
+            stacklevel=2,
+        )
         _pandas_helpers.verify_pandas_imports()
         return pandas.DataFrame()
 

--- a/packages/google-cloud-bigquery/google/cloud/bigquery/table.py
+++ b/packages/google-cloud-bigquery/google/cloud/bigquery/table.py
@@ -113,12 +113,12 @@ _RANGE_PYARROW_WARNING = (
 )
 
 _TO_DATAFRAME_DEPRECATED = (
-    "Retrieving DataFrames via core SDK conversion methods is deprecated. "
+    "Retrieving DataFrames via google-cloud-bigquery is deprecated. "
     "For direct, optimized access, please call 'pandas_gbq.read_gbq()' directly."
 )
 
 _TO_ARROW_DEPRECATED = (
-    "Retrieving PyArrow Tables via core SDK conversion methods is deprecated. "
+    "Retrieving PyArrow Tables via google-cloud-bigquery is deprecated. "
     "For direct, optimized access, please call 'pandas_gbq.arrow.read_bigquery_table()' "
     "or 'pandas_gbq.arrow.read_bigquery_query()' directly."
 )
@@ -3044,7 +3044,7 @@ class RowIterator(HTTPIterator):
             warnings.filterwarnings(
                 "ignore",
                 category=PendingDeprecationWarning,
-                message="Retrieving DataFrames via core SDK conversion methods is deprecated.*",
+                message="Retrieving DataFrames via google-cloud-bigquery is deprecated.*",
             )
             df = self.to_dataframe(
                 bqstorage_client,

--- a/packages/google-cloud-bigquery/google/cloud/bigquery/table.py
+++ b/packages/google-cloud-bigquery/google/cloud/bigquery/table.py
@@ -3040,18 +3040,24 @@ class RowIterator(HTTPIterator):
                 "one to use to create a GeoDataFrame"
             )
 
-        df = self.to_dataframe(
-            bqstorage_client,
-            dtypes,
-            progress_bar_type,
-            create_bqstorage_client,
-            geography_as_object=True,
-            bool_dtype=bool_dtype,
-            int_dtype=int_dtype,
-            float_dtype=float_dtype,
-            string_dtype=string_dtype,
-            timeout=timeout,
-        )
+        with warnings.catch_warnings():
+            warnings.filterwarnings(
+                "ignore",
+                category=PendingDeprecationWarning,
+                message="Retrieving DataFrames via core SDK conversion methods is deprecated.*",
+            )
+            df = self.to_dataframe(
+                bqstorage_client,
+                dtypes,
+                progress_bar_type,
+                create_bqstorage_client,
+                geography_as_object=True,
+                bool_dtype=bool_dtype,
+                int_dtype=int_dtype,
+                float_dtype=float_dtype,
+                string_dtype=string_dtype,
+                timeout=timeout,
+            )
 
         return geopandas.GeoDataFrame(
             df, crs=_COORDINATE_REFERENCE_SYSTEM, geometry=geography_column

--- a/packages/google-cloud-bigquery/tests/unit/test_table.py
+++ b/packages/google-cloud-bigquery/tests/unit/test_table.py
@@ -4165,7 +4165,12 @@ class TestRowIterator(unittest.TestCase):
                     continue
                 self.assertIn(
                     warning.category,
-                    [UserWarning, DeprecationWarning, tqdm.TqdmExperimentalWarning],
+                    [
+                        UserWarning,
+                        DeprecationWarning,
+                        PendingDeprecationWarning,
+                        tqdm.TqdmExperimentalWarning,
+                    ],
                 )
 
     def test_to_dataframe_w_empty_results(self):

--- a/packages/google-cloud-bigquery/tests/unit/test_table.py
+++ b/packages/google-cloud-bigquery/tests/unit/test_table.py
@@ -5761,6 +5761,34 @@ class TestRowIterator(unittest.TestCase):
         ]
         self.assertEqual(len(arrow_warnings), 0)
 
+    def test_to_geodataframe_does_not_emit_deprecation_warning(self):
+        pytest.importorskip("pandas")
+        mock_geopandas = mock.Mock()
+        mock_shapely = mock.Mock()
+        row_iterator = self._make_one_from_data(
+            (("name", "STRING"), ("geo", "GEOGRAPHY")),
+            (("foo", "POINT(1 2)"),),
+        )
+
+        with (
+            mock.patch("google.cloud.bigquery.table.geopandas", mock_geopandas),
+            mock.patch("google.cloud.bigquery.table.shapely", mock_shapely),
+            mock.patch(
+                "google.cloud.bigquery.table._read_wkt",
+                lambda x: x,
+                create=True,
+            ),
+        ):
+            with warnings.catch_warnings(record=True) as record:
+                row_iterator.to_geodataframe(create_bqstorage_client=False)
+
+        deprecation_warnings = [
+            w
+            for w in record
+            if issubclass(w.category, (PendingDeprecationWarning, DeprecationWarning))
+        ]
+        self.assertEqual(len(deprecation_warnings), 0)
+
 
 class TestPartitionRange(unittest.TestCase):
     def _get_target_class(self):

--- a/packages/google-cloud-bigquery/tests/unit/test_table.py
+++ b/packages/google-cloud-bigquery/tests/unit/test_table.py
@@ -5780,6 +5780,7 @@ class TestRowIterator(unittest.TestCase):
             ),
         ):
             with warnings.catch_warnings(record=True) as record:
+                warnings.simplefilter("always")
                 row_iterator.to_geodataframe(create_bqstorage_client=False)
 
         deprecation_warnings = [

--- a/packages/google-cloud-bigquery/tests/unit/test_table.py
+++ b/packages/google-cloud-bigquery/tests/unit/test_table.py
@@ -19,21 +19,16 @@ import re
 import time
 import types
 import unittest
-from unittest import mock
 import warnings
-
-import pytest
+from unittest import mock
 
 import google.api_core.exceptions
-from test_utils.imports import maybe_fail_import
-
-from google.cloud.bigquery import _versions_helpers
-from google.cloud.bigquery import exceptions
-from google.cloud.bigquery import external_config
-from google.cloud.bigquery import schema
+import pytest
+from google.cloud.bigquery import _versions_helpers, exceptions, external_config, schema
+from google.cloud.bigquery.dataset import DatasetReference
 from google.cloud.bigquery.enums import DefaultPandasDTypes
 from google.cloud.bigquery.table import TableReference
-from google.cloud.bigquery.dataset import DatasetReference
+from test_utils.imports import maybe_fail_import
 
 
 def _mock_client():
@@ -414,6 +409,7 @@ class TestTable(unittest.TestCase, _SchemaBase):
 
     def _setUpConstants(self):
         import datetime
+
         from google.cloud._helpers import UTC
 
         self.WHEN_TS = 1437767599.006
@@ -618,10 +614,10 @@ class TestTable(unittest.TestCase, _SchemaBase):
         self.assertEqual(table.table_id, "some_tbl")
 
     def test_ctor_tablelistitem(self):
-        from google.cloud.bigquery.table import Table, TableListItem
-
         import datetime
-        from google.cloud._helpers import _millis, UTC
+
+        from google.cloud._helpers import UTC, _millis
+        from google.cloud.bigquery.table import Table, TableListItem
 
         self.WHEN_TS = 1437767599.125
         self.EXP_TIME = datetime.datetime(2015, 8, 1, 23, 59, 59, tzinfo=UTC)
@@ -818,8 +814,8 @@ class TestTable(unittest.TestCase, _SchemaBase):
 
     def test_props_set_by_server(self):
         import datetime
-        from google.cloud._helpers import UTC
-        from google.cloud._helpers import _millis
+
+        from google.cloud._helpers import UTC, _millis
 
         CREATED = datetime.datetime(2015, 7, 29, 12, 13, 22, tzinfo=UTC)
         MODIFIED = datetime.datetime(2015, 7, 29, 14, 47, 15, tzinfo=UTC)
@@ -1162,6 +1158,7 @@ class TestTable(unittest.TestCase, _SchemaBase):
 
     def test_expires_setter(self):
         import datetime
+
         from google.cloud._helpers import UTC
 
         WHEN = datetime.datetime(2015, 7, 28, 16, 39, tzinfo=UTC)
@@ -1374,8 +1371,8 @@ class TestTable(unittest.TestCase, _SchemaBase):
 
     def test_from_api_repr_w_properties(self):
         import datetime
-        from google.cloud._helpers import UTC
-        from google.cloud._helpers import _millis
+
+        from google.cloud._helpers import UTC, _millis
 
         RESOURCE = self._make_resource()
         RESOURCE["view"] = {"query": "select fullname, age from person_ages"}
@@ -1389,8 +1386,8 @@ class TestTable(unittest.TestCase, _SchemaBase):
 
     def test_from_api_repr_w_partial_streamingbuffer(self):
         import datetime
-        from google.cloud._helpers import UTC
-        from google.cloud._helpers import _millis
+
+        from google.cloud._helpers import UTC, _millis
 
         RESOURCE = self._make_resource()
         self.OLDEST_TIME = datetime.datetime(2015, 8, 1, 23, 59, 59, tzinfo=UTC)
@@ -1554,8 +1551,7 @@ class TestTable(unittest.TestCase, _SchemaBase):
             table._build_resource(["bad"])
 
     def test_range_partitioning(self):
-        from google.cloud.bigquery.table import RangePartitioning
-        from google.cloud.bigquery.table import PartitionRange
+        from google.cloud.bigquery.table import PartitionRange, RangePartitioning
 
         table = self._make_one("proj.dset.tbl")
         assert table.range_partitioning is None
@@ -1588,8 +1584,7 @@ class TestTable(unittest.TestCase, _SchemaBase):
         assert table.require_partition_filter is None
 
     def test_time_partitioning_getter(self):
-        from google.cloud.bigquery.table import TimePartitioning
-        from google.cloud.bigquery.table import TimePartitioningType
+        from google.cloud.bigquery.table import TimePartitioning, TimePartitioningType
 
         dataset = DatasetReference(self.PROJECT, self.DS_ID)
         table_ref = dataset.table(self.TABLE_NAME)
@@ -1646,8 +1641,7 @@ class TestTable(unittest.TestCase, _SchemaBase):
             self.assertIs(warning.category, PendingDeprecationWarning)
 
     def test_time_partitioning_setter(self):
-        from google.cloud.bigquery.table import TimePartitioning
-        from google.cloud.bigquery.table import TimePartitioningType
+        from google.cloud.bigquery.table import TimePartitioning, TimePartitioningType
 
         dataset = DatasetReference(self.PROJECT, self.DS_ID)
         table_ref = dataset.table(self.TABLE_NAME)
@@ -1903,7 +1897,7 @@ class Test_row_from_mapping(unittest.TestCase, _SchemaBase):
         return _row_from_mapping(mapping, schema)
 
     def test__row_from_mapping_wo_schema(self):
-        from google.cloud.bigquery.table import Table, _TABLE_HAS_NO_SCHEMA
+        from google.cloud.bigquery.table import _TABLE_HAS_NO_SCHEMA, Table
 
         MAPPING = {"full_name": "Phred Phlyntstone", "age": 32}
         dataset = DatasetReference(self.PROJECT, self.DS_ID)
@@ -2517,6 +2511,26 @@ class Test_EmptyRowIterator(unittest.TestCase):
         else:
             assert not hasattr(df, "crs")
 
+    def test_to_arrow_emits_pending_deprecation_warning(self):
+        pytest.importorskip("pyarrow")
+        row_iterator = self._make_one()
+
+        with pytest.warns(
+            PendingDeprecationWarning,
+            match="Retrieving PyArrow Tables via core SDK conversion methods is deprecated",
+        ):
+            row_iterator.to_arrow()
+
+    def test_to_dataframe_emits_pending_deprecation_warning(self):
+        pytest.importorskip("pandas")
+        row_iterator = self._make_one()
+
+        with pytest.warns(
+            PendingDeprecationWarning,
+            match="Retrieving DataFrames via core SDK conversion methods is deprecated",
+        ):
+            row_iterator.to_dataframe()
+
     def test_methods_w_timeout(self):
         pytest.importorskip("pyarrow")
         pytest.importorskip("geopandas")
@@ -2581,8 +2595,7 @@ class TestRowIterator(unittest.TestCase):
         return self._make_one(_mock_client(), api_request, path, schema)
 
     def test_constructor(self):
-        from google.cloud.bigquery.table import _item_to_row
-        from google.cloud.bigquery.table import _rows_page_start
+        from google.cloud.bigquery.table import _item_to_row, _rows_page_start
 
         client = _mock_client()
         path = "/some/path"
@@ -3048,13 +3061,12 @@ class TestRowIterator(unittest.TestCase):
         pyarrow = pytest.importorskip("pyarrow")
         pytest.importorskip("google.cloud.bigquery_storage")
         from google.cloud import bigquery_storage
+        from google.cloud.bigquery import schema
+        from google.cloud.bigquery import table as mut
         from google.cloud.bigquery_storage_v1 import reader
         from google.cloud.bigquery_storage_v1.services.big_query_read.transports import (
             grpc as big_query_read_grpc_transport,
         )
-
-        from google.cloud.bigquery import schema
-        from google.cloud.bigquery import table as mut
 
         bqstorage_client = mock.create_autospec(bigquery_storage.BigQueryReadClient)
         bqstorage_client._transport = mock.create_autospec(
@@ -3291,8 +3303,8 @@ class TestRowIterator(unittest.TestCase):
         self.assertEqual(sports, ["volleyball", "basketball"])
 
         # Expect warning from both the arrow conversion, and the json deserialization.
-        self.assertEqual(len(warned), 2)
-        self.assertTrue(all("sport" in str(warning) for warning in warned))
+        sport_warnings = [w for w in warned if "sport" in str(w.message)]
+        self.assertEqual(len(sport_warnings), 2)
 
     def test_to_arrow_w_empty_table(self):
         pytest.importorskip("numpy")
@@ -3422,9 +3434,9 @@ class TestRowIterator(unittest.TestCase):
         pytest.importorskip("numpy")
         pyarrow = pytest.importorskip("pyarrow")
         pytest.importorskip("google.cloud.bigquery_storage")
+        from google.cloud import bigquery_storage
         from google.cloud.bigquery import schema
         from google.cloud.bigquery import table as mut
-        from google.cloud import bigquery_storage
         from google.cloud.bigquery_storage_v1 import reader
         from google.cloud.bigquery_storage_v1.services.big_query_read.transports import (
             grpc as big_query_read_grpc_transport,
@@ -3506,9 +3518,9 @@ class TestRowIterator(unittest.TestCase):
         pytest.importorskip("numpy")
         pytest.importorskip("pyarrow")
         pytest.importorskip("google.cloud.bigquery_storage")
+        from google.cloud import bigquery_storage
         from google.cloud.bigquery import schema
         from google.cloud.bigquery import table as mut
-        from google.cloud import bigquery_storage
         from google.cloud.bigquery_storage_v1.services.big_query_read.transports import (
             grpc as big_query_read_grpc_transport,
         )
@@ -3574,9 +3586,9 @@ class TestRowIterator(unittest.TestCase):
         pytest.importorskip("numpy")
         pyarrow = pytest.importorskip("pyarrow")
         pytest.importorskip("google.cloud.bigquery_storage")
+        from google.cloud import bigquery_storage
         from google.cloud.bigquery import schema
         from google.cloud.bigquery import table as mut
-        from google.cloud import bigquery_storage
 
         bqstorage_client = mock.create_autospec(bigquery_storage.BigQueryReadClient)
         session = bigquery_storage.types.ReadSession()
@@ -3749,9 +3761,9 @@ class TestRowIterator(unittest.TestCase):
         pandas = pytest.importorskip("pandas")
         pyarrow = pytest.importorskip("pyarrow")
         pytest.importorskip("google.cloud.bigquery_storage")
+        from google.cloud import bigquery_storage
         from google.cloud.bigquery import schema
         from google.cloud.bigquery import table as mut
-        from google.cloud import bigquery_storage
         from google.cloud.bigquery_storage_v1 import reader
         from google.cloud.bigquery_storage_v1.services.big_query_read.transports import (
             grpc as big_query_read_grpc_transport,
@@ -3823,9 +3835,9 @@ class TestRowIterator(unittest.TestCase):
         pytest.importorskip("numpy")
         pandas = pytest.importorskip("pandas")
         pytest.importorskip("google.cloud.bigquery_storage")
+        from google.cloud import bigquery_storage
         from google.cloud.bigquery import schema
         from google.cloud.bigquery import table as mut
-        from google.cloud import bigquery_storage
 
         bqstorage_client = mock.create_autospec(bigquery_storage.BigQueryReadClient)
 
@@ -4176,6 +4188,7 @@ class TestRowIterator(unittest.TestCase):
     def test_to_dataframe_w_various_types_nullable(self):
         pandas = pytest.importorskip("pandas")
         import datetime
+
         from google.cloud.bigquery.schema import SchemaField
 
         schema = [
@@ -4855,9 +4868,9 @@ class TestRowIterator(unittest.TestCase):
         pytest.importorskip("numpy")
         pytest.importorskip("pandas")
         pytest.importorskip("google.cloud.bigquery_storage")
+        from google.cloud import bigquery_storage
         from google.cloud.bigquery import schema
         from google.cloud.bigquery import table as mut
-        from google.cloud import bigquery_storage
         from google.cloud.bigquery_storage_v1.services.big_query_read.transports import (
             grpc as big_query_read_grpc_transport,
         )
@@ -4889,9 +4902,9 @@ class TestRowIterator(unittest.TestCase):
         pytest.importorskip("numpy")
         pytest.importorskip("pandas")
         pytest.importorskip("google.cloud.bigquery_storage")
+        from google.cloud import bigquery_storage
         from google.cloud.bigquery import schema
         from google.cloud.bigquery import table as mut
-        from google.cloud import bigquery_storage
 
         bqstorage_client = mock.create_autospec(bigquery_storage.BigQueryReadClient)
         session = bigquery_storage.types.ReadSession()
@@ -4919,8 +4932,8 @@ class TestRowIterator(unittest.TestCase):
         pytest.importorskip("google.cloud.bigquery_storage")
         pytest.importorskip("pandas")
         pytest.importorskip("pyarrow")
-        from google.cloud.bigquery.table import Table
         from google.cloud import bigquery_storage
+        from google.cloud.bigquery.table import Table
 
         bqstorage_client = mock.create_autospec(bigquery_storage.BigQueryReadClient)
         session = bigquery_storage.types.ReadSession()
@@ -4999,9 +5012,9 @@ class TestRowIterator(unittest.TestCase):
         pytest.importorskip("google.cloud.bigquery_storage")
         pytest.importorskip("pandas")
         pyarrow = pytest.importorskip("pyarrow")
+        from google.cloud import bigquery_storage
         from google.cloud.bigquery import schema
         from google.cloud.bigquery import table as mut
-        from google.cloud import bigquery_storage
         from google.cloud.bigquery_storage_v1 import reader
         from google.cloud.bigquery_storage_v1.services.big_query_read.transports import (
             grpc as big_query_read_grpc_transport,
@@ -5723,6 +5736,31 @@ class TestRowIterator(unittest.TestCase):
 
         self.assertEqual([v.__class__.__name__ for v in df.g], ["Point"])
 
+    def test_to_arrow_emits_pending_deprecation_warning(self):
+        pytest.importorskip("pyarrow")
+        row_iterator = self._make_one_from_data((("name", "STRING"),), (("foo",),))
+
+        with pytest.warns(
+            PendingDeprecationWarning,
+            match="Retrieving PyArrow Tables via core SDK conversion methods is deprecated",
+        ):
+            row_iterator.to_arrow(create_bqstorage_client=False)
+
+    def test_to_dataframe_emits_pending_deprecation_warning(self):
+        pytest.importorskip("pandas")
+        row_iterator = self._make_one_from_data((("name", "STRING"),), (("foo",),))
+
+        with pytest.warns(
+            PendingDeprecationWarning,
+            match="Retrieving DataFrames via core SDK conversion methods is deprecated",
+        ) as record:
+            row_iterator.to_dataframe(create_bqstorage_client=False)
+
+        arrow_warnings = [
+            w for w in record if "Retrieving PyArrow Tables" in str(w.message)
+        ]
+        self.assertEqual(len(arrow_warnings), 0)
+
 
 class TestPartitionRange(unittest.TestCase):
     def _get_target_class(self):
@@ -6329,10 +6367,10 @@ class TestTableConstraint(unittest.TestCase):
 
     def test_constructor_explicit(self):
         from google.cloud.bigquery.table import (
-            PrimaryKey,
-            ForeignKey,
-            TableReference,
             ColumnReference,
+            ForeignKey,
+            PrimaryKey,
+            TableReference,
         )
 
         primary_key = PrimaryKey(columns=["my_pk_id"])
@@ -6364,10 +6402,10 @@ class TestTableConstraint(unittest.TestCase):
 
     def test__eq__other_type(self):
         from google.cloud.bigquery.table import (
-            PrimaryKey,
-            ForeignKey,
-            TableReference,
             ColumnReference,
+            ForeignKey,
+            PrimaryKey,
+            TableReference,
         )
 
         table_constraint = self._make_one(
@@ -6602,8 +6640,8 @@ def test_table_constraint_eq_parametrized(
         ColumnReference,
         ForeignKey,
         PrimaryKey,
-        TableReference,
         TableConstraints,
+        TableReference,
     )
 
     # Helper function to create a PrimaryKey object or None
@@ -6850,9 +6888,9 @@ def test_table_reference_to_bqstorage_v1_stable(table_path):
 def test_to_arrow_iterable_w_bqstorage_max_stream_count(preserve_order):
     pytest.importorskip("pandas")
     pytest.importorskip("google.cloud.bigquery_storage")
+    from google.cloud import bigquery_storage
     from google.cloud.bigquery import schema
     from google.cloud.bigquery import table as mut
-    from google.cloud import bigquery_storage
 
     bqstorage_client = mock.create_autospec(bigquery_storage.BigQueryReadClient)
     session = bigquery_storage.types.ReadSession()
@@ -6887,9 +6925,9 @@ def test_to_arrow_iterable_w_bqstorage_max_stream_count(preserve_order):
 def test_to_dataframe_iterable_w_bqstorage_max_stream_count(preserve_order):
     pytest.importorskip("pandas")
     pytest.importorskip("google.cloud.bigquery_storage")
+    from google.cloud import bigquery_storage
     from google.cloud.bigquery import schema
     from google.cloud.bigquery import table as mut
-    from google.cloud import bigquery_storage
 
     bqstorage_client = mock.create_autospec(bigquery_storage.BigQueryReadClient)
     session = bigquery_storage.types.ReadSession()

--- a/packages/google-cloud-bigquery/tests/unit/test_table.py
+++ b/packages/google-cloud-bigquery/tests/unit/test_table.py
@@ -2517,7 +2517,7 @@ class Test_EmptyRowIterator(unittest.TestCase):
 
         with pytest.warns(
             PendingDeprecationWarning,
-            match="Retrieving PyArrow Tables via core SDK conversion methods is deprecated",
+            match="Retrieving PyArrow Tables via google-cloud-bigquery is deprecated",
         ):
             row_iterator.to_arrow()
 
@@ -2527,7 +2527,7 @@ class Test_EmptyRowIterator(unittest.TestCase):
 
         with pytest.warns(
             PendingDeprecationWarning,
-            match="Retrieving DataFrames via core SDK conversion methods is deprecated",
+            match="Retrieving DataFrames via google-cloud-bigquery is deprecated",
         ):
             row_iterator.to_dataframe()
 
@@ -5742,7 +5742,7 @@ class TestRowIterator(unittest.TestCase):
 
         with pytest.warns(
             PendingDeprecationWarning,
-            match="Retrieving PyArrow Tables via core SDK conversion methods is deprecated",
+            match="Retrieving PyArrow Tables via google-cloud-bigquery is deprecated",
         ):
             row_iterator.to_arrow(create_bqstorage_client=False)
 
@@ -5752,7 +5752,7 @@ class TestRowIterator(unittest.TestCase):
 
         with pytest.warns(
             PendingDeprecationWarning,
-            match="Retrieving DataFrames via core SDK conversion methods is deprecated",
+            match="Retrieving DataFrames via google-cloud-bigquery is deprecated",
         ) as record:
             row_iterator.to_dataframe(create_bqstorage_client=False)
 


### PR DESCRIPTION
As part of the `pandas-gbq` migration and API unification strategy, this PR introduces `PendingDeprecationWarning`  to the core conversion wrapper methods in `google-cloud-bigquery`.

This alerts developers to adopt direct, optimized `pandas-gbq` entry points (`pandas_gbq.read_gbq()` and `pandas_gbq.arrow.*`) ahead of future deprecation phases.

Fixes #<526614511> 🦕