### PR TITLE
feat(api_core): add deprecation warning for grpcio < 1.83.0 for PQC

### DIFF
--- a/packages/google-api-core/google/api_core/_python_package_support.py
+++ b/packages/google-api-core/google/api_core/_python_package_support.py
@@ -30,14 +30,37 @@ ParsedVersion = Tuple[int, ...]
 # about deprecated and unsupported versions.
 DependencyConstraint = namedtuple(
     "DependencyConstraint",
-    ["package_name", "minimum_fully_supported_version", "recommended_version"],
+    [
+        "package_name",
+        "minimum_fully_supported_version",
+        "recommended_version",
+        "message_template",
+    ],
+    defaults=(None, None),
 )
+
+PQC_GRPC_WARNING_TEMPLATE = (
+    "Package {consumer_package} depends on {dependency_package}, currently installed at version {version_used_string}. "
+    "grpcio < 1.83.0 does not support Post-Quantum Cryptography (PQC). "
+    "Support for non-PQC environments is deprecated. In October 2026, "
+    "Google Cloud Python packages will raise their minimum requirements "
+    "(including google-api-core, grpcio, and grpcio-status) to enforce grpcio >= 1.83.0. "
+    "For more details on Google Cloud's post-quantum security migration, visit: "
+    "https://cloud.google.com/security/resources/post-quantum-cryptography"
+)
+
 _PACKAGE_DEPENDENCY_WARNINGS = [
     DependencyConstraint(
         "google.protobuf",
         minimum_fully_supported_version="6.33.5",
         recommended_version="6.x",
-    )
+    ),
+    DependencyConstraint(
+        "grpcio",
+        minimum_fully_supported_version="1.83.0",
+        recommended_version="1.83.x",
+        message_template=PQC_GRPC_WARNING_TEMPLATE,
+    ),
 ]
 
 
@@ -50,8 +73,8 @@ UNKNOWN_VERSION_STRING = "--"
 def parse_version_to_tuple(version_string: str) -> ParsedVersion:
     """Safely converts a semantic version string to a comparable tuple of integers.
 
-    Example: "6.33.5" -> (6, 33, 5)
-    Ignores non-numeric parts and handles common version formats.
+    Example: "6.33.5" -> (6, 33, 5), "1.83.1rc1" -> (1, 83, 1)
+    Parses leading digits of each component to correctly handle pre-releases.
 
     Args:
         version_string: Version string in the format "x.y.z" or "x.y.z<suffix>"
@@ -61,12 +84,14 @@ def parse_version_to_tuple(version_string: str) -> ParsedVersion:
     """
     parts = []
     for part in version_string.split("."):
-        try:
-            parts.append(int(part))
-        except ValueError:
-            # If it's a non-numeric part (e.g., '1.0.0b1' -> 'b1'), stop here.
-            # This is a simplification compared to 'packaging.parse_version', but sufficient
-            # for comparing strictly numeric semantic versions.
+        digits = ""
+        for c in part:
+            if not c.isdigit():
+                break
+            digits += c
+        if digits:
+            parts.append(int(digits))
+        else:
             break
     return tuple(parts)
 
