### PR TITLE
fix(profiler): support namespace packages without __init__.py and filter sample dirs

### DIFF
--- a/scripts/import_profiler/profiler.py
+++ b/scripts/import_profiler/profiler.py
@@ -385,14 +385,18 @@ def find_module_from_package(pkg):
     try:
         files = importlib.metadata.files(pkg)
         if files:
-            init_files = [str(f) for f in files if str(f).endswith('__init__.py') and '__pycache__' not in str(f) and not str(f).replace('\\', '/').startswith(('tests/', 'testing/', 'samples/'))]
+            ignored_parts = ('tests', 'testing', 'samples', 'examples', 'benchmark', 'benchmarks')
+            init_files = [str(f) for f in files if str(f).endswith('__init__.py') and '__pycache__' not in str(f) and not any(part in ignored_parts for part in str(f).replace('\\', '/').split('/'))]
             if init_files:
                 from pathlib import Path
                 shortest_init = min(init_files, key=lambda p: len(Path(p).parts))
                 parts = Path(shortest_init).parent.parts
                 mod = '.'.join(parts)
-                if importlib.util.find_spec(mod):
-                    return mod
+                try:
+                    if importlib.util.find_spec(mod):
+                        return mod
+                except Exception:
+                    pass
     except Exception:
         pass
 
@@ -403,12 +407,12 @@ def find_module_from_package(pkg):
         if os.path.exists('setup.py') or os.path.exists('pyproject.toml'):
             where_dir = "src" if os.path.isdir("src") else "."
             pkgs = setuptools.find_namespace_packages(where=where_dir)
-            ignored_prefixes = ("tests", "samples", "benchmark", "benchmarks", "third_party", "testing", "test_utils", "docs", "build", "dist", "bin", "ci", "scripts", "cloudbuild")
+            ignored_prefixes = ("tests", "samples", "examples", "benchmark", "benchmarks", "third_party", "testing", "test_utils", "docs", "build", "dist", "bin", "ci", "scripts", "cloudbuild", "notebooks", "assets", "scratch", "specs")
             
             filtered = []
             for p in pkgs:
                 top = p.split(".")[0]
-                if top in ignored_prefixes or top.startswith(("test", "sample", "bench")) or p in ("google", "google.cloud"):
+                if top in ignored_prefixes or top.startswith(("test_", "sample_", "bench_", "example_", "doc_", "notebook_")) or p in ("google", "google.cloud"):
                     continue
                 filtered.append(p)
 
@@ -417,8 +421,11 @@ def find_module_from_package(pkg):
                 path = os.path.join(where_dir, p.replace('.', os.sep))
                 try:
                     if os.path.isfile(os.path.join(path, '__init__.py')):
-                        if importlib.util.find_spec(p):
-                            return p
+                        try:
+                            if importlib.util.find_spec(p):
+                                return p
+                        except Exception:
+                            pass
                 except OSError:
                     continue
 
@@ -427,8 +434,11 @@ def find_module_from_package(pkg):
                 path = os.path.join(where_dir, p.replace('.', os.sep))
                 try:
                     if os.path.isdir(path) and any(f.endswith('.py') for f in os.listdir(path)):
-                        if importlib.util.find_spec(p):
-                            return p
+                        try:
+                            if importlib.util.find_spec(p):
+                                return p
+                        except Exception:
+                            pass
                 except OSError:
                     continue
     except Exception as e:

--- a/scripts/import_profiler/profiler.py
+++ b/scripts/import_profiler/profiler.py
@@ -385,7 +385,7 @@ def find_module_from_package(pkg):
     try:
         files = importlib.metadata.files(pkg)
         if files:
-            init_files = [str(f) for f in files if str(f).endswith('__init__.py') and '__pycache__' not in str(f) and not str(f).startswith(('tests/', 'testing/', 'samples/'))]
+            init_files = [str(f) for f in files if str(f).endswith('__init__.py') and '__pycache__' not in str(f) and not str(f).replace('\\', '/').startswith(('tests/', 'testing/', 'samples/'))]
             if init_files:
                 from pathlib import Path
                 shortest_init = min(init_files, key=lambda p: len(Path(p).parts))
@@ -415,18 +415,24 @@ def find_module_from_package(pkg):
             # First preference: packages containing __init__.py
             for p in sorted(filtered, key=len):
                 path = os.path.join(where_dir, p.replace('.', os.sep))
-                if os.path.isfile(os.path.join(path, '__init__.py')):
-                    if importlib.util.find_spec(p):
-                        return p
+                try:
+                    if os.path.isfile(os.path.join(path, '__init__.py')):
+                        if importlib.util.find_spec(p):
+                            return p
+                except OSError:
+                    continue
 
             # Second preference: namespace packages containing .py files (e.g. googleapis-common-protos -> google.api)
             for p in sorted(filtered, key=len):
                 path = os.path.join(where_dir, p.replace('.', os.sep))
