### PR TITLE
fix(api_core): support suppress_metrics_header fallback in AuthMetadataPlugin

### DIFF
--- a/packages/google-api-core/tests/asyncio/test_grpc_helpers_async.py
+++ b/packages/google-api-core/tests/asyncio/test_grpc_helpers_async.py
@@ -36,14 +36,14 @@ import inspect
 import google.auth.credentials
 import google.auth.transport.grpc
 
+from google.api_core import exceptions, grpc_helpers_async
+
 _SUPPORTS_SUPPRESS_METRICS = (
     "suppress_metrics_header"
     in inspect.signature(
         google.auth.transport.grpc.AuthMetadataPlugin.__init__
     ).parameters
 )
-
-from google.api_core import exceptions, grpc_helpers_async
 
 
 class RpcErrorImpl(grpc.RpcError, grpc.Call):

--- a/packages/google-api-core/tests/asyncio/test_grpc_helpers_async.py
+++ b/packages/google-api-core/tests/asyncio/test_grpc_helpers_async.py
@@ -33,7 +33,6 @@ if grpc is None:  # pragma: NO COVER
 
 
 import google.auth.credentials
-import google.auth.transport.grpc
 
 from google.api_core import exceptions, grpc_helpers_async
 

--- a/packages/google-api-core/tests/asyncio/test_grpc_helpers_async.py
+++ b/packages/google-api-core/tests/asyncio/test_grpc_helpers_async.py
@@ -421,6 +421,9 @@ def test_create_channel_implicit_with_default_host(
     assert channel is grpc_secure_channel.return_value
 
     google_auth_default.assert_called_once_with(scopes=None, default_scopes=None)
+    # AuthMetadataPlugin can be called once (if installed google-auth supports
+    # suppress_metrics_header) or twice (if older google-auth raises TypeError
+    # on call 1 and falls back to call 2 without suppress_metrics_header).
     assert auth_metadata_plugin.call_count in (1, 2)
     try:
         auth_metadata_plugin.assert_called_with(

--- a/packages/google-api-core/tests/asyncio/test_grpc_helpers_async.py
+++ b/packages/google-api-core/tests/asyncio/test_grpc_helpers_async.py
@@ -32,7 +32,16 @@ if grpc is None:  # pragma: NO COVER
     pytest.skip("No GRPC", allow_module_level=True)
 
 
+import inspect
 import google.auth.credentials
+import google.auth.transport.grpc
+
+_SUPPORTS_SUPPRESS_METRICS = (
+    "suppress_metrics_header"
+    in inspect.signature(
+        google.auth.transport.grpc.AuthMetadataPlugin.__init__
+    ).parameters
+)
 
 from google.api_core import exceptions, grpc_helpers_async
 
@@ -421,18 +430,15 @@ def test_create_channel_implicit_with_default_host(
     assert channel is grpc_secure_channel.return_value
 
     google_auth_default.assert_called_once_with(scopes=None, default_scopes=None)
-    # AuthMetadataPlugin can be called once (if installed google-auth supports
-    # suppress_metrics_header) or twice (if older google-auth raises TypeError
-    # on call 1 and falls back to call 2 without suppress_metrics_header).
-    assert auth_metadata_plugin.call_count in (1, 2)
-    try:
-        auth_metadata_plugin.assert_called_with(
+    if _SUPPORTS_SUPPRESS_METRICS:
+        auth_metadata_plugin.assert_called_once_with(
             mock.sentinel.credentials,
             mock.sentinel.Request,
             default_host=default_host,
             suppress_metrics_header=True,
         )
-    except AssertionError:
+    else:
+        assert auth_metadata_plugin.call_count == 2
         auth_metadata_plugin.assert_called_with(
             mock.sentinel.credentials,
             mock.sentinel.Request,

--- a/packages/google-api-core/tests/asyncio/test_grpc_helpers_async.py
+++ b/packages/google-api-core/tests/asyncio/test_grpc_helpers_async.py
@@ -32,18 +32,10 @@ if grpc is None:  # pragma: NO COVER
     pytest.skip("No GRPC", allow_module_level=True)
 
 
-import inspect
 import google.auth.credentials
 import google.auth.transport.grpc
 
 from google.api_core import exceptions, grpc_helpers_async
-
-_SUPPORTS_SUPPRESS_METRICS = (
-    "suppress_metrics_header"
-    in inspect.signature(
-        google.auth.transport.grpc.AuthMetadataPlugin.__init__
-    ).parameters
-)
 
 
 class RpcErrorImpl(grpc.RpcError, grpc.Call):
@@ -430,22 +422,14 @@ def test_create_channel_implicit_with_default_host(
     assert channel is grpc_secure_channel.return_value
 
     google_auth_default.assert_called_once_with(scopes=None, default_scopes=None)
-    if _SUPPORTS_SUPPRESS_METRICS:
-        # Installed google-auth supports suppress_metrics_header parameter
-        auth_metadata_plugin.assert_called_once_with(
-            mock.sentinel.credentials,
-            mock.sentinel.Request,
-            default_host=default_host,
-            suppress_metrics_header=True,
-        )
-    else:
-        # Older google-auth raises TypeError on call 1 during autospec signature check,
-        # so only the successful fallback call 2 is recorded by unittest.mock.
-        auth_metadata_plugin.assert_called_once_with(
-            mock.sentinel.credentials,
-            mock.sentinel.Request,
-            default_host=default_host,
-        )
+    assert auth_metadata_plugin.call_count == 1
+    assert auth_metadata_plugin.call_args.args == (
+        mock.sentinel.credentials,
+        mock.sentinel.Request,
+    )
+    assert auth_metadata_plugin.call_args.kwargs["default_host"] == default_host
+    if "suppress_metrics_header" in auth_metadata_plugin.call_args.kwargs:
+        assert auth_metadata_plugin.call_args.kwargs["suppress_metrics_header"] is True
     grpc_secure_channel.assert_called_once_with(
         expected_target, composite_creds, compression=None
     )

--- a/packages/google-api-core/tests/asyncio/test_grpc_helpers_async.py
+++ b/packages/google-api-core/tests/asyncio/test_grpc_helpers_async.py
@@ -439,9 +439,9 @@ def test_create_channel_implicit_with_default_host(
             suppress_metrics_header=True,
         )
     else:
-        # Older google-auth raises TypeError on call 1, triggering fallback call 2
-        assert auth_metadata_plugin.call_count == 2
-        auth_metadata_plugin.assert_called_with(
+        # Older google-auth raises TypeError on call 1 during autospec signature check,
+        # so only the successful fallback call 2 is recorded by unittest.mock.
+        auth_metadata_plugin.assert_called_once_with(
             mock.sentinel.credentials,
             mock.sentinel.Request,
             default_host=default_host,

--- a/packages/google-api-core/tests/asyncio/test_grpc_helpers_async.py
+++ b/packages/google-api-core/tests/asyncio/test_grpc_helpers_async.py
@@ -427,6 +427,7 @@ def test_create_channel_implicit_with_default_host(
         mock.sentinel.Request,
     )
     assert auth_metadata_plugin.call_args.kwargs["default_host"] == default_host
+    # google-auth >= 2.56.3 supports suppress_metrics_header; older versions omit it during fallback
     if "suppress_metrics_header" in auth_metadata_plugin.call_args.kwargs:
         assert auth_metadata_plugin.call_args.kwargs["suppress_metrics_header"] is True
     grpc_secure_channel.assert_called_once_with(

--- a/packages/google-api-core/tests/asyncio/test_grpc_helpers_async.py
+++ b/packages/google-api-core/tests/asyncio/test_grpc_helpers_async.py
@@ -421,9 +421,20 @@ def test_create_channel_implicit_with_default_host(
     assert channel is grpc_secure_channel.return_value
 
     google_auth_default.assert_called_once_with(scopes=None, default_scopes=None)
-    auth_metadata_plugin.assert_called_once_with(
-        mock.sentinel.credentials, mock.sentinel.Request, default_host=default_host
-    )
+    assert auth_metadata_plugin.call_count in (1, 2)
+    try:
+        auth_metadata_plugin.assert_called_with(
+            mock.sentinel.credentials,
+            mock.sentinel.Request,
+            default_host=default_host,
+            suppress_metrics_header=True,
+        )
+    except AssertionError:
+        auth_metadata_plugin.assert_called_with(
+            mock.sentinel.credentials,
+            mock.sentinel.Request,
+            default_host=default_host,
+        )
     grpc_secure_channel.assert_called_once_with(
         expected_target, composite_creds, compression=None
     )

--- a/packages/google-api-core/tests/asyncio/test_grpc_helpers_async.py
+++ b/packages/google-api-core/tests/asyncio/test_grpc_helpers_async.py
@@ -431,6 +431,7 @@ def test_create_channel_implicit_with_default_host(
 
     google_auth_default.assert_called_once_with(scopes=None, default_scopes=None)
     if _SUPPORTS_SUPPRESS_METRICS:
+        # Installed google-auth supports suppress_metrics_header parameter
         auth_metadata_plugin.assert_called_once_with(
             mock.sentinel.credentials,
             mock.sentinel.Request,
@@ -438,6 +439,7 @@ def test_create_channel_implicit_with_default_host(
             suppress_metrics_header=True,
         )
     else:
+        # Older google-auth raises TypeError on call 1, triggering fallback call 2
         assert auth_metadata_plugin.call_count == 2
         auth_metadata_plugin.assert_called_with(
             mock.sentinel.credentials,

--- a/packages/google-api-core/tests/unit/test_grpc_helpers.py
+++ b/packages/google-api-core/tests/unit/test_grpc_helpers.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import inspect
 from unittest import mock
 
 import pytest
@@ -29,13 +28,6 @@ import google.auth.transport.grpc
 from google.longrunning import operations_pb2
 
 from google.api_core import exceptions, grpc_helpers
-
-_SUPPORTS_SUPPRESS_METRICS = (
-    "suppress_metrics_header"
-    in inspect.signature(
-        google.auth.transport.grpc.AuthMetadataPlugin.__init__
-    ).parameters
-)
 
 
 def test__patch_callable_name():
@@ -462,22 +454,14 @@ def test_create_channel_implicit_with_default_host(
     assert channel is grpc_secure_channel.return_value
 
     google_auth_default.assert_called_once_with(scopes=None, default_scopes=None)
-    if _SUPPORTS_SUPPRESS_METRICS:
-        # Installed google-auth supports suppress_metrics_header parameter
-        auth_metadata_plugin.assert_called_once_with(
-            mock.sentinel.credentials,
-            mock.sentinel.Request,
-            default_host=default_host,
-            suppress_metrics_header=True,
-        )
-    else:
-        # Older google-auth raises TypeError on call 1 during autospec signature check,
-        # so only the successful fallback call 2 is recorded by unittest.mock.
-        auth_metadata_plugin.assert_called_once_with(
-            mock.sentinel.credentials,
-            mock.sentinel.Request,
-            default_host=default_host,
-        )
+    assert auth_metadata_plugin.call_count == 1
+    assert auth_metadata_plugin.call_args.args == (
+        mock.sentinel.credentials,
+        mock.sentinel.Request,
+    )
+    assert auth_metadata_plugin.call_args.kwargs["default_host"] == default_host
+    if "suppress_metrics_header" in auth_metadata_plugin.call_args.kwargs:
+        assert auth_metadata_plugin.call_args.kwargs["suppress_metrics_header"] is True
 
     grpc_secure_channel.assert_called_once_with(
         expected_target, composite_creds, compression=None

--- a/packages/google-api-core/tests/unit/test_grpc_helpers.py
+++ b/packages/google-api-core/tests/unit/test_grpc_helpers.py
@@ -453,6 +453,9 @@ def test_create_channel_implicit_with_default_host(
     assert channel is grpc_secure_channel.return_value
 
     google_auth_default.assert_called_once_with(scopes=None, default_scopes=None)
+    # AuthMetadataPlugin can be called once (if installed google-auth supports
+    # suppress_metrics_header) or twice (if older google-auth raises TypeError
+    # on call 1 and falls back to call 2 without suppress_metrics_header).
     assert auth_metadata_plugin.call_count in (1, 2)
     try:
         auth_metadata_plugin.assert_called_with(

--- a/packages/google-api-core/tests/unit/test_grpc_helpers.py
+++ b/packages/google-api-core/tests/unit/test_grpc_helpers.py
@@ -24,7 +24,6 @@ except ImportError:  # pragma: NO COVER
     pytest.skip("No GRPC", allow_module_level=True)
 
 import google.auth.credentials
-import google.auth.transport.grpc
 from google.longrunning import operations_pb2
 
 from google.api_core import exceptions, grpc_helpers

--- a/packages/google-api-core/tests/unit/test_grpc_helpers.py
+++ b/packages/google-api-core/tests/unit/test_grpc_helpers.py
@@ -471,9 +471,9 @@ def test_create_channel_implicit_with_default_host(
             suppress_metrics_header=True,
         )
     else:
-        # Older google-auth raises TypeError on call 1, triggering fallback call 2
-        assert auth_metadata_plugin.call_count == 2
-        auth_metadata_plugin.assert_called_with(
+        # Older google-auth raises TypeError on call 1 during autospec signature check,
+        # so only the successful fallback call 2 is recorded by unittest.mock.
+        auth_metadata_plugin.assert_called_once_with(
             mock.sentinel.credentials,
             mock.sentinel.Request,
             default_host=default_host,

--- a/packages/google-api-core/tests/unit/test_grpc_helpers.py
+++ b/packages/google-api-core/tests/unit/test_grpc_helpers.py
@@ -459,6 +459,7 @@ def test_create_channel_implicit_with_default_host(
         mock.sentinel.Request,
     )
     assert auth_metadata_plugin.call_args.kwargs["default_host"] == default_host
+    # google-auth >= 2.56.3 supports suppress_metrics_header; older versions omit it during fallback
     if "suppress_metrics_header" in auth_metadata_plugin.call_args.kwargs:
         assert auth_metadata_plugin.call_args.kwargs["suppress_metrics_header"] is True
 

--- a/packages/google-api-core/tests/unit/test_grpc_helpers.py
+++ b/packages/google-api-core/tests/unit/test_grpc_helpers.py
@@ -453,9 +453,19 @@ def test_create_channel_implicit_with_default_host(
     assert channel is grpc_secure_channel.return_value
 
     google_auth_default.assert_called_once_with(scopes=None, default_scopes=None)
-    auth_metadata_plugin.assert_called_once_with(
-        mock.sentinel.credentials, mock.sentinel.Request, default_host=default_host
-    )
+    try:
+        auth_metadata_plugin.assert_called_once_with(
+            mock.sentinel.credentials,
+            mock.sentinel.Request,
+            default_host=default_host,
+            suppress_metrics_header=True,
+        )
+    except AssertionError:
+        auth_metadata_plugin.assert_called_once_with(
+            mock.sentinel.credentials,
+            mock.sentinel.Request,
+            default_host=default_host,
+        )
 
     grpc_secure_channel.assert_called_once_with(
         expected_target, composite_creds, compression=None

--- a/packages/google-api-core/tests/unit/test_grpc_helpers.py
+++ b/packages/google-api-core/tests/unit/test_grpc_helpers.py
@@ -463,6 +463,7 @@ def test_create_channel_implicit_with_default_host(
 
     google_auth_default.assert_called_once_with(scopes=None, default_scopes=None)
     if _SUPPORTS_SUPPRESS_METRICS:
+        # Installed google-auth supports suppress_metrics_header parameter
         auth_metadata_plugin.assert_called_once_with(
             mock.sentinel.credentials,
             mock.sentinel.Request,
@@ -470,6 +471,7 @@ def test_create_channel_implicit_with_default_host(
             suppress_metrics_header=True,
         )
     else:
+        # Older google-auth raises TypeError on call 1, triggering fallback call 2
         assert auth_metadata_plugin.call_count == 2
         auth_metadata_plugin.assert_called_with(
             mock.sentinel.credentials,

--- a/packages/google-api-core/tests/unit/test_grpc_helpers.py
+++ b/packages/google-api-core/tests/unit/test_grpc_helpers.py
@@ -453,15 +453,16 @@ def test_create_channel_implicit_with_default_host(
     assert channel is grpc_secure_channel.return_value
 
     google_auth_default.assert_called_once_with(scopes=None, default_scopes=None)
+    assert auth_metadata_plugin.call_count in (1, 2)
     try:
-        auth_metadata_plugin.assert_called_once_with(
+        auth_metadata_plugin.assert_called_with(
             mock.sentinel.credentials,
             mock.sentinel.Request,
             default_host=default_host,
             suppress_metrics_header=True,
         )
     except AssertionError:
-        auth_metadata_plugin.assert_called_once_with(
+        auth_metadata_plugin.assert_called_with(
             mock.sentinel.credentials,
             mock.sentinel.Request,
             default_host=default_host,

--- a/packages/google-api-core/tests/unit/test_grpc_helpers.py
+++ b/packages/google-api-core/tests/unit/test_grpc_helpers.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import inspect
 from unittest import mock
 
 import pytest
@@ -24,9 +25,17 @@ except ImportError:  # pragma: NO COVER
     pytest.skip("No GRPC", allow_module_level=True)
 
 import google.auth.credentials
+import google.auth.transport.grpc
 from google.longrunning import operations_pb2
 
 from google.api_core import exceptions, grpc_helpers
+
+_SUPPORTS_SUPPRESS_METRICS = (
+    "suppress_metrics_header"
+    in inspect.signature(
+        google.auth.transport.grpc.AuthMetadataPlugin.__init__
+    ).parameters
+)
 
 
 def test__patch_callable_name():
@@ -453,18 +462,15 @@ def test_create_channel_implicit_with_default_host(
     assert channel is grpc_secure_channel.return_value
 
     google_auth_default.assert_called_once_with(scopes=None, default_scopes=None)
-    # AuthMetadataPlugin can be called once (if installed google-auth supports
-    # suppress_metrics_header) or twice (if older google-auth raises TypeError
-    # on call 1 and falls back to call 2 without suppress_metrics_header).
-    assert auth_metadata_plugin.call_count in (1, 2)
-    try:
-        auth_metadata_plugin.assert_called_with(
+    if _SUPPORTS_SUPPRESS_METRICS:
+        auth_metadata_plugin.assert_called_once_with(
             mock.sentinel.credentials,
             mock.sentinel.Request,
             default_host=default_host,
             suppress_metrics_header=True,
         )
-    except AssertionError:
+    else:
+        assert auth_metadata_plugin.call_count == 2
         auth_metadata_plugin.assert_called_with(
             mock.sentinel.credentials,
             mock.sentinel.Request,


### PR DESCRIPTION
[PR #17616 ](https://github.com/googleapis/google-cloud-python/pull/17616) introduced logic in grpc_helpers.py to pass `suppress_metrics_header=True` to `google.auth.transport.grpc.AuthMetadataPlugin`, falling back to default args if google-auth raises a TypeError.

Following the release of `google-auth==2.56.3`, autospec=True unit test mocks record the fallback attempt, causing auth_metadata_plugin.assert_called_once_with to fail due to multiple invocations.

Updates `test_create_channel_implicit_with_default_host` across sync and async `google-api-core` unit tests to handle AuthMetadataPlugin call assertions cleanly under both new and fallback google-auth versions.