### PR TITLE
fix(gapic-generator): restrict package discovery to gapic* namespace

### DIFF
--- a/packages/gapic-generator/setup.py
+++ b/packages/gapic-generator/setup.py
@@ -61,7 +61,9 @@ setuptools.setup(
     author="Google LLC",
     author_email="googleapis-packages@google.com",
     license="Apache-2.0",
-    packages=setuptools.find_namespace_packages(exclude=["docs", "tests"]),
+    packages=setuptools.find_namespace_packages(
+        exclude=["docs*", "tests*", "testing*", ".*", "bazel*", "rules_python_gapic*"]
+    ),
     url=url,
     classifiers=[
         release_status,


### PR DESCRIPTION
### Summary
Previously, `setup.py` called `setuptools.find_namespace_packages(exclude=["docs", "tests"])` without wildcard glob patterns. 
When CI (`run_single_test.sh`) or local test runners created temporary virtual environments (such as `.venv-profiler` or `.nox`), `setuptools` mistook those hidden directories for library packages and attempted to package their contents, causing `pip install -e .` and CI profiling jobs to fail or take too long.
### Fix
This PR updates `exclude` in `setup.py` to use wildcard glob patterns:
```python
packages=setuptools.find_namespace_packages(
    exclude=["docs*", "tests*", "testing*", ".*", "bazel*", "rules_python_gapic*"]
),