-                if os.path.isdir(path) and any(f.endswith('.py') for f in os.listdir(path)):
-                    if importlib.util.find_spec(p):
-                        return p
-    except Exception:
-        pass
+                try:
+                    if os.path.isdir(path) and any(f.endswith('.py') for f in os.listdir(path)):
+                        if importlib.util.find_spec(p):
+                            return p
+                except OSError:
+                    continue
+    except Exception as e:
+        print(f"WARNING: Package discovery failed: {e}", file=sys.stderr)
 
     # 3. Fallback to basic string manipulation heuristics
     candidates = [

--- a/scripts/import_profiler/profiler.py
+++ b/scripts/import_profiler/profiler.py
@@ -385,7 +385,7 @@ def find_module_from_package(pkg):
     try:
         files = importlib.metadata.files(pkg)
         if files:
-            init_files = [str(f) for f in files if str(f).endswith('__init__.py') and '__pycache__' not in str(f) and not str(f).startswith('tests/')]
+            init_files = [str(f) for f in files if str(f).endswith('__init__.py') and '__pycache__' not in str(f) and not str(f).startswith(('tests/', 'testing/', 'samples/'))]
             if init_files:
                 from pathlib import Path
                 shortest_init = min(init_files, key=lambda p: len(Path(p).parts))
@@ -401,12 +401,28 @@ def find_module_from_package(pkg):
         import setuptools
         import os
         if os.path.exists('setup.py') or os.path.exists('pyproject.toml'):
-            pkgs = setuptools.find_namespace_packages(where='.')
-            for p in sorted(pkgs, key=len):
-                if p in ("google", "google.cloud") or p.startswith("tests"):
+            where_dir = "src" if os.path.isdir("src") else "."
+            pkgs = setuptools.find_namespace_packages(where=where_dir)
+            ignored_prefixes = ("tests", "samples", "benchmark", "benchmarks", "third_party", "testing", "test_utils", "docs", "build", "dist", "bin", "ci", "scripts", "cloudbuild")
+            
+            filtered = []
+            for p in pkgs:
+                top = p.split(".")[0]
+                if top in ignored_prefixes or top.startswith(("test", "sample", "bench")) or p in ("google", "google.cloud"):
                     continue
-                path = p.replace('.', os.sep)
+                filtered.append(p)
+
+            # First preference: packages containing __init__.py
+            for p in sorted(filtered, key=len):
+                path = os.path.join(where_dir, p.replace('.', os.sep))
                 if os.path.isfile(os.path.join(path, '__init__.py')):
+                    if importlib.util.find_spec(p):
+                        return p
+
+            # Second preference: namespace packages containing .py files (e.g. googleapis-common-protos -> google.api)
+            for p in sorted(filtered, key=len):
+                path = os.path.join(where_dir, p.replace('.', os.sep))
+                if os.path.isdir(path) and any(f.endswith('.py') for f in os.listdir(path)):
                     if importlib.util.find_spec(p):
                         return p
     except Exception:

--- a/scripts/import_profiler/test_profiler.py
+++ b/scripts/import_profiler/test_profiler.py
@@ -674,6 +674,33 @@ def test_find_module_from_package_setuptools_not_file_and_exception():
         assert res == "my.pkg"
 
 
+def test_find_module_from_package_namespace_package_no_init():
+    sys.modules.setdefault("setuptools", MagicMock())
+    with patch("importlib.metadata.files", side_effect=Exception), \
+         patch("os.path.exists", return_value=True), \
+         patch("os.path.isdir", return_value=True), \
+         patch("setuptools.find_namespace_packages", return_value=["google.api"]), \
+         patch("os.path.isfile", return_value=False), \
+         patch("os.listdir", return_value=["http_pb2.py"]), \
+         patch("importlib.util.find_spec", return_value=True):
+        res = find_module_from_package("googleapis-common-protos")
+        assert res == "google.api"
+
+
+def test_find_module_from_package_src_layout():
+    sys.modules.setdefault("setuptools", MagicMock())
+    def mock_isdir(path):
+        return path == "src" or path == "."
+    with patch("importlib.metadata.files", side_effect=Exception), \
+         patch("os.path.exists", return_value=True), \
+         patch("os.path.isdir", side_effect=mock_isdir), \
+         patch("setuptools.find_namespace_packages", return_value=["google_crc32c"]), \
+         patch("os.path.isfile", return_value=True), \
+         patch("importlib.util.find_spec", return_value=True):
+        res = find_module_from_package("google-crc32c")
+        assert res == "google_crc32c"
+
+
 def test_find_module_from_package_exception_in_find_spec():
     sys.modules.setdefault("setuptools", MagicMock())
     def mock_find_spec(mod):

--- a/scripts/import_profiler/test_profiler.py
+++ b/scripts/import_profiler/test_profiler.py
@@ -667,11 +667,35 @@ def test_find_module_from_package_setuptools_not_file_and_exception():
         res = find_module_from_package("my-pkg")
         assert res == "my_pkg"
 
+def test_find_module_from_package_oserror_handling(capsys):
+    sys.modules.setdefault("setuptools", MagicMock())
+    def mock_isfile(path):
+        if "bad_pkg" in path:
+            raise OSError("Permission denied")
+        return False
+
+    def mock_listdir(path):
+        if "bad_pkg" in path:
+            raise OSError("Access denied")
+        return ["mod.py"]
+
     with patch("importlib.metadata.files", side_effect=Exception), \
          patch("os.path.exists", return_value=True), \
-         patch("setuptools.find_namespace_packages", side_effect=RuntimeError("setuptools fail")):
+         patch("os.path.isdir", return_value=True), \
+         patch("setuptools.find_namespace_packages", return_value=["bad_pkg", "good_pkg"]), \
+         patch("os.path.isfile", side_effect=mock_isfile), \
+         patch("os.listdir", side_effect=mock_listdir), \
+         patch("importlib.util.find_spec", return_value=True):
+        res = find_module_from_package("my-pkg")
+        assert res == "good_pkg"
+
+    with patch("importlib.metadata.files", side_effect=Exception), \
+         patch("os.path.exists", return_value=True), \
+         patch("setuptools.find_namespace_packages", side_effect=RuntimeError("setuptools failure")):
         res = find_module_from_package("my-pkg")
         assert res == "my.pkg"
+        captured = capsys.readouterr()
+        assert "WARNING: Package discovery failed: setuptools failure" in captured.err
 
 
 def test_find_module_from_package_namespace_package_no_init():

--- a/scripts/import_profiler/test_profiler.py
+++ b/scripts/import_profiler/test_profiler.py
@@ -730,8 +730,29 @@ def test_find_module_from_package_exception_in_find_spec():
     def mock_find_spec(mod):
         raise Exception("Find spec error")
 
+    # Exception during metadata lookup falls back
+    with patch("importlib.metadata.files", return_value=["foo/bar/__init__.py"]), \
+         patch("importlib.util.find_spec", side_effect=mock_find_spec), \
+         patch("setuptools.find_namespace_packages", side_effect=Exception):
+        res = find_module_from_package("foo-bar")
+        assert res == "foo.bar"
+
+    # Exception during setuptools __init__.py lookup falls back
     with patch("importlib.metadata.files", side_effect=Exception), \
-         patch("setuptools.find_namespace_packages", side_effect=Exception), \
+         patch("os.path.exists", return_value=True), \
+         patch("setuptools.find_namespace_packages", return_value=["foo_bar"]), \
+         patch("os.path.isfile", return_value=True), \
+         patch("importlib.util.find_spec", side_effect=mock_find_spec):
+        res = find_module_from_package("foo-bar")
+        assert res == "foo.bar"
+
+    # Exception during setuptools namespace package lookup falls back
+    with patch("importlib.metadata.files", side_effect=Exception), \
+         patch("os.path.exists", return_value=True), \
+         patch("os.path.isdir", return_value=True), \
+         patch("setuptools.find_namespace_packages", return_value=["foo_bar"]), \
+         patch("os.path.isfile", return_value=False), \
+         patch("os.listdir", return_value=["mod.py"]), \
          patch("importlib.util.find_spec", side_effect=mock_find_spec):
         res = find_module_from_package("foo-bar")
         assert res == "foo.bar"


### PR DESCRIPTION
### Summary
Fixes module resolution in `profiler.py` for packages without `__init__.py` files and filters out non-source directories during package discovery.

### Changes
* **Namespace packages**: Added fallback resolution for implicit PEP 420 namespace packages that contain `.py` files without an `__init__.py` (resolves `googleapis-common-protos` to `google.api` / `google.rpc` instead of `googleapis.common.protos`).
* **Ignore auxiliary directories**: Filtered out `samples/`, `benchmark/`, `third_party/`, `testing/`, and `docs/` from setuptools namespace search to prevent picking non-production directories.
* **Layout support**: Added support for `src/` directory layouts.
* **Tests**: Added unit tests in `test_profiler.py` covering implicit namespace packages and `src` layouts, maintaining 100% code coverage.