@@ -162,7 +187,7 @@ def warn_deprecation_for_versions_less_than(
         ) = _get_distribution_and_import_packages(consumer_import_package)
 
         recommendation = (
-            " (we recommend {recommended_version})" if recommended_version else ""
+            f" (we recommend {recommended_version})" if recommended_version else ""
         )
         message_template = message_template or _flatten_message(
             """
@@ -222,4 +247,5 @@ def check_dependency_versions(
             package_info.package_name,
             package_info.minimum_fully_supported_version,
             recommended_version=package_info.recommended_version,
+            message_template=package_info.message_template,
         )

--- a/packages/google-api-core/google/api_core/_python_package_support.py
+++ b/packages/google-api-core/google/api_core/_python_package_support.py
@@ -73,8 +73,8 @@ UNKNOWN_VERSION_STRING = "--"
 def parse_version_to_tuple(version_string: str) -> ParsedVersion:
     """Safely converts a semantic version string to a comparable tuple of integers.
 
-    Example: "6.33.5" -> (6, 33, 5), "1.83.1rc1" -> (1, 83, 1)
-    Parses leading digits of each component to correctly handle pre-releases.
+    Example: "6.33.5" -> (6, 33, 5)
+    Ignores non-numeric parts and handles common version formats.
 
     Args:
         version_string: Version string in the format "x.y.z" or "x.y.z<suffix>"
@@ -84,14 +84,12 @@ def parse_version_to_tuple(version_string: str) -> ParsedVersion:
     """
     parts = []
     for part in version_string.split("."):
-        digits = ""
-        for c in part:
-            if not c.isdigit():
-                break
-            digits += c
-        if digits:
-            parts.append(int(digits))
-        else:
+        try:
+            parts.append(int(part))
+        except ValueError:
+            # If it's a non-numeric part (e.g., '1.0.0b1' -> 'b1'), stop here.
+            # This is a simplification compared to 'packaging.parse_version', but sufficient
+            # for comparing strictly numeric semantic versions.
             break
     return tuple(parts)
 

--- a/packages/google-api-core/pyproject.toml
+++ b/packages/google-api-core/pyproject.toml
@@ -85,7 +85,7 @@ filterwarnings = [
   "error",
   # Prevent Python version warnings from interfering with tests
   "ignore:.* Python version .*:FutureWarning",
-  # TODO: Remove once https://github.com/googleapis/google-cloud-python/issues/XXXXX is resolved (when grpcio >= 1.83.0 is enforced)
+  # TODO: Remove once b/544782314 is resolved (when grpcio >= 1.83.0 is enforced)
   "ignore:.*does not support Post-Quantum Cryptography.*:FutureWarning",
   # Remove once https://github.com/pytest-dev/pytest-cov/issues/621 is fixed
   "ignore:.*The --rsyncdir command line argument and rsyncdirs config variable are deprecated:DeprecationWarning",

--- a/packages/google-api-core/pyproject.toml
+++ b/packages/google-api-core/pyproject.toml
@@ -85,6 +85,8 @@ filterwarnings = [
   "error",
   # Prevent Python version warnings from interfering with tests
   "ignore:.* Python version .*:FutureWarning",
+  # TODO: Remove once https://github.com/googleapis/google-cloud-python/issues/XXXXX is resolved (when grpcio >= 1.83.0 is enforced)
+  "ignore:.*does not support Post-Quantum Cryptography.*:FutureWarning",
   # Remove once https://github.com/pytest-dev/pytest-cov/issues/621 is fixed
   "ignore:.*The --rsyncdir command line argument and rsyncdirs config variable are deprecated:DeprecationWarning",
   # Remove once https://github.com/protocolbuffers/protobuf/issues/12186 is fixed

--- a/packages/google-api-core/tests/unit/test_python_package_support.py
+++ b/packages/google-api-core/tests/unit/test_python_package_support.py
@@ -41,15 +41,8 @@ def test_get_dependency_version(mocker, version_string_to_test):
     mock_importlib.assert_called_once_with("some-package")
 
     # Test package not found
-    mock_importlib.side_effect = Exception
+    mock_importlib.side_effect = ImportError
     assert get_dependency_version("not-a-package") == DependencyVersion(None, "--")
-
-
-def test_parse_version_to_tuple_prerelease():
-    """Test parse_version_to_tuple with pre-release versions."""
-    assert parse_version_to_tuple("1.83.1rc1") == (1, 83, 1)
-    assert parse_version_to_tuple("1.83.0dev0") == (1, 83, 0)
-    assert parse_version_to_tuple("6.33.5b2") == (6, 33, 5)
 
 
 @patch("google.api_core._python_package_support._get_distribution_and_import_packages")

--- a/packages/google-api-core/tests/unit/test_python_package_support.py
+++ b/packages/google-api-core/tests/unit/test_python_package_support.py
@@ -18,6 +18,7 @@ from unittest.mock import patch
 import pytest
 
 from google.api_core._python_package_support import (
+    PQC_GRPC_WARNING_TEMPLATE,
     DependencyConstraint,
     DependencyVersion,
     check_dependency_versions,
@@ -37,12 +38,18 @@ def test_get_dependency_version(mocker, version_string_to_test):
         parse_version_to_tuple(version_string_to_test), version_string_to_test
     )
     assert get_dependency_version("some-package") == expected
-
     mock_importlib.assert_called_once_with("some-package")
 
     # Test package not found
-    mock_importlib.side_effect = ImportError
+    mock_importlib.side_effect = Exception
     assert get_dependency_version("not-a-package") == DependencyVersion(None, "--")
+
+
+def test_parse_version_to_tuple_prerelease():
+    """Test parse_version_to_tuple with pre-release versions."""
+    assert parse_version_to_tuple("1.83.1rc1") == (1, 83, 1)
+    assert parse_version_to_tuple("1.83.0dev0") == (1, 83, 0)
+    assert parse_version_to_tuple("6.33.5b2") == (6, 33, 5)
 
 
 @patch("google.api_core._python_package_support._get_distribution_and_import_packages")
@@ -125,8 +132,40 @@ def test_check_dependency_versions_with_custom_warnings(mock_warn):
 
     assert mock_warn.call_count == 2
     mock_warn.assert_any_call(
-        "my-consumer", "pkg1", "1.0.0", recommended_version="2.0.0"
+        "my-consumer",
+        "pkg1",
+        "1.0.0",
+        recommended_version="2.0.0",
+        message_template=None,
     )
     mock_warn.assert_any_call(
-        "my-consumer", "pkg2", "2.0.0", recommended_version="3.0.0"
+        "my-consumer",
+        "pkg2",
+        "2.0.0",
+        recommended_version="3.0.0",
+        message_template=None,
+    )
+
+
+@patch(
+    "google.api_core._python_package_support.warn_deprecation_for_versions_less_than"
+)
+def test_check_dependency_versions_default(mock_warn):
+    """Test check_dependency_versions with default package dependency warnings."""
+    check_dependency_versions("my-consumer")
+
+    assert mock_warn.call_count == 2
+    mock_warn.assert_any_call(
+        "my-consumer",
+        "google.protobuf",
+        "6.33.5",
+        recommended_version="6.x",
+        message_template=None,
+    )
+    mock_warn.assert_any_call(
+        "my-consumer",
+        "grpcio",
+        "1.83.0",
+        recommended_version="1.83.x",
+        message_template=PQC_GRPC_WARNING_TEMPLATE,
     )

--- a/packages/google-api-core/tests/unit/test_python_package_support.py
+++ b/packages/google-api-core/tests/unit/test_python_package_support.py
@@ -126,9 +126,7 @@ def test_warn_deprecation_for_versions_less_than(mock_get_version, mock_get_pack
             "my.package", "dep.package", "2.0.0", recommended_version="3.0.0"
         )
     assert len(record) == 1
-    assert "version 2.0.0 or higher (we recommend 3.0.0)." in str(
-        record[0].message
-    )
+    assert "version 2.0.0 or higher (we recommend 3.0.0)." in str(record[0].message)
 
 
 @patch(

--- a/packages/google-api-core/tests/unit/test_python_package_support.py
+++ b/packages/google-api-core/tests/unit/test_python_package_support.py
@@ -112,6 +112,24 @@ def test_warn_deprecation_for_versions_less_than(mock_get_version, mock_get_pack
         in str(record[0].message)
     )
 
+    # Case 6: Recommended version is properly formatted.
+    mock_get_packages.reset_mock()
+    mock_get_packages.side_effect = [
+        ("dep-package (dep.package)", "dep-package"),
+        ("my-package (my.package)", "my-package"),
+    ]
+    mock_get_version.return_value = DependencyVersion(
+        parse_version_to_tuple("1.0.0"), "1.0.0"
+    )
+    with pytest.warns(FutureWarning) as record:
+        warn_deprecation_for_versions_less_than(
+            "my.package", "dep.package", "2.0.0", recommended_version="3.0.0"
+        )
+    assert len(record) == 1
+    assert "version 2.0.0 or higher (we recommend 3.0.0)." in str(
+        record[0].message
+    )
+
 
 @patch(
     "google.api_core._python_package_support.warn_deprecation_for_versions_less_than"


### PR DESCRIPTION
Adds deprecation warnings for `grpcio < 1.83.0` to `google.api_core._python_package_support`. 
In October 2026, Google Cloud client libraries will raise their minimum requirements to enforce `grpcio >= 1.83.0` for Post-Quantum Cryptography (PQC) support.

Towards: b/537446703