### PR TITLE
fix(django-spanner): declare django dependency in setup.py

### DIFF
--- a/ci/run_single_test.sh
+++ b/ci/run_single_test.sh
@@ -149,7 +149,7 @@ case ${TEST_TYPE} in
                                 if pip install -e . ; then
                                     # Install framework peer dependencies for packages that omit them from install_requires
                                     if [ "${PACKAGE_NAME}" = "django-google-spanner" ]; then
-                                        pip install "django~=5.2"
+                                        pip install "django"
                                     fi
                                     echo "INFO: Successfully installed baseline dependencies for ${PACKAGE_NAME}."
                                     python "${PROFILER_SCRIPT}" --package "${PACKAGE_NAME}" --iterations 11 --csv "${BASELINE_CSV}"
@@ -189,7 +189,7 @@ case ${TEST_TYPE} in
             else
                 # Install framework peer dependencies for packages that omit them from install_requires
                 if [ "${PACKAGE_NAME}" = "django-google-spanner" ]; then
-                    pip install "django~=5.2"
+                    pip install "django"
                 fi
                 echo "INFO: Successfully installed dependencies for ${PACKAGE_NAME} on Python ${PY_VERSION}."
                 if [ -f "${BASELINE_CSV}" ]; then

--- a/ci/run_single_test.sh
+++ b/ci/run_single_test.sh
@@ -147,6 +147,10 @@ case ${TEST_TYPE} in
                             cd "${WORKTREE_DIR}/${REPO_PREFIX}"
                             if [ -f setup.py ] || [ -f pyproject.toml ]; then
                                 if pip install -e . ; then
+                                    # Install framework peer dependencies for packages that omit them from install_requires
+                                    if [ "${PACKAGE_NAME}" = "django-google-spanner" ]; then
+                                        pip install "django~=5.2"
+                                    fi
                                     echo "INFO: Successfully installed baseline dependencies for ${PACKAGE_NAME}."
                                     python "${PROFILER_SCRIPT}" --package "${PACKAGE_NAME}" --iterations 11 --csv "${BASELINE_CSV}"
                                     if [ $? -eq 0 ]; then
@@ -183,6 +187,10 @@ case ${TEST_TYPE} in
                     retval=1
                 fi
             else
+                # Install framework peer dependencies for packages that omit them from install_requires
+                if [ "${PACKAGE_NAME}" = "django-google-spanner" ]; then
+                    pip install "django~=5.2"
+                fi
                 echo "INFO: Successfully installed dependencies for ${PACKAGE_NAME} on Python ${PY_VERSION}."
                 if [ -f "${BASELINE_CSV}" ]; then
                     python ${PROFILER_SCRIPT} --package ${PACKAGE_NAME} --iterations 11 --fail-threshold 5000 --diff-baseline "${BASELINE_CSV}" --diff-threshold 100

--- a/ci/run_single_test.sh
+++ b/ci/run_single_test.sh
@@ -147,10 +147,6 @@ case ${TEST_TYPE} in
                             cd "${WORKTREE_DIR}/${REPO_PREFIX}"
                             if [ -f setup.py ] || [ -f pyproject.toml ]; then
                                 if pip install -e . ; then
-                                    # Install framework peer dependencies for packages that omit them from install_requires
-                                    if [ "${PACKAGE_NAME}" = "django-google-spanner" ]; then
-                                        pip install "django"
-                                    fi
                                     echo "INFO: Successfully installed baseline dependencies for ${PACKAGE_NAME}."
                                     python "${PROFILER_SCRIPT}" --package "${PACKAGE_NAME}" --iterations 11 --csv "${BASELINE_CSV}"
                                     if [ $? -eq 0 ]; then
@@ -187,10 +183,6 @@ case ${TEST_TYPE} in
                     retval=1
                 fi
             else
-                # Install framework peer dependencies for packages that omit them from install_requires
-                if [ "${PACKAGE_NAME}" = "django-google-spanner" ]; then
-                    pip install "django"
-                fi
                 echo "INFO: Successfully installed dependencies for ${PACKAGE_NAME} on Python ${PY_VERSION}."
                 if [ -f "${BASELINE_CSV}" ]; then
                     python ${PROFILER_SCRIPT} --package ${PACKAGE_NAME} --iterations 11 --fail-threshold 5000 --diff-baseline "${BASELINE_CSV}" --diff-threshold 100

--- a/packages/django-google-spanner/setup.py
+++ b/packages/django-google-spanner/setup.py
@@ -18,7 +18,11 @@ description = "Bridge to enable using Django with Spanner."
 # 'Development Status :: 4 - Beta'
 # 'Development Status :: 5 - Production/Stable'
 release_status = "Development Status :: 5 - Production/Stable"
-dependencies = ["sqlparse >= 0.3.0", "google-cloud-spanner >= 3.13.0"]
+dependencies = [
+    "sqlparse >= 0.3.0",
+    "google-cloud-spanner >= 3.13.0",
+    "django >= 5.2, < 5.3",
+]
 extras = {
     "tracing": [
         "opentelemetry-api >= 1.1.0",

--- a/packages/django-google-spanner/setup.py
+++ b/packages/django-google-spanner/setup.py
@@ -18,10 +18,12 @@ description = "Bridge to enable using Django with Spanner."
 # 'Development Status :: 4 - Beta'
 # 'Development Status :: 5 - Production/Stable'
 release_status = "Development Status :: 5 - Production/Stable"
+# TODO: Update upper bound when adding support for Django 6.0+
+# (django_spanner/__init__.py currently enforces SUPPORTED_DJANGO_VERSIONS = [(5, 2)])
 dependencies = [
     "sqlparse >= 0.3.0",
     "google-cloud-spanner >= 3.13.0",
-    "django >= 5.2, < 5.3",
+    "django >= 5.2, < 6.0",
 ]
 extras = {
     "tracing": [

--- a/packages/django-google-spanner/setup.py
+++ b/packages/django-google-spanner/setup.py
@@ -18,7 +18,7 @@ description = "Bridge to enable using Django with Spanner."
 # 'Development Status :: 4 - Beta'
 # 'Development Status :: 5 - Production/Stable'
 release_status = "Development Status :: 5 - Production/Stable"
-# TODO: Update upper bound when adding support for Django 6.0+
+# TODO(https://github.com/googleapis/google-cloud-python/issues/18053): Update upper bound when adding support for Django 6.0+
 # (django_spanner/__init__.py currently enforces SUPPORTED_DJANGO_VERSIONS = [(5, 2)])
 dependencies = [
     "sqlparse >= 0.3.0",


### PR DESCRIPTION
## Description
Declares `"django >= 5.2, < 5.3"` in `install_requires` (`dependencies`) for `django-google-spanner`.

## Motivation
`django_spanner` imports and requires `django` directly at top-level import time and explicitly checks for Django 5.2 compatibility in `django_spanner/__init__.py`. 

Without `django` listed in `setup.py`, installing `django-google-spanner` in a clean environment (such as during the `import-profiler` presubmit check) caused imports to fail with: ModuleNotFoundError: No module named 'django'

Tracking issue for Django 6.0 support: #18053 